### PR TITLE
Fix the concurrency matcher in run-tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ on:
       - development
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### What does this do?

Since we run the tests on every branch push vs on PRs we need the concurrency matcher to use the github ref vs the PR ref.
