### PR TITLE
Run lint and quick type check before deploying to development/production

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - development
 jobs:
-  test:
+  validate:
     runs-on: ubuntu-latest
     env:
       REACT_APP_INFURA_URL: ${{secrets.INFURA_URL}}
@@ -15,9 +15,11 @@ jobs:
           node-version: '16'
       - run: echo '//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}' >> .npmrc
       - run: npm install
+      - run: npm run lint
+      - run: npx tsc
       - run: npm run test
   deploy:
-    needs: test
+    needs: validate
     runs-on: ubuntu-latest
     environment: development
     env:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 jobs:
-  test:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,9 +13,11 @@ jobs:
           node-version: '16'
       - run: echo '//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}' >> .npmrc
       - run: npm install
+      - run: npm run lint
+      - run: npx tsc
       - run: npm run test
   deploy:
-    needs: test
+    needs: validate
     runs-on: ubuntu-latest
     environment: production
     env:


### PR DESCRIPTION
### What does this do?

Note: Do not merge until #305 has been merged as that will ensure the current branches pass the checks.

This adds the lint and typecheck to the set of pre-checks prior to doing a build on `development` or `main`.

### Why are we making this change?

Added verification to detect when merge issues occur.

### How do I test this?

Merge to development or main.

