### PR TITLE
bump feed version to fix scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@web3-react/walletconnect-connector": "^6.2.13",
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.7.1",
-        "@zer0-os/zos-feed": "1.18.0",
+        "@zer0-os/zos-feed": "1.18.1",
         "@zer0-os/zos-zns": "2.2.0",
         "classnames": "^2.3.1",
         "es6-promise-debounce": "^1.0.1",
@@ -5126,9 +5126,9 @@
       }
     },
     "node_modules/@zer0-os/zos-feed": {
-      "version": "1.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.18.0/d4fae156617f511c1c019e2f6b1ce0c98c3fd09fae49f7e27e258c801180c50e",
-      "integrity": "sha512-2Sm7UFfQV62Bywc3wdWu7/0EHv4tPgUZzgHoQevicxKWFZSs8Sldh9au0sstdChVnqG1EsniV9TzyBolfpl9Vw==",
+      "version": "1.18.1",
+      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.18.1/a074a8c98628baee6d9f4f9a09b602a6461e2550899f24c34670545bca8b47c9",
+      "integrity": "sha512-HcbUdB4HoqJQVXwZUCznjGfYPaq+hjk/lswGzboWa73f9hd4JjS2mXAI+cdalLVzt72oL/wuvOb4iOcMCU38cA==",
       "license": "ISC",
       "dependencies": {
         "@cloudinary/react": "^1.3.0",
@@ -30333,9 +30333,9 @@
       }
     },
     "@zer0-os/zos-feed": {
-      "version": "1.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.18.0/d4fae156617f511c1c019e2f6b1ce0c98c3fd09fae49f7e27e258c801180c50e",
-      "integrity": "sha512-2Sm7UFfQV62Bywc3wdWu7/0EHv4tPgUZzgHoQevicxKWFZSs8Sldh9au0sstdChVnqG1EsniV9TzyBolfpl9Vw==",
+      "version": "1.18.1",
+      "resolved": "https://npm.pkg.github.com/download/@zer0-os/zos-feed/1.18.1/a074a8c98628baee6d9f4f9a09b602a6461e2550899f24c34670545bca8b47c9",
+      "integrity": "sha512-HcbUdB4HoqJQVXwZUCznjGfYPaq+hjk/lswGzboWa73f9hd4JjS2mXAI+cdalLVzt72oL/wuvOb4iOcMCU38cA==",
       "requires": {
         "@cloudinary/react": "^1.3.0",
         "@cloudinary/url-gen": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@web3-react/walletconnect-connector": "^6.2.13",
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.7.1",
-    "@zer0-os/zos-feed": "1.18.0",
+    "@zer0-os/zos-feed": "1.18.1",
     "@zer0-os/zos-zns": "2.2.0",
     "classnames": "^2.3.1",
     "es6-promise-debounce": "^1.0.1",


### PR DESCRIPTION
### What does this do?
fixes the feed scrolling.
### Why are we making this change?
adding a fixed height to the app container caused the feed to stop scrolling. each app should be responsible for a) managing its own scrolling, or b) using its height to trigger scrolling on the parent/sandbox container.

### How do I test this?
go to the feed. see it scroll.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
