### PR TITLE
chore: bump zapp staking (`0.3.1`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@zer0-os/zos-zns": "2.2.0",
         "@zero-tech/zapp-buy-domains": "^0.1.1",
         "@zero-tech/zapp-daos": "^0.1.2",
-        "@zero-tech/zapp-nfts": "^0.2.2",
+        "@zero-tech/zapp-nfts": "^0.3.1",
         "@zero-tech/zapp-staking": "^0.4.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -45,6 +45,7 @@
         "react": "^17.0.2",
         "react-collapsible": "^2.10.0",
         "react-dom": "^17.0.2",
+        "react-mentions": "^4.4.7",
         "react-portal": "^4.2.1",
         "react-redux": "^7.2.6",
         "react-router-dom": "^5.3.0",
@@ -6130,6 +6131,18 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "license": "MIT",
@@ -7868,14 +7881,15 @@
       }
     },
     "node_modules/@zero-tech/zapp-nfts": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zapp-nfts/-/zapp-nfts-0.2.2.tgz",
-      "integrity": "sha512-Dr7eaUltcnLv/mtS+uUAU4X9CHUJrRanjIT/21Jev9lkZPmFJBKQXnI2yU7zpG9PBBcWeFkspw8BEAW7fDVQNQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zapp-nfts/-/zapp-nfts-0.3.1.tgz",
+      "integrity": "sha512-QtEzA1R51fCRNpHx5mv807C1ovYzcDwhOh0xhoHDpmodVAPtVH8n6RidNM4NGaYs9XeMS1rZWmFh2pbfGfa/0A==",
       "dependencies": {
         "@ethersproject/units": "^5.6.1",
         "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/user-event": "^14.4.3",
         "@zero-tech/zns-sdk": "0.6.1",
-        "@zero-tech/zui": "0.7.0",
+        "@zero-tech/zui": "0.11.2",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "moment": "^2.29.4",
@@ -7954,6 +7968,72 @@
       "peerDependencies": {
         "@zero-tech/zauction-sdk": ">=0.1.4",
         "ethers": "^5.4.6"
+      }
+    },
+    "node_modules/@zero-tech/zapp-nfts/node_modules/@zero-tech/zui": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.11.2.tgz",
+      "integrity": "sha512-EI5WKMhCVbHLF6SdnISCaEyO1PBfdpfy8XKdRWeG/KlrNFgTUK+oKYj76/lstod4snAPOhFKWC6xTZCz+J6OIA==",
+      "dependencies": {
+        "@radix-ui/react-accessible-icon": "^1.0.0",
+        "@radix-ui/react-aspect-ratio": "^1.0.0",
+        "@radix-ui/react-dialog": "^0.1.7",
+        "@radix-ui/react-dropdown-menu": "^0.1.6",
+        "@radix-ui/react-tabs": "^0.1.5",
+        "@radix-ui/react-toggle": "^1.0.0",
+        "@radix-ui/react-toggle-group": "^1.0.0",
+        "@radix-ui/react-tooltip": "^1.0.0",
+        "@react-aria/button": "^3.5.0",
+        "@react-aria/i18n": "^3.4.1",
+        "@react-aria/numberfield": "^3.2.1",
+        "@react-aria/textfield": "^3.6.1",
+        "@react-stately/numberfield": "^3.1.1",
+        "@stitches/react": "^1.2.8",
+        "@storybook/preset-scss": "^1.0.3",
+        "@uiw/react-md-editor": "^3.12.3",
+        "classnames": "^2.3.1",
+        "ethers": "^5.6.9",
+        "focus-visible": "^5.2.0",
+        "react-infinite-scroll-component": "^6.1.0",
+        "react-loading-skeleton": "^3.1.0",
+        "react-router-dom": "^6.3.0",
+        "remark-emoji": "^3.0.2",
+        "remark-gemoji": "^7.0.1",
+        "sass": "^1.52.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@zero-tech/zapp-nfts/node_modules/@zero-tech/zui/node_modules/react-router-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.2.tgz",
+      "integrity": "sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==",
+      "dependencies": {
+        "@remix-run/router": "1.0.2",
+        "react-router": "6.4.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@zero-tech/zapp-nfts/node_modules/react-router": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.2.tgz",
+      "integrity": "sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==",
+      "dependencies": {
+        "@remix-run/router": "1.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/@zero-tech/zapp-staking": {
@@ -26549,6 +26629,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
+    "node_modules/react-mentions": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/react-mentions/-/react-mentions-4.4.7.tgz",
+      "integrity": "sha512-VNriu2h/uOB+RS0mwZgPG2Vf+UtdDvRh5zbXa2TNc1WqacKuNDgTdhlbo9LEOZRBxRzIeTUYQmYJ7p9M9rDHqQ==",
+      "dependencies": {
+        "@babel/runtime": "7.4.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.8",
+        "substyle": "^9.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.3",
+        "react-dom": ">=16.8.3"
+      }
+    },
+    "node_modules/react-mentions/node_modules/@babel/runtime": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "node_modules/react-modal": {
       "version": "3.15.1",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.15.1.tgz",
@@ -29396,6 +29499,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/substyle": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/substyle/-/substyle-9.4.1.tgz",
+      "integrity": "sha512-VOngeq/W1/UkxiGzeqVvDbGDPM8XgUyJVWjrqeh+GgKqspEPiLYndK+XRcsKUHM5Muz/++1ctJ1QCF/OqRiKWA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.4",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.3"
       }
     },
     "node_modules/sumchecker": {
@@ -37059,6 +37174,12 @@
         "@testing-library/dom": "^7.28.1"
       }
     },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "requires": {}
+    },
     "@tootallnate/once": {
       "version": "1.1.2"
     },
