### PR TITLE
Mark componentWillReceiveProps as unsafe

### DIFF
--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -92,7 +92,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Properties) {
+  UNSAFE_componentWillReceiveProps(nextProps: Properties) {
     if (nextProps.value !== this.props.value) {
       this.setState({ value: nextProps.value || '' });
     }


### PR DESCRIPTION
### What does this do?

Changes the deprecated componentWillReceiveProps hook to the UNSAFE version.

### Why are we making this change?

>      Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.
>
>      * Move data fetching code or side effects to componentDidUpdate.
>      * If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state
>      * Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
>
>      Please update the following components: AutocompleteDropdown

### How do I test this?

Automated tests pass

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? N/A
  1. How will this affect performance? N/A
  1. Does this change any APIs? N/A
