### PR TITLE
Fetch the next page of messages in chat

### DIFF
--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -11,7 +11,7 @@ export async function fetchMessagesByChannelId(channelId: string, lastCreatedAt?
     filter.lastCreatedAt = lastCreatedAt;
   }
 
-  const response = await get<any>(`/chatChannels/${channelId}/messages`).send(filter);
+  const response = await get<any>(`/chatChannels/${channelId}/messages`, filter);
   return response.body;
 }
 


### PR DESCRIPTION
### What does this do?

Properly fetchs the next page of chat messages when scrolling up.

### Why are we making this change?

Bug fix.

### How do I test this?

In a chat with more than 50 messages, scroll up to the top of the pane. The next set of messages should be loaded.

Note: There's a scroll position jump bug here still but this fixes the loading of more messages rather than the same 50 over and over again.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? N/A
  1. How will this affect performance? N/A
  1. Does this change any APIs? N/A