@@ -38348,14 +38469,15 @@
       }
     },
     "@zero-tech/zapp-nfts": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zapp-nfts/-/zapp-nfts-0.2.2.tgz",
-      "integrity": "sha512-Dr7eaUltcnLv/mtS+uUAU4X9CHUJrRanjIT/21Jev9lkZPmFJBKQXnI2yU7zpG9PBBcWeFkspw8BEAW7fDVQNQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zapp-nfts/-/zapp-nfts-0.3.1.tgz",
+      "integrity": "sha512-QtEzA1R51fCRNpHx5mv807C1ovYzcDwhOh0xhoHDpmodVAPtVH8n6RidNM4NGaYs9XeMS1rZWmFh2pbfGfa/0A==",
       "requires": {
         "@ethersproject/units": "^5.6.1",
         "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/user-event": "^14.4.3",
         "@zero-tech/zns-sdk": "0.6.1",
-        "@zero-tech/zui": "0.7.0",
+        "@zero-tech/zui": "0.11.2",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "moment": "^2.29.4",
@@ -38401,6 +38523,57 @@
             "cross-fetch": "3.1.4",
             "graphql": "15.5.3",
             "lolex": "6.0.0"
+          }
+        },
+        "@zero-tech/zui": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.11.2.tgz",
+          "integrity": "sha512-EI5WKMhCVbHLF6SdnISCaEyO1PBfdpfy8XKdRWeG/KlrNFgTUK+oKYj76/lstod4snAPOhFKWC6xTZCz+J6OIA==",
+          "requires": {
+            "@radix-ui/react-accessible-icon": "^1.0.0",
+            "@radix-ui/react-aspect-ratio": "^1.0.0",
+            "@radix-ui/react-dialog": "^0.1.7",
+            "@radix-ui/react-dropdown-menu": "^0.1.6",
+            "@radix-ui/react-tabs": "^0.1.5",
+            "@radix-ui/react-toggle": "^1.0.0",
+            "@radix-ui/react-toggle-group": "^1.0.0",
+            "@radix-ui/react-tooltip": "^1.0.0",
+            "@react-aria/button": "^3.5.0",
+            "@react-aria/i18n": "^3.4.1",
+            "@react-aria/numberfield": "^3.2.1",
+            "@react-aria/textfield": "^3.6.1",
+            "@react-stately/numberfield": "^3.1.1",
+            "@stitches/react": "^1.2.8",
+            "@storybook/preset-scss": "^1.0.3",
+            "@uiw/react-md-editor": "^3.12.3",
+            "classnames": "^2.3.1",
+            "ethers": "^5.6.9",
+            "focus-visible": "^5.2.0",
+            "react-infinite-scroll-component": "^6.1.0",
+            "react-loading-skeleton": "^3.1.0",
+            "react-router-dom": "^6.3.0",
+            "remark-emoji": "^3.0.2",
+            "remark-gemoji": "^7.0.1",
+            "sass": "^1.52.2"
+          },
+          "dependencies": {
+            "react-router-dom": {
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.2.tgz",
+              "integrity": "sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==",
+              "requires": {
+                "@remix-run/router": "1.0.2",
+                "react-router": "6.4.2"
+              }
+            }
+          }
+        },
+        "react-router": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.2.tgz",
+          "integrity": "sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==",
+          "requires": {
+            "@remix-run/router": "1.0.2"
           }
         }
       }
@@ -50594,6 +50767,27 @@
         }
       }
     },
+    "react-mentions": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/react-mentions/-/react-mentions-4.4.7.tgz",
+      "integrity": "sha512-VNriu2h/uOB+RS0mwZgPG2Vf+UtdDvRh5zbXa2TNc1WqacKuNDgTdhlbo9LEOZRBxRzIeTUYQmYJ7p9M9rDHqQ==",
+      "requires": {
+        "@babel/runtime": "7.4.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.8",
+        "substyle": "^9.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "react-modal": {
       "version": "3.15.1",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.15.1.tgz",
@@ -52550,6 +52744,15 @@
             "uniq": "^1.0.1"
           }
         }
+      }
+    },
+    "substyle": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/substyle/-/substyle-9.4.1.tgz",
+      "integrity": "sha512-VOngeq/W1/UkxiGzeqVvDbGDPM8XgUyJVWjrqeh+GgKqspEPiLYndK+XRcsKUHM5Muz/++1ctJ1QCF/OqRiKWA==",
+      "requires": {
+        "@babel/runtime": "^7.3.4",
+        "invariant": "^2.2.4"
       }
     },
     "sumchecker": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@zer0-os/zos-zns": "2.2.0",
     "@zero-tech/zapp-buy-domains": "^0.1.1",
     "@zero-tech/zapp-daos": "^0.1.2",
-    "@zero-tech/zapp-nfts": "^0.2.2",
+    "@zero-tech/zapp-nfts": "^0.3.1",
     "@zero-tech/zapp-staking": "^0.4.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
Bumps zApp Staking version to `0.3.1`.
