### PR TITLE
Set the default app to NFTS during tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+REACT_APP_DEFAULT_APP='nfts'


### PR DESCRIPTION
### What does this do?

The tests expect the default app to be NFTS. This creates a `.env.text` to ensure consistent setup of the test environment.

### Why are we making this change?

Tests should pass out of the box without extra setup.

### How do I test this?

* Run the full test suite. All tests should pass now.
* Manually verified that `npm start` still respects the `.env` file values and ignores `.env.test`.
* Also verified that vars that are already set in the environment are not overridden by the `.env.test` file.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? No
  1. How will this affect performance? N/A
  1. Does this change any APIs? No
