### PR TITLE
Fix collapse animation

### DIFF
--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -51,7 +51,7 @@ describe('Main', () => {
     const main = wrapper.find('.main');
 
     expect(main.hasClass('has-context-panel')).toBe(false);
-    expect(main.hasClass('is-context-panel-open')).toBe(false);
+    expect(main.hasClass('context-panel-open')).toBe(false);
   });
 
   it('adds class when hasContextPanel is true', () => {
@@ -63,7 +63,7 @@ describe('Main', () => {
   it('adds class when isContextPanelOpen is true', () => {
     const wrapper = subject({ isContextPanelOpen: true });
 
-    expect(wrapper.find('.main').hasClass('is-context-panel-open')).toBe(true);
+    expect(wrapper.find('.main').hasClass('context-panel-open')).toBe(true);
   });
 
   describe('mapState', () => {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -32,7 +32,7 @@ export class Container extends React.Component<Properties> {
 
   render() {
     const mainClassName = classNames('main', {
-      'is-context-panel-open': this.props.isContextPanelOpen,
+      'context-panel-open': this.props.isContextPanelOpen,
       'has-context-panel': this.props.hasContextPanel,
     });
 

--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -1,0 +1,38 @@
+@use 'modules/animation' as animation;
+
+$left-content-space: 32px;
+$width-world-navigation: 56px;
+$width-platform-navigation: 224px;
+$width-collapsed-platform-navigation: 54px;
+$width-application-navigation: 224px;
+
+$width-navigation: calc($width-platform-navigation + $width-world-navigation);
+$width-collapsed-navigation: calc($width-world-navigation + $width-collapsed-platform-navigation);
+$width-application-content: 736px;
+$width-sidekick: 117px;
+$height-main: 65px;
+
+$breakpoint-collapse-menu: 1294px;
+
+@mixin root-layout-vars {
+  --layout-transition-easing-function: ease-in;
+
+  &.context-panel-open {
+    --layout-transition-easing-function: ease-out;
+  }
+}
+
+@mixin layout-transition($first-prop, $second-prop: null) {
+  @if $second-prop {
+    transition: $first-prop animation.$animation-duration-double var(--layout-transition-easing-function),
+      $second-prop animation.$animation-duration-double var(--layout-transition-easing-function);
+  } @else {
+    transition: $first-prop animation.$animation-duration-double var(--layout-transition-easing-function);
+  }
+}
+
+@mixin for-left-collapse {
+  @media (max-width: $breakpoint-collapse-menu) {
+    @content;
+  }
+}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,22 +1,3 @@
-$left-content-space: 32px;
-$width-world-navigation: 56px;
-$width-platform-navigation: 224px;
-$width-application-navigation: 224px;
-
-$width-navigation: calc($width-platform-navigation + $width-world-navigation);
-$width-collapsed-navigation: calc(56px + 54px);
-$width-application-content: 736px;
-$width-sidekick: 117px;
-$height-main: 65px;
-
-$breakpoint-collapse-menu: 1294px;
-
 $font-size-small: 12px;
 $font-size-large: 16px;
 $font-size-xl: 20px;
-
-@mixin for-left-collapse {
-  @media (max-width: $breakpoint-collapse-menu) {
-    @content;
-  }
-}

--- a/src/app-sandbox/index.test.tsx
+++ b/src/app-sandbox/index.test.tsx
@@ -149,4 +149,46 @@ describe('AppSandbox', () => {
 
     expect(onUpdateLayout).toHaveBeenCalledWith({ hasContextPanel: true });
   });
+
+  it('adds classes for no context panel', () => {
+    const wrapper = subject({
+      layout: {
+        hasContextPanel: false,
+        isContextPanelOpen: false,
+      },
+    });
+
+    const sandbox = wrapper.find('.app-sandbox');
+
+    expect(sandbox.hasClass('context-panel-open')).toBe(false);
+    expect(sandbox.hasClass('has-context-panel')).toBe(false);
+  });
+
+  it('sets classes when hasContextPanel is true', () => {
+    const wrapper = subject({
+      layout: {
+        hasContextPanel: true,
+        isContextPanelOpen: false,
+      },
+    });
+
+    const sandbox = wrapper.find('.app-sandbox');
+
+    expect(sandbox.hasClass('context-panel-open')).toBe(false);
+    expect(sandbox.hasClass('has-context-panel')).toBe(true);
+  });
+
+  it('sets classes when isContextPanelOpen is true', () => {
+    const wrapper = subject({
+      layout: {
+        hasContextPanel: true,
+        isContextPanelOpen: true,
+      },
+    });
+
+    const sandbox = wrapper.find('.app-sandbox');
+
+    expect(sandbox.hasClass('context-panel-open')).toBe(true);
+    expect(sandbox.hasClass('has-context-panel')).toBe(true);
+  });
 });

--- a/src/app-sandbox/index.tsx
+++ b/src/app-sandbox/index.tsx
@@ -17,6 +17,7 @@ import { AppLayout } from '../store/layout';
 import { AppLayoutContextProvider } from '@zer0-os/zos-component-library';
 
 import './styles.scss';
+import classNames from 'classnames';
 
 export interface AppInterface {
   provider: ethers.providers.Web3Provider;
@@ -104,8 +105,15 @@ export class AppSandbox extends React.Component<Properties> {
   }
 
   render() {
+    const { hasContextPanel, isContextPanelOpen } = this.props.layout;
+
+    const className = classNames('app-sandbox', {
+      'context-panel-open': isContextPanelOpen,
+      'has-context-panel': hasContextPanel,
+    });
+
     return (
-      <div className='app-sandbox'>
+      <div className={className}>
         <AppLayoutContextProvider value={this.layoutContext}>{this.renderSelectedApp()}</AppLayoutContextProvider>
       </div>
     );

--- a/src/app-sandbox/styles.scss
+++ b/src/app-sandbox/styles.scss
@@ -1,6 +1,7 @@
 @use '../shared-components/theme-engine/theme' as theme;
 @use '../modules/animation' as animation;
 @import '../variables';
+@import '../layout';
 
 $speed: animation.$animation-duration;
 
@@ -9,6 +10,8 @@ $speed: animation.$animation-duration;
   height: 100vh;
   left: $width-navigation;
   right: 0;
+
+  @include layout-transition(left);
 
   @include for-left-collapse() {
     left: $width-collapsed-navigation;
@@ -24,21 +27,21 @@ $speed: animation.$animation-duration;
 }
 
 .app-layout {
+  @include root-layout-vars;
+
   position: relative;
   display: flex;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
 
-  &.has-context-panel {
-    transition: left animation.$animation-duration-double ease-in, width animation.$animation-duration-double ease-in;
+  @include layout-transition(left, width);
 
+  &.has-context-panel {
     left: calc(0px - $width-application-navigation + 8px);
     width: calc(100% + $width-application-navigation - 8px);
 
     &.context-panel-open {
-      transition: left animation.$animation-duration-double ease-out,
-        width animation.$animation-duration-double ease-out;
       left: 0;
       width: 100%;
     }

--- a/src/app-sandbox/styles.scss
+++ b/src/app-sandbox/styles.scss
@@ -6,6 +6,8 @@
 $speed: animation.$animation-duration;
 
 .app-sandbox {
+  @include root-layout-vars;
+
   position: absolute;
   height: 100vh;
   left: $width-navigation;
@@ -27,8 +29,6 @@ $speed: animation.$animation-duration;
 }
 
 .app-layout {
-  @include root-layout-vars;
-
   position: relative;
   display: flex;
   width: 100%;

--- a/src/components/app-menu/styles.scss
+++ b/src/components/app-menu/styles.scss
@@ -1,5 +1,5 @@
 @use '../../shared-components/theme-engine/theme' as theme;
-@import '../../variables';
+@import '../../layout';
 
 .app-menu {
   font-size: 20px;

--- a/src/main.scss
+++ b/src/main.scss
@@ -2,8 +2,11 @@
 @use 'modules/animation' as animation;
 
 @import 'variables';
+@import 'layout';
 
 .main {
+  @include root-layout-vars;
+
   display: flex;
   justify-content: space-between;
   position: fixed;
@@ -30,6 +33,8 @@
   }
 
   &__navigation-platform {
+    @include layout-transition(width);
+
     box-sizing: border-box;
     width: $width-platform-navigation;
     border-right: 1px solid theme.$primary-border-color;
@@ -37,14 +42,13 @@
     background-color: theme.$background-color-platform-navigation;
 
     @include for-left-collapse() {
-      width: 54px;
+      width: $width-collapsed-platform-navigation;
       padding-left: 5px;
     }
   }
 
-  &.has-context-panel.is-context-panel-open &__header {
+  &.has-context-panel.context-panel-open &__header {
     left: calc($width-navigation + $width-application-navigation);
-    transition: left animation.$animation-duration-double ease-out;
 
     @include for-left-collapse() {
       left: calc($width-collapsed-navigation + $width-application-navigation);
@@ -57,7 +61,7 @@
     align-items: flex-end;
     box-sizing: border-box;
 
-    transition: left animation.$animation-duration-double ease-in;
+    @include layout-transition(left);
     left: $width-navigation;
     right: 0;
     height: 72px;


### PR DESCRIPTION
### What does this do?
fixes the animation of the search bar when the platform menu collapses/expands

### Why are we making this change?
because the animation is off, which looks bad.

### How do I test this?
open the app. expand the browser so that the app menu is expanded. shirnk the browser so that it collapses. all of the layout elements, including the search bar, should animate at the same speed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
