### PR TITLE
Fix autocomplete escape key test

### DIFF
--- a/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
+++ b/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
@@ -189,14 +189,9 @@ describe('autocomplete-dropdown', () => {
     const findMatches = stubSearchFor('someSearch', stubResults(1));
     const wrapper = subject({ findMatches });
 
-    jest.useFakeTimers();
-    pressKey(wrapper, Key.ArrowUp);
-    pressKey(wrapper, Key.Enter);
-    jest.runAllTimers();
+    pressKeyOn(wrapper, Key.Escape);
 
-    await new Promise(setImmediate);
-
-    expect(wrapper.find('.autocomplete-dropdown__item-container').exists()).toBe(false);
+    expect(onCloseBar).toHaveBeenCalled();
   });
 
   it('does not close search bar when empty value', async () => {
@@ -296,8 +291,11 @@ function stubResults(num) {
 }
 
 function pressKey(wrapper, key) {
-  const input = wrapper.find('input');
-  input.simulate('keydown', {
+  pressKeyOn(wrapper.find('input'), key);
+}
+
+function pressKeyOn(node, key) {
+  node.simulate('keydown', {
     key,
     preventDefault: () => {},
     stopPropagation: () => {},

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -62,7 +62,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
 
   escFunction = (event): void => {
     if (event.key === Key.Escape) {
-      this.props.onCloseBar();
+      this.abortChange();
     }
   };
 
@@ -72,9 +72,6 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
 
   componentDidMount() {
     this._isMounted = true;
-    if (this.anchorElement) {
-      this.anchorElement.addEventListener('keydown', this.escFunction, false);
-    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -87,9 +84,6 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
 
   componentWillUnmount() {
     this._isMounted = false;
-    if (this.anchorElement) {
-      this.anchorElement.removeEventListener('keydown', this.escFunction, false);
-    }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: Properties) {
@@ -281,6 +275,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
       <div
         className={classNames('autocomplete-dropdown', this.props.className)}
         ref={this.setAnchorElements}
+        onKeyDown={this.escFunction}
       >
         <input
           className='autocomplete-dropdown__input'


### PR DESCRIPTION
### What does this do?

Fixes the "escape" test for the autocomplete-dropdown

### Why are we making this change?

While refactoring the tests I noticed that the test for pressing the escape key did not, in fact, press the escape key.

### How do I test this?

* Run the tests
* Open zOS and start typing in the network search. Press Escape. Verify that the autocomplete component disappears.
