### PR TITLE
Add concurrency protection to github actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,6 +3,9 @@ on:
   release:
     types:
       - published
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -2,6 +2,10 @@ name: run-build
 on:
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   run-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -2,6 +2,10 @@ name: run-lint
 on:
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   run-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,11 @@ on:
     branches-ignore:
       - main
       - development
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-typecheck.yml
+++ b/.github/workflows/run-typecheck.yml
@@ -2,6 +2,10 @@ name: run-typecheck
 on:
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   run-typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this do?

Adds concurrency protection to github actions to ensure only one run is happening at a time.

### Why are we making this change?

When merging PRs to developemnt, for example, we don't want to have competing deploys as they may collide and the timing would be indeterminate.

