### PR TITLE
Move wallet disconnect to a user menu

### DIFF
--- a/src/components/user-actions/container.test.tsx
+++ b/src/components/user-actions/container.test.tsx
@@ -14,7 +14,7 @@ describe('UserActionsContainer', () => {
       isConversationListOpen: false,
       unreadConversationMessageCount: 0,
       updateConversationState: (_) => undefined,
-      onDisconnect: (_) => undefined,
+      onDisconnect: () => undefined,
       ...props,
     };
 

--- a/src/components/user-actions/container.test.tsx
+++ b/src/components/user-actions/container.test.tsx
@@ -8,11 +8,13 @@ import { normalize } from '../../store/channels-list';
 describe('UserActionsContainer', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps = {
+      userAddress: '',
       userImageUrl: '',
       userIsOnline: false,
       isConversationListOpen: false,
       unreadConversationMessageCount: 0,
       updateConversationState: (_) => undefined,
+      onDisconnect: (_) => undefined,
       ...props,
     };
 
@@ -21,19 +23,23 @@ describe('UserActionsContainer', () => {
 
   it('renders UserActions', () => {
     const wrapper = subject({
+      userAddress: 'the-address',
       userImageUrl: 'image-url',
       userIsOnline: true,
       isConversationListOpen: true,
       unreadConversationMessageCount: 7,
       updateConversationState: undefined,
+      onDisconnect: undefined,
     });
 
     expect(wrapper.find('UserActions').props()).toEqual({
+      userAddress: 'the-address',
       userImageUrl: 'image-url',
       userIsOnline: true,
       isConversationListOpen: true,
       unreadConversationMessageCount: 7,
       updateConversationState: undefined,
+      onDisconnect: undefined,
     });
   });
 

--- a/src/components/user-actions/container.tsx
+++ b/src/components/user-actions/container.tsx
@@ -7,10 +7,12 @@ import { denormalizeConversations } from '../../store/channels-list';
 import { UserActions } from '.';
 
 interface PublicProperties {
+  userAddress: string;
   userImageUrl?: string;
   userIsOnline: boolean;
   isConversationListOpen: boolean;
   updateConversationState: (isOpen: boolean) => void;
+  onDisconnect: () => void;
 }
 export interface Properties extends PublicProperties {
   unreadConversationMessageCount: number;
@@ -38,11 +40,13 @@ export class Container extends React.Component<Properties> {
     return (
       <>
         <UserActions
+          userAddress={this.props.userAddress}
           userImageUrl={this.props.userImageUrl}
           userIsOnline={this.props.userIsOnline}
           isConversationListOpen={this.props.isConversationListOpen}
           unreadConversationMessageCount={this.props.unreadConversationMessageCount}
           updateConversationState={this.props.updateConversationState}
+          onDisconnect={this.props.onDisconnect}
         />
       </>
     );

--- a/src/components/user-actions/index.test.tsx
+++ b/src/components/user-actions/index.test.tsx
@@ -6,11 +6,13 @@ import { Properties, UserActions } from '.';
 describe('UserActions', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps = {
+      userAddress: '',
       userImageUrl: '',
       userIsOnline: false,
       isConversationListOpen: false,
       unreadConversationMessageCount: 0,
-      updateConversationState: (_) => undefined,
+      updateConversationState: () => undefined,
+      onDisconnect: () => undefined,
       ...props,
     };
 
@@ -109,6 +111,29 @@ describe('UserActions', () => {
 
     expect(conversationButton(wrapper).find('.user-actions__badge').text()).toEqual('9+');
   });
+
+  it('opens and closes the user menu', () => {
+    const wrapper = subject({ userAddress: 'the-address' });
+
+    userMenuButton(wrapper).simulate('click');
+
+    const popup = wrapper.find('UserMenuPopup');
+    expect(popup.prop('address')).toEqual('the-address');
+
+    userMenuButton(wrapper).simulate('click');
+
+    expect(wrapper.find('UserMenuPopup').exists()).toBeFalse();
+  });
+
+  it('disconnects user wallet', () => {
+    const onDisconnect = jest.fn();
+
+    const wrapper = subject({ onDisconnect });
+    userMenuButton(wrapper).simulate('click');
+    wrapper.find('UserMenuPopup').simulate('disconnect');
+
+    expect(onDisconnect).toHaveBeenCalledOnce();
+  });
 });
 
 function notificationButton(wrapper) {
@@ -117,4 +142,8 @@ function notificationButton(wrapper) {
 
 function conversationButton(wrapper) {
   return wrapper.find('button').at(0);
+}
+
+function userMenuButton(wrapper) {
+  return wrapper.find('button').at(2);
 }

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -78,6 +78,7 @@ export class UserActions extends React.Component<Properties, State> {
           <UserMenuPopup
             address={this.props.userAddress}
             onDisconnect={this.props.onDisconnect}
+            onAbort={this.toggleUserPopupState}
           />
         )}
       </>

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -50,7 +50,7 @@ export class UserActions extends React.Component<Properties, State> {
       <>
         <div className='user-actions'>
           <button
-            className='button-reset'
+            className='user-actions__icon-button'
             onClick={this.toggleConversationListState}
           >
             <IconMessageSquare2 isFilled={this.props.isConversationListOpen} />
@@ -59,7 +59,7 @@ export class UserActions extends React.Component<Properties, State> {
             )}
           </button>
           <button
-            className='button-reset'
+            className='user-actions__icon-button'
             onClick={this.toggleNotificationState}
           >
             <IconBell1 isFilled={this.state.isNotificationPopupOpen} />

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -5,21 +5,25 @@ import { Avatar } from '@zero-tech/zui/components';
 import './styles.scss';
 import { IconBell1, IconMessageSquare2 } from '@zero-tech/zui/icons';
 import { NotificationPopup } from '../notification/popup';
+import { UserMenuPopup } from './user-menu-popup';
 
 export interface Properties {
+  userAddress: string;
   userImageUrl?: string;
   userIsOnline: boolean;
   isConversationListOpen: boolean;
   unreadConversationMessageCount: number;
   updateConversationState: (isOpen: boolean) => void;
+  onDisconnect: () => void;
 }
 
 interface State {
   isNotificationPopupOpen: boolean;
+  isUserPopupOpen: boolean;
 }
 
 export class UserActions extends React.Component<Properties, State> {
-  state = { isNotificationPopupOpen: false };
+  state = { isNotificationPopupOpen: false, isUserPopupOpen: false };
 
   get userStatus(): 'active' | 'offline' {
     return this.props.userIsOnline ? 'active' : 'offline';
@@ -35,6 +39,10 @@ export class UserActions extends React.Component<Properties, State> {
 
   toggleConversationListState = () => {
     this.props.updateConversationState(!this.props.isConversationListOpen);
+  };
+
+  toggleUserPopupState = () => {
+    this.setState({ isUserPopupOpen: !this.state.isUserPopupOpen });
   };
 
   render() {
@@ -56,14 +64,22 @@ export class UserActions extends React.Component<Properties, State> {
           >
             <IconBell1 isFilled={this.state.isNotificationPopupOpen} />
           </button>
-          <Avatar
-            type='circle'
-            size='regular'
-            imageURL={this.props.userImageUrl}
-            statusType={this.userStatus}
-          />
+          <button onClick={this.toggleUserPopupState}>
+            <Avatar
+              type='circle'
+              size='regular'
+              imageURL={this.props.userImageUrl}
+              statusType={this.userStatus}
+            />
+          </button>
         </div>
         {this.state.isNotificationPopupOpen && <NotificationPopup />}
+        {this.state.isUserPopupOpen && (
+          <UserMenuPopup
+            address={this.props.userAddress}
+            onDisconnect={this.props.onDisconnect}
+          />
+        )}
       </>
     );
   }

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -64,7 +64,7 @@
   right: 20px;
   z-index: 500;
   background-color: theme.$color-primary-2;
-  padding: 0px 16px;
+  padding: 0px 16px 20px 16px;
 
   // Elevation 3
   box-shadow: 12px 11px 54px #040304;

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -81,4 +81,15 @@
     font-size: 16px;
     line-height: 24px;
   }
+
+  &__underlay {
+    justify-content: center;
+    position: fixed;
+    z-index: 15;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.9);
+  }
 }

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -7,9 +7,13 @@
   color: theme.$color-primary-transparency-11;
 
   button {
+    // Reset
+    cursor: pointer;
+    background: none;
+    border: none;
+    display: inline-block;
+
     border-radius: 50%;
-    height: 40px;
-    width: 40px;
     line-height: 0px;
     margin: 0px;
     position: relative;
@@ -17,6 +21,11 @@
     > * {
       margin: auto; // Center the icon
     }
+  }
+
+  &__icon-button {
+    height: 40px;
+    width: 40px;
 
     &:hover {
       background-color: theme.$color-primary-4;
@@ -59,7 +68,7 @@
 
   // Elevation 3
   box-shadow: 12px 11px 54px #040304;
-  border-radius: 16px 0px 16px 16px;
+  border-radius: 16px 16px 16px 16px;
 
   font-family: 'Inter';
 

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -48,3 +48,28 @@
     text-transform: uppercase;
   }
 }
+
+.user-menu-popup {
+  position: absolute;
+  top: 75px;
+  right: 20px;
+  z-index: 500;
+  background-color: theme.$color-primary-2;
+  padding: 0px 16px;
+
+  // Elevation 3
+  box-shadow: 12px 11px 54px #040304;
+  border-radius: 16px 0px 16px 16px;
+
+  font-family: 'Inter';
+
+  h3 {
+    color: theme.$color-white;
+    margin: 20px 0px;
+
+    font-style: normal;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 24px;
+  }
+}

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -73,7 +73,7 @@
   font-family: 'Inter';
 
   h3 {
-    color: theme.$color-white;
+    color: theme.$color-greyscale-12;
     margin: 20px 0px;
 
     font-style: normal;

--- a/src/components/user-actions/user-menu-popup.test.tsx
+++ b/src/components/user-actions/user-menu-popup.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Properties, UserMenuPopupContent } from './user-menu-popup';
+
+describe('UserActions', () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps = {
+      address: '',
+      onDisconnect: () => undefined,
+      ...props,
+    };
+
+    return shallow(<UserMenuPopupContent {...allProps} />);
+  };
+
+  it('renders user address', () => {
+    const wrapper = subject({ address: '0x1234000000000000000000000000000000009876' });
+
+    expect(wrapper.find('.user-menu-popup__address').text()).toEqual('0x1234...9876');
+  });
+
+  it('publishes disconnect', () => {
+    const onDisconnect = jest.fn();
+
+    const wrapper = subject({ onDisconnect });
+    wrapper.find('Button').simulate('press');
+
+    expect(onDisconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -35,11 +35,18 @@ export interface Properties {
 }
 
 export class UserMenuPopupContent extends React.Component<Properties> {
+  blockClick(e) {
+    e.stopPropagation();
+  }
+
   render() {
     const { address } = this.props;
 
     return (
-      <div className='user-menu-popup'>
+      <div
+        className='user-menu-popup'
+        onClick={this.blockClick}
+      >
         <h3>
           <span
             title={address}

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@zero-tech/zui/components';
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+import './styles.scss';
+
+export interface Properties {
+  address: string;
+  onDisconnect: () => void;
+}
+
+export class UserMenuPopup extends React.Component<Properties> {
+  render() {
+    return <>{createPortal(<UserMenuPopupContent {...this.props} />, document.body)}</>;
+  }
+}
+
+export class UserMenuPopupContent extends React.Component<Properties> {
+  render() {
+    const { address } = this.props;
+
+    return (
+      <div className='user-menu-popup'>
+        <h3>
+          <span
+            title={address}
+            className='user-menu-popup__address'
+          >
+            <span>{address.slice(0, 6)}</span>
+            <span>...</span>
+            <span className='eth-address__address-last-four'>{address.slice(-4)}</span>
+          </span>
+        </h3>
+        <Button
+          variant='primary'
+          onPress={this.props.onDisconnect}
+        >
+          Disconnect
+        </Button>
+      </div>
+    );
+  }
+}

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -4,13 +4,13 @@ import { createPortal } from 'react-dom';
 
 import './styles.scss';
 
-export interface Properties {
+export interface PopupProperties {
   address: string;
   onAbort: () => void;
   onDisconnect: () => void;
 }
 
-export class UserMenuPopup extends React.Component<Properties> {
+export class UserMenuPopup extends React.Component<PopupProperties> {
   render() {
     return <>{createPortal(this.renderPortal(), document.body)}</>;
   }
@@ -27,6 +27,11 @@ export class UserMenuPopup extends React.Component<Properties> {
       </>
     );
   }
+}
+
+export interface Properties {
+  address: string;
+  onDisconnect: () => void;
 }
 
 export class UserMenuPopupContent extends React.Component<Properties> {

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -6,12 +6,26 @@ import './styles.scss';
 
 export interface Properties {
   address: string;
+  onAbort: () => void;
   onDisconnect: () => void;
 }
 
 export class UserMenuPopup extends React.Component<Properties> {
   render() {
-    return <>{createPortal(<UserMenuPopupContent {...this.props} />, document.body)}</>;
+    return <>{createPortal(this.renderPortal(), document.body)}</>;
+  }
+
+  renderPortal() {
+    return (
+      <>
+        <div
+          className='user-menu-popup__underlay'
+          onClick={this.props.onAbort}
+        >
+          <UserMenuPopupContent {...this.props} />
+        </div>
+      </>
+    );
   }
 }
 

--- a/src/components/wallet-manager/index.test.tsx
+++ b/src/components/wallet-manager/index.test.tsx
@@ -61,12 +61,25 @@ describe('WalletManager', () => {
     });
     const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
 
-    expect(ifAuthenticated.find(UserActionsContainer).props()).toEqual({
-      userImageUrl: 'image-url',
-      userIsOnline: true,
-      isConversationListOpen: true,
-      updateConversationState: undefined,
-    });
+    expect(ifAuthenticated.find(UserActionsContainer).props()).toEqual(
+      expect.objectContaining({
+        userAddress: currentAddress,
+        userImageUrl: 'image-url',
+        userIsOnline: true,
+        isConversationListOpen: true,
+      })
+    );
+  });
+
+  it('calls update connector when disconnect event occurs', () => {
+    const updateConnector = jest.fn();
+    const currentAddress = '0x0000000000000000000000000000000000000001';
+
+    const wrapper = subject({ updateConnector, currentAddress });
+
+    wrapper.find(UserActionsContainer).simulate('disconnect');
+
+    expect(updateConnector).toHaveBeenCalledWith('none');
   });
 
   it('renders wallet address when set', () => {

--- a/src/components/wallet-manager/index.test.tsx
+++ b/src/components/wallet-manager/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { RootState } from '../../store';
 
-import { EthAddress, Button, WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
+import { Button, WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
 import { ConnectionStatus, Connectors } from '../../lib/web3';
 import { Container } from '.';
 import { IfAuthenticated } from '../authentication/if-authenticated';
@@ -80,24 +80,7 @@ describe('WalletManager', () => {
     wrapper.find(UserActionsContainer).simulate('disconnect');
 
     expect(updateConnector).toHaveBeenCalledWith('none');
-  });
-
-  it('renders wallet address when set', () => {
-    const currentAddress = '0x0000000000000000000000000000000000000001';
-
-    const wrapper = subject({ currentAddress });
-    const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
-
-    expect(ifAuthenticated.find(EthAddress).exists()).toBe(true);
-  });
-
-  it('does not render wallet address when not set', () => {
-    const currentAddress = '';
-
-    const wrapper = subject({ currentAddress });
-    const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: false });
-
-    expect(ifAuthenticated.find(EthAddress).exists()).toBe(false);
+    expect(wrapper.find(ConnectButton).exists()).toBe(true);
   });
 
   it('does not render wallet select modal', () => {
@@ -199,32 +182,6 @@ describe('WalletManager', () => {
     wrapper.find(WalletSelectModal).simulate('select', Connectors.Metamask);
 
     expect(updateConnector).toHaveBeenCalledWith(Connectors.Metamask);
-  });
-
-  it('calls update connector when disconnect btn clicked', () => {
-    const updateConnector = jest.fn();
-    const currentAddress = '0x0000000000000000000000000000000000000001';
-
-    const wrapper = subject({ updateConnector, currentAddress });
-
-    wrapper.find(EthAddress).simulate('click');
-
-    expect(updateConnector).toHaveBeenCalledWith('none');
-  });
-
-  it('render connect button after disconnected', () => {
-    const updateConnector = jest.fn();
-    const currentAddress = '0x0000000000000000000000000000000000000001';
-
-    const wrapper = subject({ updateConnector, currentAddress });
-
-    wrapper.find(EthAddress).simulate('click');
-
-    wrapper.setProps({
-      currentAddress: '',
-    });
-
-    expect(wrapper.find(ConnectButton).exists()).toBe(true);
   });
 
   it('passes isNotSupportedNetwork of true when network is not supported', () => {

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -141,10 +141,12 @@ export class Container extends React.Component<Properties, State> {
               onClick={this.handleDisconnect}
             />
             <UserActionsContainer
+              userAddress={this.props.currentAddress}
               userImageUrl={this.props.userImageUrl}
               userIsOnline={this.props.userIsOnline}
               updateConversationState={this.props.updateConversationState}
               isConversationListOpen={this.props.isConversationListOpen}
+              onDisconnect={this.handleDisconnect}
             />
           </div>
         </IfAuthenticated>

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -1,4 +1,4 @@
-import { EthAddress, WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
+import { WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
 import classNames from 'classnames';
 import React from 'react';
 import { config } from '../../config';
@@ -135,20 +135,14 @@ export class Container extends React.Component<Properties, State> {
     return (
       <div className={classNames('wallet-manager', this.props.className)}>
         <IfAuthenticated showChildren>
-          <div style={{ display: 'flex', gap: '25px' }}>
-            <EthAddress
-              address={this.props.currentAddress}
-              onClick={this.handleDisconnect}
-            />
-            <UserActionsContainer
-              userAddress={this.props.currentAddress}
-              userImageUrl={this.props.userImageUrl}
-              userIsOnline={this.props.userIsOnline}
-              updateConversationState={this.props.updateConversationState}
-              isConversationListOpen={this.props.isConversationListOpen}
-              onDisconnect={this.handleDisconnect}
-            />
-          </div>
+          <UserActionsContainer
+            userAddress={this.props.currentAddress}
+            userImageUrl={this.props.userImageUrl}
+            userIsOnline={this.props.userIsOnline}
+            updateConversationState={this.props.updateConversationState}
+            isConversationListOpen={this.props.isConversationListOpen}
+            onDisconnect={this.handleDisconnect}
+          />
         </IfAuthenticated>
         <IfAuthenticated hideChildren>
           <ConnectButton />


### PR DESCRIPTION
### What does this do?

Moves the wallet disconnect functionality into a popup triggered by the user avatar.

### Why are we making this change?

Design work

Note: Designs for the popup itself are still pending. This is sufficient to move the wallet address out of the header and still allow the functionality of disconnecting.

### How do I test this?

Connect a wallet. Click the user Avatar. Click Disconnect. Verify you are disconnected as before.


https://user-images.githubusercontent.com/43770/226710870-013e6ceb-8dbb-41d8-b15e-2839e0b79125.mp4

