### PR TITLE
Move notification popup to UserActions

### DIFF
--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -85,21 +85,6 @@ describe('Sidekick', () => {
     expect(setActiveSidekickTab).toHaveBeenCalledWith({ activeTab: SidekickTabs.MESSAGES });
   });
 
-  it('handle notifications tab content', () => {
-    const setActiveSidekickTab = jest.fn();
-    const wrapper = subject({ setActiveSidekickTab });
-    wrapper.find('.sidekick__tabs-notifications').simulate('click');
-
-    expect(setActiveSidekickTab).toHaveBeenCalledWith({ activeTab: SidekickTabs.NOTIFICATIONS });
-  });
-
-  it('render notifications tab content', () => {
-    const wrapper = subject({ activeTab: SidekickTabs.NOTIFICATIONS });
-    wrapper.find('.sidekick__tabs-notifications').simulate('click');
-
-    expect(wrapper.find('NotificationPopup').exists()).toBe(true);
-  });
-
   it('render messages tab content', () => {
     const wrapper = subject({ activeTab: SidekickTabs.MESSAGES });
     wrapper.find('.sidekick__tabs-messages').simulate('click');

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -17,7 +17,6 @@ import { denormalize } from '../../store/channels';
 import { SidekickTabs as Tabs } from './types';
 
 import './styles.scss';
-import { NotificationList } from '../notification';
 
 interface PublicProperties {
   className?: string;
@@ -140,11 +139,6 @@ export class Container extends React.Component<Properties, State> {
           onClick={this.clickTab.bind(this, Tabs.NETWORK)}
         />
         {this.renderMessageTab()}
-        <IconButton
-          className='sidekick__tabs-notifications'
-          icon={Icons.Notifications}
-          onClick={this.clickTab.bind(this, Tabs.NOTIFICATIONS)}
-        />
       </div>
     );
   }
@@ -159,8 +153,6 @@ export class Container extends React.Component<Properties, State> {
             <MessengerList />
           </div>
         );
-      case Tabs.NOTIFICATIONS:
-        return <NotificationList />;
       default:
         return null;
     }

--- a/src/components/sidekick/types.ts
+++ b/src/components/sidekick/types.ts
@@ -1,5 +1,4 @@
 export enum SidekickTabs {
   NETWORK = 'network',
   MESSAGES = 'messages',
-  NOTIFICATIONS = 'notifications',
 }

--- a/src/components/user-actions/index.test.tsx
+++ b/src/components/user-actions/index.test.tsx
@@ -44,4 +44,18 @@ describe('UserActions', () => {
 
     expect(wrapper.find('Avatar').prop('statusType')).toEqual('offline');
   });
+
+  it('opens and closes the notification list', () => {
+    const wrapper = subject();
+
+    wrapper.find('button').simulate('click');
+
+    expect(wrapper.find('IconBell1').prop('isFilled')).toBeTrue();
+    expect(wrapper.find('NotificationPopup').exists()).toBeTrue();
+
+    wrapper.find('button').simulate('click');
+
+    expect(wrapper.find('IconBell1').prop('isFilled')).toBeFalse();
+    expect(wrapper.find('NotificationPopup').exists()).toBeFalse();
+  });
 });

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -3,27 +3,48 @@ import React from 'react';
 import { Avatar } from '@zero-tech/zui/components';
 
 import './styles.scss';
+import { IconBell1 } from '@zero-tech/zui/icons';
+import { NotificationPopup } from '../notification/popup';
 
 export interface Properties {
   userImageUrl?: string;
   userIsOnline: boolean;
 }
 
-export class UserActions extends React.Component<Properties> {
+interface State {
+  isNotificationPopupOpen: boolean;
+}
+
+export class UserActions extends React.Component<Properties, State> {
+  state = { isNotificationPopupOpen: false };
+
   get userStatus(): 'active' | 'offline' {
     return this.props.userIsOnline ? 'active' : 'offline';
   }
 
+  toggleNotificationState = () => {
+    this.setState({ isNotificationPopupOpen: !this.state.isNotificationPopupOpen });
+  };
+
   render() {
     return (
-      <div className='user-actions'>
-        <Avatar
-          type='circle'
-          size='regular'
-          imageURL={this.props.userImageUrl}
-          statusType={this.userStatus}
-        />
-      </div>
+      <>
+        <div className='user-actions'>
+          <button
+            className='button-reset'
+            onClick={this.toggleNotificationState}
+          >
+            <IconBell1 isFilled={this.state.isNotificationPopupOpen} />
+          </button>
+          <Avatar
+            type='circle'
+            size='regular'
+            imageURL={this.props.userImageUrl}
+            statusType={this.userStatus}
+          />
+        </div>
+        {this.state.isNotificationPopupOpen && <NotificationPopup />}
+      </>
     );
   }
 }

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -1,4 +1,24 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
 .user-actions {
-  // The Avatar component doesn't restrict itself to 40px at the moment
-  width: 40px;
+  display: flex;
+  gap: 15px;
+
+  color: theme.$color-primary-transparency-11;
+
+  button {
+    border-radius: 50%;
+    height: 40px;
+    width: 40px;
+    line-height: 0px;
+    margin: 0px;
+
+    > * {
+      margin: auto; // Center the icon
+    }
+
+    &:hover {
+      background-color: theme.$color-primary-4;
+    }
+  }
 }

--- a/src/store/layout/utils.test.ts
+++ b/src/store/layout/utils.test.ts
@@ -17,10 +17,10 @@ describe('layout.utils', () => {
 
     it('returns stored active tab', () => {
       const key = 'key';
-      global.localStorage.getItem = jest.fn().mockReturnValue('notifications');
+      global.localStorage.getItem = jest.fn().mockReturnValue('messages');
 
       const activeTab = resolveActiveTab(key);
-      expect(activeTab).toEqual(SidekickTabs.NOTIFICATIONS);
+      expect(activeTab).toEqual(SidekickTabs.MESSAGES);
     });
 
     it('returns default in case stored tab is not matching any tab', () => {


### PR DESCRIPTION
### What does this do?

Moves the notification popup from the sidekick to the UserActions.

Note: This does not yet position the popup relative to the button. That will be completed after moving the Conversations panel button to the UserActions.

### Why are we making this change?

Matching design

![image](https://user-images.githubusercontent.com/43770/225770494-3a6fcf52-6367-4817-ae69-9a488faf2c3b.png)
