### PR TITLE
UX: changed Search copy, modified top Connect wrapper.

### DIFF
--- a/src/components/zns-dropdown/index.tsx
+++ b/src/components/zns-dropdown/index.tsx
@@ -54,7 +54,7 @@ export class ZNSDropdown extends React.Component<Properties, State> {
     return (
       <AutocompleteDropdown
         value=''
-        placeholder='Search by ZERO name address (zNA)'
+        placeholder='Search'
         itemContainerClassName={this.props.itemContainerClassName}
         findMatches={this.findMatches}
         onSelect={this.onSelect}

--- a/src/main.scss
+++ b/src/main.scss
@@ -71,7 +71,7 @@
     display: flex;
     justify-content: center;
     flex: 1 0;
-    padding: 0 64px;
+    padding: 0 4px 0 64px;
   }
 
   &__address-bar {
@@ -81,16 +81,22 @@
 
   &__wallet-manager-wrapper {
     flex: 0 0 auto;
-    width: $width-sidekick;
-
+    width: $width-sidekick + 60;
     display: flex;
-    justify-content: flex-start;
+    justify-content: center;
     align-items: center;
   }
 
   &__wallet-manager {
     margin-bottom: 8px;
     pointer-events: auto;
+
+    .eth-address {
+      flex: 0 0 auto;
+      display: flex;
+      min-height: 32px;
+      align-items: center;
+    }
   }
 
   &__sidekick {


### PR DESCRIPTION
### What does this do?

Modifies the spacing and alignment of the top left Connect wrapper and changes the copy in the Search.

### Before
![before-connect](https://user-images.githubusercontent.com/31045/195933885-11951157-b1be-4c06-a443-0a4d48288fb0.png)
![before connected](https://user-images.githubusercontent.com/31045/195933891-807df991-5119-48c1-a58e-2055bcd5a7d3.png)

### After
![after connect](https://user-images.githubusercontent.com/31045/195933914-951feb73-5ea1-48bd-b9d0-933753680622.png)
![after connected](https://user-images.githubusercontent.com/31045/195933915-4e9aad76-276b-4d8a-8ae5-b5b68093e006.png)
