### PR TITLE
Reduce the size of link preview 

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -358,6 +358,7 @@ $scrollbar-width: 5px;
             display: flex;
             flex-direction: row;
             align-items: self-start;
+            max-width: 85%;
           }
         }
 


### PR DESCRIPTION
### What does this do?

Reduces the size of the link preview so that the 'X' icon is visible in a DM with link preview. Previously it was being overlapped.

Before:
<img width="456" alt="image" src="https://user-images.githubusercontent.com/33264364/227357300-c77cb203-8bae-47a3-96b2-15159675132f.png">


After:
<img width="490" alt="image" src="https://user-images.githubusercontent.com/33264364/227356985-34eaf113-8871-4c7a-8b10-6a049acfb564.png">

