### PR TITLE
Deploy to production when a release is published

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,6 +2,7 @@ name: Deploy Development
 on:
   push:
     branches:
+      - main
       - development
 jobs:
   validate:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,23 +1,10 @@
 name: Deploy Production
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - published
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-      - run: echo '//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}' >> .npmrc
-      - run: npm install
-      - run: npm run lint
-      - run: npx tsc
-      - run: npm run test
   deploy:
-    needs: validate
     runs-on: ubuntu-latest
     environment: production
     env:


### PR DESCRIPTION
### What does this do?

This changes the production deployment action to only run when a release is published rather than on merge to main. After this step we'll have to manually create the release after merging the release branch into `main` until the rest of the process becomes more automated.

### Why are we making this change?

This is the first step in moving towards development on the `main` branch and using tags/releases for deployment.

### How do I test this?

Create a release and verify that it runs the deploy as expected.

