### PR TITLE
Resolved an issue where the public channels did not load for anonymous users

### DIFF
--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -154,7 +154,7 @@ describe('channels list saga', () => {
       category: 'channel-category',
       unreadCount: 1,
       hasJoined: true,
-      isChannel: false,
+      isChannel: true,
       otherMembers: [],
     };
 
@@ -165,7 +165,7 @@ describe('channels list saga', () => {
       category: 'dm',
       unreadCount: 1,
       hasJoined: true,
-      isChannel: true,
+      isChannel: false,
       otherMembers: [],
       lastMessage: {},
       lastMessageCreatedAt: undefined,

--- a/src/store/channels-list/utils.test.ts
+++ b/src/store/channels-list/utils.test.ts
@@ -1,0 +1,33 @@
+import { channelMapper } from './utils';
+
+describe('channelMapper', () => {
+  it('isChannel from Anonymous view', async function () {
+    const channel = {
+      isChannel: undefined,
+    };
+
+    const result = channelMapper(channel as any);
+
+    expect(result).toMatchObject({ isChannel: true });
+  });
+
+  it('isChannel true from Authenticated view', async function () {
+    const channel = {
+      isChannel: true,
+    };
+
+    const result = channelMapper(channel as any);
+
+    expect(result).toMatchObject({ isChannel: true });
+  });
+
+  it('isChannel false from Authenticated view', async function () {
+    const channel = {
+      isChannel: false,
+    };
+
+    const result = channelMapper(channel as any);
+
+    expect(result).toMatchObject({ isChannel: false });
+  });
+});

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -27,7 +27,7 @@ export const channelMapper = (currentChannel): Partial<Channel> => {
     otherMembers: currentChannel.otherMembers || [],
     lastMessage: currentChannel.lastMessage || null,
     lastMessageCreatedAt: currentChannel.lastMessageCreatedAt || null,
-    isChannel: currentChannel.isChannel,
+    isChannel: currentChannel.isChannel === undefined ? true : currentChannel.isChannel,
     groupChannelType: currentChannel.groupChannelType || '',
   };
 };


### PR DESCRIPTION
### What does this do?

Allows public channels to load for anonymous users.

### Why are we making this change?

When public channels are fetched from our API they don't have an `isChannel` property, but we use the `isChannel` property within zOS to delineate between Messenger Conversations and Channels. This resulted in our Public Channels being treated as Messenger Conversations.

### How do I test this?

View zOS as a Disconnected Anonymous user, force a cache refresh, verify that the public channels are loaded.

### Screen capture
<img width="1648" alt="Screen Shot 2023-03-22 at 8 14 16 PM" src="https://user-images.githubusercontent.com/31045/227066771-3e1b2bfd-2d75-43b4-9352-58b5ab2eb2a2.png">
