### PR TITLE
Fix messages bug

### DIFF
--- a/src/platform-apps/channels/channel-view-container.test.tsx
+++ b/src/platform-apps/channels/channel-view-container.test.tsx
@@ -76,13 +76,14 @@ describe('ChannelViewContainer', () => {
     expect(fetchMessages).toHaveBeenLastCalledWith({ channelId: 'the-channel-id' });
   });
 
-  it('should call fetchMore when hasMore is true', () => {
+  it('should call fetchMore with reference timestamp when hasMore is true', () => {
     const fetchMessages = jest.fn();
     const messages = [
       { id: 'the-second-message-id', message: 'the second message', createdAt: 1659016677502 },
       { id: 'the-first-message-id', message: 'the first message', createdAt: 1658776625730 },
       { id: 'the-third-message-id', message: 'the third message', createdAt: 1659016677502 },
     ] as unknown as Message[];
+
     const wrapper = subject({
       fetchMessages,
       channelId: 'the-channel-id',
@@ -93,11 +94,10 @@ describe('ChannelViewContainer', () => {
 
     expect(fetchMessages).toHaveBeenLastCalledWith({
       channelId: 'the-channel-id',
-      filter: {
-        lastCreatedAt: 1658776625730,
-      },
+      referenceTimestamp: 1658776625730,
     });
   });
+
   it('should not call fetchMore when hasMore is false', () => {
     const fetchMessages = jest.fn();
     const messages = [
@@ -105,6 +105,7 @@ describe('ChannelViewContainer', () => {
       { id: 'the-first-message-id', message: 'the first message', createdAt: 1658776625730 },
       { id: 'the-third-message-id', message: 'the third message', createdAt: 1659016677502 },
     ] as unknown as Message[];
+
     const wrapper = subject({
       fetchMessages,
       channelId: 'the-channel-id',
@@ -196,18 +197,6 @@ describe('ChannelViewContainer', () => {
       const props = Container.mapState(state, { channelId: '' });
 
       expect(props.channel).toBeNull();
-    });
-
-    test('getOldestTimestamp with messages', () => {
-      const messages = [
-        { id: 'the-second-message-id', message: 'the second message', createdAt: 1659016677502 },
-        { id: 'the-first-message-id', message: 'the first message', createdAt: 1658776625730 },
-        { id: 'the-third-message-id', message: 'the third message', createdAt: 1659016677502 },
-      ] as unknown as Message[];
-
-      const oldestTimestamp = Container.getOldestTimestamp(messages);
-
-      expect(oldestTimestamp).toEqual(messages[1].createdAt);
     });
   });
 });

--- a/src/platform-apps/channels/channel-view-container.tsx
+++ b/src/platform-apps/channels/channel-view-container.tsx
@@ -48,7 +48,7 @@ export class Container extends React.Component<Properties> {
     }
   }
 
-  static getOldestTimestamp(messages: Message[] = []): number {
+  getOldestTimestamp(messages: Message[] = []): number {
     return messages.reduce((previousTimestamp, message: any) => {
       return message.createdAt < previousTimestamp ? message.createdAt : previousTimestamp;
     }, Date.now());
@@ -62,9 +62,9 @@ export class Container extends React.Component<Properties> {
     const { channelId, channel } = this.props;
 
     if (channel.hasMore) {
-      const oldestTimestamp = Container.getOldestTimestamp(channel.messages);
+      const referenceTimestamp = this.getOldestTimestamp(channel.messages);
 
-      this.props.fetchMessages({ channelId, filter: { lastCreatedAt: oldestTimestamp } });
+      this.props.fetchMessages({ channelId, referenceTimestamp });
     }
   };
 

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -2,13 +2,10 @@ import * as Request from 'superagent';
 import { MessagesResponse } from './index';
 import { config } from '../../config';
 
-export interface MessagesFilter {
-  lastCreatedAt: number;
-}
+export async function fetchMessagesByChannelId(channelId: string, lastCreatedAt?: number): Promise<MessagesResponse> {
+  const filter = lastCreatedAt ? { lastCreatedAt } : {};
 
-export async function fetchMessagesByChannelId(channelId: string, filter?: MessagesFilter): Promise<MessagesResponse> {
-  const response = await Request.get(`${config.ZERO_API_URL}/chatChannels/${channelId}/messages`).query({
-    filter: filter || {},
-  });
+  const response = await Request.get(`${config.ZERO_API_URL}/chatChannels/${channelId}/messages`).query({ filter });
+
   return response.body;
 }

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -47,6 +47,45 @@ describe('messages saga', () => {
       .run();
   });
 
+  it('sets hasMore on channel', async () => {
+    const channelId = 'channel-id';
+    const messageResponse = {
+      hasMore: false,
+      messages: [
+        { id: 'the-first-message-id', message: 'the first message' },
+        { id: 'the-second-message-id', message: 'the second message' },
+        { id: 'the-third-message-id', message: 'the third message' },
+      ],
+    };
+
+    const initialState = {
+      normalized: {
+        channels: {
+          [channelId]: {
+            id: channelId,
+            hasMore: true,
+          },
+        },
+      },
+    };
+
+    const {
+      storeState: {
+        normalized: { channels },
+      },
+    } = await expectSaga(fetch, { payload: { channelId } })
+      .withReducer(rootReducer, initialState as any)
+      .provide([
+        [
+          matchers.call.fn(fetchMessagesByChannelId),
+          messageResponse,
+        ],
+      ])
+      .run();
+
+    expect(channels[channelId].hasMore).toBe(false);
+  });
+
   it('adds message ids to channels state', async () => {
     const channelId = 'channel-id';
     const messageResponse = {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -2,19 +2,25 @@ import { takeLatest, put, call, select } from 'redux-saga/effects';
 import { SagaActionTypes } from '.';
 import { receive, denormalize } from '../channels';
 
-import { fetchMessagesByChannelId, MessagesFilter } from './api';
+import { fetchMessagesByChannelId } from './api';
 
 export interface Payload {
   channelId: string;
-  filter?: MessagesFilter;
+  referenceTimestamp?: number;
 }
 
 const getState = (state) => state;
 
 export function* fetch(action) {
-  const { channelId, filter } = action.payload;
+  const { channelId, referenceTimestamp } = action.payload;
 
-  const messagesResponse = yield call(fetchMessagesByChannelId, channelId, filter);
+  let messagesResponse: any;
+
+  if (referenceTimestamp) {
+    messagesResponse = yield call(fetchMessagesByChannelId, channelId, referenceTimestamp);
+  } else {
+    messagesResponse = yield call(fetchMessagesByChannelId, channelId);
+  }
 
   const state = yield select(getState);
   const channel = denormalize(channelId, state) || null;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -1,6 +1,7 @@
+import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, select } from 'redux-saga/effects';
 import { SagaActionTypes } from '.';
-import { receive, denormalize } from '../channels';
+import { receive } from '../channels';
 
 import { fetchMessagesByChannelId } from './api';
 
@@ -9,25 +10,30 @@ export interface Payload {
   referenceTimestamp?: number;
 }
 
-const getState = (state) => state;
+const rawMessagesSelector = (channelId) => (state) => {
+  return getDeepProperty(state, `normalized.channels[${channelId}].messages`, []);
+};
 
 export function* fetch(action) {
   const { channelId, referenceTimestamp } = action.payload;
 
   let messagesResponse: any;
+  let messages: any[];
 
   if (referenceTimestamp) {
+    const existingMessages = yield select(rawMessagesSelector(channelId));
+
     messagesResponse = yield call(fetchMessagesByChannelId, channelId, referenceTimestamp);
+    messages = [
+      ...existingMessages,
+      ...messagesResponse.messages,
+    ];
   } else {
     messagesResponse = yield call(fetchMessagesByChannelId, channelId);
+    messages = messagesResponse.messages;
   }
 
-  const state = yield select(getState);
-  const channel = denormalize(channelId, state) || null;
-  const prevMessages = channel?.messages || [];
-  const messages = messagesResponse.messages.concat(prevMessages);
-
-  yield put(receive({ id: channelId, ...messagesResponse, messages }));
+  yield put(receive({ id: channelId, messages }));
 }
 
 export function* saga() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -33,7 +33,13 @@ export function* fetch(action) {
     messages = messagesResponse.messages;
   }
 
-  yield put(receive({ id: channelId, messages }));
+  yield put(
+    receive({
+      id: channelId,
+      messages,
+      hasMore: messagesResponse.hasMore,
+    })
+  );
 }
 
 export function* saga() {


### PR DESCRIPTION
### What does this do?
fixes a bug where new messages were always appended to the message list.

### Why are we making this change?
because duplicate messages are no fun.

### How do I test this?
go to a channel.
go to another channel.
go back to the first channel.
you should only see messages that you should see.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
