### PR TITLE
Allow mentions menu to render in portal

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -204,6 +204,8 @@ export class MessageInput extends React.Component<Properties, State> {
                   onChange={this.contentChanged}
                   onBlur={this._handleBlur}
                   value={this.state.value}
+                  allowSuggestionsAboveCursor
+                  suggestionsPortalHost={document.body}
                 >
                   {this.renderMentionTypes()}
                 </MentionsInput>

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -37,7 +37,6 @@
     .message-input__input-wrapper {
       flex-grow: 99;
       margin-left: 8px;
-      overflow: hidden;
     }
 
     .mentions-text-area {

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -37,6 +37,7 @@
     .message-input__input-wrapper {
       flex-grow: 99;
       margin-left: 8px;
+      overflow: hidden;
     }
 
     .mentions-text-area {


### PR DESCRIPTION
### What does this do?

The mentions popup was being cut off as it renders outside the message input. Allow overflow so that it's visible.
