### PR TITLE
Fix import of cjs lib that causes errors in the tests

### DIFF
--- a/src/components/message-audio-recorder/index.tsx
+++ b/src/components/message-audio-recorder/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import AudioReactRecorder, { RecordState } from 'audio-react-recorder-fixed';
+import { RecordState } from 'audio-react-recorder-fixed';
 import { IconCheck, IconTrash4 } from '@zero-tech/zui/icons';
 import { IconButton } from '../icon-button';
 import { Media } from '../message-input/utils';
 
 import './styles.scss';
+
+const AudioReactRecorder = require('audio-react-recorder-fixed').default;
 
 export interface Properties {
   onMediaSelected: (file: Media) => void;
@@ -12,14 +14,14 @@ export interface Properties {
 }
 
 export interface State {
-  isMicRecording: boolean;
+  isMicRecording: RecordState;
 }
 
 export default class MessageAudioRecorder extends React.Component<Properties, State> {
   constructor(props) {
     super(props);
     this.state = {
-      isMicRecording: false,
+      isMicRecording: null,
     };
   }
 


### PR DESCRIPTION
### What does this do?

1. This changes how we import the AudioReactRecorder component.
2. Change a property type to the proper thing.

### Why are we making this change?

We're seeing these errors when running the tests:
> Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.

It's related to how the tests transpile/load the library.

### How do I test this?

* Run the tests
* Test sending an audio message

