### PR TITLE
Resolve: 'Warning: Setting defaultProps...' warning

### DIFF
--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Container, Properties } from './container';

--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Container, Properties } from './container';
@@ -29,7 +25,6 @@ describe('AppSandboxContainer', () => {
       layout: {} as AppLayout,
       updateLayout: () => undefined,
       isAuthenticated: false,
-      document: null,
       ...props,
     };
 

--- a/src/app-sandbox/container.tsx
+++ b/src/app-sandbox/container.tsx
@@ -32,7 +32,6 @@ export interface Properties extends PublicProperties {
   layout: AppLayout;
   updateLayout: (layout: Partial<AppLayout>) => void;
   isAuthenticated: boolean;
-  document?: Document;
 }
 
 interface State {
@@ -41,10 +40,6 @@ interface State {
 }
 
 export class Container extends React.Component<Properties, State> {
-  static defaultProps = {
-    document,
-  };
-
   static mapState(state: RootState): Partial<Properties> {
     const {
       layout,
@@ -82,11 +77,6 @@ export class Container extends React.Component<Properties, State> {
         hasConnected: true,
         web3Provider: this.props.providerService.get(),
       });
-    }
-
-    // reset background color from the body tag
-    if (this.props.document) {
-      document.body.style.backgroundColor = '';
     }
   }
 

--- a/src/app-sandbox/container.tsx
+++ b/src/app-sandbox/container.tsx
@@ -41,7 +41,7 @@ interface State {
 }
 
 export class Container extends React.Component<Properties, State> {
-  defaultProps = {
+  static defaultProps = {
     document,
   };
 


### PR DESCRIPTION
Removes console warning: 'Warning: Setting defaultProps as an instance property on Container is not supported and will be ignored. Instead, define defaultProps as a static property on Container.'

![Screen Shot 2023-03-22 at 2 00 24 PM](https://user-images.githubusercontent.com/31045/226996278-643d41df-9b7c-4c32-8935-4a9576554bba.png)
