### PR TITLE
No longer deploy to development when the development branch is updated

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - development
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this do?

Removes the development branch from the deploy action

### Why are we making this change?

No longer using the development branch and we don't want conflicting deploys.

