### PR TITLE
Fix the Notifcation popup title color

### DIFF
--- a/src/components/notification/popup/style.scss
+++ b/src/components/notification/popup/style.scss
@@ -16,7 +16,7 @@
   font-family: 'Inter';
 
   h3 {
-    color: theme.$color-white;
+    color: theme.$color-greyscale-12;
     margin: 20px 0px;
 
     font-style: normal;


### PR DESCRIPTION
### What does this do?

Uses a proper theme based color for the Notifications heading in the popup

### Why are we making this change?

So we can see the title in light mode!

### How do I test this?

Open the notifications popup, switch themes, verify the title changes color appropriately.

