### PR TITLE
Fix error when using the global clipboard

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -54,7 +54,7 @@ export class MessageInput extends React.Component<Properties, State> {
   }
 
   get clipboard() {
-    return this.props.clipboard || windowClipboard;
+    return this.props.clipboard || windowClipboard();
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
### What does this do?

Fix an error where we were returning a function rather than calling the function.

### Why are we making this change?

Because Dale is a fool.

### How do I test this?

Paste an image into the message input.

