### PR TITLE
Fixes a bug in authentication where we are referencing a result even in the case of an error

### DIFF
--- a/src/components/authentication/index.test.tsx
+++ b/src/components/authentication/index.test.tsx
@@ -131,6 +131,7 @@ describe('Authentication', () => {
 
   it('should call updateConnector when sendAsync return error', () => {
     const updateConnector = jest.fn();
+    const nonceOrAuthorize = jest.fn();
     const currentAddress = '0x00';
 
     const wrapper = subject({
@@ -150,10 +151,12 @@ describe('Authentication', () => {
         data: null,
       },
       updateConnector,
+      nonceOrAuthorize,
     });
     wrapper.setProps({ connectionStatus: ConnectionStatus.Connected });
 
     expect(updateConnector).toHaveBeenCalledWith(Connectors.None);
+    expect(nonceOrAuthorize).not.toHaveBeenCalled();
   });
 
   it('should call clearSession when disconnect btn clicked', () => {

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -89,25 +89,22 @@ export class Container extends React.Component<Properties, State> {
       from,
     ];
 
-    try {
-      web3Provider.provider.sendAsync(
-        {
-          method,
-          params,
-          from,
-        },
-        (err, res) => {
-          if (err) {
-            this.props.updateConnector(Connectors.None);
-            console.log(err);
-          }
-
-          this.props.nonceOrAuthorize({ signedWeb3Token: res.result });
+    web3Provider.provider.sendAsync(
+      {
+        method,
+        params,
+        from,
+      },
+      (err, res) => {
+        if (err) {
+          this.props.updateConnector(Connectors.None);
+          console.log(err);
+          return;
         }
-      );
-    } catch (error) {
-      console.log(error);
-    }
+
+        this.props.nonceOrAuthorize({ signedWeb3Token: res.result });
+      }
+    );
   }
 
   render() {

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -98,7 +98,6 @@ export class Container extends React.Component<Properties, State> {
       (err, res) => {
         if (err) {
           this.props.updateConnector(Connectors.None);
-          console.log(err);
           return;
         }
 


### PR DESCRIPTION
### What does this do?

1. When authenticating, if we receive an error from web3 then we shouldn't expect that there's a valid response object to reference.
1. Removes a console.log statement as we shouldn't log raw errors
1. Removes try/catch

### Why are we making this change?

Bug fix.

### How do I test this?

Authenticate

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? N/A
  1. How will this affect performance? N/A
  1. Does this change any APIs? N/A
