### PR TITLE
Create tag via github action when the package.json version changes

### DIFF
--- a/.github/create-tag
+++ b/.github/create-tag
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+TAG="v$(npm pkg get version | tr -d \")"
+git fetch --tags # In case only a shallow clone was done
+if ! git tag | grep "${TAG}"; then
+  git tag ${TAG}
+  git push -u origin $TAG
+else
+  echo "'${TAG}' already exists. No action taken."
+fi

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,17 @@
+name: Create Tag
+on:
+  push:
+    branches:
+      - main
+      - 'hotfix/**'
+    paths:
+      - package.json
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: ./.github/create-tag

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ssh-key: '${{ secrets.COMMIT_KEY }}'
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
### What does this do?

Adds a github action to create a new tag based on the package.json version whenever the file is changed. If the tag already exists this silently passes as it is an indication that the package.json file changed in an unrelated way.

### Why are we making this change?

To reduce the manual work to create new releases
