### PR TITLE
Extract an IconButton component and update the chat window

### DIFF
--- a/src/components/icon-button/index.test.tsx
+++ b/src/components/icon-button/index.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { IconButton, Properties } from '.';
+import { IconXClose } from '@zero-tech/zui/icons';
+
+describe('IconButton', () => {
+  const subject = (props: Partial<Properties> = {}, children = <></>) => {
+    const allProps = {
+      getIcon: () => <path />,
+      onClick: () => undefined,
+      Icon: () => <></>,
+      ...props,
+    };
+
+    return shallow(<IconButton {...allProps}>{children}</IconButton>);
+  };
+
+  it('adds className to main element', () => {
+    const wrapper = subject({ className: 'tacos' });
+
+    expect(wrapper.is('.tacos')).toBe(true);
+  });
+
+  it('renders the chosen icon', () => {
+    const wrapper = subject({
+      Icon: IconXClose,
+      label: 'the-label',
+      size: 12,
+      isFilled: false,
+    });
+
+    expect(wrapper.find('IconXClose').props()).toEqual({
+      label: 'the-label',
+      size: 12,
+      isFilled: false,
+    });
+  });
+
+  it('fires onClick', () => {
+    const onClick = jest.fn();
+    const wrapper = subject({ onClick });
+
+    click(wrapper.find('button'));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('prevents propagation of click event', () => {
+    const stopPropagation = jest.fn();
+    const wrapper = subject({});
+
+    click(wrapper.find('button'), { stopPropagation });
+
+    expect(stopPropagation).toHaveBeenCalledOnce();
+  });
+});
+
+function click(node, eventAttrs = {}) {
+  node.simulate('click', {
+    preventDefault: () => {},
+    stopPropagation: () => {},
+    ...eventAttrs,
+  });
+}

--- a/src/components/icon-button/index.tsx
+++ b/src/components/icon-button/index.tsx
@@ -1,0 +1,37 @@
+import React, { JSXElementConstructor } from 'react';
+import classNames from 'classnames';
+
+import './styles.scss';
+import { IconProps } from '@zero-tech/zui/components/Icons/Icons.types';
+
+export interface Properties {
+  className?: string;
+  onClick: () => void;
+
+  Icon: JSXElementConstructor<IconProps>;
+  label?: string;
+  size?: string | number;
+  isFilled?: boolean;
+}
+
+export class IconButton extends React.Component<Properties> {
+  handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.stopPropagation();
+    this.props.onClick();
+  };
+
+  render() {
+    return (
+      <button
+        className={classNames('icon-button', this.props.className)}
+        onClick={this.handleClick}
+      >
+        <this.props.Icon
+          label={this.props.label}
+          size={this.props.size}
+          isFilled={this.props.isFilled}
+        />
+      </button>
+    );
+  }
+}

--- a/src/components/icon-button/styles.scss
+++ b/src/components/icon-button/styles.scss
@@ -1,0 +1,17 @@
+@use '../../shared-components/theme-engine/theme' as theme;
+
+.icon-button {
+  border-radius: 50%;
+  padding: 2px;
+  line-height: 0px;
+
+  cursor: pointer;
+  background: none;
+  border: none;
+  display: inline-block;
+  margin: 0px;
+
+  &:hover {
+    background-color: theme.$color-greyscale-transparency-3;
+  }
+}

--- a/src/components/message-input/menu.tsx
+++ b/src/components/message-input/menu.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import { dropzoneToMedia, Media } from './utils';
 import { IconPaperclip } from '@zero-tech/zui/icons';
+import { IconButton } from '../icon-button';
 
 export interface Properties {
   onSelected: (images: Media[]) => void;
@@ -25,11 +26,13 @@ export default class Menu extends React.Component<Properties> {
         accept={this.props.mimeTypes}
         maxSize={this.props.maxSize}
       >
-        {({ getRootProps, getInputProps }) => (
+        {({ getRootProps, getInputProps, open }) => (
           <div className='image-send'>
             <div {...getRootProps({ className: 'image-send__dropzone' })}>
               <input {...getInputProps()} />
-              <IconPaperclip
+              <IconButton
+                onClick={open}
+                Icon={IconPaperclip}
                 size={16}
                 className='image-send__icon'
               />

--- a/src/platform-apps/channels/direct-message-chat/index.test.tsx
+++ b/src/platform-apps/channels/direct-message-chat/index.test.tsx
@@ -38,42 +38,21 @@ describe('direct-message-chat', () => {
     expect(wrapper.find(ChannelViewContainer).prop('channelId')).toStrictEqual(activeDirectMessageId);
   });
 
-  it('minimize chat', function () {
-    const stopPropagation = jest.fn();
+  it('minimizes chat', function () {
     const wrapper = subject({});
 
-    const minimizeButton = wrapper.find('.direct-message-chat__minimize-button');
-    minimizeButton.simulate('click', {
-      stopPropagation,
-    });
+    icon(wrapper, IconMinus).simulate('click');
+
     expect(getDirectMessageChat(wrapper).hasClass('direct-message-chat--minimized')).toBe(true);
-    expect(stopPropagation).toHaveBeenCalled();
   });
 
-  it('renders minimize icon', function () {
-    const wrapper = subject({});
-
-    const minimizeButton = wrapper.find('.direct-message-chat__minimize-button');
-
-    expect(minimizeButton.find(IconMinus).exists()).toBe(true);
-  });
-
-  it('handle close chat', function () {
+  it('closes chat', function () {
     const setActiveDirectMessageId = jest.fn();
     const wrapper = subject({ setActiveDirectMessageId });
 
-    const minimizeButton = wrapper.find('.direct-message-chat__close-button');
-    minimizeButton.simulate('click');
+    icon(wrapper, IconXClose).simulate('click');
 
     expect(setActiveDirectMessageId).toHaveBeenCalledWith('');
-  });
-
-  it('renders close icon', function () {
-    const wrapper = subject({});
-
-    const minimizeButton = wrapper.find('.direct-message-chat__close-button');
-
-    expect(minimizeButton.find(IconXClose).exists()).toBe(true);
   });
 
   describe('title', () => {
@@ -308,4 +287,8 @@ function stubUser(attrs: Partial<User> = {}): User {
     lastSeenAt: 'last-seen',
     ...attrs,
   };
+}
+
+function icon(wrapper, icon) {
+  return wrapper.find('IconButton').findWhere((n) => n.prop('Icon') === icon);
 }

--- a/src/platform-apps/channels/direct-message-chat/index.tsx
+++ b/src/platform-apps/channels/direct-message-chat/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconXClose, IconMinus, IconUsers1 } from '@zero-tech/zui/icons';
+import { IconMinus, IconUsers1, IconXClose } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import { setActiveDirectMessageId } from '../../../store/direct-messages';
 import { RootState } from '../../../store';
@@ -10,6 +10,7 @@ import Tooltip from '../../../components/tooltip';
 import './styles.scss';
 import { DirectMessage } from '../../../store/direct-messages/types';
 import { provider as imageProvider } from '../../../lib/cloudinary/provider';
+import { IconButton } from '../../../components/icon-button';
 
 export interface PublicProperties {}
 
@@ -56,8 +57,7 @@ export class Container extends React.Component<Properties, State> {
     this.setState((state) => ({ isMinimized: false, isFullScreen: state.isMinimized ? false : !state.isFullScreen }));
   };
 
-  handleMinimizeClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
-    event.stopPropagation();
+  handleMinimizeClick = (): void => {
     this.setState((state) => ({ isMinimized: !state.isMinimized, isFullScreen: false }));
   };
 
@@ -149,18 +149,16 @@ export class Container extends React.Component<Properties, State> {
             className='direct-message-chat__title-bar'
             onClick={this.handleHeaderClick}
           >
-            <button
-              className='button-reset direct-message-chat__minimize-button'
+            <IconButton
               onClick={this.handleMinimizeClick}
-            >
-              <IconMinus size={12} />
-            </button>
-            <button
-              className='button-reset direct-message-chat__close-button'
+              Icon={IconMinus}
+              size={12}
+            />
+            <IconButton
               onClick={this.handleClose}
-            >
-              <IconXClose size={12} />
-            </button>
+              Icon={IconXClose}
+              size={12}
+            />
           </div>
 
           <div className='direct-message-chat__header'>

--- a/src/platform-apps/channels/direct-message-chat/styles.scss
+++ b/src/platform-apps/channels/direct-message-chat/styles.scss
@@ -63,14 +63,11 @@ $recent-indicator-size: 8px;
     justify-content: flex-end;
     align-items: center;
     padding-right: 12px;
-    gap: 12px;
+    gap: 10px;
     background-color: $title-bar-background-color;
     height: $title-bar-height;
     border-radius: $title-bar-border-radius;
-
-    &:hover {
-      background-color: theme.$background-color-secondary-hover;
-    }
+    color: theme.$color-primary-transparency-11;
   }
 
   &__header {
@@ -149,24 +146,6 @@ $recent-indicator-size: 8px;
     font-size: 12px;
     line-height: 15px;
     color: theme.$color-greyscale-11;
-  }
-
-  &__minimize-button,
-  &__close-button,
-  &__video-toggle-button {
-    height: 12px;
-    width: 12px;
-    padding: 0px;
-    line-height: 0px;
-  }
-
-  &__minimize-button,
-  &__close-button {
-    color: theme.$color-primary-transparency-11;
-  }
-
-  &__video-toggle-button {
-    color: theme.$color-greyscale-12;
   }
 
   &--transition {

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -28,9 +28,7 @@ describe('Message Menu', () => {
     const onDelete = jest.fn();
     const wrapper = subject({ onDelete, canEdit: true });
 
-    expect(wrapper.find('.message__menu-item__icon').exists()).toBe(true);
-
-    wrapper.find('.message__menu-item__icon').simulate('click');
+    wrapper.find('IconButton').simulate('click');
 
     expect(wrapper.find('.delete-item').exists()).toBe(true);
   });
@@ -61,9 +59,7 @@ describe('Message Menu', () => {
     const onEdit = jest.fn();
     const wrapper = subject({ onEdit, canEdit: true });
 
-    expect(wrapper.find('.message__menu-item__icon').exists()).toBe(true);
-
-    wrapper.find('.message__menu-item__icon').simulate('click');
+    wrapper.find('IconButton').simulate('click');
 
     expect(wrapper.find('.edit-item').exists()).toBe(true);
   });

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -1,6 +1,8 @@
 import { Dialog } from '@zer0-os/zos-component-library';
+import { IconDotsVertical } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import React from 'react';
+import { IconButton } from '../../../components/icon-button';
 import PortalMenu from './portal-menu';
 
 import './styles.scss';
@@ -131,25 +133,11 @@ export class MessageMenu extends React.Component<Properties, State> {
 
     return (
       <div className={this.props.className}>
-        <div
-          className='message__menu-item__icon'
+        <IconButton
           onClick={this.open}
-        >
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            width='1em'
-            height='1em'
-            preserveAspectRatio='xMidYMid meet'
-            viewBox='0 0 512 512'
-          >
-            <g transform='rotate(90 256 256)'>
-              <path
-                fill='currentColor'
-                d='M328 256c0 39.8-32.2 72-72 72s-72-32.2-72-72s32.2-72 72-72s72 32.2 72 72zm104-72c-39.8 0-72 32.2-72 72s32.2 72 72 72s72-32.2 72-72s-32.2-72-72-72zm-352 0c-39.8 0-72 32.2-72 72s32.2 72 72 72s72-32.2 72-72s-32.2-72-72-72z'
-              />
-            </g>
-          </svg>
-        </div>
+          Icon={IconDotsVertical}
+          size={20}
+        />
         <PortalMenu
           className='portal-menu'
           onClose={this.close}

--- a/src/platform-apps/channels/messages-menu/styles.scss
+++ b/src/platform-apps/channels/messages-menu/styles.scss
@@ -1,18 +1,6 @@
 @use '../../../shared-components/theme-engine/theme' as theme;
 
 .message__menu {
-  &-item {
-    &.active {
-      visibility: visible;
-    }
-
-    &__icon {
-      display: inline-block;
-      cursor: pointer;
-      transform: translate(0);
-    }
-  }
-
   &:hover {
     .message__menu {
       visibility: visible;

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -409,13 +409,8 @@ $scrollbar-width: 5px;
           border-radius: 8px;
           width: 48px;
           height: 100%;
-
-          &__icon {
-            position: absolute;
-            right: 0px;
-            padding-top: 12px;
-            padding-right: 10px;
-          }
+          text-align: right;
+          margin: 8px;
         }
       }
 


### PR DESCRIPTION
### What does this do?

Creates an IconButton component to have common styling for all clickable icons.

Note: In a future PR this will be pulled into the zUI repository.

### Why are we making this change?

To make it easier to adhere to the standard design for clickable icons.
