### PR TITLE
Add padding to AppContent components

### DIFF
--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -16,6 +16,7 @@ $breakpoint-collapse-menu: 1294px;
 
 @mixin root-layout-vars {
   --layout-transition-easing-function: ease-in;
+  --layout-app-content-right-padding: 64px;
 
   &.context-panel-open {
     --layout-transition-easing-function: ease-out;

--- a/src/app-sandbox/styles.scss
+++ b/src/app-sandbox/styles.scss
@@ -86,6 +86,7 @@ $speed: animation.$animation-duration;
     overflow: hidden;
     box-sizing: border-box;
     background-color: theme.$background-color-app-content;
+    padding-left: 64px;
   }
 }
 

--- a/src/platform-apps/channels/channel-view.tsx
+++ b/src/platform-apps/channels/channel-view.tsx
@@ -186,27 +186,29 @@ export class ChannelView extends React.Component<Properties, State> {
           />
         )}
         <InvertedScroll className='channel-view__inverted-scroll'>
-          <div className='channel-view__name'>
-            <h1>Welcome to #{this.props.name}</h1>
-            <span>This is the start of the channel.</span>
+          <div className='channel-view__main'>
+            <div className='channel-view__name'>
+              <h1>Welcome to #{this.props.name}</h1>
+              <span>This is the start of the channel.</span>
+            </div>
+            {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
+            {this.props.messages.length > 0 && this.renderMessages()}
+            <IfAuthenticated showChildren>
+              {isMemberOfChannel && (
+                <MessageInput
+                  onMessageInputRendered={this.props.onMessageInputRendered}
+                  placeholder='Speak your truth...'
+                  onSubmit={this.props.sendMessage}
+                  users={this.props.users}
+                />
+              )}
+              {!isMemberOfChannel && this.renderJoinButton()}
+            </IfAuthenticated>
+            <IfAuthenticated hideChildren>
+              <ConnectButton className='authentication__connect-wrapper--with-space' />
+            </IfAuthenticated>
+            <div ref={this.bottomRef} />
           </div>
-          {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
-          {this.props.messages.length > 0 && this.renderMessages()}
-          <IfAuthenticated showChildren>
-            {isMemberOfChannel && (
-              <MessageInput
-                onMessageInputRendered={this.props.onMessageInputRendered}
-                placeholder='Speak your truth...'
-                onSubmit={this.props.sendMessage}
-                users={this.props.users}
-              />
-            )}
-            {!isMemberOfChannel && this.renderJoinButton()}
-          </IfAuthenticated>
-          <IfAuthenticated hideChildren>
-            <ConnectButton className='authentication__connect-wrapper--with-space' />
-          </IfAuthenticated>
-          <div ref={this.bottomRef} />
         </InvertedScroll>
       </div>
     );

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -116,6 +116,10 @@
       visibility: visible;
     }
 
+    &__main {
+      padding-right: var(--layout-app-content-right-padding);
+    }
+
     &__name {
       padding: 110px 0 10px 20px;
 


### PR DESCRIPTION
### What does this do?

1. Adds left padding (64px) to the AppContent component
2. Adds a css variable for apps to use to add right padding as necessary
3. Updates the Channels app to use the right hand padding

Note: PR to add the right padding to the Feed app to follow.

### Why are we making this change?

https://www.notion.so/zerotech/9a4ed77a5ea14501a3e6ef7a33f5a546?v=21e3add7413040bfb3eaf77e8c689cec&p=a2badc2a9c354fee800342544f121f8c&pm=s

We decided that, due to apps potentially having scrollbars, we'd enforce the 64px padding on the left side of the AppContent node but provide a simple mechanism for the apps to define where in their structure the 64px right padding should go. While not ideal, it's a simple compromise between flexibiity and consistency. Otherwise, the scrollbars would be seen 64px inside the right edge of the browser and that's not likely what design wants.

### How do I test this?

Load up zOS and verify that the Channel app has 64px of padding on the left and right sides.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? No
  1. How will this affect performance? N/A
  1. Does this change any APIs? The layout conventions now include having to add right hand padding.
