### PR TITLE
Fixed spaces in the names of the Direct Message member list

### DIFF
--- a/src/platform-apps/channels/direct-message-chat/index.tsx
+++ b/src/platform-apps/channels/direct-message-chat/index.tsx
@@ -11,6 +11,7 @@ import './styles.scss';
 import { DirectMessage } from '../../../store/direct-messages/types';
 import { provider as imageProvider } from '../../../lib/cloudinary/provider';
 import { IconButton } from '../../../components/icon-button';
+import { otherMembersToString } from '../util';
 
 export interface PublicProperties {}
 
@@ -66,16 +67,7 @@ export class Container extends React.Component<Properties, State> {
 
     if (!directMessage) return '';
 
-    const otherMembers = directMessage.otherMembers
-      .map((member) =>
-        [
-          member.firstName,
-          member.lastName,
-        ]
-          .filter((e) => e)
-          .join(' ')
-      )
-      .join(', ');
+    const otherMembers = otherMembersToString(directMessage.otherMembers);
 
     return (
       <Tooltip

--- a/src/platform-apps/channels/direct-message-members/index.tsx
+++ b/src/platform-apps/channels/direct-message-members/index.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store';
 import { DirectMessage } from '../../../store/direct-messages/types';
-import { User } from '../../../store/channels';
 import {
   setActiveDirectMessageId,
   startSyncDirectMessage,
@@ -11,6 +10,7 @@ import {
 } from '../../../store/direct-messages';
 import Tooltip from '../../../components/tooltip';
 import { lastSeenText } from './utils';
+import { otherMembersToString } from '../util';
 
 import './styles.scss';
 
@@ -53,18 +53,6 @@ export class Container extends React.Component<Properties> {
     this.props.setActiveDirectMessage(directMessageId);
   }
 
-  renderMemberName(members: User[]): string {
-    return members
-      .map((member) =>
-        [
-          member.firstName,
-          member.lastName,
-        ].join(' ')
-      )
-      .join(', ')
-      .trim();
-  }
-
   renderStatus(directMessage: DirectMessage): JSX.Element {
     const isAnyUserOnline = directMessage.otherMembers.some((user) => user.isOnline);
 
@@ -82,7 +70,7 @@ export class Container extends React.Component<Properties> {
       return lastSeenText(directMessage.otherMembers[0]);
     }
 
-    return this.renderMemberName(directMessage.otherMembers);
+    return otherMembersToString(directMessage.otherMembers);
   }
 
   renderMember = (directMessage: DirectMessage): JSX.Element => {
@@ -106,7 +94,7 @@ export class Container extends React.Component<Properties> {
         >
           {this.renderStatus(directMessage)}
           <div className='direct-message-members__user-name'>
-            {directMessage.name || this.renderMemberName(directMessage.otherMembers)}
+            {directMessage.name || otherMembersToString(directMessage.otherMembers)}
           </div>
           {directMessage.unreadCount !== 0 && (
             <div className='direct-message-members__user-unread-count'>{directMessage.unreadCount}</div>

--- a/src/platform-apps/channels/util/index.test.ts
+++ b/src/platform-apps/channels/util/index.test.ts
@@ -1,0 +1,26 @@
+import { otherMembersToString } from './index';
+
+describe('otherMembersToString', () => {
+  it('maps user names', async function () {
+    const otherMembers = [
+      {
+        firstName: 'first-name',
+        lastName: 'last-name',
+      },
+      {
+        firstName: 'first-name-with-last-name-as-empty-string',
+        lastName: '',
+      },
+      {
+        firstName: '',
+        lastName: 'last-name-with-first-name-as-empty',
+      },
+    ];
+
+    const result = otherMembersToString(otherMembers as any);
+
+    expect(result).toEqual(
+      'first-name last-name, first-name-with-last-name-as-empty-string, last-name-with-first-name-as-empty'
+    );
+  });
+});

--- a/src/platform-apps/channels/util/index.ts
+++ b/src/platform-apps/channels/util/index.ts
@@ -1,0 +1,15 @@
+import { User } from '../../../store/channels';
+
+export function otherMembersToString(otherMembers: User[]) {
+  return otherMembers
+    .map((member) =>
+      [
+        member.firstName,
+        member.lastName,
+      ]
+        .filter((e) => e)
+        .join(' ')
+    )
+    .join(', ')
+    .trim();
+}


### PR DESCRIPTION
### What does this do?

Removes spaces in the list of names in the Direct Message member list.

### Before
<img width="554" alt="Screen Shot 2023-02-08 at 10 16 47 AM" src="https://user-images.githubusercontent.com/31045/217571349-8977b6fc-df1d-4b64-be78-3900d59e7e0e.png">

### After
![Screen Shot 2023-02-08 at 10 17 23 AM](https://user-images.githubusercontent.com/31045/217571483-4b42d73e-6438-4f3a-a873-7743183f2a80.png)
