### PR TITLE
Add unread count to the UserActions Conversation icon

### DIFF
--- a/src/components/user-actions/container.test.tsx
+++ b/src/components/user-actions/container.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { RootState } from '../../store';
+
+import { Container, Properties } from './container';
+import { normalize } from '../../store/channels-list';
+
+describe('UserActionsContainer', () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps = {
+      userImageUrl: '',
+      userIsOnline: false,
+      isConversationListOpen: false,
+      unreadConversationMessageCount: 0,
+      updateConversationState: (_) => undefined,
+      ...props,
+    };
+
+    return shallow(<Container {...allProps} />);
+  };
+
+  it('renders UserActions', () => {
+    const wrapper = subject({
+      userImageUrl: 'image-url',
+      userIsOnline: true,
+      isConversationListOpen: true,
+      unreadConversationMessageCount: 7,
+      updateConversationState: undefined,
+    });
+
+    expect(wrapper.find('UserActions').props()).toEqual({
+      userImageUrl: 'image-url',
+      userIsOnline: true,
+      isConversationListOpen: true,
+      unreadConversationMessageCount: 7,
+      updateConversationState: undefined,
+    });
+  });
+
+  describe('mapState', () => {
+    const subject = (channels) => {
+      const channelData = normalize(channels);
+      const state = {
+        channelsList: { value: channelData.result },
+        normalized: channelData.entities,
+      } as RootState;
+      return Container.mapState(state);
+    };
+
+    test('unreadConversationMessageCount', () => {
+      const state = subject([
+        { id: 'convo-1', unreadCount: 2, isChannel: false },
+        { id: 'channel-2', unreadCount: 11, isChannel: true },
+        { id: 'convo-2', unreadCount: 5, isChannel: false },
+      ]);
+
+      expect(state.unreadConversationMessageCount).toEqual(7);
+    });
+  });
+});

--- a/src/components/user-actions/container.tsx
+++ b/src/components/user-actions/container.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { connectContainer } from '../../store/redux-container';
+import { RootState } from '../../store';
+import { denormalizeConversations } from '../../store/channels-list';
+
+import { UserActions } from '.';
+
+interface PublicProperties {
+  userImageUrl?: string;
+  userIsOnline: boolean;
+  isConversationListOpen: boolean;
+  updateConversationState: (isOpen: boolean) => void;
+}
+export interface Properties extends PublicProperties {
+  unreadConversationMessageCount: number;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    const conversations = denormalizeConversations(state);
+
+    const unreadConversationMessageCount = conversations.reduce(
+      (count, conversation) => count + conversation.unreadCount,
+      0
+    );
+
+    return {
+      unreadConversationMessageCount,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {};
+  }
+
+  render() {
+    return (
+      <>
+        <UserActions
+          userImageUrl={this.props.userImageUrl}
+          userIsOnline={this.props.userIsOnline}
+          isConversationListOpen={this.props.isConversationListOpen}
+          unreadConversationMessageCount={this.props.unreadConversationMessageCount}
+          updateConversationState={this.props.updateConversationState}
+        />
+      </>
+    );
+  }
+}
+
+export const UserActionsContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/user-actions/index.test.tsx
+++ b/src/components/user-actions/index.test.tsx
@@ -9,6 +9,7 @@ describe('UserActions', () => {
       userImageUrl: '',
       userIsOnline: false,
       isConversationListOpen: false,
+      unreadConversationMessageCount: 0,
       updateConversationState: (_) => undefined,
       ...props,
     };
@@ -89,6 +90,24 @@ describe('UserActions', () => {
     const wrapper = subject({ isConversationListOpen: true });
 
     expect(wrapper.find('IconMessageSquare2').prop('isFilled')).toBeTrue();
+  });
+
+  it('does not render the message count if it is zero', () => {
+    const wrapper = subject({ unreadConversationMessageCount: 0 });
+
+    expect(conversationButton(wrapper).find('.user-actions__badge').exists()).toBeFalse();
+  });
+
+  it('renders the message count if it is greater than 0', () => {
+    const wrapper = subject({ unreadConversationMessageCount: 7 });
+
+    expect(conversationButton(wrapper).find('.user-actions__badge').text()).toEqual('7');
+  });
+
+  it('renders the message count if it is greater than 9', () => {
+    const wrapper = subject({ unreadConversationMessageCount: 10 });
+
+    expect(conversationButton(wrapper).find('.user-actions__badge').text()).toEqual('9+');
   });
 });
 

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -10,6 +10,7 @@ export interface Properties {
   userImageUrl?: string;
   userIsOnline: boolean;
   isConversationListOpen: boolean;
+  unreadConversationMessageCount: number;
   updateConversationState: (isOpen: boolean) => void;
 }
 
