### PR TITLE
Update create-release script to create a git tag instead of a branch

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -2,22 +2,17 @@
 
 set -e
 
-VERSION=$(npm pkg get version | tr -d \")
-DEFAULT_BRANCH_NAME="release/${VERSION}"
-
 help() {
   echo -e "Usage: $0 [OPTIONS]"
   echo -e ""
-  echo -e "Create a release branch off of development and push it to origin. By default, the branch name will follow the format 'release/YYYY-MM-DD'."
+  echo -e "Create a tag off of main and push it to origin."
   echo -e ""
   echo -e "Note: This assumes that you have access to push to GitHub."
-  echo -e "      If a branch already exists for the specified name, then this script will fail."
+  echo -e "      If a tag already exists for the specified name, then this script will fail."
   echo -e ""
   echo -e "Options:"
   echo -e ""
   echo -e "  -h \t Print this message. All other options will be ignored if this is included."
-  echo -e "  -c \t The commit-ish to create the release branch off of. Default 'origin/development'."
-  echo -e "  -b \t Specify the branch name to create."
   echo -e "  -d \t Do a dry run."
   echo -e ""
   echo -e "Examples:"
@@ -25,37 +20,22 @@ help() {
   echo -e ""
   echo -e "  This will:"
   echo -e "    1) Do a fetch from 'origin'."
-  echo -e "    2) Create branch '${DEFAULT_BRANCH_NAME}' off of 'origin/development'."
-  echo -e "    3) Push this branch to origin (GitHub)."
+  echo -e "    2) Create a tag 'vX.Y.Z' off of 'origin/main'."
+  echo -e "    3) Push this tag to origin (GitHub)."
   echo -e ""
-  echo -e "  > $0 -b my-fun-branch -c 8fdc797"
-  echo -e ""
-  echo -e "  This will:"
-  echo -e "    1) Do a fetch from 'origin'."
-  echo -e "    2) Create branch 'my-fun-branch' off of '8fdc797'."
-  echo -e "    3) Push this branch to origin (GitHub)."
-  echo -e ""
-  echo -e "  > $0 -b my-fun-branch -c 8fdc797 -d"
+  echo -e "  > $0 -d"
   echo -e ""
   echo -e "  This will"
   echo -e "    1) Do a fetch from 'origin'."
-  echo -e "    2) Create branch 'my-fun-branch' off of '8fdc797'."
+  echo -e "    2) Create a tag 'vX.Y.Z' off of 'origin/main'."
   echo -e "    3) Stop. This will not push to GitHub as it is a 'dry run'."
   echo -e ""
 }
 
-BRANCH_NAME="${DEFAULT_BRANCH_NAME}"
-COMMITISH="origin/development"
 DRY_RUN="no"
 
 while getopts ":hdc:b:" opt; do
   case $opt in
-    c)
-      COMMITISH=$OPTARG
-      ;;
-    b)
-      BRANCH_NAME=$OPTARG
-      ;;
     h)
       help
       exit 0
@@ -71,29 +51,45 @@ while getopts ":hdc:b:" opt; do
   esac
 done
 
-check_git() {
+ensure_git_is_installed() {
   command -v git >/dev/null 2>&1 || { echo >&2 "You need have the 'git' command installed in order to continue.  Aborting."; exit 1; }
 }
 
 fetch_origin() {
+  echo "Fetching origin..."
   git fetch origin
 }
 
-create_release_branch() {
-  BRANCH_NAME=$1
-  COMMITISH=$2
-  git checkout -b $BRANCH_NAME $COMMITISH
+ensure_tag_is_new() {
+  TAG=$1
+
+  if [[ $(git tag | grep "${VERSION}") ]]; then
+    echo >&2 "There is already a tag named ${VERSION}. You may need to update package.json with a new version. Aborting."; exit 1; 
+  fi
+}
+
+create_tag() {
+  TAG=$1
+
+  echo "Creating Tag ${VERSION}..."
+  git tag ${VERSION}
 }
 
 push_to_origin() {
   DRY_RUN=$1
-  BRANCH_NAME=$2
+  TAG=$2
 
   if [[ "$DRY_RUN" == "no" ]]; then
-    git push -u origin $BRANCH_NAME
+    echo "Pushing ${TAG} to origin"
+    git push -u origin $TAG
   else
-    echo "(not pushing $BRANCH_NAME to origin since this is a dry run)"
+    echo "(not pushing $TAG to origin since this is a dry run)"
   fi
+}
+
+checkout_main() {
+  echo "Checking out origin/main. To restore use 'git switch -'"
+  git checkout origin/main
 }
 
 if [[ "$DRY_RUN" == "yes" ]]; then
@@ -101,8 +97,18 @@ if [[ "$DRY_RUN" == "yes" ]]; then
   echo ""
 fi
 
-check_git
-
+ensure_git_is_installed
 fetch_origin
-create_release_branch $BRANCH_NAME $COMMITISH
-push_to_origin $DRY_RUN $BRANCH_NAME
+checkout_main
+
+VERSION=v$(npm pkg get version | tr -d \")
+echo "Preparing to create tag ${VERSION}"
+
+ensure_tag_is_new $VERSION
+
+create_tag $VERSION
+push_to_origin $DRY_RUN $VERSION
+
+if [[ "$DRY_RUN" == "no" ]]; then
+  echo "To deploy, visit https://github.com/zer0-os/zOS/releases/new and create a release for ${VERSION}"
+fi


### PR DESCRIPTION
### What does this do?

Updates the `create-release` script to create a tag instead of a release branch.

### Why are we making this change?

We're moving toward using tags and github releases for deployment.

### How do I test this?

Run `./bin/create-release -d`. This should perform a dry-run and tell you which version you're about to publish.

You may need to comment out the `checkout_main` call and then change your `package.json` version to something new to get past the sanity checks. Be sure to delete the newly created tag if you need to with `git tag -d vX.Y.Z`

