### PR TITLE
Fix the polarity of the isChannel flag in redux

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -208,8 +208,8 @@ describe('messenger-list', () => {
 
     test('gets sorted conversations', () => {
       const state = subject([
-        { id: 'convo-1', lastMessage: { createdAt: moment('2023-03-01').valueOf() }, isChannel: true },
-        { id: 'convo-2', lastMessage: { createdAt: moment('2023-03-02').valueOf() }, isChannel: true },
+        { id: 'convo-1', lastMessage: { createdAt: moment('2023-03-01').valueOf() }, isChannel: false },
+        { id: 'convo-2', lastMessage: { createdAt: moment('2023-03-02').valueOf() }, isChannel: false },
       ]);
 
       expect(state.directMessages.map((c) => c.id)).toEqual([
@@ -219,12 +219,10 @@ describe('messenger-list', () => {
     });
 
     test('gets only conversations', () => {
-      // Note: There's currently a bug where we're labelling channels as isChannel: false
-      // and Conversations as true.
       const state = subject([
-        { id: 'convo-1', isChannel: true },
-        { id: 'convo-2', isChannel: false },
-        { id: 'convo-3', isChannel: true },
+        { id: 'convo-1', isChannel: false },
+        { id: 'convo-2', isChannel: true },
+        { id: 'convo-3', isChannel: false },
       ]);
 
       expect(state.directMessages.map((c) => c.id)).toEqual([

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store';
-import { Channel, denormalize } from '../../../store/channels';
+import { Channel } from '../../../store/channels';
 import { setActiveMessengerId } from '../../../store/chat';
 import Tooltip from '../../tooltip';
 import { lastSeenText } from './utils';
-import { fetchDirectMessages } from '../../../store/channels-list';
+import { denormalizeConversations, fetchDirectMessages } from '../../../store/channels-list';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { compareDatesDesc } from '../../../lib/date';
 import { MemberNetworks } from '../../../store/users/types';
@@ -43,11 +43,9 @@ export class Container extends React.Component<Properties, State> {
   state = { showCreateConversation: false, userIds: [], directMessagesList: [] };
 
   static mapState(state: RootState): Partial<Properties> {
-    const messengerList = denormalize(state.channelsList.value, state)
-      .filter((messenger) => Boolean(messenger.isChannel))
-      .sort((messengerA, messengerB) =>
-        compareDatesDesc(messengerA.lastMessage?.createdAt, messengerB.lastMessage?.createdAt)
-      );
+    const messengerList = denormalizeConversations(state).sort((messengerA, messengerB) =>
+      compareDatesDesc(messengerA.lastMessage?.createdAt, messengerB.lastMessage?.createdAt)
+    );
 
     return {
       directMessages: messengerList,

--- a/src/platform-apps/channels/container.test.tsx
+++ b/src/platform-apps/channels/container.test.tsx
@@ -167,13 +167,11 @@ describe('ChannelsContainer', () => {
           ],
         },
         normalized: {
-          // Note: There's currently a bug where we're labelling channels as isChannel: false
-          // and Conversations as true.
           channels: {
-            'the-id': { id: 'the-id', name: 'the channel', isChannel: false },
-            'the-second-id': { id: 'the-second-id', name: 'the second channel', isChannel: false },
-            'the-third-id': { id: 'the-third-id', name: 'the third channel', isChannel: false },
-            'the-conversation-id': { id: 'the-conversation-id', name: 'the conversation', isChannel: true },
+            'the-id': { id: 'the-id', name: 'the channel', isChannel: true },
+            'the-second-id': { id: 'the-second-id', name: 'the second channel', isChannel: true },
+            'the-third-id': { id: 'the-third-id', name: 'the third channel', isChannel: true },
+            'the-conversation-id': { id: 'the-conversation-id', name: 'the conversation', isChannel: false },
           },
         },
       });

--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -8,7 +8,12 @@ import { Store } from 'redux';
 
 import { connectContainer } from '../../store/redux-container';
 
-import { fetch as fetchChannels, receiveUnreadCount, stopSyncChannels, denormalize } from '../../store/channels-list';
+import {
+  fetch as fetchChannels,
+  receiveUnreadCount,
+  stopSyncChannels,
+  denormalizeChannels,
+} from '../../store/channels-list';
 import { Channel } from '../../store/channels';
 
 import { ChannelList } from './channel-list';
@@ -37,7 +42,7 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
-    const channels = denormalize(state.channelsList.value, state).filter((channel) => !Boolean(channel.isChannel));
+    const channels = denormalizeChannels(state);
 
     const {
       authentication: { user },

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -28,9 +28,9 @@ export const { reducer, normalize, denormalize } = slice;
 export { fetch, receiveUnreadCount, stopSyncChannels, fetchDirectMessages, createDirectMessage };
 
 export function denormalizeChannels(state) {
-  return denormalize(state.channelsList.value, state).filter((c) => !c.isChannel);
+  return denormalize(state.channelsList.value, state).filter((c) => c.isChannel);
 }
 
 export function denormalizeConversations(state) {
-  return denormalize(state.channelsList.value, state).filter((c) => c.isChannel);
+  return denormalize(state.channelsList.value, state).filter((c) => !c.isChannel);
 }

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -26,3 +26,11 @@ const slice = createNormalizedListSlice({
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
 export { fetch, receiveUnreadCount, stopSyncChannels, fetchDirectMessages, createDirectMessage };
+
+export function denormalizeChannels(state) {
+  return denormalize(state.channelsList.value, state).filter((c) => !c.isChannel);
+}
+
+export function denormalizeConversations(state) {
+  return denormalize(state.channelsList.value, state).filter((c) => c.isChannel);
+}

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -117,6 +117,7 @@ describe('channels list saga', () => {
     const category = 'channel-category';
     const unreadCount = 1;
     const hasJoined = true;
+    const isChannel = true;
 
     const {
       storeState: { normalized },
@@ -124,7 +125,7 @@ describe('channels list saga', () => {
       .provide([
         [
           matchers.call.fn(fetchChannels),
-          [{ id, name, icon, category, unreadCount, hasJoined }],
+          [{ id, name, icon, category, unreadCount, hasJoined, isChannel }],
         ],
       ])
       .withReducer(rootReducer)
@@ -137,8 +138,11 @@ describe('channels list saga', () => {
       category,
       unreadCount,
       hasJoined,
-      isChannel: false,
+      isChannel,
       otherMembers: [],
+      groupChannelType: '',
+      lastMessage: null,
+      lastMessageCreatedAt: null,
     });
   });
 
@@ -186,9 +190,14 @@ describe('channels list saga', () => {
     expect(normalized.channels).toStrictEqual({
       [channel.id]: {
         ...channel,
+        groupChannelType: '',
+        lastMessage: null,
+        lastMessageCreatedAt: null,
       },
       [directMessage.id]: {
         ...directMessage,
+        groupChannelType: '',
+        lastMessageCreatedAt: null,
       },
     });
   });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -23,7 +23,7 @@ export function* fetch(action) {
   yield put(setStatus(AsyncListStatus.Fetching));
 
   const channels = yield call(fetchChannels, action.payload);
-  const channelsList = channels.map((currentChannel) => channelMapper(currentChannel, ChannelType.Channel));
+  const channelsList = channels.map((currentChannel) => channelMapper(currentChannel));
 
   const directMessages = yield select(rawDirectMessages());
 
@@ -41,9 +41,7 @@ export function* fetchDirectMessages() {
   const directMessages = yield call(fetchDirectMessagesApi);
   const channelsList = yield select(rawChannelsList());
 
-  const directMessagesList = directMessages.map((currentChannel) =>
-    channelMapper(currentChannel, ChannelType.DirectMessage)
-  );
+  const directMessagesList = directMessages.map((currentChannel) => channelMapper(currentChannel));
 
   yield put(
     receive([
@@ -57,7 +55,7 @@ export function* createDirectMessage(action) {
   const { userIds } = action.payload;
   const response: DirectMessage = yield call(createDirectMessageApi, userIds);
 
-  const directMessage = channelMapper(response, ChannelType.DirectMessage);
+  const directMessage = channelMapper(response);
   const existingDirectMessages = yield select(rawDirectMessages());
   const channelsList = yield select(rawChannelsList());
 
@@ -77,9 +75,9 @@ export function* unreadCountUpdated(action) {
   const channels = yield call(fetchChannels, action.payload);
   const directMessages = yield call(fetchDirectMessagesApi);
 
-  const channelsList = channels.map((channel) => channelMapper(channel, ChannelType.Channel));
+  const channelsList = channels.map((channel) => channelMapper(channel));
 
-  const directMessagesList = directMessages.map((channel) => channelMapper(channel, ChannelType.DirectMessage));
+  const directMessagesList = directMessages.map((channel) => channelMapper(channel));
 
   yield put(
     receive([

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -9,15 +9,15 @@ export function filterChannelsList(state, filter: ChannelType) {
     const channel = denormalize(channelId, state);
 
     if (filter === ChannelType.DirectMessage) {
-      return Boolean(channel.isChannel);
+      return !channel.isChannel;
     } else {
-      return !Boolean(channel.isChannel);
+      return channel.isChannel;
     }
   });
 }
 
-export const channelMapper = (currentChannel, channelType: ChannelType) => {
-  const channel: Partial<Channel> = {
+export const channelMapper = (currentChannel): Partial<Channel> => {
+  return {
     id: currentChannel.id,
     name: currentChannel.name,
     icon: currentChannel.icon,
@@ -25,21 +25,9 @@ export const channelMapper = (currentChannel, channelType: ChannelType) => {
     unreadCount: currentChannel.unreadCount,
     hasJoined: currentChannel.hasJoined,
     otherMembers: currentChannel.otherMembers || [],
+    lastMessage: currentChannel.lastMessage || null,
+    lastMessageCreatedAt: currentChannel.lastMessageCreatedAt || null,
+    isChannel: currentChannel.isChannel,
+    groupChannelType: currentChannel.groupChannelType || '',
   };
-
-  if (channelType === ChannelType.DirectMessage) {
-    channel.otherMembers = currentChannel.otherMembers || [];
-    channel.lastMessage = currentChannel.lastMessage;
-    channel.lastMessageCreatedAt = currentChannel.lastMessageAt;
-    channel.isChannel = true;
-  } else {
-    channel.otherMembers = [];
-    channel.isChannel = false;
-  }
-
-  if (currentChannel.groupChannelType) {
-    channel.groupChannelType = currentChannel.groupChannelType;
-  }
-
-  return channel;
 };


### PR DESCRIPTION
### What does this do?

This fixes the polarity of the `isChannel` flag in redux.

### Why are we making this change?

We had accidentally inverted the `isChannel` flag.

### How do I test this?

Load zOS and verify that the user's Conversations load correctly. Go to the Channels app and verify the list of Channels loads correctly.
