### PR TITLE
Moved DM title ellipsis to tooltip (title is now a tooltip)

### DIFF
--- a/src/platform-apps/channels/direct-message-chat/styles.scss
+++ b/src/platform-apps/channels/direct-message-chat/styles.scss
@@ -125,7 +125,7 @@ $recent-indicator-size: 8px;
     overflow: hidden;
   }
 
-  &__title {
+  &__user-tooltip {
     font-weight: 400;
     font-size: 14px;
     line-height: 17px;


### PR DESCRIPTION
### Before

<img width="574" alt="Screen Shot 2023-02-08 at 10 27 54 AM" src="https://user-images.githubusercontent.com/31045/217574374-3a8ef0cf-d247-42d6-8c67-4afb5a51d731.png">

### After
<img width="937" alt="Screen Shot 2023-02-08 at 10 28 43 AM" src="https://user-images.githubusercontent.com/31045/217574598-98ab84eb-8a91-4a38-8114-9c34f8269ca3.png">
