### PR TITLE
Refactor apps

### DIFF
--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { Container, Properties } from './container';
 import { RootState } from '../store';
 import { AppSandbox } from '.';
-import { Apps } from '../lib/apps';
+import { Apps, PlatformApp } from '../lib/apps';
 import { ConnectionStatus } from '../lib/web3';
 import { ProviderService } from '../lib/web3/provider-service';
 
@@ -13,7 +13,7 @@ describe('AppSandboxContainer', () => {
       route: '',
       connectionStatus: ConnectionStatus.Connected,
       providerService: { get: () => null } as ProviderService,
-      selectedApp: '',
+      selectedApp: Apps.Channels,
       ...props,
     };
 
@@ -40,8 +40,9 @@ describe('AppSandboxContainer', () => {
     expect(wrapper.find(AppSandbox).exists()).toBe(true);
   });
 
-  it('defaults selected app to feed', () => {
+  it('passes selected app to sandbox', () => {
     const selectedApp = Apps.Feed;
+
     const wrapper = subject({ selectedApp });
 
     expect(wrapper.find(AppSandbox).prop('selectedApp')).toBe(selectedApp);
@@ -88,14 +89,14 @@ describe('AppSandboxContainer', () => {
   });
 
   describe('mapState', () => {
-    const subject = (state: RootState) => Container.mapState({
+    const subject = (state: Partial<RootState>) => Container.mapState({
       zns: { value: { route: '' }, ...(state.zns || {}) },
       web3: {
         status: ConnectionStatus.Connecting,
         ...(state.web3 || {}),
       },
       apps: { selectedApp: '', ...(state.apps || {}) },
-    } as any);
+    } as RootState);
 
     test('connectionStatus', () => {
       const state = subject({ web3: { status: ConnectionStatus.Connected } });
@@ -112,9 +113,9 @@ describe('AppSandboxContainer', () => {
     });
 
     test('selectedApp', () => {
-      const selectedApp = 'MS Paint';
+      const selectedApp = Apps.DAOS;
 
-      const state = subject({ apps: { selectedApp } } as RootState);
+      const state = subject({ apps: { selectedApp: { type: selectedApp } as PlatformApp } });
 
       expect(state).toMatchObject({ selectedApp });
     });

--- a/src/app-sandbox/container.tsx
+++ b/src/app-sandbox/container.tsx
@@ -22,10 +22,12 @@ interface State {
 
 export class Container extends React.Component<Properties, State> {
   static mapState(state: RootState): Partial<Properties> {
+    const { type } = state.apps.selectedApp;
+
     return {
       route: state.zns.value.route,
       connectionStatus: state.web3.status,
-      selectedApp: state.apps.selectedApp as Apps,
+      selectedApp: type,
     };
   }
 

--- a/src/components/address-bar/container.test.tsx
+++ b/src/components/address-bar/container.test.tsx
@@ -20,6 +20,8 @@ describe('AddressBarContainer', () => {
     return shallow(<Container {...allProps} />);
   };
 
+  const getAppFor = (app: Apps) => ({ type: app });
+
   it('passes route to address bar', () => {
     const wrapper = subject({ route: 'the.cats.pajamas' });
 
@@ -27,10 +29,11 @@ describe('AddressBarContainer', () => {
   });
 
   it('passes app to address bar', () => {
-    const app = 'Winamp';
-    const wrapper = subject({ app });
+    const selectedApp = { type: Apps.Channels } as PlatformApp; 
 
-    expect(wrapper.find(AddressBar).prop('app')).toBe(app);
+    const wrapper = subject({ app: selectedApp });
+
+    expect(wrapper.find(AddressBar).prop('app')).toBe(selectedApp);
   });
 
   it('passes className to address bar', () => {
@@ -74,7 +77,7 @@ describe('AddressBarContainer', () => {
 
     const wrapper = subject({
       route: 'food',
-      app: 'feed',
+      app: getAppFor(Apps.Feed),
       deepestVisitedRoute: 'food.tacos.bean.pinto',
       history: { push },
     });
@@ -103,7 +106,7 @@ describe('AddressBarContainer', () => {
 
     const wrapper = subject({
       route: 'food.tacos.bean',
-      app: 'staking',
+      app: getAppFor(Apps.Staking),
       deepestVisitedRoute: 'food.tacos.bean.pinto',
       history: { push },
     });

--- a/src/components/address-bar/container.test.tsx
+++ b/src/components/address-bar/container.test.tsx
@@ -4,6 +4,8 @@ import { RootState } from '../../store';
 
 import { AddressBar } from '.';
 import { Container } from './container';
+import { Apps, PlatformApp } from '../../lib/apps';
+import { ZnsDomainDescriptor } from '../../store/zns';
 
 describe('AddressBarContainer', () => {
   const subject = (props: any = {}) => {
@@ -126,22 +128,35 @@ describe('AddressBarContainer', () => {
   });
 
   describe('mapState', () => {
-    const subject = (state: Partial<RootState>) => Container.mapState({
-      ...state,
-      zns: {
-        ...(state.zns || {}),
-      },
-      apps: { ...(state.apps || {})},
-    } as RootState);
+    const subject = (state: Partial<RootState>) => {
+      const zns: any = (state.zns || {});
+
+      return Container.mapState({
+        ...state,
+        zns: {
+          ...zns,
+          value: {
+            ...(zns.value || { deepestVisitedRoute: '', route: 'yo' }),
+          },
+        },
+        apps: { ...(state.apps || {})},
+      } as RootState);
+    };
 
     test('route', () => {
-      const state = subject({ zns: { value: { route: 'what.is.this' } } });
+      const state = subject({ zns: { value: { route: 'what.is.this' } as ZnsDomainDescriptor } });
 
       expect(state.route).toEqual('what.is.this');
     });
 
+    test('app', () => {
+      const state = subject({ apps: { selectedApp: { type: Apps.Feed } as PlatformApp } });
+
+      expect(state.app).toEqual({ type: Apps.Feed });
+    });
+
     test('deepestVisitedRoute', () => {
-      const state = subject({ zns: { value: { deepestVisitedRoute: 'what.is.this' } } });
+      const state = subject({ zns: { value: { deepestVisitedRoute: 'what.is.this' } as ZnsDomainDescriptor } });
 
       expect(state.deepestVisitedRoute).toEqual('what.is.this');
     });

--- a/src/components/address-bar/container.tsx
+++ b/src/components/address-bar/container.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router-dom';
 
 import { AddressBar } from '.';
 import { routeWithApp } from './util';
+import { PlatformApp } from '../../lib/apps';
 
 interface PublicProperties {
   className?: string;
@@ -15,7 +16,7 @@ export interface Properties extends PublicProperties {
   history: History;
   route: string;
   deepestVisitedRoute: string;
-  app: string;
+  app: PlatformApp;
 }
 
 export class Container extends React.Component<Properties> {
@@ -74,7 +75,7 @@ export class Container extends React.Component<Properties> {
   }
 
   goToRoute(route) {
-    this.props.history.push(routeWithApp(route, this.props.app));
+    this.props.history.push(routeWithApp(route, this.props.app.type));
   }
 
   render() {

--- a/src/components/address-bar/index.test.tsx
+++ b/src/components/address-bar/index.test.tsx
@@ -29,6 +29,18 @@ describe('AddressBar', () => {
     expect(wrapper.find('.address-bar__protocol').text().trim()).toStrictEqual('0://');
   });
 
+  it('renders app name', () => {
+    const wrapper = subject({ app: { type: Apps.Feed, name: 'Feed' }});
+    
+    expect(wrapper.find('.address-bar__route .address-bar__route-app').text().trim()).toStrictEqual('Feed');
+  });
+
+  it('does not render app name no app selected', () => {
+    const wrapper = subject({ app: null });
+    
+    expect(wrapper.find('.address-bar__route .address-bar__route-app').exists()).toBe(false);
+  });
+
   it('renders route in segments', () => {
     const wrapper = subject({ route: 'food.street.tacos' });
     
@@ -38,13 +50,21 @@ describe('AddressBar', () => {
   });
 
   it('renders Link to route with app at segment', () => {
-    const app = 'feed';
+    const app = { type: Apps.Feed };
     const wrapper = subject({ route: 'food.street.tacos', app });
     
     const segments = wrapper.find(Link);
 
-    expect(segments.at(0).prop('to')).toStrictEqual(`/food/${app}`);
-    expect(segments.at(1).prop('to')).toStrictEqual(`/food.street/${app}`);
+    expect(segments.at(0).prop('to')).toStrictEqual('/food/feed');
+    expect(segments.at(1).prop('to')).toStrictEqual('/food.street/feed');
+  });
+
+  it('does not add app link if no selected app', () => {
+    const wrapper = subject({ route: 'food.street.tacos', app: null });
+    
+    const segments = wrapper.find(Link);
+
+    expect(segments.at(0).prop('to')).toStrictEqual('/food');
   });
 
   it('renders route seperators', () => {

--- a/src/components/address-bar/index.tsx
+++ b/src/components/address-bar/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
 import { routeWithApp } from './util';
-import { apps } from '../../lib/apps';
+import { apps, PlatformApp } from '../../lib/apps';
 
 import { Icons, IconButton } from '@zer0-os/zos-component-library';
 
@@ -12,7 +12,7 @@ import './styles.scss';
 export interface Properties {
   className?: string;
   route: string;
-  app: string;
+  app: PlatformApp;
 
   canGoBack?: boolean;
   canGoForward?: boolean;
@@ -26,6 +26,14 @@ export class AddressBar extends React.Component<Properties> {
     return this.props.route.split('.');
   }
 
+  get hasSelectedApp() {
+    return !!this.props.app;
+  }
+
+  get app() {
+    return this.props.app || {} as PlatformApp;
+  }
+
   renderSegments() {
     const { elements } = this.routeSegments.reduce(({ elements, route }, segment, index) => {
       if (elements.length) {
@@ -37,7 +45,7 @@ export class AddressBar extends React.Component<Properties> {
       return {
         elements: [
           ...elements,
-          <Link key={segment} className='address-bar__route-segment' to={routeWithApp(route, this.props.app)}>{segment}</Link>
+          <Link key={segment} className='address-bar__route-segment' to={routeWithApp(route, this.app.type)}>{segment}</Link>
         ],
         route,
       };
@@ -49,7 +57,8 @@ export class AddressBar extends React.Component<Properties> {
   renderRoute() {
     return (
       <span className='address-bar__route'>
-        {this.renderSegments()}<span className='address-bar__route-app'>{apps[this.props.app]?.name}</span>
+        {this.renderSegments()}
+        {this.hasSelectedApp && <span className='address-bar__route-app'>{this.app.name}</span>}
       </span>
     );
   }

--- a/src/components/app-menu/container.test.tsx
+++ b/src/components/app-menu/container.test.tsx
@@ -4,7 +4,7 @@ import { RootState } from '../../store';
 
 import { Container } from './container';
 import { AppMenu } from './index';
-import { Apps } from '../../lib/apps';
+import { Apps, PlatformApp } from '../../lib/apps';
 
 describe('AppMenuContainer', () => {
   const subject = (props: any = {}) => {
@@ -26,9 +26,10 @@ describe('AppMenuContainer', () => {
 
   it('passes selectedApp', () => {
     const selectedApp = Apps.Feed;
+
     const wrapper = subject({ selectedApp });
 
-    expect(wrapper.find(AppMenu).prop('selectedApp')).toBe(Apps[selectedApp]);
+    expect(wrapper.find(AppMenu).prop('selectedApp')).toBe(selectedApp);
   });
 
   describe('mapState', () => {
@@ -47,11 +48,11 @@ describe('AppMenuContainer', () => {
     });
 
     test('selectedApp', () => {
-      const selectedApp = 'Trumpet Winsock';
+      const selectedApp = { type: Apps.Channels } as PlatformApp;
 
       const state = subject({ apps: { selectedApp } });
 
-      expect(state.selectedApp).toEqual(selectedApp);
+      expect(state.selectedApp).toEqual(Apps.Channels);
     });
   });
 });

--- a/src/components/app-menu/container.test.tsx
+++ b/src/components/app-menu/container.test.tsx
@@ -4,7 +4,7 @@ import { RootState } from '../../store';
 
 import { Container } from './container';
 import { AppMenu } from './index';
-import { Apps, PlatformApp } from '../../lib/apps';
+import { allApps, Apps, PlatformApp } from '../../lib/apps';
 
 describe('AppMenuContainer', () => {
   const subject = (props: any = {}) => {
@@ -22,6 +22,12 @@ describe('AppMenuContainer', () => {
     const wrapper = subject({ route });
 
     expect(wrapper.find(AppMenu).prop('route')).toBe(route);
+  });
+
+  it('passes apps to child', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find(AppMenu).prop('apps')).toBe(allApps);
   });
 
   it('passes selectedApp', () => {

--- a/src/components/app-menu/container.tsx
+++ b/src/components/app-menu/container.tsx
@@ -5,16 +5,16 @@ import { AppMenu } from '.';
 import { Apps, apps as PlatformApps } from '../../lib/apps';
 
 export interface Properties {
-  selectedApp: string;
+  selectedApp: Apps;
 
   route: string;
 }
 
 export class Container extends React.Component<Properties, {}> {
   static mapState(state: RootState): Partial<Properties> {
-    const { zns: { value: { route } }, apps: { selectedApp } } = state;
+    const { zns: { value: { route } }, apps: { selectedApp: { type } } } = state;
 
-    return { selectedApp, route };
+    return { selectedApp: type, route };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
@@ -32,7 +32,7 @@ export class Container extends React.Component<Properties, {}> {
 
     return (
       <AppMenu
-        selectedApp={Apps[selectedApp]}
+        selectedApp={selectedApp}
         route={route}
         apps={this.availableApps()}
       />

--- a/src/components/app-menu/container.tsx
+++ b/src/components/app-menu/container.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { RootState } from '../../store';
 import { connectContainer } from '../../store/redux-container';
 import { AppMenu } from '.';
-import { Apps, apps as PlatformApps } from '../../lib/apps';
+import { Apps, allApps } from '../../lib/apps';
 
 export interface Properties {
   selectedApp: Apps;
@@ -21,12 +21,6 @@ export class Container extends React.Component<Properties, {}> {
     return {};
   }
 
-  availableApps() {
-    const availableApps = [Apps.Feed] as string[];
-
-    return Object.keys(PlatformApps).filter(key => availableApps.includes(key)).map(key => PlatformApps[key]);
-  }
-
   render() {
     const { selectedApp, route } = this.props;
 
@@ -34,7 +28,7 @@ export class Container extends React.Component<Properties, {}> {
       <AppMenu
         selectedApp={selectedApp}
         route={route}
-        apps={this.availableApps()}
+        apps={allApps}
       />
     );
   }

--- a/src/lib/apps/index.ts
+++ b/src/lib/apps/index.ts
@@ -20,7 +20,7 @@ Object.keys(Apps).forEach(app => {
   apps[Apps[app]] = {
     type: Apps[app],
     name: app,
-    imageSource: ['https://res.cloudinary.com/fact0ry-dev/image/upload/v1649095368/zero-assets/zer0-os/apps', `${Apps[app]}.svg`].join('/'),
+    imageSource: `https://res.cloudinary.com/fact0ry-dev/image/upload/v1649095368/zero-assets/zer0-os/apps/${Apps[app]}.svg`,
   };
 });
 

--- a/src/lib/apps/index.ts
+++ b/src/lib/apps/index.ts
@@ -24,4 +24,6 @@ Object.keys(Apps).forEach(app => {
   };
 });
 
-export { apps };
+const allApps = [ apps[Apps.Feed] ];
+
+export { apps, allApps };

--- a/src/store/apps/index.test.ts
+++ b/src/store/apps/index.test.ts
@@ -1,0 +1,26 @@
+import {
+  reducer,
+  receive,
+  AppsState,
+} from '.';
+
+import { apps, Apps } from '../../lib/apps';
+
+
+describe('apps reducer', () => {
+  const initialExistingState: AppsState = {
+    selectedApp: apps[Apps.Members],
+  };
+
+  it('should handle initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
+      selectedApp: apps[Apps.Feed],
+    });
+  });
+
+  it('should replace existing state with new app', () => {
+    const actual = reducer(initialExistingState, receive(apps[Apps.Channels]));
+
+    expect(actual.selectedApp).toEqual(apps[Apps.Channels]);
+  });
+});

--- a/src/store/apps/index.ts
+++ b/src/store/apps/index.ts
@@ -5,26 +5,27 @@ import {
 } from '@reduxjs/toolkit';
 
 import { config } from '../../config';
+import { apps, PlatformApp } from '../../lib/apps';
 
 export enum SagaActionTypes {
-  UpdateRoute = 'app/saga/updateRoute',
+  UpdateApp = 'app/saga/updateApp',
 }
 
-const setSelectedApp = createAction<string>(SagaActionTypes.UpdateRoute);
+const setSelectedApp = createAction<string>(SagaActionTypes.UpdateApp);
 
 export interface AppsState {
-  selectedApp: string,
+  selectedApp: PlatformApp,
 }
 
 const initialState: AppsState = {
-  selectedApp: config.defaultApp,
+  selectedApp: apps[config.defaultApp],
 };
 
 const slice = createSlice({
   name: 'apps',
   initialState,
   reducers: {
-    receive: (state, action: PayloadAction<string>) => {
+    receive: (state, action: PayloadAction<PlatformApp>) => {
       state.selectedApp = action.payload;
     },
   },

--- a/src/store/apps/index.ts
+++ b/src/store/apps/index.ts
@@ -5,13 +5,13 @@ import {
 } from '@reduxjs/toolkit';
 
 import { config } from '../../config';
-import { apps, PlatformApp } from '../../lib/apps';
+import { apps, PlatformApp, Apps } from '../../lib/apps';
 
 export enum SagaActionTypes {
   UpdateApp = 'app/saga/updateApp',
 }
 
-const setSelectedApp = createAction<string>(SagaActionTypes.UpdateApp);
+const setSelectedApp = createAction<Apps>(SagaActionTypes.UpdateApp);
 
 export interface AppsState {
   selectedApp: PlatformApp,

--- a/src/store/apps/saga.test.ts
+++ b/src/store/apps/saga.test.ts
@@ -14,6 +14,10 @@ describe('apps saga', () => {
       .withReducer(reducer)
       .run();
 
-    expect(selectedApp).toBe(selectedAppType);
+    expect(selectedApp).toMatchObject({
+      type: selectedAppType,
+      name: 'Members',
+      imageSource: 'https://res.cloudinary.com/fact0ry-dev/image/upload/v1649095368/zero-assets/zer0-os/apps/members.svg',
+    });
   });
 });

--- a/src/store/apps/saga.test.ts
+++ b/src/store/apps/saga.test.ts
@@ -1,0 +1,19 @@
+import { expectSaga } from 'redux-saga-test-plan';
+
+import { setSelectedApp } from './saga';
+
+import { reducer } from '.';
+
+import { Apps } from '../../lib/apps';
+
+describe('apps saga', () => {
+  it('sets selected app', async () => {
+    const selectedAppType = Apps.Members;
+
+    const { storeState: { selectedApp } } = await expectSaga(setSelectedApp, { payload: selectedAppType })
+      .withReducer(reducer)
+      .run();
+
+    expect(selectedApp).toBe(selectedAppType);
+  });
+});

--- a/src/store/apps/saga.ts
+++ b/src/store/apps/saga.ts
@@ -3,7 +3,7 @@ import { SagaActionTypes, receive } from '.';
 import { apps } from '../../lib/apps';
 
 export function* setSelectedApp(action) {
-  const selectedApp = action.payload as string;
+  const selectedApp = action.payload;
 
   yield put(receive(apps[selectedApp]));
 }

--- a/src/store/apps/saga.ts
+++ b/src/store/apps/saga.ts
@@ -1,12 +1,13 @@
 import { takeLatest, put } from 'redux-saga/effects';
 import { SagaActionTypes, receive } from '.';
+import { apps } from '../../lib/apps';
 
 export function* setSelectedApp(action) {
   const selectedApp = action.payload as string;
 
-  yield put(receive(selectedApp));
+  yield put(receive(apps[selectedApp]));
 }
 
 export function* saga() {
-  yield takeLatest(SagaActionTypes.UpdateRoute, setSelectedApp);
+  yield takeLatest(SagaActionTypes.UpdateApp, setSelectedApp);
 }

--- a/src/store/zns/index.ts
+++ b/src/store/zns/index.ts
@@ -12,7 +12,7 @@ export enum SagaActionTypes {
 
 const setRoute = createAction<string>(SagaActionTypes.UpdateRoute);
 
-interface ZnsDomainDescriptor {
+export interface ZnsDomainDescriptor {
   route: string,
   deepestVisitedRoute: string,
 }

--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -6,10 +6,11 @@ import { setRoute } from './store/zns';
 import { setSelectedApp } from './store/apps';
 import { Web3Connect } from './components/web3-connect';
 import { Main } from './Main';
+import { Apps } from './lib/apps';
 
 export interface Properties {
   setRoute: (route: string) => void;
-  setSelectedApp: (selectedApp: string) => void;
+  setSelectedApp: (selectedApp: Apps) => void;
 
   match: { params: { znsRoute: string, app: string } };
 }
@@ -47,7 +48,7 @@ export class Container extends React.Component<Properties> {
   }
 
   extractAppFromProps(props: Properties = this.props) {
-    return props.match.params.app;
+    return props.match.params.app as Apps;
   }
   
   render() {


### PR DESCRIPTION
### What does this do?
small refactor to apps types and structure across the platform.
adds app object to state rather than just the type.

### Why are we making this change?
to make things a bit more explicit, so it's easier to add new apps, and easier to access data about the current app.

### How do I test this?
load the app. click around. observe.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
