### PR TITLE
Create user based initialization saga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "enzyme": "^3.11.0",
         "husky": "^8.0.1",
         "jest-extended": "^1.2.0",
+        "jest-when": "^3.5.2",
         "prettier": "^2.7.1",
         "prettier-plugin-multiline-arrays": "^1.0.0",
         "pretty-quick": "^3.1.3",
@@ -22936,6 +22937,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-4rDvnhaWh08RcPsoEVXgxRnUIE9wVIbZtGqZ5x2Wm9Ziz9aQs89PipQFmOK0ycbEhVAgiV3MUeTXp3Ar4s2FcQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
       }
     },
     "node_modules/jest-worker": {
@@ -50416,6 +50426,13 @@
           }
         }
       }
+    },
+    "jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-4rDvnhaWh08RcPsoEVXgxRnUIE9wVIbZtGqZ5x2Wm9Ziz9aQs89PipQFmOK0ycbEhVAgiV3MUeTXp3Ar4s2FcQ==",
+      "dev": true,
+      "requires": {}
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "enzyme": "^3.11.0",
     "husky": "^8.0.1",
     "jest-extended": "^1.2.0",
+    "jest-when": "^3.5.2",
     "prettier": "^2.7.1",
     "prettier-plugin-multiline-arrays": "^1.0.0",
     "pretty-quick": "^3.1.3",

