### PR TITLE
Add a log statement to the release output to test hotfix deploys

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ declare let window: ElectronWindow;
 export const isElectron = (): boolean => typeof window !== 'undefined' && window?.isElectron;
 
 export const showReleaseVersionInConsole = (): void => {
+  console.log('Main update');
   console.log('Release version:', config.appVersion);
 };
 


### PR DESCRIPTION
### What does this do?

This adds a temporary extra log message to the release output to simulate a change that has been made on main when we want to do a hotfix that does not include the change.

