### PR TITLE
Improve performance of message-input tests

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -1,10 +1,6 @@
-/**
- * @jest-environment jsdom
- */
-
 import React from 'react';
 import { MentionsInput } from 'react-mentions';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { MessageInput, Properties } from '.';
 import { Key } from '../../lib/keyboard-search';
@@ -21,23 +17,14 @@ describe('MessageInput', () => {
       getUsersForMentions: () => undefined,
       onMessageInputRendered: () => undefined,
       renderAfterInput: () => undefined,
+      clipboard: {
+        addPasteListener: (_) => {},
+        removePasteListener: (_) => {},
+      },
       ...props,
     };
 
     return shallow(<MessageInput {...allProps}>{child}</MessageInput>);
-  };
-  const subjectMount = (props: Partial<Properties>, child: any = <div />) => {
-    const allProps: Properties = {
-      className: '',
-      placeholder: '',
-      users: [],
-      onSubmit: () => undefined,
-      getUsersForMentions: () => undefined,
-      onMessageInputRendered: () => undefined,
-      ...props,
-    };
-
-    return mount(<MessageInput {...allProps}>{child}</MessageInput>);
   };
 
   it('adds className', () => {
@@ -47,9 +34,10 @@ describe('MessageInput', () => {
   });
 
   it('adds placeholder', () => {
-    const wrapper = subjectMount({ placeholder: 'Speak' });
+    const wrapper = subject({ placeholder: 'Speak' });
+    const dropzone = wrapper.find(Dropzone).shallow();
 
-    expect(wrapper.find(MentionsInput).prop('placeholder')).toEqual('Speak');
+    expect(dropzone.find(MentionsInput).prop('placeholder')).toEqual('Speak');
   });
 
   it('it renders the messageInput', function () {
@@ -60,18 +48,20 @@ describe('MessageInput', () => {
 
   it('should call editActions', function () {
     const renderAfterInput = jest.fn();
-    subjectMount({ renderAfterInput, className: 'chat' });
+    const wrapper = subject({ renderAfterInput, className: 'chat' });
+    const _dropzone = wrapper.find(Dropzone).shallow();
 
     expect(renderAfterInput).toHaveBeenCalled();
   });
 
-  it('submit message when click on textearea', () => {
+  it('submit message when click on textarea', () => {
     const onSubmit = jest.fn();
-    const wrapper = subjectMount({ onSubmit, placeholder: 'Speak' });
+    const wrapper = subject({ onSubmit, placeholder: 'Speak' });
+    const dropzone = wrapper.find(Dropzone).shallow();
 
-    const textarea = wrapper.find(MentionsInput).find('textarea');
-    textarea.simulate('change', { target: { value: 'Hello' } });
-    textarea.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
+    const input = dropzone.find(MentionsInput);
+    input.simulate('change', { target: { value: 'Hello' } });
+    input.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
 
     expect(onSubmit).toHaveBeenCalledOnce();
   });

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { userMentionsConfig } from './mentions-config';
 import { Key } from '../../lib/keyboard-search';
 import { User } from '../../store/channels';
-import { UserForMention, getUsersForMentions, Media, dropzoneToMedia, addImagePreview } from './utils';
+import { UserForMention, getUsersForMentions, Media, dropzoneToMedia, addImagePreview, windowClipboard } from './utils';
 import Menu from './menu';
 import ImageCards from '../../platform-apps/channels/image-cards';
 import { config } from '../../config';
@@ -21,6 +21,10 @@ export interface Properties {
   getUsersForMentions: (search: string, users: User[]) => UserForMention[];
   onMessageInputRendered?: (textareaRef: RefObject<HTMLTextAreaElement>) => void;
   renderAfterInput?: (value: string, mentionedUserIds: User['id'][]) => React.ReactNode;
+  clipboard?: {
+    addPasteListener: (listener: EventListenerOrEventListenerObject) => void;
+    removePasteListener: (listener: EventListenerOrEventListenerObject) => void;
+  };
 }
 
 interface State {
@@ -46,7 +50,11 @@ export class MessageInput extends React.Component<Properties, State> {
     if (this.props.onMessageInputRendered) {
       this.props.onMessageInputRendered(this.textareaRef);
     }
-    window.addEventListener('paste', this.clipboardEvent);
+    this.clipboard.addPasteListener(this.clipboardEvent);
+  }
+
+  get clipboard() {
+    return this.props.clipboard || windowClipboard;
   }
 
   componentDidUpdate() {
@@ -56,7 +64,7 @@ export class MessageInput extends React.Component<Properties, State> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('paste', this.clipboardEvent);
+    this.clipboard.removePasteListener(this.clipboardEvent);
   }
 
   get images() {

--- a/src/components/message-input/utils.ts
+++ b/src/components/message-input/utils.ts
@@ -73,3 +73,14 @@ export const getUsersForMentions = (search: string, users: User[]): UserForMenti
   }
   return [];
 };
+
+export function windowClipboard() {
+  return {
+    addPasteListener: (handler) => {
+      window.addEventListener('paste', handler);
+    },
+    removePasteListener: (handler) => {
+      window.removeEventListener('paste', handler);
+    },
+  };
+}


### PR DESCRIPTION
### What does this do?

Improves the performance of the message-input test by not fully rendering the complicated nested component. While they have all improved the significant differences are:
* adds placeholder
* submit message when click on textarea

Before:
![before](https://user-images.githubusercontent.com/43770/212752038-00874ba0-5f3c-41c0-a920-97a727df7c3a.png)

After:
![after](https://user-images.githubusercontent.com/43770/212752028-874a9d96-218b-4eb9-8370-734066a85584.png)


### Why are we making this change?

While having the fastest possible tests isn't an end goal in itself, it is a factor in the developer experience. This is a simple change that improves some of our slowest tests.

### How do I test this?

Run the automated tests.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? N/A
  1. How will this affect performance? Faster testing
  1. Does this change any APIs? No
