### PR TITLE
Center align the chat date

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -236,6 +236,8 @@ $scrollbar-width: 5px;
 
       &-date {
         color: theme.$color-greyscale-transparency-11;
+        width: 100%;
+        text-align: center;
       }
     }
 


### PR DESCRIPTION
### What does this do?

Center the date heading in chat to match design

