### PR TITLE
Draft release when tag created

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,13 +3,23 @@ on:
   push:
     tags:
       - '**'
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: false
+        type: string
 
 jobs:
   create_release:
     name: 'Create Release'
     runs-on: 'ubuntu-latest'
     steps:
+      - name: Print variable if not empty
+        if: "${{ github.event.inputs.tag != '' }}"
+        run: 'echo "RELEASE_TAG=${{github.event.inputs.tag}}" >> $GITHUB_ENV'
+
       - name: 'Determine tag'
+        if: "${{ github.event.inputs.tag == '' }}"
         run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
 
       - name: 'Create release'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,32 @@
+name: 'Create Release'
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  create_release:
+    name: 'Create Release'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Determine tag'
+        run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
+
+      - name: 'Create release'
+        uses: 'actions/github-script@v5'
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          script: |
+            try {
+              await github.rest.repos.createRelease({
+                draft: true,
+                generate_release_notes: true,
+                name: "Release ${{process.env.RELEASE_TAG}}",
+                owner: context.repo.owner,
+                prerelease: false,
+                repo: context.repo.repo,
+                tag_name: process.env.RELEASE_TAG,
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }


### PR DESCRIPTION
### What does this do?

Adds a github action that will, hopefully, create a new Release when a tag is pushed.

This is untested at the moment and includes the ability to manually trigger it. Unfortunately, in order to do that it must first exist on the default branch.

### Why are we making this change?

To automate the step of creating the Release on github.

### How do I test this?

To be tested once merged to main
