### PR TITLE
feat: bump zapp-staking version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@zer0-os/zos-component-library": "0.14.1",
     "@zer0-os/zos-feed": "1.23.0",
     "@zer0-os/zos-zns": "2.2.0",
-    "@zero-tech/zapp-staking": "0.2.9",
+    "@zero-tech/zapp-staking": "0.3.0",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",
     "es6-promise-debounce": "^1.0.1",


### PR DESCRIPTION
### What does this do?

Increments `@zero-tech/zapp-staking` version number.

### Why are we making this change?

There have been a number of changes pushed to the Staking zApp.

### How do I test this?

Unsure if we ironed out this process - let me know!