--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -1,29 +1,21 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Container } from '.';
+import { Container, Properties } from '.';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { MessengerList } from '../messenger/list';
 
 describe('Sidekick', () => {
-  const subject = (props: any = {}) => {
+  const subject = (props: Partial<Properties> = {}) => {
     const allProps = {
       className: '',
-      updateSidekick: jest.fn(),
-      setActiveSidekickTab: jest.fn(),
-      syncSidekickState: jest.fn(),
+      isOpen: false,
+      closeConversations: () => null,
       ...props,
     };
 
     return shallow(<Container {...allProps} />);
   };
-
-  it('sync state', () => {
-    const syncSidekickState = jest.fn();
-    subject({ syncSidekickState });
-
-    expect(syncSidekickState).toHaveBeenCalled();
-  });
 
   it('adds className', () => {
     const wrapper = subject({ className: 'todo' });

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -3,7 +3,7 @@ import { RootState } from '../../store';
 import { connectContainer } from '../../store/redux-container';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import classNames from 'classnames';
-import { syncSidekickState, updateSidekick } from '../../store/layout';
+import { updateSidekick } from '../../store/layout';
 import { MessengerList } from '../messenger/list';
 
 import './styles.scss';
@@ -13,7 +13,6 @@ interface PublicProperties {
 }
 
 export interface Properties extends PublicProperties {
-  syncSidekickState: () => void;
   closeConversations: () => void;
   isOpen: boolean;
 }
@@ -31,13 +30,8 @@ export class Container extends React.Component<Properties> {
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
-      syncSidekickState,
       closeConversations: () => updateSidekick({ isOpen: false }),
     };
-  }
-
-  componentDidMount() {
-    this.props.syncSidekickState();
   }
 
   get isOpen() {

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -39,11 +39,11 @@ export class Container extends React.Component<Properties, State> {
   static mapState(state: RootState): Partial<Properties> {
     const {
       web3: { status, value, isWalletModalOpen },
-      authentication: {
-        user: { data: userData },
-      },
+      authentication: { user },
       layout,
     } = state;
+
+    const userData = user?.data;
 
     return {
       currentConnector: value.connector,

--- a/src/lib/storage/index.test.ts
+++ b/src/lib/storage/index.test.ts
@@ -1,31 +1,46 @@
+import { when } from 'jest-when';
+
 import { resolveFromLocalStorageAsBoolean } from './';
 
 describe('storage', () => {
   describe('resolveFromLocalStorage', () => {
-    it('should use the key to get the data', () => {
-      const storageKey = 'key-store';
+    it('returns defaultValue when no data exists', () => {
+      stubLocalStorageValue('key', null);
 
-      resolveFromLocalStorageAsBoolean(storageKey);
-      expect(global.localStorage.getItem).toHaveBeenCalledWith(storageKey);
+      let value = resolveFromLocalStorageAsBoolean('key', true);
+      expect(value).toBeTrue();
+
+      value = resolveFromLocalStorageAsBoolean('key', false);
+      expect(value).toBeFalse();
     });
 
-    it('returns false in case no data is saved', () => {
-      const value = resolveFromLocalStorageAsBoolean('key');
-      expect(value).toEqual(false);
+    it('returns defaultValue if data is bad', () => {
+      stubLocalStorageValue('key', 'garbage');
+
+      let value = resolveFromLocalStorageAsBoolean('key', true);
+      expect(value).toBeTrue();
+
+      value = resolveFromLocalStorageAsBoolean('key', false);
+      expect(value).toBeFalse();
     });
 
-    it('returns false', () => {
-      global.localStorage.getItem = jest.fn().mockReturnValue('data hjere');
+    it('returns true if value is "true"', () => {
+      stubLocalStorageValue('key', 'true');
 
-      const value = resolveFromLocalStorageAsBoolean('key');
-      expect(value).toEqual(false);
+      const value = resolveFromLocalStorageAsBoolean('key', true);
+      expect(value).toBeTrue();
     });
 
-    it('returns true', () => {
-      global.localStorage.getItem = jest.fn().mockReturnValue('true');
+    it('returns false if value is "false"', () => {
+      stubLocalStorageValue('key', 'false');
 
-      const value = resolveFromLocalStorageAsBoolean('key');
-      expect(value).toEqual(true);
+      const value = resolveFromLocalStorageAsBoolean('key', true);
+      expect(value).toBeFalse();
     });
   });
 });
+
+function stubLocalStorageValue(key: string, value: string | null) {
+  global.localStorage.getItem = jest.fn();
+  when(global.localStorage.getItem).calledWith(key).mockReturnValue(value);
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,5 +1,11 @@
-export function resolveFromLocalStorageAsBoolean(key) {
+export function resolveFromLocalStorageAsBoolean(key: string, defaultValue: boolean) {
   const value = localStorage.getItem(key);
 
-  return value === null || value === 'true';
+  if (value === 'false') {
+    return false;
+  } else if (value === 'true') {
+    return true;
+  }
+
+  return defaultValue;
 }

--- a/src/store/authentication/index.ts
+++ b/src/store/authentication/index.ts
@@ -12,7 +12,7 @@ const clearSession = createAction<Payload>(SagaActionTypes.ClearSession);
 const fetchCurrentUserWithChatAccessToken = createAction<Payload>(SagaActionTypes.FetchCurrentUserWithChatAccessToken);
 
 const initialState: AuthenticationState = {
-  user: null,
+  user: { data: null },
   loading: false,
 };
 

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -87,10 +87,6 @@ function* setUserAndChatAccessToken(params: {
 }
 
 export function* initializeUserState(user: User) {
-  if (!user?.id) {
-    return;
-  }
-
   yield initializeUserLayout(user);
 }
 

--- a/src/store/layout/index.ts
+++ b/src/store/layout/index.ts
@@ -3,11 +3,9 @@ import type { AppLayout, LayoutState, UpdateSidekickPayload } from './types';
 
 export enum SagaActionTypes {
   updateSidekick = 'layout/saga/updateSidekick',
-  syncSidekickState = 'layout/saga/syncSidekickState',
 }
 
 export const updateSidekick = createAction<UpdateSidekickPayload>(SagaActionTypes.updateSidekick);
-export const syncSidekickState = createAction(SagaActionTypes.syncSidekickState);
 
 const initialState: LayoutState = {
   value: {

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -3,14 +3,19 @@ import { SIDEKICK_OPEN_STORAGE } from './constants';
 import { put, takeLatest, select } from 'redux-saga/effects';
 import { update, SagaActionTypes } from './';
 import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
+import { User } from '../authentication/types';
 
 export const getKeyWithUserId = (key: string) => (state) => {
-  const user = getDeepProperty(state, 'authentication.user.data', null);
+  const user: User = getDeepProperty(state, 'authentication.user.data', null);
 
   if (user) {
-    return `${user.id}-${key}`;
+    return keyForUser(user.id, key);
   }
 };
+
+function keyForUser(id: string, key: string) {
+  return `${id}-${key}`;
+}
 
 export function* updateSidekick(action) {
   const { isOpen } = action.payload;
@@ -28,21 +33,24 @@ export function* updateSidekick(action) {
   }
 }
 
-export function* syncSidekickState() {
-  const sidekickOpenStorageWithUserId = yield select(getKeyWithUserId(SIDEKICK_OPEN_STORAGE));
+export function* initializeUserLayout(user: { id: string }) {
+  const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE));
 
-  if (sidekickOpenStorageWithUserId) {
-    const isSidekickOpen = resolveFromLocalStorageAsBoolean(sidekickOpenStorageWithUserId);
+  yield put(
+    update({
+      isSidekickOpen,
+    })
+  );
+}
 
-    yield put(
-      update({
-        isSidekickOpen,
-      })
-    );
-  }
+export function* clearUserLayout() {
+  yield put(
+    update({
+      isSidekickOpen: false,
+    })
+  );
 }
 
 export function* saga() {
   yield takeLatest(SagaActionTypes.updateSidekick, updateSidekick);
-  yield takeLatest(SagaActionTypes.syncSidekickState, syncSidekickState);
 }

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -34,7 +34,7 @@ export function* updateSidekick(action) {
 }
 
 export function* initializeUserLayout(user: { id: string }) {
-  const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE));
+  const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE), true);
 
   yield put(
     update({


### PR DESCRIPTION
### What does this do?

Moves the code that was initializing the remembered user sidekick state into an initialize saga.

### Why are we making this change?

This felt a little cleaner to set the global state rather than having components try to initialize themselves directly.

### How do I test this?

Log in as a user, open the sidekick. Log out. Log in as the same user again and verify the sidekick opens.
