### PR TITLE
Render notification count in UserActions

### DIFF
--- a/src/components/notification/list/container.tsx
+++ b/src/components/notification/list/container.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store';
-import { fetch as fetchNotifications, denormalize } from '../../../store/notifications';
+import { fetch as fetchNotifications, denormalizeNotifications } from '../../../store/notifications';
 import { denormalize as denormalizeChannel } from '../../../store/channels';
 
 import { NotificationList } from '.';
@@ -18,7 +18,7 @@ export class Container extends React.Component<Properties> {
     const {
       authentication: { user },
     } = state;
-    const notifications = denormalize(state.notificationsList.value, state)
+    const notifications = denormalizeNotifications(state)
       .map((n) => Container.mapNotification(n, state))
       .filter((n) => !!n);
 

--- a/src/components/user-actions/container.tsx
+++ b/src/components/user-actions/container.tsx
@@ -5,6 +5,7 @@ import { RootState } from '../../store';
 import { denormalizeConversations } from '../../store/channels-list';
 
 import { UserActions } from '.';
+import { denormalizeNotifications } from '../../store/notifications';
 
 interface PublicProperties {
   userAddress: string;
@@ -16,6 +17,7 @@ interface PublicProperties {
 }
 export interface Properties extends PublicProperties {
   unreadConversationMessageCount: number;
+  unreadNotificationCount: number;
 }
 
 export class Container extends React.Component<Properties> {
@@ -27,8 +29,11 @@ export class Container extends React.Component<Properties> {
       0
     );
 
+    const unreadNotificationCount = denormalizeNotifications(state).filter((n) => n.isUnread).length;
+
     return {
       unreadConversationMessageCount,
+      unreadNotificationCount,
     };
   }
 
@@ -45,6 +50,7 @@ export class Container extends React.Component<Properties> {
           userIsOnline={this.props.userIsOnline}
           isConversationListOpen={this.props.isConversationListOpen}
           unreadConversationMessageCount={this.props.unreadConversationMessageCount}
+          unreadNotificationCount={this.props.unreadNotificationCount}
           updateConversationState={this.props.updateConversationState}
           onDisconnect={this.props.onDisconnect}
         />

--- a/src/components/user-actions/index.test.tsx
+++ b/src/components/user-actions/index.test.tsx
@@ -11,6 +11,7 @@ describe('UserActions', () => {
       userIsOnline: false,
       isConversationListOpen: false,
       unreadConversationMessageCount: 0,
+      unreadNotificationCount: 0,
       updateConversationState: () => undefined,
       onDisconnect: () => undefined,
       ...props,
@@ -62,6 +63,24 @@ describe('UserActions', () => {
 
     expect(wrapper.find('IconBell1').prop('isFilled')).toBeFalse();
     expect(wrapper.find('NotificationPopup').exists()).toBeFalse();
+  });
+
+  it('does not render the notification count if it is zero', () => {
+    const wrapper = subject({ unreadNotificationCount: 0 });
+
+    expect(notificationButton(wrapper).find('.user-actions__badge').exists()).toBeFalse();
+  });
+
+  it('renders the notification count if it is greater than 0', () => {
+    const wrapper = subject({ unreadNotificationCount: 7 });
+
+    expect(notificationButton(wrapper).find('.user-actions__badge').text()).toEqual('7');
+  });
+
+  it('renders the notification count if it is greater than 9', () => {
+    const wrapper = subject({ unreadNotificationCount: 10 });
+
+    expect(notificationButton(wrapper).find('.user-actions__badge').text()).toEqual('9+');
   });
 
   it('opens the conversation list', () => {

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -13,6 +13,7 @@ export interface Properties {
   userIsOnline: boolean;
   isConversationListOpen: boolean;
   unreadConversationMessageCount: number;
+  unreadNotificationCount: number;
   updateConversationState: (isOpen: boolean) => void;
   onDisconnect: () => void;
 }
@@ -31,6 +32,10 @@ export class UserActions extends React.Component<Properties, State> {
 
   get unreadConversationCount() {
     return this.props.unreadConversationMessageCount <= 9 ? this.props.unreadConversationMessageCount : '9+';
+  }
+
+  get unreadNotificationCount() {
+    return this.props.unreadNotificationCount <= 9 ? this.props.unreadNotificationCount : '9+';
   }
 
   toggleNotificationState = () => {
@@ -63,6 +68,9 @@ export class UserActions extends React.Component<Properties, State> {
             onClick={this.toggleNotificationState}
           >
             <IconBell1 isFilled={this.state.isNotificationPopupOpen} />
+            {this.props.unreadNotificationCount > 0 && (
+              <div className='user-actions__badge'>{this.unreadNotificationCount}</div>
+            )}
           </button>
           <button onClick={this.toggleUserPopupState}>
             <Avatar

--- a/src/store/notifications/index.ts
+++ b/src/store/notifications/index.ts
@@ -21,6 +21,15 @@ const listSlice = createNormalizedListSlice({
 });
 
 export const { receiveNormalized, setStatus, receive } = listSlice.actions;
-export const { reducer, normalize, denormalize } = listSlice;
+export const { reducer, normalize } = listSlice;
 
 export { fetch };
+
+const relevantNotificationTypes = ['chat_channel_mention'];
+export function denormalizeNotifications(state) {
+  const result = listSlice
+    .denormalize(state.notificationsList.value, state)
+    .filter((n) => relevantNotificationTypes.includes(n.notificationType));
+
+  return result;
+}


### PR DESCRIPTION
### What does this do?

Adds the count to the notification icon in the UserActions.

Note: This will only update when you open the notification list at the moment. Live updating to come in a future PR.

### Why are we making this change?

So the user can see how many unread notifications they have.

### How do I test this?

Create a `chat_channel_mention` notification. Open the Notification list. Confirm the unread count shows up by the icon.
