### PR TITLE
Lint: Make unused variables in typescript an error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     ],
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
-      "warn", // or "error"
+      "error",
       {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",

--- a/src/components/indicator-message/index.test.tsx
+++ b/src/components/indicator-message/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ZnsLink } from '@zer0-os/zos-component-library';
 import IndicatorMessage from '.';
 
 describe('Indicator new message', () => {

--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -12,7 +12,6 @@ import Dropzone from 'react-dropzone';
 import { config } from '../../config';
 
 describe('MessageInput', () => {
-  const window = jest.fn();
   const subject = (props: Partial<Properties>, child: any = <div />) => {
     const allProps: Properties = {
       className: '',

--- a/src/components/message-input/menu.test.tsx
+++ b/src/components/message-input/menu.test.tsx
@@ -5,8 +5,6 @@ import Dropzone from 'react-dropzone';
 
 import Menu, { Properties } from './menu';
 
-let featureFlags: any = {};
-
 describe('Menu', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {

--- a/src/components/message-input/utils.test.ts
+++ b/src/components/message-input/utils.test.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import { User } from '../../store/channels';
 import { getUsersForMentions } from './utils';
 

--- a/src/platform-apps/channels/channel-view.test.tsx
+++ b/src/platform-apps/channels/channel-view.test.tsx
@@ -10,7 +10,6 @@ import { Lightbox } from '@zer0-os/zos-component-library';
 import { MessageInput } from '../../components/message-input';
 import { Button as ConnectButton } from '../../components/authentication/button';
 import { IfAuthenticated } from '../../components/authentication/if-authenticated';
-import { Button as ComponentButton } from '@zer0-os/zos-component-library';
 
 describe('ChannelView', () => {
   const MESSAGES_TEST = [

--- a/src/platform-apps/channels/message.test.tsx
+++ b/src/platform-apps/channels/message.test.tsx
@@ -8,7 +8,6 @@ import { LinkPreview } from '../../components/link-preview';
 import { LinkPreviewType } from '../../lib/link-preview';
 import { MessageInput } from '../../components/message-input';
 import MessageMenu from './messages-menu';
-import EditMessageActions from './messages-menu/edit-message-actions';
 
 describe('message', () => {
   const sender = {

--- a/src/store/theme/index.test.ts
+++ b/src/store/theme/index.test.ts
@@ -1,4 +1,4 @@
-import { receive, reducer, setViewMode, ThemeState } from '.';
+import { receive, reducer, ThemeState } from '.';
 
 import { ViewModes } from '../../shared-components/theme-engine';
 


### PR DESCRIPTION
### What does this do?

This turns no-unused-vars in typescript files to be a lint error rather than a warning and fixes up the current errors.

### Why are we making this change?

Code cleanliness

### How do I test this?

Run the lint

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? N/A
  1. How will this affect performance? N/A
  1. Does this change any APIs? N/A
