### PR TITLE
Tests: Mock imports that are loading large sets of code

### DIFF
--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -9,9 +9,7 @@ import { ProviderService } from '../lib/web3/provider-service';
 import { AppLayout } from '../store/layout';
 
 // Don't load full external projects
-jest.mock('.', () => {
-  return { AppSandbox: () => <></> };
-});
+jest.mock('.', () => ({ AppSandbox: () => <></> }));
 
 describe('AppSandboxContainer', () => {
   const subject = (props: Partial<Properties> = {}) => {

--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -8,6 +8,11 @@ import { Chains, ConnectionStatus, Connectors } from '../lib/web3';
 import { ProviderService } from '../lib/web3/provider-service';
 import { AppLayout } from '../store/layout';
 
+// Don't load full external projects
+jest.mock('.', () => {
+  return { AppSandbox: () => <></> };
+});
+
 describe('AppSandboxContainer', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {

--- a/src/app-sandbox/index.test.tsx
+++ b/src/app-sandbox/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow } from 'enzyme'; // relative path of the file you plan to mock
 
 import { App } from '@zer0-os/zos-feed';
 import { AppSandbox } from '.';
@@ -8,6 +8,23 @@ import { Chains } from '../lib/web3';
 import { Channels } from '../platform-apps/channels';
 import { AppLayoutContextProvider } from '@zer0-os/zos-component-library';
 import { AppLayout } from '../store/layout';
+
+// Don't load full external projects
+jest.mock('@zero-tech/zapp-nfts', () => {
+  return {};
+});
+jest.mock('@zero-tech/zapp-staking', () => {
+  return {};
+});
+jest.mock('@zero-tech/zapp-daos', () => {
+  return {};
+});
+jest.mock('@zero-tech/zapp-buy-domains', () => {
+  return {};
+});
+jest.mock('@zer0-os/zos-feed', () => {
+  return { App: () => <></> };
+});
 
 describe('AppSandbox', () => {
   const subject = (props: any = {}) => {

--- a/src/app-sandbox/index.test.tsx
+++ b/src/app-sandbox/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme'; // relative path of the file you plan to mock
+import { shallow } from 'enzyme';
 
 import { App } from '@zer0-os/zos-feed';
 import { AppSandbox } from '.';

--- a/src/app-sandbox/index.test.tsx
+++ b/src/app-sandbox/index.test.tsx
@@ -10,21 +10,11 @@ import { AppLayoutContextProvider } from '@zer0-os/zos-component-library';
 import { AppLayout } from '../store/layout';
 
 // Don't load full external projects
-jest.mock('@zero-tech/zapp-nfts', () => {
-  return {};
-});
-jest.mock('@zero-tech/zapp-staking', () => {
-  return {};
-});
-jest.mock('@zero-tech/zapp-daos', () => {
-  return {};
-});
-jest.mock('@zero-tech/zapp-buy-domains', () => {
-  return {};
-});
-jest.mock('@zer0-os/zos-feed', () => {
-  return { App: () => <></> };
-});
+jest.mock('@zero-tech/zapp-nfts', () => ({}));
+jest.mock('@zero-tech/zapp-staking', () => ({}));
+jest.mock('@zero-tech/zapp-daos', () => ({}));
+jest.mock('@zero-tech/zapp-buy-domains', () => ({}));
+jest.mock('@zer0-os/zos-feed', () => ({ App: () => <></> }));
 
 describe('AppSandbox', () => {
   const subject = (props: any = {}) => {


### PR DESCRIPTION
### What does this do?

This change mocks the importing of large external project during some tests. This saves a significant amount of time.

Before:
![before](https://user-images.githubusercontent.com/43770/212951886-746ff9e0-cf77-495f-88e4-a75117995345.png)

After:
![after](https://user-images.githubusercontent.com/43770/212951909-08443bae-4624-4dac-90f2-b0dc1f22f644.png)

### Why are we making this change?

Importing these libraries is quite expensive and we don't directly render them during the tests so we don't need the full projects to be loaded.

### How do I test this?

Run the automated tests