@@ -22,6 +23,10 @@ export class UserActions extends React.Component<Properties, State> {
 
   get userStatus(): 'active' | 'offline' {
     return this.props.userIsOnline ? 'active' : 'offline';
+  }
+
+  get unreadConversationCount() {
+    return this.props.unreadConversationMessageCount <= 9 ? this.props.unreadConversationMessageCount : '9+';
   }
 
   toggleNotificationState = () => {
@@ -41,6 +46,9 @@ export class UserActions extends React.Component<Properties, State> {
             onClick={this.toggleConversationListState}
           >
             <IconMessageSquare2 isFilled={this.props.isConversationListOpen} />
+            {this.props.unreadConversationMessageCount > 0 && (
+              <div className='user-actions__badge'>{this.unreadConversationCount}</div>
+            )}
           </button>
           <button
             className='button-reset'

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -12,6 +12,7 @@
     width: 40px;
     line-height: 0px;
     margin: 0px;
+    position: relative;
 
     > * {
       margin: auto; // Center the icon
@@ -20,5 +21,30 @@
     &:hover {
       background-color: theme.$color-primary-4;
     }
+  }
+
+  &__badge {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    right: -1px;
+    top: -1px;
+
+    background: theme.$color-primary-10;
+    border: 1px solid theme.$color-primary-1;
+    border-radius: 50%;
+
+    color: theme.$color-primary-transparency-12;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-family: 'Roboto Mono';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 8px;
+    line-height: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
 }

--- a/src/components/wallet-manager/index.test.tsx
+++ b/src/components/wallet-manager/index.test.tsx
@@ -7,6 +7,7 @@ import { ConnectionStatus, Connectors } from '../../lib/web3';
 import { Container } from '.';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { Button as ConnectButton } from '../../components/authentication/button';
+import { UserActionsContainer } from '../user-actions/container';
 
 describe('WalletManager', () => {
   const subject = (props: any = {}) => {
@@ -49,7 +50,7 @@ describe('WalletManager', () => {
     expect(wrapper.find(Button).exists()).toBe(false);
   });
 
-  it('renders user actions address when set', () => {
+  it('renders user actions when set', () => {
     const currentAddress = '0x0000000000000000000000000000000000000001';
 
     const wrapper = subject({
@@ -60,7 +61,7 @@ describe('WalletManager', () => {
     });
     const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
 
-    expect(ifAuthenticated.find('UserActions').props()).toEqual({
+    expect(ifAuthenticated.find(UserActionsContainer).props()).toEqual({
       userImageUrl: 'image-url',
       userIsOnline: true,
       isConversationListOpen: true,

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -11,8 +11,8 @@ import { isElectron } from '../../utils';
 import { Button as ConnectButton } from '../../components/authentication/button';
 import './styles.scss';
 import { IfAuthenticated } from '../authentication/if-authenticated';
-import { UserActions } from '../user-actions';
 import { updateSidekick } from '../../store/layout';
+import { UserActionsContainer } from '../user-actions/container';
 
 interface PublicProperties {
   className?: string;
@@ -140,7 +140,7 @@ export class Container extends React.Component<Properties, State> {
               address={this.props.currentAddress}
               onClick={this.handleDisconnect}
             />
-            <UserActions
+            <UserActionsContainer
               userImageUrl={this.props.userImageUrl}
               userIsOnline={this.props.userIsOnline}
               updateConversationState={this.props.updateConversationState}


### PR DESCRIPTION
### What does this do?

Adds the unread message count to the Conversation icon

### Why are we making this change?

Design implementation

### How do I test this?

Open the app and send a message to the user from another login. Verify the unread count updates.
Note: at the moment we have a bug where you have to open a chat window first to connect to sendbird to get real time updates.
