### PR TITLE
Render UserAction popups relative to the right nodes

### DIFF
--- a/src/components/notification/popup/index.tsx
+++ b/src/components/notification/popup/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { createPortal } from 'react-dom';
 
 import { NotificationListContainer } from '../list/container';
 
@@ -9,7 +8,7 @@ export interface Properties {}
 
 export class NotificationPopup extends React.Component<Properties> {
   render() {
-    return <>{createPortal(this.renderPopup(), document.body)}</>;
+    return this.renderPopup();
   }
 
   renderPopup() {

--- a/src/components/user-actions/index.test.tsx
+++ b/src/components/user-actions/index.test.tsx
@@ -119,10 +119,11 @@ describe('UserActions', () => {
 
     const popup = wrapper.find('UserMenuPopup');
     expect(popup.prop('address')).toEqual('the-address');
+    expect(popup.prop('isOpen')).toBeTrue();
 
     userMenuButton(wrapper).simulate('click');
 
-    expect(wrapper.find('UserMenuPopup').exists()).toBeFalse();
+    expect(wrapper.find('UserMenuPopup').prop('isOpen')).toBeFalse();
   });
 
   it('disconnects user wallet', () => {

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -74,13 +74,12 @@ export class UserActions extends React.Component<Properties, State> {
           </button>
         </div>
         {this.state.isNotificationPopupOpen && <NotificationPopup />}
-        {this.state.isUserPopupOpen && (
-          <UserMenuPopup
-            address={this.props.userAddress}
-            onDisconnect={this.props.onDisconnect}
-            onAbort={this.toggleUserPopupState}
-          />
-        )}
+        <UserMenuPopup
+          address={this.props.userAddress}
+          onDisconnect={this.props.onDisconnect}
+          onAbort={this.toggleUserPopupState}
+          isOpen={this.state.isUserPopupOpen}
+        />
       </>
     );
   }

--- a/src/components/user-actions/styles.scss
+++ b/src/components/user-actions/styles.scss
@@ -59,10 +59,6 @@
 }
 
 .user-menu-popup {
-  position: absolute;
-  top: 75px;
-  right: 20px;
-  z-index: 500;
   background-color: theme.$color-primary-2;
   padding: 0px 16px 20px 16px;
 
@@ -74,7 +70,8 @@
 
   h3 {
     color: theme.$color-greyscale-12;
-    margin: 20px 0px;
+    margin: 0px;
+    padding: 20px 0px;
 
     font-style: normal;
     font-weight: 700;
@@ -91,5 +88,9 @@
     width: 100vw;
     height: 100vh;
     background: rgba(0, 0, 0, 0.9);
+  }
+
+  &__content {
+    position: absolute;
   }
 }

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -6,23 +6,50 @@ import './styles.scss';
 
 export interface PopupProperties {
   address: string;
+  isOpen: boolean;
   onAbort: () => void;
   onDisconnect: () => void;
 }
 
 export class UserMenuPopup extends React.Component<PopupProperties> {
+  ref: HTMLDivElement = null;
+
+  blockClick(e) {
+    e.stopPropagation();
+  }
+
+  setPositionRef = (el) => {
+    this.ref = el;
+  };
+
   render() {
-    return <>{createPortal(this.renderPortal(), document.body)}</>;
+    return (
+      <>
+        <div ref={this.setPositionRef}></div>
+        {createPortal(this.renderPortal(), document.body)}
+      </>
+    );
   }
 
   renderPortal() {
+    if (!this.ref || !this.props.isOpen) {
+      return null;
+    }
+    const { x, y } = this.ref.getBoundingClientRect();
+
     return (
       <>
         <div
           className='user-menu-popup__underlay'
           onClick={this.props.onAbort}
         >
-          <UserMenuPopupContent {...this.props} />
+          <div
+            className='user-menu-popup__content'
+            style={{ top: y, left: x }}
+            onClick={this.blockClick}
+          >
+            <UserMenuPopupContent {...this.props} />
+          </div>
         </div>
       </>
     );
@@ -35,18 +62,11 @@ export interface Properties {
 }
 
 export class UserMenuPopupContent extends React.Component<Properties> {
-  blockClick(e) {
-    e.stopPropagation();
-  }
-
   render() {
     const { address } = this.props;
 
     return (
-      <div
-        className='user-menu-popup'
-        onClick={this.blockClick}
-      >
+      <div className='user-menu-popup'>
         <h3>
           <span
             title={address}


### PR DESCRIPTION
### What does this do?

Fixes the Notification popup and UserMenu popup to render relative to the activation nodes

### Why are we making this change?

Match design better

### How do I test this?

Click the Notification icon with the conversations open and closed. Verify the popup is relative to the notification icon.
Click the User Avatar with the Conversations open and closed. Verify again.


Notifications w/ conversation open:
![image](https://user-images.githubusercontent.com/43770/226726335-62b852d2-7f50-44f3-aa73-57eeb25f4603.png)

Notifications w/ conversations closed:
![image](https://user-images.githubusercontent.com/43770/226726485-89e6baa8-da4f-4b7a-979e-4720d8881ca0.png)

User Menu w/ conversations open:
![image](https://user-images.githubusercontent.com/43770/226726565-e8135f90-492c-48f4-bb63-00dc02481539.png)

User Menu w/ conversations closed:
![image](https://user-images.githubusercontent.com/43770/226726635-f8ed5878-8064-479e-b625-c9dfcd04c291.png)
