### PR TITLE
Add custom matcher toHaveElement

### DIFF
--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -26,25 +26,25 @@ describe('Main', () => {
   it('renders wallet manager container', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(WalletManager).exists()).toBe(true);
+    expect(wrapper).toHaveElement(WalletManager);
   });
 
   it('renders view mode toggle', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(ViewModeToggle).exists()).toBe(true);
+    expect(wrapper).toHaveElement(ViewModeToggle);
   });
 
   it('renders theme engine', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(ThemeEngine).exists()).toBe(true);
+    expect(wrapper).toHaveElement(ThemeEngine);
   });
 
   it('renders address bar container', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(AddressBarContainer).exists()).toBe(true);
+    expect(wrapper).toHaveElement(AddressBarContainer);
   });
 
   it('does not set layout classes when values are false', () => {
@@ -74,7 +74,7 @@ describe('Main', () => {
   it('renders direct message chat component', () => {
     const wrapper = subject({ context: { isAuthenticated: true } });
 
-    expect(wrapper.find(MessengerChat).exists()).toBe(true);
+    expect(wrapper).toHaveElement(MessengerChat);
   });
 
   describe('mapState', () => {

--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -1,0 +1,22 @@
+/// <reference types="jest" />
+
+interface ZOSCustomMatchers<R> extends Record<string, any> {
+  toHaveElement<P2>(statelessComponent: FunctionComponent<P2>): ShallowWrapper<P2, never>;
+  toHaveElement<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
+  toHaveElement<C2 extends Component>(
+    componentClass: ComponentClass<C2['props']>
+  ): ShallowWrapper<C2['props'], C2['state'], C2>;
+  toHaveElement(props: EnzymePropSelector): ShallowWrapper<any, any>;
+  toHaveElement(selector: string): R;
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R = void, _T = {}> extends ZOSCustomMatchers<R> {}
+  }
+}
+
+// Not entirely sure why we need to export something but I've found VSCode
+// couldn't autocomplete without this.
+declare const matchers: ZOSCustomMatchers<void>;
+export default matchers;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,3 +14,13 @@ const localStorageMock = {
 };
 
 global.localStorage = localStorageMock;
+
+expect.extend({
+  toHaveElement(actual, finder) {
+    const pass = actual.find(finder).exists();
+    return {
+      pass,
+      message: pass ? () => `expected node [${finder}] not to exist` : () => `expected node [${finder}] to exist`,
+    };
+  },
+});


### PR DESCRIPTION
### What does this do?

Adds a custom matcher `toHaveElement`. Usage:
```ts
// Previous
expect(wrapper.find(MessengerChat).exists()).toBeTrue();

// Now
expect(wrapper).toHaveElement(MessengerChat);

```

### Why are we making this change?

Makes the tests read slightly nicer

