### PR TITLE
Put the messages in the right order when fetching more

### DIFF
--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -559,7 +559,7 @@ describe('messages saga', () => {
     ]);
   });
 
-  it('appends message ids to channels state when referenceTimestamp included', async () => {
+  it('prepends message ids to channels state when referenceTimestamp included', async () => {
     const channelId = 'channel-id';
     const messageResponse = {
       hasMore: true,
@@ -596,10 +596,10 @@ describe('messages saga', () => {
       ])
       .run();
 
-    expect(channels[channelId].messages).toIncludeSameMembers([
-      'the-first-message-id',
+    expect(channels[channelId].messages).toEqual([
       'the-second-message-id',
       'the-third-message-id',
+      'the-first-message-id',
     ]);
   });
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -91,8 +91,8 @@ export function* fetch(action) {
     const existingMessages = yield select(rawMessagesSelector(channelId));
     messagesResponse = yield call(fetchMessagesByChannelId, channelId, referenceTimestamp);
     messages = [
-      ...existingMessages,
       ...messagesResponse.messages,
+      ...existingMessages,
     ];
   } else {
     messagesResponse = yield call(fetchMessagesByChannelId, channelId);


### PR DESCRIPTION
### What does this do?

When we fetch the next set of messages (i.e., scrolling) this adds the new messages to the start of the message list since we receive everything in chronological order.

### Why are we making this change?

Bug fix

### How do I test this?

Scroll up in a conversation and ensure the second page of messages correcly renders at the top of the chat and not the bottom.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? N/A
  1. How will this affect performance? N/A
  1. Does this change any APIs? N/A
