### PR TITLE
show unread count

### DIFF
--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -68,4 +68,10 @@ describe('Sidekick', () => {
 
     expect(wrapper.find('.sidekick__tab-content--notifications').exists()).toBe(true);
   });
+
+  it('renders total unread messages', () => {
+    const wrapper = subject({ allUnreadMessages: 10 });
+
+    expect(wrapper.find('.sidekick__tab-notifications--unread-messages').exists()).toBe(true);
+  });
 });

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -23,6 +23,7 @@ interface PublicProperties {
 export interface Properties extends PublicProperties {
   user: AuthenticationState['user'];
   updateLayout: (layout: Partial<AppLayout>) => void;
+  allUnreadMessages: number;
 }
 
 export interface State {
@@ -36,10 +37,12 @@ export class Container extends React.Component<Properties, State> {
   static mapState(state: RootState): Partial<Properties> {
     const {
       authentication: { user },
+      directMessages: { list },
     } = state;
 
     return {
       user,
+      allUnreadMessages: list.reduce((count, directMessage) => count + directMessage.unreadCount, 0),
     };
   }
 
@@ -87,6 +90,27 @@ export class Container extends React.Component<Properties, State> {
     );
   }
 
+  renderMessageTab() {
+    if (this.props.allUnreadMessages > 0) {
+      return (
+        <div
+          className='sidekick__tab-notifications sidekick__tab-notifications--unread-messages'
+          onClick={this.clickTab.bind(this, Tabs.MESSAGES)}
+        >
+          {this.props.allUnreadMessages}
+        </div>
+      );
+    } else {
+      return (
+        <IconButton
+          className='sidekick__tabs-messages'
+          icon={Icons.Messages}
+          onClick={this.clickTab.bind(this, Tabs.MESSAGES)}
+        />
+      );
+    }
+  }
+
   renderTabs(): JSX.Element {
     return (
       <div className='sidekick__tabs'>
@@ -95,11 +119,7 @@ export class Container extends React.Component<Properties, State> {
           icon={Icons.Network}
           onClick={this.clickTab.bind(this, Tabs.NETWORK)}
         />
-        <IconButton
-          className='sidekick__tabs-messages'
-          icon={Icons.Messages}
-          onClick={this.clickTab.bind(this, Tabs.MESSAGES)}
-        />
+        {this.renderMessageTab()}
         <IconButton
           className='sidekick__tabs-notifications'
           icon={Icons.Notifications}

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -71,6 +71,17 @@
     width: 100%;
     padding-top: 56px;
   }
+
+  &__tab-notifications {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: theme.$accent-color;
+    color: theme.$font-color-primary;
+    height: 34px;
+    width: 34px;
+    border-radius: 50%;
+  }
 }
 
 .app-sidekick-panel__target {

--- a/src/platform-apps/channels/direct-message-members/index.test.tsx
+++ b/src/platform-apps/channels/direct-message-members/index.test.tsx
@@ -49,4 +49,31 @@ describe('direct-message-members', () => {
 
     expect(setActiveDirectMessage).toHaveBeenCalledWith('292444273_bd035e84edfbaf11251ffef196de2ab47496439c');
   });
+
+  it('should not render unread messages', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find('.direct-message-members__user-unread-count').exists()).toBe(false);
+  });
+
+  it('renders unread messages', function () {
+    const [
+      firstDirectMessage,
+      ...restOfDirectMessages
+    ] = DIRECT_MESSAGES_TEST;
+
+    const unreadCount = 10;
+
+    const wrapper = subject({
+      directMessages: [
+        {
+          ...firstDirectMessage,
+          unreadCount,
+        },
+        ...restOfDirectMessages,
+      ],
+    });
+
+    expect(wrapper.find('.direct-message-members__user-unread-count').text()).toEqual(unreadCount.toString());
+  });
 });

--- a/src/platform-apps/channels/direct-message-members/index.test.tsx
+++ b/src/platform-apps/channels/direct-message-members/index.test.tsx
@@ -50,7 +50,7 @@ describe('direct-message-members', () => {
     expect(setActiveDirectMessage).toHaveBeenCalledWith('292444273_bd035e84edfbaf11251ffef196de2ab47496439c');
   });
 
-  it('should not render unread messages', function () {
+  it('should not render read messages', function () {
     const wrapper = subject({});
 
     expect(wrapper.find('.direct-message-members__user-unread-count').exists()).toBe(false);

--- a/src/platform-apps/channels/direct-message-members/index.tsx
+++ b/src/platform-apps/channels/direct-message-members/index.tsx
@@ -61,6 +61,9 @@ export class Container extends React.Component<Properties> {
       >
         <div className='direct-message-members__user-status'></div>
         <div className='direct-message-members__user-name'>{this.renderMemberName(directMessage.otherMembers)}</div>
+        {directMessage.unreadCount !== 0 && (
+          <div className='direct-message-members__user-unread-count'>{directMessage.unreadCount}</div>
+        )}
       </div>
     );
   };

--- a/src/platform-apps/channels/direct-message-members/styles.scss
+++ b/src/platform-apps/channels/direct-message-members/styles.scss
@@ -5,14 +5,13 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  color: var(--actionable-inactive-color, #737373);
+  color: theme.$actionable-inactive-color;
   padding: 0 20px;
   height: 36px;
-  width: 100%;
 
   &:hover {
-    color: var(--actionable-active-color, #fff);
-    background-color: var(--actionable-hover-background, hsla(0, 0%, 100%, 0.1));
+    color: theme.$actionable-active-color;
+    background-color: theme.$actionable-hover-background;
   }
 
   &-status {
@@ -28,5 +27,24 @@
     &--active {
       background-color: #c9fd51;
     }
+  }
+
+  &-unread-count {
+    background-color: theme.$accent-color;
+    color: theme.$font-color-primary;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    text-align: center;
+    font-size: 12px;
+    line-height: 21px;
+    margin-left: 3px;
+  }
+
+  &-name {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    flex: 1 1;
   }
 }


### PR DESCRIPTION
### What does this do?
render unread messages :
- in front of each chat
- total on all unread messages in tab head

![Screenshot 2023-01-26 at 17 07 01](https://user-images.githubusercontent.com/102802882/214887062-7950f85c-20a8-4ec8-81a6-055de4745b93.png)


### Why are we making this change?

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
