### PR TITLE
Add to app interface

### DIFF
--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -4,13 +4,15 @@ import { Container, Properties } from './container';
 import { RootState } from '../store';
 import { AppSandbox } from '.';
 import { Apps, PlatformApp } from '../lib/apps';
-import { ConnectionStatus } from '../lib/web3';
+import { Chains, ConnectionStatus } from '../lib/web3';
 import { ProviderService } from '../lib/web3/provider-service';
 
 describe('AppSandboxContainer', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
       route: '',
+      address: '',
+      chainId: null,
       connectionStatus: ConnectionStatus.Connected,
       providerService: { get: () => null } as ProviderService,
       selectedApp: Apps.Channels,
@@ -58,6 +60,18 @@ describe('AppSandboxContainer', () => {
     expect(wrapper.find(AppSandbox).prop('znsRoute')).toBe('tacos.street.pollo');
   });
 
+  it('passes address to sandbox', () => {
+    const wrapper = subject({ address: '0x0000000000000000000000000000000000000009' });
+
+    expect(wrapper.find(AppSandbox).prop('address')).toBe('0x0000000000000000000000000000000000000009');
+  });
+
+  it('passes chainId to sandbox', () => {
+    const wrapper = subject({ chainId: Chains.Morden });
+
+    expect(wrapper.find(AppSandbox).prop('chainId')).toBe(Chains.Morden);
+  });
+
   it('passes provider to sandbox', () => {
     const provider = { hey: 'what' };
 
@@ -93,20 +107,37 @@ describe('AppSandboxContainer', () => {
   });
 
   describe('mapState', () => {
-    const subject = (state: Partial<RootState>) =>
+    const subject = (state: any) =>
       Container.mapState({
         zns: { value: { route: '' }, ...(state.zns || {}) },
         web3: {
           status: ConnectionStatus.Connecting,
           ...(state.web3 || {}),
+          value: {
+            address: '',
+            chainId: null,
+            ...(state?.web3?.value || {}),
+          },
         },
         apps: { selectedApp: '', ...(state.apps || {}) },
-      } as RootState);
+      } as any);
 
     test('connectionStatus', () => {
       const state = subject({ web3: { status: ConnectionStatus.Connected } });
 
       expect(state.connectionStatus).toEqual(ConnectionStatus.Connected);
+    });
+
+    test('address', () => {
+      const state = subject({ web3: { value: { address: '0x0000000000000000000000000000000000000044' } } });
+
+      expect(state.address).toEqual('0x0000000000000000000000000000000000000044');
+    });
+
+    test('chainId', () => {
+      const state = subject({ web3: { value: { chainId: Chains.Rinkeby } } });
+
+      expect(state.chainId).toEqual(Chains.Rinkeby);
     });
 
     test('route', () => {

--- a/src/app-sandbox/container.tsx
+++ b/src/app-sandbox/container.tsx
@@ -3,11 +3,13 @@ import { RootState } from '../store';
 import { connectContainer } from '../store/redux-container';
 import { AppSandbox } from '.';
 import { Apps } from '../lib/apps';
-import { ConnectionStatus } from '../lib/web3';
+import { Chains, ConnectionStatus } from '../lib/web3';
 import { ProviderService, inject as injectProviderService } from '../lib/web3/provider-service';
 
 export interface Properties {
   route: string;
+  address: string;
+  chainId: Chains;
   connectionStatus: ConnectionStatus;
 
   providerService: ProviderService;
@@ -23,14 +25,18 @@ interface State {
 export class Container extends React.Component<Properties, State> {
   static mapState(state: RootState): Partial<Properties> {
     const {
+      web3,
       apps: {
         selectedApp: { type },
       },
     } = state;
+    const { chainId, address } = web3.value;
 
     return {
       route: state.zns.value.route,
-      connectionStatus: state.web3.status,
+      chainId,
+      address,
+      connectionStatus: web3.status,
       selectedApp: type,
     };
   }
@@ -72,8 +78,11 @@ export class Container extends React.Component<Properties, State> {
 
   render() {
     if (!this.shouldRender) return null;
+
     return (
       <AppSandbox
+        address={this.props.address}
+        chainId={this.props.chainId}
         selectedApp={this.props.selectedApp}
         znsRoute={this.props.route}
         web3Provider={this.web3Provider}

--- a/src/app-sandbox/index.test.tsx
+++ b/src/app-sandbox/index.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import { App } from '@zer0-os/zos-feed';
 import { AppSandbox } from '.';
 import { Apps } from '../lib/apps';
+import {Chains} from '../lib/web3';
 
 describe('AppSandbox', () => {
   const subject = (props: any) => {
@@ -26,6 +27,27 @@ describe('AppSandbox', () => {
     const wrapper = subject({ selectedApp: null });
 
     expect(wrapper.find(App).exists()).toBe(false);
+  });
+
+  it('passes AppInterface properties to Feed app', () => {
+    const web3Provider = { chain: '7' };
+
+    const wrapper = subject({
+      selectedApp: Apps.Feed,
+      web3Provider,
+      znsRoute: 'food.tacos',
+      chainId: Chains.MainNet,
+      address: '0x0000000000000000000000000000000000000009',
+    });
+
+    expect(wrapper.find(App).props()).toMatchObject({
+      provider: web3Provider,
+      route: 'food.tacos',
+      web3: {
+        chainId: Chains.MainNet,
+        address: '0x0000000000000000000000000000000000000009',
+      },
+    })
   });
 
   it('passes route to feed app', () => {

--- a/src/app-sandbox/index.tsx
+++ b/src/app-sandbox/index.tsx
@@ -2,29 +2,50 @@ import React from 'react';
 
 import { Apps } from '../lib/apps';
 import { App as FeedApp } from '@zer0-os/zos-feed';
+import { Chains } from '../lib/web3';
+import { ethers } from 'ethers';
 
 import './styles.scss';
 
+export interface AppInterface {
+  provider: ethers.providers.Web3Provider;
+  route: string;
+  web3: {
+    chainId: Chains;
+    address: string;
+  },
+}
+
 export interface Properties {
-  web3Provider: any;
+  web3Provider: ethers.providers.Web3Provider;
   znsRoute: string;
+  address: string;
+  chainId: Chains;
   selectedApp: Apps;
 }
 
 export class AppSandbox extends React.Component<Properties> {
-  renderSelectedApp() {
-    const { znsRoute, selectedApp: app, web3Provider } = this.props;
+  get appProperties() {
+    const { znsRoute, web3Provider, address, chainId } = this.props;
 
-    if (app === Apps.Feed) {
-      return (
-        <FeedApp
-          route={znsRoute}
-          provider={web3Provider}
-        />
-      );
+    return {
+      route: znsRoute,
+      provider: web3Provider,
+      web3: {
+        address,
+        chainId,
+      },
+    };;
+  }
+
+  renderSelectedApp() {
+    const { selectedApp } = this.props;
+
+    if (selectedApp === Apps.Feed) {
+      return <FeedApp {...this.appProperties} />;
     }
 
-    return <div className='error'>Error {app} application has not been implemented.</div>;
+    return <div className='error'>Error {selectedApp} application has not been implemented.</div>;
   }
 
   render() {

--- a/src/components/web3-connect/index.test.tsx
+++ b/src/components/web3-connect/index.test.tsx
@@ -6,7 +6,7 @@ import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 import { RootState } from '../../store';
 
 const getWeb3 = (web3 = {}) => ({
-  activate: (connector: any) => undefined,
+  activate: () => undefined,
   account: '',
   chainId: undefined,
   active: false,

--- a/src/components/web3-connect/index.test.tsx
+++ b/src/components/web3-connect/index.test.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Container, Properties } from '.';
 
-import { ConnectionStatus, Connectors } from '../../lib/web3';
+import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 import { RootState } from '../../store';
 
 const getWeb3 = (web3 = {}) => ({
   activate: (connector: any) => undefined,
   account: '',
+  chainId: undefined,
   active: false,
   library: null,
   connector: null,
@@ -22,6 +23,7 @@ describe('Web3Connect', () => {
       connectionStatus: ConnectionStatus.Disconnected,
       setConnectionStatus: () => undefined,
       setAddress: () => undefined,
+      setChain: () => undefined,
       updateConnector: () => undefined,
       ...props,
       web3: getWeb3(props.web3),
@@ -40,6 +42,57 @@ describe('Web3Connect', () => {
     subject({ updateConnector });
 
     expect(updateConnector).toHaveBeenCalledWith(Connectors.Infura);
+  });
+
+  it('sets chain when chain changes', () => {
+    const setChain = jest.fn();
+
+    const wrapper = subject({ setChain });
+
+    wrapper.setProps({ web3: getWeb3({ chainId: Chains.Goerli }) });
+
+    expect(setChain).toHaveBeenCalledWith(Chains.Goerli);
+  });
+
+  it('does not set chain when chain does not change', () => {
+    const setChain = jest.fn();
+
+    const wrapper = subject({ setChain });
+
+    wrapper.setProps({ web3: getWeb3({ account: '0x0000000000000000000000000000000000000009', chainId: Chains.Goerli }) });
+    wrapper.setProps({ web3: getWeb3({ account: '0x0000000000000000000000000000000000000033', chainId: Chains.Goerli }) });
+
+    expect(setChain).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not set chain when chain has not been set', () => {
+    const setChain = jest.fn();
+
+    const wrapper = subject({ setChain });
+
+    wrapper.setProps({ web3: getWeb3({ active: true }) });
+
+    expect(setChain).toHaveBeenCalledTimes(0);
+  });
+
+  it('sets chain if chain is null', () => {
+    const setChain = jest.fn();
+
+    const wrapper = subject({ web3: getWeb3({ chainId: Chains.Goerli }),  setChain });
+
+    wrapper.setProps({ web3: getWeb3({ chainId: null }) });
+
+    expect(setChain).toHaveBeenCalledWith(null);
+  });
+
+  it('sets chain if chain is undefined', () => {
+    const setChain = jest.fn();
+
+    const wrapper = subject({ web3: getWeb3({ chainId: Chains.Goerli }),  setChain });
+
+    wrapper.setProps({ web3: getWeb3({ chainId: undefined }) });
+
+    expect(setChain).toHaveBeenCalledWith(undefined);
   });
 
   it('activates new connector when connector changes', () => {

--- a/src/components/web3-connect/index.tsx
+++ b/src/components/web3-connect/index.tsx
@@ -6,7 +6,7 @@ import { providers } from 'ethers';
 import { inject as injectWeb3 } from '../../lib/web3/web3-react';
 import { inject as injectProviderService } from '../../lib/web3/provider-service';
 import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
-import { setAddress, setConnectionStatus, updateConnector } from '../../store/web3';
+import { setChain, setAddress, setConnectionStatus, updateConnector } from '../../store/web3';
 
 export interface Properties {
   connectionStatus: ConnectionStatus;
@@ -48,7 +48,7 @@ export class Container extends React.Component<Properties, State> {
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
-      setChain: (chainId: Chains) => undefined,
+      setChain,
       setAddress,
       setConnectionStatus,
       updateConnector,

--- a/src/components/web3-connect/index.tsx
+++ b/src/components/web3-connect/index.tsx
@@ -5,13 +5,14 @@ import { providers } from 'ethers';
 
 import { inject as injectWeb3 } from '../../lib/web3/web3-react';
 import { inject as injectProviderService } from '../../lib/web3/provider-service';
-import { ConnectionStatus, Connectors } from '../../lib/web3';
+import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 import { setAddress, setConnectionStatus, updateConnector } from '../../store/web3';
 
 export interface Properties {
   connectionStatus: ConnectionStatus;
   setConnectionStatus: (status: ConnectionStatus) => void;
   setAddress: (address: string) => void;
+  setChain: (chain: Chains) => void;
   updateConnector: (connector: Connectors) => void;
   providerService: { register: (provider: any) => void };
   connectors: { get: (connector: Connectors) => any };
@@ -20,6 +21,7 @@ export interface Properties {
     activate: (connector: any, onError?: (error: Error) => void, throwErrors?: boolean) => Promise<any>;
     active: boolean;
     account: string;
+    chainId: Chains;
     library: providers.Web3Provider;
     connector: any;
   };
@@ -46,6 +48,7 @@ export class Container extends React.Component<Properties, State> {
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
+      setChain: (chainId: Chains) => undefined,
       setAddress,
       setConnectionStatus,
       updateConnector,
@@ -100,7 +103,7 @@ export class Container extends React.Component<Properties, State> {
   componentDidUpdate(prevProps: Properties) {
     const {
       connectionStatus: previousConnectionStatus,
-      web3: { active: previouslyActive, library: previousLibrary, account: previouslyAccount },
+      web3: { chainId: prevChainId, active: previouslyActive, library: previousLibrary, account: previouslyAccount },
     } = prevProps;
     const { web3, connectionStatus } = this.props;
 
@@ -117,6 +120,10 @@ export class Container extends React.Component<Properties, State> {
 
     if (previousConnectionStatus !== ConnectionStatus.Connected && connectionStatus === ConnectionStatus.Connected) {
       this.setState({ hasConnected: true });
+    }
+
+    if (web3.chainId !== prevChainId) {
+      this.props.setChain(web3.chainId);
     }
   }
 

--- a/src/store/web3/index.test.ts
+++ b/src/store/web3/index.test.ts
@@ -32,7 +32,7 @@ describe('web3 reducer', () => {
     expect(actual.value.address).toEqual('0x0000000000000000000000000000000000000007');
   });
 
-  it('should replace existing state with new address', () => {
+  it('should replace existing state with new chain id', () => {
     const actual = reducer(initialExistingState, setChain(Chains.Kovan));
 
     expect(actual.value.chainId).toEqual(Chains.Kovan);

--- a/src/store/web3/index.test.ts
+++ b/src/store/web3/index.test.ts
@@ -1,16 +1,16 @@
-import { reducer, setConnectionStatus, setConnector, setAddress, Web3State } from '.';
-import { ConnectionStatus, Connectors } from '../../lib/web3';
+import { reducer, setConnectionStatus, setConnector, setAddress, setChain, Web3State } from '.';
+import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 
 describe('web3 reducer', () => {
   const initialExistingState: Web3State = {
     status: ConnectionStatus.Disconnected,
-    value: { address: '', connector: Connectors.None },
+    value: { chainId: null,  address: '', connector: Connectors.None },
   };
 
   it('should handle initial state', () => {
     expect(reducer(undefined, { type: 'unknown' })).toEqual({
       status: ConnectionStatus.Disconnected,
-      value: { address: '', connector: Connectors.None },
+      value: { chainId: null, address: '', connector: Connectors.None },
     });
   });
 
@@ -30,5 +30,11 @@ describe('web3 reducer', () => {
     const actual = reducer(initialExistingState, setAddress('0x0000000000000000000000000000000000000007'));
 
     expect(actual.value.address).toEqual('0x0000000000000000000000000000000000000007');
+  });
+
+  it('should replace existing state with new address', () => {
+    const actual = reducer(initialExistingState, setChain(Chains.Kovan));
+
+    expect(actual.value.chainId).toEqual(Chains.Kovan);
   });
 });

--- a/src/store/web3/index.ts
+++ b/src/store/web3/index.ts
@@ -1,5 +1,5 @@
 import { createSlice, createAction, PayloadAction } from '@reduxjs/toolkit';
-import { ConnectionStatus, Connectors } from '../../lib/web3';
+import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 import { WalletType } from '@zer0-os/zos-component-library';
 
 export enum SagaActionTypes {
@@ -11,6 +11,7 @@ const updateConnector = createAction<Connectors | WalletType>(SagaActionTypes.Up
 export interface Web3State {
   status: ConnectionStatus;
   value: {
+    chainId: Chains;
     address: string;
     connector: Connectors;
   };
@@ -18,7 +19,7 @@ export interface Web3State {
 
 const initialState: Web3State = {
   status: ConnectionStatus.Disconnected,
-  value: { address: '', connector: Connectors.None },
+  value: { chainId: null, address: '', connector: Connectors.None },
 };
 
 const slice = createSlice({
@@ -34,9 +35,12 @@ const slice = createSlice({
     setAddress: (state, action: PayloadAction<string>) => {
       state.value.address = action.payload;
     },
+    setChain: (state, action: PayloadAction<Chains>) => {
+      state.value.chainId = action.payload;
+    },
   },
 });
 
-export const { setConnector, setAddress, setConnectionStatus } = slice.actions;
+export const { setConnector, setAddress, setChain, setConnectionStatus } = slice.actions;
 export const { reducer } = slice;
 export { updateConnector };


### PR DESCRIPTION
### What does this do?
adds address & chainId to app interface.

### Why are we making this change?
to provide contextual data to the current app

### How do I test this?
if the app loads, it's good. unless you're building an app. then you can make sure you've got the current chain and address when they update.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
