### PR TITLE
Update instructions at the end of create-release

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -110,5 +110,5 @@ create_tag $VERSION
 push_to_origin $DRY_RUN $VERSION
 
 if [[ "$DRY_RUN" == "no" ]]; then
-  echo "To deploy, visit https://github.com/zer0-os/zOS/releases/new and create a release for ${VERSION}"
+  echo "To deploy, visit https://github.com/zer0-os/zOS/releases and publish the release [${VERSION}]"
 fi


### PR DESCRIPTION
### What does this do?

Updates the instructions at the end of create-release to just publish the newly created release.

### Why are we making this change?

This is the new process now that we have a github action to automatically create a release when a tag is created.

