### PR TITLE
make sidekick opening interactive with storage

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -66,7 +66,9 @@ export class Container extends React.Component<Properties> {
             <WalletManager className='main__wallet-manager' />
           </div>
         </div>
-        <Sidekick className='main__sidekick' />
+
+        {this.props.context.isAuthenticated && <Sidekick className='main__sidekick' />}
+
         <ThemeEngine />
 
         {this.props.context.isAuthenticated && <MessengerChat />}

--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -12,11 +12,19 @@ describe('Sidekick', () => {
       className: '',
       updateSidekick: jest.fn(),
       setActiveSidekickTab: jest.fn(),
+      syncSidekickState: jest.fn(),
       ...props,
     };
 
     return shallow(<Container {...allProps} />);
   };
+
+  it('sync state', () => {
+    const syncSidekickState = jest.fn();
+    subject({ syncSidekickState });
+
+    expect(syncSidekickState).toHaveBeenCalled();
+  });
 
   it('adds className', () => {
     const wrapper = subject({ className: 'todo' });

--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -6,10 +6,21 @@ import { IfAuthenticated } from '../authentication/if-authenticated';
 import { MessengerList } from '../messenger/list';
 
 describe('Sidekick', () => {
+  beforeAll(() => {
+    global.localStorage = {
+      setItem: jest.fn(),
+      getItem: () => null,
+      removeItem: () => {},
+      length: 0,
+      clear: () => {},
+      key: (_) => '',
+    };
+  });
+
   const subject = (props: any = {}) => {
     const allProps = {
       className: '',
-      updateLayout: () => undefined,
+      updateSidekick: jest.fn(),
       ...props,
     };
 
@@ -24,6 +35,29 @@ describe('Sidekick', () => {
     expect(ifAuthenticated.find('.todo').exists()).toBe(true);
   });
 
+  it('open the sidekick in case not data found in storage', () => {
+    const updateSidekick = jest.fn();
+    subject({ updateSidekick });
+
+    expect(updateSidekick).toHaveBeenCalledWith({ isOpen: true });
+  });
+
+  it('renders sidekick with class animation in', () => {
+    const wrapper = subject({ isOpen: true });
+
+    const sidekick = wrapper.find('.sidekick');
+
+    expect(sidekick.hasClass('sidekick--slide-in')).toBe(true);
+  });
+
+  it('it should not render out class animation', () => {
+    const wrapper = subject({ isOpen: false });
+
+    const sidekick = wrapper.find('.sidekick');
+
+    expect(sidekick.hasClass('sidekick--slide-out')).toBe(false);
+  });
+
   it('renders sidekick panel', () => {
     const wrapper = subject();
 
@@ -33,13 +67,16 @@ describe('Sidekick', () => {
   });
 
   it('renders sidekick when panel tab is clicked', () => {
-    const updateLayout = jest.fn();
-    const wrapper = subject(updateLayout);
+    const updateSidekick = jest.fn();
+    const wrapper = subject({ updateSidekick });
 
     const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
+
     ifAuthenticated.find('.app-sidekick-panel__target').simulate('click');
 
-    expect(ifAuthenticated.find('.sidekick__slide-out').exists()).toBe(false);
+    expect(ifAuthenticated.find('.sidekick--slide-out').exists()).toBe(false);
+
+    expect(updateSidekick).toHaveBeenCalledWith({ isOpen: true });
   });
 
   it('renders default active tab', () => {

--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -4,12 +4,14 @@ import { shallow } from 'enzyme';
 import { Container } from '.';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { MessengerList } from '../messenger/list';
+import { SidekickTabs } from './types';
 
 describe('Sidekick', () => {
   const subject = (props: any = {}) => {
     const allProps = {
       className: '',
       updateSidekick: jest.fn(),
+      setActiveSidekickTab: jest.fn(),
       ...props,
     };
 
@@ -59,31 +61,50 @@ describe('Sidekick', () => {
     expect(updateSidekick).toHaveBeenCalledWith({ isOpen: true });
   });
 
-  it('renders default active tab', () => {
-    const wrapper = subject();
-
-    expect(wrapper.find(MessengerList).exists()).toBe(true);
-  });
-
   it('handle network tab content', () => {
-    const wrapper = subject();
+    const setActiveSidekickTab = jest.fn();
+    const wrapper = subject({ setActiveSidekickTab });
     wrapper.find('.sidekick__tabs-network').simulate('click');
 
-    expect(wrapper.find('.sidekick__tab-content--network').exists()).toBe(true);
+    expect(setActiveSidekickTab).toHaveBeenCalledWith({ activeTab: SidekickTabs.NETWORK });
   });
 
   it('handle messages tab content', () => {
-    const wrapper = subject();
+    const setActiveSidekickTab = jest.fn();
+    const wrapper = subject({ setActiveSidekickTab });
     wrapper.find('.sidekick__tabs-messages').simulate('click');
 
-    expect(wrapper.find('.sidekick__tab-content--messages').exists()).toBe(true);
+    expect(setActiveSidekickTab).toHaveBeenCalledWith({ activeTab: SidekickTabs.MESSAGES });
   });
 
   it('handle notifications tab content', () => {
-    const wrapper = subject();
+    const setActiveSidekickTab = jest.fn();
+    const wrapper = subject({ setActiveSidekickTab });
+    wrapper.find('.sidekick__tabs-notifications').simulate('click');
+
+    expect(setActiveSidekickTab).toHaveBeenCalledWith({ activeTab: SidekickTabs.NOTIFICATIONS });
+  });
+
+  it('render notifications tab content', () => {
+    const wrapper = subject({ activeTab: SidekickTabs.NOTIFICATIONS });
     wrapper.find('.sidekick__tabs-notifications').simulate('click');
 
     expect(wrapper.find('.sidekick__tab-content--notifications').exists()).toBe(true);
+  });
+
+  it('render messages tab content', () => {
+    const wrapper = subject({ activeTab: SidekickTabs.MESSAGES });
+    wrapper.find('.sidekick__tabs-messages').simulate('click');
+
+    expect(wrapper.find(MessengerList).exists()).toBe(true);
+    expect(wrapper.find('.sidekick__tab-content--messages').exists()).toBe(true);
+  });
+
+  it('render network tab content', () => {
+    const wrapper = subject({ activeTab: SidekickTabs.NETWORK });
+    wrapper.find('.sidekick__tabs-network').simulate('click');
+
+    expect(wrapper.find('.sidekick__tab-content--network').exists()).toBe(true);
   });
 
   it('renders total unread messages', () => {

--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -6,17 +6,6 @@ import { IfAuthenticated } from '../authentication/if-authenticated';
 import { MessengerList } from '../messenger/list';
 
 describe('Sidekick', () => {
-  beforeAll(() => {
-    global.localStorage = {
-      setItem: jest.fn(),
-      getItem: () => null,
-      removeItem: () => {},
-      length: 0,
-      clear: () => {},
-      key: (_) => '',
-    };
-  });
-
   const subject = (props: any = {}) => {
     const allProps = {
       className: '',
@@ -33,13 +22,6 @@ describe('Sidekick', () => {
     const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
 
     expect(ifAuthenticated.find('.todo').exists()).toBe(true);
-  });
-
-  it('open the sidekick in case not data found in storage', () => {
-    const updateSidekick = jest.fn();
-    subject({ updateSidekick });
-
-    expect(updateSidekick).toHaveBeenCalledWith({ isOpen: true });
   });
 
   it('renders sidekick with class animation in', () => {
@@ -68,13 +50,11 @@ describe('Sidekick', () => {
 
   it('renders sidekick when panel tab is clicked', () => {
     const updateSidekick = jest.fn();
-    const wrapper = subject({ updateSidekick });
+    const wrapper = subject({ updateSidekick, isOpen: false });
 
-    const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
+    expect(wrapper.find('.sidekick').hasClass('sidekick--slide-out')).toBe(false);
 
-    ifAuthenticated.find('.app-sidekick-panel__target').simulate('click');
-
-    expect(ifAuthenticated.find('.sidekick--slide-out').exists()).toBe(false);
+    wrapper.find('.app-sidekick-panel__target').simulate('click');
 
     expect(updateSidekick).toHaveBeenCalledWith({ isOpen: true });
   });

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -5,17 +5,17 @@ import { IfAuthenticated } from '../authentication/if-authenticated';
 import { IconButton, Icons } from '@zer0-os/zos-component-library';
 import classNames from 'classnames';
 import { AuthenticationState } from '../../store/authentication/types';
-import { UpdateSidekickPayload, updateSidekick } from '../../store/layout';
+import {
+  UpdateSidekickPayload,
+  updateSidekick,
+  setActiveSidekickTab,
+  SetActiveSidekickTabPayload,
+} from '../../store/layout';
 import { MessengerList } from '../messenger/list';
 import { denormalize } from '../../store/channels';
+import { SidekickTabs as Tabs } from './types';
 
 import './styles.scss';
-
-enum Tabs {
-  NETWORK,
-  MESSAGES,
-  NOTIFICATIONS,
-}
 
 interface PublicProperties {
   className?: string;
@@ -24,17 +24,21 @@ interface PublicProperties {
 export interface Properties extends PublicProperties {
   user: AuthenticationState['user'];
   updateSidekick: (action: UpdateSidekickPayload) => void;
+  setActiveSidekickTab: (action: SetActiveSidekickTabPayload) => void;
   countAllUnreadMessages: number;
   isOpen: boolean;
+  activeTab: Tabs;
 }
 
 export interface State {
-  activeTab: Tabs;
   canStartAnimation: boolean;
 }
 
 export class Container extends React.Component<Properties, State> {
-  state = { canStartAnimation: false, activeTab: Tabs.MESSAGES };
+  state = { canStartAnimation: false };
+  defaultProps: {
+    activeTab: Tabs.MESSAGES;
+  };
 
   static mapState(state: RootState): Partial<Properties> {
     const directMessages = denormalize(state.channelsList.value, state).filter((channel) => Boolean(channel.isChannel));
@@ -53,11 +57,12 @@ export class Container extends React.Component<Properties, State> {
       user,
       countAllUnreadMessages,
       isOpen: value.isSidekickOpen,
+      activeTab: value.activeSidekickTab,
     };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { updateSidekick };
+    return { updateSidekick, setActiveSidekickTab };
   }
 
   get isOpen() {
@@ -65,7 +70,7 @@ export class Container extends React.Component<Properties, State> {
   }
 
   clickTab(tab: Tabs): void {
-    this.setState({
+    this.props.setActiveSidekickTab({
       activeTab: tab,
     });
   }
@@ -138,7 +143,7 @@ export class Container extends React.Component<Properties, State> {
   }
 
   renderTabContent(): JSX.Element {
-    switch (this.state.activeTab) {
+    switch (this.props.activeTab) {
       case Tabs.NETWORK:
         return <div className='sidekick__tab-content--network'>NETWORK</div>;
       case Tabs.MESSAGES:

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -10,7 +10,6 @@ import { MessengerList } from '../messenger/list';
 import { denormalize } from '../../store/channels';
 
 import './styles.scss';
-import { SIDEKICK_OPEN_STORAGE } from '../../store/layout/constants';
 
 enum Tabs {
   NETWORK,
@@ -63,17 +62,6 @@ export class Container extends React.Component<Properties, State> {
 
   get isOpen() {
     return this.props.isOpen;
-  }
-
-  componentDidMount() {
-    const sidekickOpenValue = localStorage.getItem(SIDEKICK_OPEN_STORAGE);
-    const isSidekickOpen = sidekickOpenValue === 'true';
-
-    if (sidekickOpenValue === null) {
-      this.props.updateSidekick({ isOpen: true });
-    } else if (isSidekickOpen !== this.props.isOpen) {
-      this.props.updateSidekick({ isOpen: isSidekickOpen });
-    }
   }
 
   clickTab(tab: Tabs): void {

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -10,6 +10,7 @@ import {
   updateSidekick,
   setActiveSidekickTab,
   SetActiveSidekickTabPayload,
+  syncSidekickState,
 } from '../../store/layout';
 import { MessengerList } from '../messenger/list';
 import { denormalize } from '../../store/channels';
@@ -25,6 +26,7 @@ export interface Properties extends PublicProperties {
   user: AuthenticationState['user'];
   updateSidekick: (action: UpdateSidekickPayload) => void;
   setActiveSidekickTab: (action: SetActiveSidekickTabPayload) => void;
+  syncSidekickState: () => void;
   countAllUnreadMessages: number;
   isOpen: boolean;
   activeTab: Tabs;
@@ -62,7 +64,11 @@ export class Container extends React.Component<Properties, State> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { updateSidekick, setActiveSidekickTab };
+    return { updateSidekick, setActiveSidekickTab, syncSidekickState };
+  }
+
+  componentDidMount() {
+    this.props.syncSidekickState();
   }
 
   get isOpen() {

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -8,7 +8,14 @@
   background-color: theme.$background-color-tertiary-hover;
   width: $width-sidekick;
   height: 100%;
-  animation: sidekick-slide-in animation.$animation-duration-double ease-in forwards;
+  margin-right: -$width-sidekick;
+
+  &--slide-in {
+    animation: sidekick-slide-in animation.$animation-duration-double ease-in forwards;
+  }
+  &--slide-out {
+    animation: sidekick-slide-out animation.$animation-duration-double ease-out forwards;
+  }
 
   &__tabs {
     position: absolute;
@@ -39,10 +46,6 @@
         transition-duration: animation.$animation-duration-double;
       }
     }
-  }
-
-  &__slide-out {
-    animation: sidekick-slide-out animation.$animation-duration-double ease-out forwards;
   }
 
   .scroll-container__gradient {

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -88,6 +88,7 @@
     height: 34px;
     width: 34px;
     border-radius: 50%;
+    cursor: pointer;
   }
 }
 

--- a/src/components/sidekick/types.ts
+++ b/src/components/sidekick/types.ts
@@ -1,0 +1,5 @@
+export enum SidekickTabs {
+  NETWORK = 'network',
+  MESSAGES = 'messages',
+  NOTIFICATIONS = 'notifications',
+}

--- a/src/lib/storage/index.test.ts
+++ b/src/lib/storage/index.test.ts
@@ -1,0 +1,31 @@
+import { resolveFromLocalStorageAsBoolean } from './';
+
+describe('storage', () => {
+  describe('resolveFromLocalStorage', () => {
+    it('should use the key to get the data', () => {
+      const storageKey = 'key-store';
+
+      resolveFromLocalStorageAsBoolean(storageKey);
+      expect(global.localStorage.getItem).toHaveBeenCalledWith(storageKey);
+    });
+
+    it('returns false in case no data is saved', () => {
+      const value = resolveFromLocalStorageAsBoolean('key');
+      expect(value).toEqual(false);
+    });
+
+    it('returns false', () => {
+      global.localStorage.getItem = jest.fn().mockReturnValue('data hjere');
+
+      const value = resolveFromLocalStorageAsBoolean('key');
+      expect(value).toEqual(false);
+    });
+
+    it('returns true', () => {
+      global.localStorage.getItem = jest.fn().mockReturnValue('true');
+
+      const value = resolveFromLocalStorageAsBoolean('key');
+      expect(value).toEqual(true);
+    });
+  });
+});

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,7 +1,5 @@
 export function resolveFromLocalStorageAsBoolean(key) {
   const value = localStorage.getItem(key);
 
-  if (value === null || value === 'true') return true;
-
-  return false;
+  return value === null || value === 'true';
 }

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,7 @@
+export function resolveFromLocalStorageAsBoolean(key) {
+  const value = localStorage.getItem(key);
+
+  if (value === null || value === 'true') return true;
+
+  return false;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,14 @@ import { configure } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 configure({ adapter: new Adapter() });
+
+const localStorageMock = {
+  setItem: jest.fn(),
+  getItem: jest.fn(),
+  removeItem: jest.fn(),
+  length: 0,
+  clear: jest.fn(),
+  key: jest.fn(),
+};
+
+global.localStorage = localStorageMock;

--- a/src/store/layout/constants.ts
+++ b/src/store/layout/constants.ts
@@ -1,1 +1,7 @@
+import { SidekickTabs } from './../../components/sidekick/types';
+
 export const SIDEKICK_OPEN_STORAGE = 'isSidekickOpen';
+
+export const SIDEKICK_TAB_KEY = 'sidekick-tab';
+
+export const DEFAULT_ACTIVE_TAB = SidekickTabs.MESSAGES;

--- a/src/store/layout/constants.ts
+++ b/src/store/layout/constants.ts
@@ -1,0 +1,1 @@
+export const SIDEKICK_OPEN_STORAGE = 'isSidekickOpen';

--- a/src/store/layout/index.test.ts
+++ b/src/store/layout/index.test.ts
@@ -1,4 +1,5 @@
 import { reducer, update, LayoutState } from '.';
+import { SidekickTabs } from '../../components/sidekick/types';
 
 describe('layout reducer', () => {
   const initialExistingState: LayoutState = {
@@ -6,6 +7,7 @@ describe('layout reducer', () => {
       isContextPanelOpen: false,
       isSidekickOpen: false,
       hasContextPanel: false,
+      activeSidekickTab: SidekickTabs.MESSAGES,
     },
   };
 
@@ -15,6 +17,7 @@ describe('layout reducer', () => {
         isContextPanelOpen: false,
         isSidekickOpen: false,
         hasContextPanel: false,
+        activeSidekickTab: SidekickTabs.MESSAGES,
       },
     });
   });

--- a/src/store/layout/index.test.ts
+++ b/src/store/layout/index.test.ts
@@ -4,7 +4,7 @@ describe('layout reducer', () => {
   const initialExistingState: LayoutState = {
     value: {
       isContextPanelOpen: false,
-      isSidekickOpen: true,
+      isSidekickOpen: false,
       hasContextPanel: false,
     },
   };
@@ -13,7 +13,7 @@ describe('layout reducer', () => {
     expect(reducer(undefined, { type: 'unknown' })).toEqual({
       value: {
         isContextPanelOpen: false,
-        isSidekickOpen: true,
+        isSidekickOpen: false,
         hasContextPanel: false,
       },
     });

--- a/src/store/layout/index.test.ts
+++ b/src/store/layout/index.test.ts
@@ -1,5 +1,4 @@
 import { reducer, update, LayoutState } from '.';
-import { SidekickTabs } from '../../components/sidekick/types';
 
 describe('layout reducer', () => {
   const initialExistingState: LayoutState = {
@@ -7,7 +6,7 @@ describe('layout reducer', () => {
       isContextPanelOpen: false,
       isSidekickOpen: false,
       hasContextPanel: false,
-      activeSidekickTab: SidekickTabs.MESSAGES,
+      activeSidekickTab: null,
     },
   };
 
@@ -17,7 +16,7 @@ describe('layout reducer', () => {
         isContextPanelOpen: false,
         isSidekickOpen: false,
         hasContextPanel: false,
-        activeSidekickTab: SidekickTabs.MESSAGES,
+        activeSidekickTab: null,
       },
     });
   });

--- a/src/store/layout/index.ts
+++ b/src/store/layout/index.ts
@@ -1,23 +1,22 @@
-import { SIDEKICK_OPEN_STORAGE } from './constants';
 import { createSlice, PayloadAction, createAction } from '@reduxjs/toolkit';
 import type { AppLayout, LayoutState, UpdateSidekickPayload, SetActiveSidekickTabPayload } from './types';
-import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
-import { resolveActiveTab } from './utils';
 
 export enum SagaActionTypes {
   updateSidekick = 'layout/saga/updateSidekick',
   setActiveSidekickTab = 'layout/saga/setActiveSidekickTab',
+  syncSidekickState = 'layout/saga/syncSidekickState',
 }
 
 export const updateSidekick = createAction<UpdateSidekickPayload>(SagaActionTypes.updateSidekick);
 export const setActiveSidekickTab = createAction<SetActiveSidekickTabPayload>(SagaActionTypes.setActiveSidekickTab);
+export const syncSidekickState = createAction(SagaActionTypes.syncSidekickState);
 
 const initialState: LayoutState = {
   value: {
     isContextPanelOpen: false,
-    isSidekickOpen: resolveFromLocalStorageAsBoolean(SIDEKICK_OPEN_STORAGE),
     hasContextPanel: false,
-    activeSidekickTab: resolveActiveTab(),
+    isSidekickOpen: false,
+    activeSidekickTab: null,
   },
 };
 

--- a/src/store/layout/index.ts
+++ b/src/store/layout/index.ts
@@ -1,19 +1,23 @@
 import { SIDEKICK_OPEN_STORAGE } from './constants';
 import { createSlice, PayloadAction, createAction } from '@reduxjs/toolkit';
-import type { AppLayout, LayoutState, UpdateSidekickPayload } from './types';
+import type { AppLayout, LayoutState, UpdateSidekickPayload, SetActiveSidekickTabPayload } from './types';
 import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
+import { resolveActiveTab } from './utils';
 
 export enum SagaActionTypes {
   updateSidekick = 'layout/saga/updateSidekick',
+  setActiveSidekickTab = 'layout/saga/setActiveSidekickTab',
 }
 
 export const updateSidekick = createAction<UpdateSidekickPayload>(SagaActionTypes.updateSidekick);
+export const setActiveSidekickTab = createAction<SetActiveSidekickTabPayload>(SagaActionTypes.setActiveSidekickTab);
 
 const initialState: LayoutState = {
   value: {
     isContextPanelOpen: false,
     isSidekickOpen: resolveFromLocalStorageAsBoolean(SIDEKICK_OPEN_STORAGE),
     hasContextPanel: false,
+    activeSidekickTab: resolveActiveTab(),
   },
 };
 
@@ -32,4 +36,4 @@ const slice = createSlice({
 
 export const { update } = slice.actions;
 export const { reducer } = slice;
-export { AppLayout, LayoutState, UpdateSidekickPayload };
+export { AppLayout, LayoutState, UpdateSidekickPayload, SetActiveSidekickTabPayload };

--- a/src/store/layout/index.ts
+++ b/src/store/layout/index.ts
@@ -1,19 +1,16 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, createAction } from '@reduxjs/toolkit';
+import type { AppLayout, LayoutState, UpdateSidekickPayload } from './types';
 
-export interface AppLayout {
-  hasContextPanel: boolean;
-  isContextPanelOpen: boolean;
-  isSidekickOpen: boolean;
+export enum SagaActionTypes {
+  updateSidekick = 'layout/saga/updateSidekick',
 }
 
-export interface LayoutState {
-  value: AppLayout;
-}
+export const updateSidekick = createAction<UpdateSidekickPayload>(SagaActionTypes.updateSidekick);
 
 const initialState: LayoutState = {
   value: {
     isContextPanelOpen: false,
-    isSidekickOpen: true,
+    isSidekickOpen: false,
     hasContextPanel: false,
   },
 };
@@ -33,3 +30,4 @@ const slice = createSlice({
 
 export const { update } = slice.actions;
 export const { reducer } = slice;
+export { AppLayout, LayoutState, UpdateSidekickPayload };

--- a/src/store/layout/index.ts
+++ b/src/store/layout/index.ts
@@ -1,5 +1,7 @@
+import { SIDEKICK_OPEN_STORAGE } from './constants';
 import { createSlice, PayloadAction, createAction } from '@reduxjs/toolkit';
 import type { AppLayout, LayoutState, UpdateSidekickPayload } from './types';
+import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
 
 export enum SagaActionTypes {
   updateSidekick = 'layout/saga/updateSidekick',
@@ -10,7 +12,7 @@ export const updateSidekick = createAction<UpdateSidekickPayload>(SagaActionType
 const initialState: LayoutState = {
   value: {
     isContextPanelOpen: false,
-    isSidekickOpen: false,
+    isSidekickOpen: resolveFromLocalStorageAsBoolean(SIDEKICK_OPEN_STORAGE),
     hasContextPanel: false,
   },
 };

--- a/src/store/layout/saga.test.ts
+++ b/src/store/layout/saga.test.ts
@@ -1,0 +1,31 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { updateSidekick as updateSidekickSaga } from './saga';
+
+import { reducer } from '.';
+
+describe('layout saga', () => {
+  beforeAll(() => {
+    global.localStorage = {
+      setItem: jest.fn(),
+      getItem: (_) => '',
+      removeItem: () => {},
+      length: 0,
+      clear: () => {},
+      key: (_) => '',
+    };
+  });
+
+  it('should store sidekick', async () => {
+    const { storeState } = await expectSaga(updateSidekickSaga, { payload: { isOpen: true } })
+      .withReducer(reducer)
+      .run();
+
+    expect(storeState).toMatchObject({
+      value: {
+        isSidekickOpen: true,
+      },
+    });
+
+    expect(localStorage.setItem).toHaveBeenCalled();
+  });
+});

--- a/src/store/layout/saga.test.ts
+++ b/src/store/layout/saga.test.ts
@@ -1,5 +1,6 @@
+import { SidekickTabs } from './../../components/sidekick/types';
 import { expectSaga } from 'redux-saga-test-plan';
-import { updateSidekick as updateSidekickSaga } from './saga';
+import { updateSidekick as updateSidekickSaga, updateActiveSidekickTab } from './saga';
 
 import { reducer } from '.';
 
@@ -16,5 +17,19 @@ describe('layout saga', () => {
     });
 
     expect(global.localStorage.setItem).toHaveBeenCalled();
+  });
+
+  it('should store active tab', async () => {
+    const { storeState } = await expectSaga(updateActiveSidekickTab, { payload: { activeTab: SidekickTabs.MESSAGES } })
+      .withReducer(reducer)
+      .run();
+
+    expect(storeState).toMatchObject({
+      value: {
+        activeSidekickTab: SidekickTabs.MESSAGES,
+      },
+    });
+
+    expect(global.localStorage.setItem).toHaveBeenCalledWith('sidekick-tab', 'messages');
   });
 });

--- a/src/store/layout/saga.test.ts
+++ b/src/store/layout/saga.test.ts
@@ -1,13 +1,22 @@
 import { SidekickTabs } from './../../components/sidekick/types';
 import { expectSaga } from 'redux-saga-test-plan';
-import { updateSidekick as updateSidekickSaga, updateActiveSidekickTab } from './saga';
+import { updateSidekick as updateSidekickSaga, updateActiveSidekickTab, syncSidekickState } from './saga';
 
 import { reducer } from '.';
 
 describe('layout saga', () => {
+  const state = {
+    authentication: {
+      user: {
+        data: {
+          id: 'user-id',
+        },
+      },
+    },
+  };
   it('should store sidekick', async () => {
     const { storeState } = await expectSaga(updateSidekickSaga, { payload: { isOpen: true } })
-      .withReducer(reducer)
+      .withReducer(reducer, state as any)
       .run();
 
     expect(storeState).toMatchObject({
@@ -21,7 +30,7 @@ describe('layout saga', () => {
 
   it('should store active tab', async () => {
     const { storeState } = await expectSaga(updateActiveSidekickTab, { payload: { activeTab: SidekickTabs.MESSAGES } })
-      .withReducer(reducer)
+      .withReducer(reducer, state as any)
       .run();
 
     expect(storeState).toMatchObject({
@@ -30,6 +39,24 @@ describe('layout saga', () => {
       },
     });
 
-    expect(global.localStorage.setItem).toHaveBeenCalledWith('sidekick-tab', 'messages');
+    expect(global.localStorage.setItem).toHaveBeenCalledWith('user-id-sidekick-tab', 'messages');
+  });
+
+  it('should sync sidekick state', async () => {
+    global.localStorage.getItem = jest.fn().mockReturnValue('true');
+
+    const { storeState } = await expectSaga(syncSidekickState)
+      .withReducer(reducer, state as any)
+      .run();
+
+    expect(storeState).toMatchObject({
+      value: {
+        activeSidekickTab: SidekickTabs.MESSAGES,
+        isSidekickOpen: true,
+      },
+    });
+
+    expect(global.localStorage.getItem).toHaveBeenNthCalledWith(1, 'user-id-isSidekickOpen');
+    expect(global.localStorage.getItem).toHaveBeenNthCalledWith(2, 'user-id-sidekick-tab');
   });
 });

--- a/src/store/layout/saga.test.ts
+++ b/src/store/layout/saga.test.ts
@@ -4,17 +4,6 @@ import { updateSidekick as updateSidekickSaga } from './saga';
 import { reducer } from '.';
 
 describe('layout saga', () => {
-  beforeAll(() => {
-    global.localStorage = {
-      setItem: jest.fn(),
-      getItem: (_) => '',
-      removeItem: () => {},
-      length: 0,
-      clear: () => {},
-      key: (_) => '',
-    };
-  });
-
   it('should store sidekick', async () => {
     const { storeState } = await expectSaga(updateSidekickSaga, { payload: { isOpen: true } })
       .withReducer(reducer)
@@ -26,6 +15,6 @@ describe('layout saga', () => {
       },
     });
 
-    expect(localStorage.setItem).toHaveBeenCalled();
+    expect(global.localStorage.setItem).toHaveBeenCalled();
   });
 });

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -1,32 +1,69 @@
+import getDeepProperty from 'lodash.get';
 import { SIDEKICK_OPEN_STORAGE, SIDEKICK_TAB_KEY } from './constants';
-import { put, takeLatest } from 'redux-saga/effects';
+import { put, takeLatest, select } from 'redux-saga/effects';
 import { update, SagaActionTypes } from './';
+import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
+import { resolveActiveTab } from './utils';
+
+export const getKeyWithUserId = (key: string) => (state) => {
+  const user = getDeepProperty(state, 'authentication.user.data', null);
+
+  if (user) {
+    return `${user.id}-${key}`;
+  }
+};
 
 export function* updateSidekick(action) {
   const { isOpen } = action.payload;
 
-  localStorage.setItem(SIDEKICK_OPEN_STORAGE, isOpen);
+  const sidekickOpenStorageWithUserId = yield select(getKeyWithUserId(SIDEKICK_OPEN_STORAGE));
 
-  yield put(
-    update({
-      isSidekickOpen: isOpen,
-    })
-  );
+  if (sidekickOpenStorageWithUserId) {
+    localStorage.setItem(sidekickOpenStorageWithUserId, isOpen);
+
+    yield put(
+      update({
+        isSidekickOpen: isOpen,
+      })
+    );
+  }
 }
 
 export function* updateActiveSidekickTab(action) {
   const { activeTab } = action.payload;
 
-  localStorage.setItem(SIDEKICK_TAB_KEY, activeTab);
+  const sidekickTabKeyWithUserId = yield select(getKeyWithUserId(SIDEKICK_TAB_KEY));
 
-  yield put(
-    update({
-      activeSidekickTabOpen: activeTab,
-    })
-  );
+  if (sidekickTabKeyWithUserId) {
+    localStorage.setItem(sidekickTabKeyWithUserId, activeTab);
+
+    yield put(
+      update({
+        activeSidekickTab: activeTab,
+      })
+    );
+  }
+}
+
+export function* syncSidekickState() {
+  const sidekickTabKeyWithUserId = yield select(getKeyWithUserId(SIDEKICK_TAB_KEY));
+  const sidekickOpenStorageWithUserId = yield select(getKeyWithUserId(SIDEKICK_OPEN_STORAGE));
+
+  if (sidekickTabKeyWithUserId && sidekickOpenStorageWithUserId) {
+    const isSidekickOpen = resolveFromLocalStorageAsBoolean(sidekickOpenStorageWithUserId);
+    const activeSidekickTab = resolveActiveTab(sidekickTabKeyWithUserId);
+
+    yield put(
+      update({
+        isSidekickOpen,
+        activeSidekickTab,
+      })
+    );
+  }
 }
 
 export function* saga() {
   yield takeLatest(SagaActionTypes.updateSidekick, updateSidekick);
   yield takeLatest(SagaActionTypes.setActiveSidekickTab, updateActiveSidekickTab);
+  yield takeLatest(SagaActionTypes.syncSidekickState, syncSidekickState);
 }

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -1,4 +1,4 @@
-import { SIDEKICK_OPEN_STORAGE } from './constants';
+import { SIDEKICK_OPEN_STORAGE, SIDEKICK_TAB_KEY } from './constants';
 import { put, takeLatest } from 'redux-saga/effects';
 import { update, SagaActionTypes } from './';
 
@@ -14,6 +14,19 @@ export function* updateSidekick(action) {
   );
 }
 
+export function* updateActiveSidekickTab(action) {
+  const { activeTab } = action.payload;
+
+  localStorage.setItem(SIDEKICK_TAB_KEY, activeTab);
+
+  yield put(
+    update({
+      activeSidekickTabOpen: activeTab,
+    })
+  );
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.updateSidekick, updateSidekick);
+  yield takeLatest(SagaActionTypes.setActiveSidekickTab, updateActiveSidekickTab);
 }

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -1,0 +1,19 @@
+import { SIDEKICK_OPEN_STORAGE } from './constants';
+import { put, takeLatest } from 'redux-saga/effects';
+import { update, SagaActionTypes } from './';
+
+export function* updateSidekick(action) {
+  const { isOpen } = action.payload;
+
+  localStorage.setItem(SIDEKICK_OPEN_STORAGE, isOpen);
+
+  yield put(
+    update({
+      isSidekickOpen: isOpen,
+    })
+  );
+}
+
+export function* saga() {
+  yield takeLatest(SagaActionTypes.updateSidekick, updateSidekick);
+}

--- a/src/store/layout/types.ts
+++ b/src/store/layout/types.ts
@@ -1,0 +1,13 @@
+export interface AppLayout {
+  hasContextPanel: boolean;
+  isContextPanelOpen: boolean;
+  isSidekickOpen: boolean;
+}
+
+export interface LayoutState {
+  value: AppLayout;
+}
+
+export interface UpdateSidekickPayload {
+  isOpen: boolean;
+}

--- a/src/store/layout/types.ts
+++ b/src/store/layout/types.ts
@@ -1,7 +1,10 @@
+import { SidekickTabs } from './../../components/sidekick/types';
+
 export interface AppLayout {
   hasContextPanel: boolean;
   isContextPanelOpen: boolean;
   isSidekickOpen: boolean;
+  activeSidekickTab: SidekickTabs;
 }
 
 export interface LayoutState {
@@ -10,4 +13,8 @@ export interface LayoutState {
 
 export interface UpdateSidekickPayload {
   isOpen: boolean;
+}
+
+export interface SetActiveSidekickTabPayload {
+  activeTab: SidekickTabs;
 }

--- a/src/store/layout/utils.test.ts
+++ b/src/store/layout/utils.test.ts
@@ -1,0 +1,31 @@
+import { SidekickTabs } from './../../components/sidekick/types';
+import { SIDEKICK_TAB_KEY } from './constants';
+import { resolveActiveTab } from './utils';
+
+describe('layout.utils', () => {
+  describe('resolveActiveTab', () => {
+    it('should use the key to get the data', () => {
+      resolveActiveTab();
+      expect(global.localStorage.getItem).toHaveBeenCalledWith(SIDEKICK_TAB_KEY);
+    });
+
+    it('returns default active tab', () => {
+      const activeTab = resolveActiveTab();
+      expect(activeTab).toEqual(SidekickTabs.MESSAGES);
+    });
+
+    it('returns stored active tab', () => {
+      global.localStorage.getItem = jest.fn().mockReturnValue('notifications');
+
+      const activeTab = resolveActiveTab();
+      expect(activeTab).toEqual(SidekickTabs.NOTIFICATIONS);
+    });
+
+    it('returns default in case stored tab is not matching any tab', () => {
+      global.localStorage.getItem = jest.fn().mockReturnValue('data here');
+
+      const activeTab = resolveActiveTab();
+      expect(activeTab).toEqual(SidekickTabs.MESSAGES);
+    });
+  });
+});

--- a/src/store/layout/utils.test.ts
+++ b/src/store/layout/utils.test.ts
@@ -1,30 +1,33 @@
 import { SidekickTabs } from './../../components/sidekick/types';
-import { SIDEKICK_TAB_KEY } from './constants';
 import { resolveActiveTab } from './utils';
 
 describe('layout.utils', () => {
   describe('resolveActiveTab', () => {
     it('should use the key to get the data', () => {
-      resolveActiveTab();
-      expect(global.localStorage.getItem).toHaveBeenCalledWith(SIDEKICK_TAB_KEY);
+      const key = 'key';
+      resolveActiveTab(key);
+      expect(global.localStorage.getItem).toHaveBeenCalledWith(key);
     });
 
     it('returns default active tab', () => {
-      const activeTab = resolveActiveTab();
+      const key = 'key';
+      const activeTab = resolveActiveTab(key);
       expect(activeTab).toEqual(SidekickTabs.MESSAGES);
     });
 
     it('returns stored active tab', () => {
+      const key = 'key';
       global.localStorage.getItem = jest.fn().mockReturnValue('notifications');
 
-      const activeTab = resolveActiveTab();
+      const activeTab = resolveActiveTab(key);
       expect(activeTab).toEqual(SidekickTabs.NOTIFICATIONS);
     });
 
     it('returns default in case stored tab is not matching any tab', () => {
+      const key = 'key';
       global.localStorage.getItem = jest.fn().mockReturnValue('data here');
 
-      const activeTab = resolveActiveTab();
+      const activeTab = resolveActiveTab(key);
       expect(activeTab).toEqual(SidekickTabs.MESSAGES);
     });
   });

--- a/src/store/layout/utils.ts
+++ b/src/store/layout/utils.ts
@@ -1,8 +1,8 @@
 import { SidekickTabs } from '../../components/sidekick/types';
-import { SIDEKICK_TAB_KEY, DEFAULT_ACTIVE_TAB } from './constants';
+import { DEFAULT_ACTIVE_TAB } from './constants';
 
-export function resolveActiveTab() {
-  const activeTab = localStorage.getItem(SIDEKICK_TAB_KEY) as SidekickTabs;
+export function resolveActiveTab(key: string) {
+  const activeTab = localStorage.getItem(key) as SidekickTabs;
 
   if (Object.values(SidekickTabs).includes(activeTab)) {
     return activeTab;

--- a/src/store/layout/utils.ts
+++ b/src/store/layout/utils.ts
@@ -1,0 +1,12 @@
+import { SidekickTabs } from '../../components/sidekick/types';
+import { SIDEKICK_TAB_KEY, DEFAULT_ACTIVE_TAB } from './constants';
+
+export function resolveActiveTab() {
+  const activeTab = localStorage.getItem(SIDEKICK_TAB_KEY) as SidekickTabs;
+
+  if (Object.values(SidekickTabs).includes(activeTab)) {
+    return activeTab;
+  }
+
+  return DEFAULT_ACTIVE_TAB;
+}

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -9,6 +9,7 @@ import { saga as channels } from './channels/saga';
 import { saga as authentication } from './authentication/saga';
 import { saga as chat } from './chat/saga';
 import { saga as theme } from './theme/saga';
+import { saga as layout } from './layout/saga';
 
 export function* rootSaga() {
   const allSagas = {
@@ -21,6 +22,7 @@ export function* rootSaga() {
     authentication,
     chat,
     theme,
+    layout,
   };
 
   yield all(


### PR DESCRIPTION
### What does this do?
- store the state of sidekick if it's open or closed.
- in case no value in the storage, we open the sidekick and we store the value.

### Why are we making this change?

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
