### PR TITLE
bump feed patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@web3-react/walletconnect-connector": "^6.2.13",
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.7.0",
-        "@zer0-os/zos-feed": "1.13.0",
+        "@zer0-os/zos-feed": "1.13.1",
         "@zer0-os/zos-zns": "2.0.1",
         "classnames": "^2.3.1",
         "es6-promise-debounce": "^1.0.1",
@@ -5121,9 +5121,9 @@
       }
     },
     "node_modules/@zer0-os/zos-feed": {
-      "version": "1.13.0",
-      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.13.0/efa1a2f60a7c9d471cae59ff5b3e46371c2ed61be775e4c29730257fc9d73880",
-      "integrity": "sha512-ZuT7M+EQ4UBzbKWAI4WlY1GtwEXH5CL01osczhFOMk2B2mF99Hie1vdyezjQKhxgDPgh5Sx6h7rPlAD/3EIv2Q==",
+      "version": "1.13.1",
+      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.13.1/38b8a92f5150c67895de82f32951919516890cc39f15b621da46fb7deac51e91",
+      "integrity": "sha512-k9OqtXYo+TVnIobiXvQmacbh6vgRdNJG6/8JtXRR0nQZB64tTGQ1bYai/RHDuXixfiDeHkYlvHzrVfLgwrQuRQ==",
       "license": "ISC",
       "dependencies": {
         "@cloudinary/react": "^1.3.0",
@@ -5131,6 +5131,7 @@
         "@zer0-os/zos-component-library": "0.7.0",
         "@zer0-os/zos-zns": "2.0.1",
         "classnames": "^2.3.1",
+        "lodash.isequalwith": "^4.4.0",
         "react-infinite-scroll-component": "^6.1.0"
       },
       "peerDependencies": {
@@ -17247,6 +17248,11 @@
       "version": "4.5.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.isequalwith": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
+      "integrity": "sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ=="
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -29885,15 +29891,16 @@
       }
     },
     "@zer0-os/zos-feed": {
-      "version": "1.13.0",
-      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.13.0/efa1a2f60a7c9d471cae59ff5b3e46371c2ed61be775e4c29730257fc9d73880",
-      "integrity": "sha512-ZuT7M+EQ4UBzbKWAI4WlY1GtwEXH5CL01osczhFOMk2B2mF99Hie1vdyezjQKhxgDPgh5Sx6h7rPlAD/3EIv2Q==",
+      "version": "1.13.1",
+      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.13.1/38b8a92f5150c67895de82f32951919516890cc39f15b621da46fb7deac51e91",
+      "integrity": "sha512-k9OqtXYo+TVnIobiXvQmacbh6vgRdNJG6/8JtXRR0nQZB64tTGQ1bYai/RHDuXixfiDeHkYlvHzrVfLgwrQuRQ==",
       "requires": {
         "@cloudinary/react": "^1.3.0",
         "@cloudinary/url-gen": "^1.7.0",
         "@zer0-os/zos-component-library": "0.7.0",
         "@zer0-os/zos-zns": "2.0.1",
         "classnames": "^2.3.1",
+        "lodash.isequalwith": "^4.4.0",
         "react-infinite-scroll-component": "^6.1.0"
       }
     },
@@ -38210,6 +38217,11 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "dev": true
+    },
+    "lodash.isequalwith": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
+      "integrity": "sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ=="
     },
     "lodash.ismatch": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@web3-react/walletconnect-connector": "^6.2.13",
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.7.0",
-    "@zer0-os/zos-feed": "1.13.0",
+    "@zer0-os/zos-feed": "1.13.1",
     "@zer0-os/zos-zns": "2.0.1",
     "classnames": "^2.3.1",
     "es6-promise-debounce": "^1.0.1",


### PR DESCRIPTION
### What does this do?
updates the feed version to fix paging.

### Why are we making this change?
the feed paging was resetting whenever the metadata was loaded for the items. it is now smarter, and also dumber. we will reset whenever the item collection updates, but not when individual item data is changed.

### How do I test this?
load the feed. scroll. watch the magic. (there should not be duplicate metadata requests)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
