### PR TITLE
Use just the version for the release name

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,7 @@ jobs:
               await github.rest.repos.createRelease({
                 draft: true,
                 generate_release_notes: true,
-                name: "Release ${{process.env.RELEASE_TAG}}",
+                name: process.env.RELEASE_TAG,
                 owner: context.repo.owner,
                 prerelease: false,
                 repo: context.repo.repo,


### PR DESCRIPTION
### What does this do?

Changes the release creation action to use the version as the release name and not a concatenated string.
