### PR TITLE
build(craco): configure for linked ES6 modules 

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,4 +1,21 @@
 const path = require('path');
+const fs = require('fs');
+const appDirectory = fs.realpathSync(process.cwd());
+
+/**
+ * Converts a relative path to an absolute path.
+ * e.g. '../zApp-Staking' -> '/users/zero/zApp-Staking'
+ */
+const resolveApp = (relativePath) => {
+  path.resolve(appDirectory, relativePath);
+};
+
+/**
+ * Maps a list of relative app locations to absolute paths
+ */
+const resolveApps = (appLocations) => {
+  return appLocations.map((app) => resolveApp(app));
+};
 
 module.exports = {
   webpack: {
@@ -9,6 +26,18 @@ module.exports = {
       'react-router-dom': path.resolve('./node_modules/react-router-dom'),
     },
   },
+  plugins: [
+    {
+      /* Runs babel-loader on arbitrary folders, enabling us to use ES6
+       * syntax in linked zApps */
+      plugin: require('craco-babel-loader'),
+      options: {
+        // Relative locations of linked packages e.g. '../zApp-BuyDomains', '../zApp-Staking'
+        // Note: do not commit any changes to this array
+        includes: resolveApps([]),
+      },
+    },
+  ],
   devServer: {
     watchOptions: {
       ignored: '**/node_modules/**',

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/react-portal": "^4.0.4",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
         "concurrently": "^7.1.0",
+        "craco-babel-loader": "^1.0.3",
         "cross-env": "^7.0.3",
         "electron": "^18.1.0",
         "electron-builder": "^23.0.3",
@@ -8798,6 +8799,15 @@
         "@types/node": "*",
         "cosmiconfig": ">=7",
         "typescript": ">=3"
+      }
+    },
+    "node_modules/craco-babel-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/craco-babel-loader/-/craco-babel-loader-1.0.3.tgz",
+      "integrity": "sha512-kkXRwI8ieNO5ypmBz6NPz/4f5xQ/qFnI0g6O6ztkGpi/TEfMJQ65sZP3vYRJaHqfAx/V7YGxcSjkgA7U1thXJw==",
+      "dev": true,
+      "peerDependencies": {
+        "@craco/craco": "^6.4.2"
       }
     },
     "node_modules/crc": {
@@ -33029,6 +33039,13 @@
         "cosmiconfig": "^7",
         "ts-node": "^10.7.0"
       }
+    },
+    "craco-babel-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/craco-babel-loader/-/craco-babel-loader-1.0.3.tgz",
+      "integrity": "sha512-kkXRwI8ieNO5ypmBz6NPz/4f5xQ/qFnI0g6O6ztkGpi/TEfMJQ65sZP3vYRJaHqfAx/V7YGxcSjkgA7U1thXJw==",
+      "dev": true,
+      "requires": {}
     },
     "crc": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/react-portal": "^4.0.4",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
     "concurrently": "^7.1.0",
+    "craco-babel-loader": "^1.0.3",
     "cross-env": "^7.0.3",
     "electron": "^18.1.0",
     "electron-builder": "^23.0.3",


### PR DESCRIPTION
### What does this do?

`babel-loader`, by default, doesn't run on `node_modules`. This means we will get an error if we use ES6+ syntax (i.e. function components) in a packages symlinked through `npm link`. The error looks something like the below:

```
Module parse failed: Unexpected token (23:46)
File was processed with these loaders:
 * ./node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
You may need an additional loader to handle the result of these loaders.

> export const Component = () => (
|       <>
```

[`craco-babel-loader`](https://www.npmjs.com/package/craco-babel-loader) is a CRACO plug-in which can run `babel-loader` on any folder. This means we can point it to our symlinked folders, and it will compile them at the same time as the host app (zOS).

### Why are we making this change?

As mentioned above, symlinked components using ES6+ syntax aren't being run through `babel-loader` and thus causing errors.

### How do I test this?

1. Create a function component in an external package.
2. Symlink (`npm link`) the external package into zOS.
3. Render the symlinked component in zOS.
(If you run zOS here, you'll see the error we're trying to solve!)
4. Add the relative link to your external package folder to the array parameter of `resolveApps` in `craco.config.js`.
5. Start zOS (or restart, if you tested at step 3)
6. The symlinked component should render, and not throw any errors.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
This should be configured to only run in a dev environment.
  2. How will this affect performance?
It won't affect production performance, and will only marginally affect dev performance.
  3. Does this change any APIs?
Nope!
