### PR TITLE
Refactor: Rename event published by autocomplete-dropdown

### DIFF
--- a/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
+++ b/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
@@ -125,10 +125,11 @@ describe('autocomplete-dropdown', () => {
     pressKey(wrapper, Key.ArrowUp);
     pressKey(wrapper, Key.Enter);
 
+    expect(wrapper.find('input').prop('value')).toEqual(searchResults[1].value);
     expect(onSelect).toHaveBeenCalledWith(searchResults[1]);
   });
 
-  it('selecting a match triggers change event', async () => {
+  it('it selects the item via mouse', async () => {
     const searchResults = stubResults(2);
     const valueToSelect = searchResults[0].value;
     const findMatches = stubSearchFor('anything', searchResults);
@@ -136,11 +137,10 @@ describe('autocomplete-dropdown', () => {
     const wrapper = subject({ findMatches });
 
     await performSearch(wrapper, 'anything');
-
     wrapper.update();
-
     selectOption(wrapper, valueToSelect);
 
+    expect(wrapper.find('input').prop('value')).toEqual(searchResults[0].value);
     expect(onSelect).toHaveBeenCalledWith(searchResults[0]);
   });
 

--- a/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
+++ b/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
@@ -144,11 +144,10 @@ describe('autocomplete-dropdown', () => {
     expect(onSelect).toHaveBeenCalledWith(searchResults[0]);
   });
 
-  it('selecting an option verifies value and closes dropdown', async () => {
+  it('selecting an option closes results dropdown', async () => {
     const searchResults = stubResults(1);
     const valueToSelect = searchResults[0].value;
-    const findMatches = stubSearchFor('anything', searchResults);
-    const wrapper = subject({ findMatches });
+    const wrapper = subject({ findMatches: stubSearchFor('anything', searchResults) });
 
     await performSearch(wrapper, 'anything');
 
@@ -156,24 +155,30 @@ describe('autocomplete-dropdown', () => {
 
     selectOption(wrapper, valueToSelect);
 
-    expect(wrapper.find('input').prop('value')).toEqual(valueToSelect);
-    expect(wrapper.find(Result).exists()).toBe(false);
+    expect(wrapper.find('.autocomplete-dropdown__results').exists()).toBe(false);
   });
 
-  it('it closes dropdown when focus lost', async () => {
-    const findMatches = stubSearchFor('someSearch', stubResults(1));
-    const wrapper = subject({ findMatches, value: 'original value' });
+  describe('when focus is lost', () => {
+    it('it resets the input', async () => {
+      const findMatches = stubSearchFor('someSearch', stubResults(1));
+      const wrapper = subject({ findMatches, value: 'original value' });
+      await performSearch(wrapper, 'someSearch');
 
-    const input = wrapper.find('input');
+      wrapper.find('input').simulate('blur');
 
-    jest.useFakeTimers();
-    input.simulate('change', { target: { value: 'someSearch' } });
-    jest.runAllTimers();
+      expect(wrapper.find('input').prop('value')).toEqual('original value');
+    });
 
-    input.simulate('blur');
+    it('it closes dropdown', async () => {
+      const findMatches = stubSearchFor('someSearch', stubResults(1));
+      const wrapper = subject({ findMatches, value: 'original value' });
+      await performSearch(wrapper, 'someSearch');
+      expect(wrapper.find('.autocomplete-dropdown__results').exists()).toBe(true);
 
-    expect(input.prop('value')).toEqual('original value');
-    expect(wrapper.find('[className*="__items"]').exists()).toBe(false);
+      wrapper.find('input').simulate('blur');
+
+      expect(wrapper.find('.autocomplete-dropdown__results').exists()).toBe(false);
+    });
   });
 
   it('it displays "No results found" when there are no matches', async () => {

--- a/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
+++ b/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
@@ -194,6 +194,18 @@ describe('autocomplete-dropdown', () => {
     expect(onCloseBar).toHaveBeenCalled();
   });
 
+  it('closes search results when input cleared', async () => {
+    const findMatches = stubSearchFor('anything', stubResults(1));
+    const wrapper = subject({ findMatches });
+    await performSearch(wrapper, 'anything');
+
+    expect(wrapper.find('.autocomplete-dropdown__item-container').exists()).toBe(true);
+
+    wrapper.find('input').simulate('change', { target: { value: '' } });
+
+    expect(wrapper.find('.autocomplete-dropdown__item-container').exists()).toBe(false);
+  });
+
   it('does not close search bar when empty value', async () => {
     const wrapper = subject({ value: 'lets delete this' });
 

--- a/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
+++ b/src/components/autocomplete-dropdown/autocomplete-dropdown.test.tsx
@@ -5,13 +5,11 @@ import { shallow } from 'enzyme';
 import { Key } from '../../lib/keyboard-search';
 
 let onSelect;
-let onCloseBar;
 let onCancel;
 
 describe('autocomplete-dropdown', () => {
   beforeEach(() => {
     onSelect = jest.fn();
-    onCloseBar = jest.fn();
     onCancel = jest.fn();
   });
 
@@ -19,7 +17,6 @@ describe('autocomplete-dropdown', () => {
     const state: Properties = {
       findMatches: null,
       onSelect,
-      onCloseBar,
       onCancel,
       value: null,
       ...initialData,
@@ -212,16 +209,6 @@ describe('autocomplete-dropdown', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
-  it('hides search bar when pressing "escape"', async () => {
-    const findMatches = stubSearchFor('someSearch', stubResults(1));
-    const wrapper = subject({ findMatches });
-
-    pressKeyOn(wrapper, Key.Escape);
-
-    // TODO: Remove this event
-    expect(onCloseBar).toHaveBeenCalled();
-  });
-
   it('closes search results when input cleared', async () => {
     const findMatches = stubSearchFor('anything', stubResults(1));
     const wrapper = subject({ findMatches });
@@ -242,16 +229,6 @@ describe('autocomplete-dropdown', () => {
     input.simulate('change', { target: { value: '' } });
 
     expect(onCancel).not.toHaveBeenCalled();
-  });
-
-  it('does not close search bar when empty value', async () => {
-    const wrapper = subject({ value: 'lets delete this' });
-
-    let input = wrapper.find('input');
-
-    input.simulate('change', { target: { value: '' } });
-
-    expect(onCloseBar).not.toHaveBeenCalled();
   });
 
   it('set min height to results wrapper', async () => {

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -23,7 +23,6 @@ export interface Properties {
   itemContainerClassName?: string;
   findMatches: (term: string) => Promise<AutocompleteItem[]>;
   onSelect: (item: AutocompleteItem) => void;
-  onCloseBar?: () => void;
   onCancel: () => void;
 }
 
@@ -129,16 +128,9 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
       });
 
       this.props.onSelect(item);
-      this.close();
+      this.closeResults();
     }
   };
-
-  close(): void {
-    this.closeResults();
-    if (this._isMounted) {
-      this.props.onCloseBar && this.props.onCloseBar();
-    }
-  }
 
   closeResults(): void {
     if (!this._isMounted) {
@@ -159,7 +151,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
       searchComplete: false,
       inProgress: false,
     });
-    this.close();
+    this.closeResults();
     this.props.onCancel();
   };
 
@@ -217,7 +209,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
     }
 
     closestScrollableParent.onscroll = () => {
-      this.close();
+      this.abortChange();
       closestScrollableParent.onscroll = null;
     };
   }

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -24,6 +24,7 @@ export interface Properties {
   findMatches: (term: string) => Promise<AutocompleteItem[]>;
   onSelect: (item: AutocompleteItem) => void;
   onCloseBar: () => void;
+  onCancel: () => void;
 }
 
 interface State {
@@ -159,6 +160,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
       inProgress: false,
     });
     this.close();
+    this.props.onCancel();
   };
 
   setAnchorElements = (ref: HTMLElement): void => {

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -97,7 +97,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
     this.setState({ value: searchTerm });
 
     if (searchTerm.trim() === '') {
-      this.close(false);
+      this.closeResults();
       return;
     }
 
@@ -132,18 +132,24 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
     }
   };
 
-  close(closeBar = true): void {
+  close(): void {
+    this.closeResults();
     if (this._isMounted) {
-      this.setState({
-        matches: [],
-        searchComplete: false,
-        inProgress: false,
-        currentFocusIndex: 0,
-      });
-      if (closeBar) {
-        this.props.onCloseBar();
-      }
+      this.props.onCloseBar();
     }
+  }
+
+  closeResults(): void {
+    if (!this._isMounted) {
+      return;
+    }
+
+    this.setState({
+      matches: [],
+      searchComplete: false,
+      inProgress: false,
+      currentFocusIndex: 0,
+    });
   }
 
   abortChange = (): void => {

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -23,7 +23,7 @@ export interface Properties {
   itemContainerClassName?: string;
   findMatches: (term: string) => Promise<AutocompleteItem[]>;
   onSelect: (item: AutocompleteItem) => void;
-  onCloseBar: () => void;
+  onCloseBar?: () => void;
   onCancel: () => void;
 }
 
@@ -136,7 +136,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
   close(): void {
     this.closeResults();
     if (this._isMounted) {
-      this.props.onCloseBar();
+      this.props.onCloseBar && this.props.onCloseBar();
     }
   }
 

--- a/src/components/zns-dropdown/index.test.tsx
+++ b/src/components/zns-dropdown/index.test.tsx
@@ -5,18 +5,20 @@ import { shallow } from 'enzyme';
 import { AutocompleteItem } from '../autocomplete-dropdown';
 
 let onSelect;
+let onCloseBar;
 let api;
 
 describe('zns-dropdown', () => {
   beforeEach(() => {
     onSelect = jest.fn();
+    onCloseBar = jest.fn();
     api = jest.fn();
   });
 
   function subject(initialData: Partial<Properties> = {}) {
     const state: Properties = {
-      onCloseBar: () => {},
       onSelect,
+      onCloseBar,
       api,
       ...initialData,
     };
@@ -72,7 +74,6 @@ describe('zns-dropdown', () => {
         znsRoute: 'zns-route-second',
       },
     ];
-
     const wrapper = subject({
       api: {
         search: async () => {
@@ -80,12 +81,42 @@ describe('zns-dropdown', () => {
         },
       },
     });
-
     await dropdownInstance(wrapper).findMatches('search-string');
 
-    dropdownInstance(wrapper).onSelect({ id: 'zns-id-first' } as AutocompleteItem);
+    wrapper.find('AutocompleteDropdown').simulate('select', { id: 'zns-id-first' });
 
     expect(onSelect).toHaveBeenCalledWith(apiResults[0].znsRoute);
+  });
+
+  it('announces close event when result is selected', async () => {
+    const apiResults = [
+      {
+        id: 'zns-id-first',
+        title: 'zns-title-first',
+        description: 'zns-description-first',
+        znsRoute: 'zns-route-first',
+      },
+    ];
+    const wrapper = subject({
+      api: {
+        search: async () => {
+          return apiResults;
+        },
+      },
+    });
+    await dropdownInstance(wrapper).findMatches('search-string');
+
+    wrapper.find('AutocompleteDropdown').simulate('select', { id: 'zns-id-first' });
+
+    expect(onCloseBar).toHaveBeenCalled();
+  });
+
+  it('announces close event when dropdown edit is cancelled', async () => {
+    const wrapper = subject();
+
+    wrapper.find('AutocompleteDropdown').simulate('cancel');
+
+    expect(onCloseBar).toHaveBeenCalled();
   });
 });
 

--- a/src/components/zns-dropdown/index.test.tsx
+++ b/src/components/zns-dropdown/index.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { ZNSDropdown, Properties } from './';
 import { shallow } from 'enzyme';
-import { AutocompleteItem } from '../autocomplete-dropdown';
 
 let onSelect;
 let onCloseBar;

--- a/src/components/zns-dropdown/index.tsx
+++ b/src/components/zns-dropdown/index.tsx
@@ -48,6 +48,7 @@ export class ZNSDropdown extends React.Component<Properties, State> {
 
   onSelect = (item: AutocompleteItem) => {
     this.props.onSelect(this.state.results.find((p) => p.id === item.id).znsRoute);
+    this.props.onCloseBar();
   };
 
   render() {
@@ -58,7 +59,7 @@ export class ZNSDropdown extends React.Component<Properties, State> {
         itemContainerClassName={this.props.itemContainerClassName}
         findMatches={this.findMatches}
         onSelect={this.onSelect}
-        onCloseBar={this.props.onCloseBar}
+        onCancel={this.props.onCloseBar}
       />
     );
   }


### PR DESCRIPTION
Note: I tried to refactor in steps and commit at appropriate increments in case the progression is easier to follow than just the end result.

### What does this do?

Renames an event that was published by the autocomplete-dropdown component and updates the component to be a little more clear about what the intent is.

### Why are we making this change?

I found it difficult to understand what the dropdown was meant to be doing. For example, what does "close bar" even mean from the context of a generic autocomplete dropdown?

Generally speaking, components should use events that indicate what happened vs how something should react. We want to tell the parent component that the user cancelled their search/selection but it's up to the parent to decide that means they want to "close" the whole thing.

### How do I test this?

Perform some zns searches. Use esc to cancel, select some items, click away to cancel, etc.
