### PR TITLE
Fix non-full height chat window with few messages

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -71,6 +71,10 @@ $scrollbar-width: 5px;
   }
 }
 
+.channel-view__inverted-scroll {
+  flex-grow: 99;
+}
+
 .channel {
   &-list {
     width: 100%;


### PR DESCRIPTION
### What does this do?

Fixes bug where chats with very few messages weren't rendering the proper height.

