### PR TITLE
Changed API URL joining (the 'join' method was stripping slashes)

### DIFF
--- a/src/lib/api/rest.ts
+++ b/src/lib/api/rest.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import * as Request from 'superagent';
 import { config } from '../../config';
 import { isEmpty } from 'lodash';
@@ -11,8 +10,11 @@ interface RequestFilter {
   include?: any;
 }
 
-function makePath(path: string) {
-  return join(`${config.ZERO_API_URL}`, path);
+function apiUrl(path: string) {
+  return [
+    config.ZERO_API_URL,
+    path,
+  ].join('');
 }
 
 export async function get<T>(path: string, filter?: RequestFilter) {
@@ -27,19 +29,19 @@ export async function get<T>(path: string, filter?: RequestFilter) {
     }
   }
 
-  const response = await Request.get<T>(makePath(path)).withCredentials().query(queryData);
+  const response = await Request.get<T>(apiUrl(path)).withCredentials().query(queryData);
 
   return response.body;
 }
 
 export async function post<T>(path: string, data: any = {}) {
-  const response = await Request.post<T>(makePath(path)).withCredentials().send(data);
+  const response = await Request.post<T>(apiUrl(path)).withCredentials().send(data);
 
   return response.body;
 }
 
 export async function put<T>(path: string, data: any = {}) {
-  const response = await Request.put<T>(makePath(path)).withCredentials().send(data);
+  const response = await Request.put<T>(apiUrl(path)).withCredentials().send(data);
 
   return response.body;
 }

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -1,6 +1,6 @@
 import { config } from '../../config';
 
-export async function fetchChannels(_id: string) {
-  const channels = await fetch(`${config.ZERO_API_URL}/api/networks/${_id}/chatChannels/public`);
+export async function fetchChannels(id: string) {
+  const channels = await fetch(`${config.ZERO_API_URL}/api/networks/${id}/chatChannels/public`);
   return await channels.json();
 }


### PR DESCRIPTION
The `join` method from path was removing a slash. Resulting in: `makePath https:/zero-network-development.herokuapp.com`