### PR TITLE
Fix type errors in tests

### DIFF
--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -10,8 +10,12 @@ import { AddressBarContainer } from './components/address-bar/container';
 describe('Main', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps = {
+      isSidekickOpen: false,
       hasContextPanel: false,
       isContextPanelOpen: false,
+      context: {
+        isAuthenticated: false,
+      },
       ...props,
     };
 

--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -150,10 +150,7 @@ describe('AppSandboxContainer', () => {
   });
 
   it('passes layout to child', () => {
-    const layout = {
-      isContextPanelOpen: false,
-      hasContextPanel: true,
-    };
+    const layout = {} as AppLayout;
 
     const wrapper = subject({ layout });
 

--- a/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
+++ b/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AutocompleteDropdown, Properties, Result } from './';
+import { AutocompleteDropdown, AutocompleteItem, Properties, Result, ResultProperties } from './';
 import { shallow } from 'enzyme';
 import { Key } from '../../lib/keyboard-search';
 
@@ -220,9 +220,9 @@ describe('autocomplete-dropdown', () => {
       onSelect = jest.fn();
     });
 
-    function subject(initialData = {}) {
-      const props: Properties = {
-        item: {},
+    function subject(initialData: Partial<ResultProperties> = {}) {
+      const props: ResultProperties = {
+        item: {} as AutocompleteItem,
         isFocused: false,
         onSelect,
         ...initialData,
@@ -232,17 +232,18 @@ describe('autocomplete-dropdown', () => {
     }
 
     it('verifies expected attributes are present', () => {
-      const expectation = {
+      const item = {
+        id: 'result-id',
         value: 'result-value',
         route: 'result-route',
         summary: 'result-summary',
       };
 
-      const wrapper = subject({ item: expectation });
+      const wrapper = subject({ item });
 
-      Object.values(expectation).forEach((value) => {
-        expect(wrapper.html().includes(value)).toBe(true);
-      });
+      expect(wrapper.find('.autocomplete-dropdown-item__value').text()).toEqual(item.value);
+      expect(wrapper.find('.autocomplete-dropdown-item__route').text()).toEqual(item.route);
+      expect(wrapper.find('.autocomplete-dropdown-item__text').prop('title')).toEqual(item.summary);
     });
   });
 });

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -314,10 +314,12 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
   }
 }
 
-export class Result extends React.Component<
-  { item: AutocompleteItem; isFocused: boolean; onSelect(AutocompleteItem) },
-  undefined
-> {
+export interface ResultProperties {
+  item: AutocompleteItem;
+  isFocused: boolean;
+  onSelect(AutocompleteItem);
+}
+export class Result extends React.Component<ResultProperties, undefined> {
   onSelect = (event): void => {
     // Prevent further events from happening, such as: onBlur of the input
     event.stopPropagation();

--- a/src/components/error-boundary/index.test.tsx
+++ b/src/components/error-boundary/index.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 import { ErrorBoundary, Properties } from './';
-import { ErrorBoundary as SentryErrorBoundary } from '@sentry/react';
+import { ErrorBoundary as SentryErrorBoundary, Scope } from '@sentry/react';
 import { mount } from 'enzyme';
 
 describe('error-boundary', () => {
@@ -20,6 +20,8 @@ describe('error-boundary', () => {
 
   function subject(props: Partial<Properties> = {}) {
     const allProps: Properties = {
+      children: null,
+      boundary: '',
       ...props,
     };
 
@@ -52,12 +54,12 @@ describe('error-boundary', () => {
         },
       });
 
-      const setTags = jest.fn();
+      const setTags: Scope['setTags'] = jest.fn();
 
       const wrapper = subject({ boundary });
 
       const child = wrapper.find(SentryErrorBoundary);
-      child.prop('beforeCapture')({ setTags });
+      child.prop('beforeCapture')({ setTags } as Scope, null, null);
 
       await wrapper.find(ChildComponent).simulateError(new Error('New Error'));
 
@@ -72,12 +74,12 @@ describe('error-boundary', () => {
         'application.name': undefined,
       };
 
-      const setTags = jest.fn();
+      const setTags: Scope['setTags'] = jest.fn();
 
       const wrapper = subject({ boundary });
 
       const child = wrapper.find(SentryErrorBoundary);
-      child.prop('beforeCapture')({ setTags });
+      child.prop('beforeCapture')({ setTags } as Scope, null, null);
 
       await wrapper.find(ChildComponent).simulateError(new Error('New Error'));
 

--- a/src/components/theme-engine/index.test.tsx
+++ b/src/components/theme-engine/index.test.tsx
@@ -17,6 +17,10 @@ describe('ThemeEngine', () => {
       getItem(key) {
         return this.state[key];
       },
+      removeItem(_) {},
+      length: 0,
+      clear: () => {},
+      key: (_) => '',
     };
   });
 

--- a/src/components/web3-connect/index.test.tsx
+++ b/src/components/web3-connect/index.test.tsx
@@ -30,6 +30,9 @@ describe('Web3Connect', () => {
       removeItem(key) {
         this.state[key] = false;
       },
+      length: 0,
+      clear: () => {},
+      key: (_) => '',
     };
   });
 

--- a/src/components/zns-dropdown/index.test.tsx
+++ b/src/components/zns-dropdown/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { ZNSDropdown, Properties } from './';
 import { shallow } from 'enzyme';
+import { AutocompleteItem } from '../autocomplete-dropdown';
 
 let onSelect;
 let api;
@@ -14,6 +15,7 @@ describe('zns-dropdown', () => {
 
   function subject(initialData: Partial<Properties> = {}) {
     const state: Properties = {
+      onCloseBar: () => {},
       onSelect,
       api,
       ...initialData,
@@ -34,13 +36,16 @@ describe('zns-dropdown', () => {
 
     const wrapper = subject({
       api: {
-        search: async () => {
-          return apiResults;
+        search: async (searchString) => {
+          if (searchString === 'search-string') {
+            return apiResults;
+          }
+          return [];
         },
       },
     });
 
-    const mappedResults = await wrapper.instance().findMatches();
+    const mappedResults = await dropdownInstance(wrapper).findMatches('search-string');
 
     expect([
       {
@@ -76,10 +81,14 @@ describe('zns-dropdown', () => {
       },
     });
 
-    await wrapper.instance().findMatches();
+    await dropdownInstance(wrapper).findMatches('search-string');
 
-    wrapper.instance().onSelect(apiResults[0]);
+    dropdownInstance(wrapper).onSelect({ id: 'zns-id-first' } as AutocompleteItem);
 
     expect(onSelect).toHaveBeenCalledWith(apiResults[0].znsRoute);
   });
 });
+
+function dropdownInstance(wrapper) {
+  return wrapper.instance() as ZNSDropdown;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,8 +1,5 @@
-import * as matchers from 'jest-extended';
+import 'jest-extended/all';
 import { configure } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-
-// add all jest-extended matchers
-expect.extend(matchers);
 
 configure({ adapter: new Adapter() });

--- a/src/store/theme/saga.test.ts
+++ b/src/store/theme/saga.test.ts
@@ -9,6 +9,11 @@ describe('viewMode saga', () => {
   beforeAll(() => {
     global.localStorage = {
       setItem: jest.fn(),
+      getItem: (_) => '',
+      removeItem: () => {},
+      length: 0,
+      clear: () => {},
+      key: (_) => '',
     };
   });
 


### PR DESCRIPTION
### What does this do?

This fixes existing type errors in the tests.

### Why are we making this change?

Since the build only includes production files these typescript errors were never really noticed. Now that we're going to run the type check on the whole src folder we need to have correct types in the tests. This is, of course, also just the desired thing.

### How do I test this?

Run the type check: `npx tsc`
