### PR TITLE
Support cookie renaming via client headers

### DIFF
--- a/src/lib/api/attachment.ts
+++ b/src/lib/api/attachment.ts
@@ -7,7 +7,7 @@ interface AttachmentResponse {
 
 export async function getAttachmentUrl(attachment: { key: string }): Promise<string> {
   const filter: any = { key: attachment.key };
-  const attachmentResponse = await get<AttachmentResponse>(`/api/feedItems/getAttachmentDownloadInfo`, filter).catch(
+  const attachmentResponse = await get<AttachmentResponse>('/api/feedItems/getAttachmentDownloadInfo', filter).catch(
     (err) => console.error(err)
   );
 

--- a/src/lib/api/attachment.ts
+++ b/src/lib/api/attachment.ts
@@ -1,5 +1,4 @@
-import { config } from '../../config';
-import * as Request from 'superagent';
+import { get } from './rest';
 
 interface AttachmentResponse {
   signedUrl: string;
@@ -7,15 +6,10 @@ interface AttachmentResponse {
 }
 
 export async function getAttachmentUrl(attachment: { key: string }): Promise<string> {
-  const attachmentResponse = await Request.get<AttachmentResponse>(
-    `${config.ZERO_API_URL}/api/feedItems/getAttachmentDownloadInfo`
-  )
-    .query({
-      key: attachment.key,
-    })
-    .set('X-APP-PLATFORM', 'zos')
-    .withCredentials()
-    .catch((err) => console.error(err));
+  const filter: any = { key: attachment.key };
+  const attachmentResponse = await get<AttachmentResponse>(`/api/feedItems/getAttachmentDownloadInfo`, filter).catch(
+    (err) => console.error(err)
+  );
 
   if (attachmentResponse && attachmentResponse.ok) {
     return attachmentResponse.body.signedUrl;

--- a/src/lib/api/attachment.ts
+++ b/src/lib/api/attachment.ts
@@ -13,6 +13,7 @@ export async function getAttachmentUrl(attachment: { key: string }): Promise<str
     .query({
       key: attachment.key,
     })
+    .set('X-APP-PLATFORM', 'zos')
     .withCredentials()
     .catch((err) => console.error(err));
 

--- a/src/lib/api/rest.ts
+++ b/src/lib/api/rest.ts
@@ -18,6 +18,12 @@ function apiUrl(path: string): string {
   ].join('');
 }
 
+/**
+ * The zOS code now passes an 'x-app-platform' header to ensure that the
+ * access_token cookie is unique for the scope of zos user.
+ */
+const xPlatFormHeader = { 'X-APP-PLATFORM': 'zos' };
+
 export function get<T>(path: string, filter?: RequestFilter) {
   let queryData;
   if (filter) {
@@ -30,17 +36,17 @@ export function get<T>(path: string, filter?: RequestFilter) {
     }
   }
 
-  return Request.get<T>(apiUrl(path)).withCredentials().query(queryData);
+  return Request.get<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials().query(queryData);
 }
 
 export function post<T>(path: string) {
-  return Request.post<T>(apiUrl(path)).withCredentials();
+  return Request.post<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
 }
 
 export function put<T>(path: string) {
-  return Request.put<T>(apiUrl(path)).withCredentials();
+  return Request.put<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
 }
 
 export function del<T>(path: string) {
-  return Request.delete<T>(apiUrl(path)).withCredentials();
+  return Request.delete<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
 }


### PR DESCRIPTION
ZERO-API PR: [https://github.com/m3m3n70/zero-api/pull/874](https://github.com/m3m3n70/zero-api/pull/874)

### What does this do?

Pass an X-header (`X-APP-PLATFORM`) while making any request to zero-api.

### How do I test this?

Screenshot on zero-api PR is added
