### PR TITLE
Refactor: Split message list into separate components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       },
       "devDependencies": {
         "@types/enzyme": "^3.10.10",
+        "@types/jest-when": "^3.5.2",
         "@types/react-portal": "^4.0.4",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
         "concurrently": "^7.1.0",
@@ -7406,6 +7407,15 @@
       "license": "MIT",
       "dependencies": {
         "jest-diff": "^24.3.0"
+      }
+    },
+    "node_modules/@types/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-1WP+wJDW7h4TYAVLoIebxRIVv8GPk66Qsq2nU7PkwKZ6usurnDQZgk0DfBNKAJ9gVzapCXSV53Vn/3nBHBNzAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
       }
     },
     "node_modules/@types/jest/node_modules/@jest/types": {
@@ -39747,6 +39757,15 @@
             "react-is": "^16.8.4"
           }
         }
+      }
+    },
+    "@types/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-1WP+wJDW7h4TYAVLoIebxRIVv8GPk66Qsq2nU7PkwKZ6usurnDQZgk0DfBNKAJ9gVzapCXSV53Vn/3nBHBNzAw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
       }
     },
     "@types/js-cookie": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.10",
+    "@types/jest-when": "^3.5.2",
     "@types/react-portal": "^4.0.4",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
     "concurrently": "^7.1.0",

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -26,25 +26,25 @@ describe('Main', () => {
   it('renders wallet manager container', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(WalletManager).exists()).toBe(true);
+    expect(wrapper).toHaveElement(WalletManager);
   });
 
   it('renders view mode toggle', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(ViewModeToggle).exists()).toBe(true);
+    expect(wrapper).toHaveElement(ViewModeToggle);
   });
 
   it('renders theme engine', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(ThemeEngine).exists()).toBe(true);
+    expect(wrapper).toHaveElement(ThemeEngine);
   });
 
   it('renders address bar container', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(AddressBarContainer).exists()).toBe(true);
+    expect(wrapper).toHaveElement(AddressBarContainer);
   });
 
   it('does not set layout classes when values are false', () => {
@@ -74,7 +74,7 @@ describe('Main', () => {
   it('renders direct message chat component', () => {
     const wrapper = subject({ context: { isAuthenticated: true } });
 
-    expect(wrapper.find(MessengerChat).exists()).toBe(true);
+    expect(wrapper).toHaveElement(MessengerChat);
   });
 
   describe('mapState', () => {

--- a/src/components/messenger/autocomplete-members/__mocks__/index.tsx
+++ b/src/components/messenger/autocomplete-members/__mocks__/index.tsx
@@ -1,0 +1,3 @@
+export function AutocompleteMembers() {
+  return <></>;
+}

--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -45,16 +45,6 @@ describe('autocomplete-members', () => {
     expect(wrapper.find('.autocomplete-members__search-results').exists()).toBeFalse();
   });
 
-  it('renders empty result message', async () => {
-    const search = jest.fn();
-    when(search).mockResolvedValue([]);
-    const wrapper = subject({ search });
-
-    await searchFor(wrapper, 'name');
-
-    expect(wrapper.find('.autocomplete-members__empty-results').exists()).toBeTrue();
-  });
-
   it('fires onSelect when result is clicked', async () => {
     const search = jest.fn();
     when(search).mockResolvedValue([
@@ -68,7 +58,7 @@ describe('autocomplete-members', () => {
       .find('.autocomplete-members__search-results > div')
       .simulate('click', { currentTarget: { dataset: { id: 'result-1' } } });
 
-    expect(onSelect).toHaveBeenCalledWith('result-1');
+    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1' });
   });
 });
 

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -67,6 +67,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           wrapperClassName={'autocomplete-members__search-wrapper'}
           inputClassName={'autocomplete-members__search-input'}
         />
+        {this.props.children}
         <div className='autocomplete-members__content'>
           {this.state.results && this.state.results.length > 0 && (
             <div className='autocomplete-members__search-results'>

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -8,7 +8,7 @@ import { IconSearchMd } from '@zero-tech/zui/components/Icons/icons/IconSearchMd
 
 export interface Properties {
   search: (query: string) => Promise<Item[]>;
-  onSelect: (id: string) => void;
+  onSelect: (selected: Option) => void;
 }
 
 interface State {
@@ -51,12 +51,16 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
   };
 
   itemClicked = (event: any) => {
-    this.props.onSelect(event.currentTarget.dataset.id);
+    const clickedId = event.currentTarget.dataset.id;
+    const selectedUser = this.state.results.find((r) => r.value === clickedId);
+    if (selectedUser) {
+      this.props.onSelect(selectedUser);
+    }
   };
 
   render() {
     return (
-      <>
+      <div className='autocomplete-members'>
         <Input
           autoFocus
           type='search'
@@ -64,7 +68,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           onChange={this.searchChanged}
           value={this.state.searchString}
           startEnhancer={<IconSearchMd size={18} />}
-          wrapperClassName={'autocomplete-members__search-wrapper'}
+          wrapperClassName={'autocomplete-members__search-wrapper force-extra-specificity'}
           inputClassName={'autocomplete-members__search-input'}
         />
         {this.props.children}
@@ -87,11 +91,8 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
               ))}
             </div>
           )}
-          {this.state.results && this.state.results.length === 0 && (
-            <div className='autocomplete-members__empty-results'>No citizens found</div>
-          )}
         </div>
-      </>
+      </div>
     );
   }
 }

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -1,12 +1,22 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .autocomplete-members {
+  flex-grow: 1;
+
+  display: flex;
+  flex-direction: column;
+
   &__search-input {
     width: 100%;
   }
 
   &__content {
-    padding-top: 16px;
+    margin-top: 16px;
+    border-top: 1px solid theme.$color-primary-4;
+    flex-grow: 1;
+    overflow-y: auto;
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
   }
 
   &__search-results {
@@ -31,6 +41,6 @@
   }
 }
 
-.start__chat-search .autocomplete-members__search-wrapper {
+.force-extra-specificity.autocomplete-members__search-wrapper {
   border-radius: 9999px;
 }

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -132,18 +132,16 @@ export class ConversationListPanel extends React.Component<ConversationListPanel
         <div className='messages-list__direct-messages'>{this.renderNewMessageModal()}</div>
         {this.props.directMessagesList && (
           <div className='messages-list__items'>
-            <div className='messages-list__items-conversations'>
-              <div className='messages-list__items-conversations-input'>
-                <SearchConversations
-                  className='messages-list__items-conversations-search'
-                  placeholder='Search contacts...'
-                  directMessagesList={this.props.directMessages}
-                  onChange={this.props.conversationInMyNetworks}
-                  mapSearchConversationsText={otherMembersToString}
-                />
-              </div>
-              {this.props.directMessagesList.map(this.renderMember)}
+            <div className='messages-list__items-conversations-input'>
+              <SearchConversations
+                className='messages-list__items-conversations-search'
+                placeholder='Search contacts...'
+                directMessagesList={this.props.directMessages}
+                onChange={this.props.conversationInMyNetworks}
+                mapSearchConversationsText={otherMembersToString}
+              />
             </div>
+            <div className='messages-list__item-list'>{this.props.directMessagesList.map(this.renderMember)}</div>
           </div>
         )}
         {/* Note: this does not work. directMessagesList is never null */}

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+import Tooltip from '../../tooltip';
+import { lastSeenText } from './utils';
+import { otherMembersToString } from '../../../platform-apps/channels/util';
+import { SearchConversations } from '../search-conversations';
+import { Channel } from '../../../store/channels';
+
+interface ConversationListPanelProperties {
+  directMessages: Channel[];
+  directMessagesList: Channel[];
+  conversationInMyNetworks: (directMessagesList: Channel[]) => void;
+  handleMemberClick: (directMessageId: string) => void;
+}
+
+export class ConversationListPanel extends React.Component<ConversationListPanelProperties> {
+  handleMemberClick(directMessageId: string) {
+    this.props.handleMemberClick(directMessageId);
+  }
+
+  renderStatus(directMessage: Channel) {
+    const isAnyUserOnline = directMessage.otherMembers.some((user) => user.isOnline);
+
+    return (
+      <div
+        className={classNames('direct-message-members__user-status', {
+          'direct-message-members__user-status--active': isAnyUserOnline,
+        })}
+      ></div>
+    );
+  }
+
+  tooltipContent(directMessage: Channel) {
+    if (directMessage.otherMembers && directMessage.otherMembers.length === 1) {
+      return lastSeenText(directMessage.otherMembers[0]);
+    }
+
+    return otherMembersToString(directMessage.otherMembers);
+  }
+
+  renderMember = (directMessage: Channel) => {
+    return (
+      <Tooltip
+        placement='left'
+        overlay={this.tooltipContent(directMessage)}
+        align={{
+          offset: [
+            10,
+            0,
+          ],
+        }}
+        className='direct-message-members__user-tooltip'
+        key={directMessage.id}
+      >
+        <div
+          className='direct-message-members__user'
+          onClick={this.handleMemberClick.bind(this, directMessage.id)}
+          key={directMessage.id}
+        >
+          {this.renderStatus(directMessage)}
+          <div className='direct-message-members__user-name'>
+            {directMessage.name || otherMembersToString(directMessage.otherMembers)}
+          </div>
+          {directMessage.unreadCount !== 0 && (
+            <div className='direct-message-members__user-unread-count'>{directMessage.unreadCount}</div>
+          )}
+        </div>
+      </Tooltip>
+    );
+  };
+
+  render() {
+    return (
+      <div className='messages-list__items-conversations'>
+        <div className='messages-list__items-conversations-input'>
+          <SearchConversations
+            className='messages-list__items-conversations-search'
+            placeholder='Search contacts...'
+            directMessagesList={this.props.directMessages}
+            onChange={this.props.conversationInMyNetworks}
+            mapSearchConversationsText={otherMembersToString}
+          />
+        </div>
+        {this.props.directMessagesList.map(this.renderMember)}
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -6,12 +6,15 @@ import { lastSeenText } from './utils';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { SearchConversations } from '../search-conversations';
 import { Channel } from '../../../store/channels';
+import { IconMessagePlusSquare, IconMessageQuestionSquare } from '@zero-tech/zui/icons';
+import { IconButton } from '../../icon-button';
 
 interface ConversationListPanelProperties {
   directMessages: Channel[];
   directMessagesList: Channel[];
   conversationInMyNetworks: (directMessagesList: Channel[]) => void;
   handleMemberClick: (directMessageId: string) => void;
+  toggleConversation: () => void;
 }
 
 export class ConversationListPanel extends React.Component<ConversationListPanelProperties> {
@@ -70,20 +73,82 @@ export class ConversationListPanel extends React.Component<ConversationListPanel
     );
   };
 
+  renderNewMessageModal = (): JSX.Element => {
+    return (
+      <Tooltip
+        placement='left'
+        overlay='Create Zero Message'
+        align={{
+          offset: [
+            10,
+            0,
+          ],
+        }}
+        className='direct-message-members__user-tooltip'
+      >
+        <div className='header-button'>
+          <span className='header-button__title'>Conversations</span>
+          <span
+            className='header-button__icon'
+            onClick={this.props.toggleConversation}
+          >
+            <IconButton
+              onClick={this.props.toggleConversation}
+              Icon={IconMessagePlusSquare}
+              size={18}
+              className='header-button__icon-plus'
+            />
+          </span>
+        </div>
+      </Tooltip>
+    );
+  };
+
+  renderNoMessages = (): JSX.Element => {
+    return (
+      <div className='messages-list__start'>
+        <div className='messages-list__start-title'>
+          <span className='messages-list__start-icon'>
+            <IconMessageQuestionSquare
+              size={34}
+              label='You have no messages yet'
+            />
+          </span>
+          You have no messages yet
+        </div>
+        <span
+          className='messages-list__start-conversation'
+          onClick={this.props.toggleConversation}
+        >
+          Start a Conversation
+        </span>
+      </div>
+    );
+  };
+
   render() {
     return (
-      <div className='messages-list__items-conversations'>
-        <div className='messages-list__items-conversations-input'>
-          <SearchConversations
-            className='messages-list__items-conversations-search'
-            placeholder='Search contacts...'
-            directMessagesList={this.props.directMessages}
-            onChange={this.props.conversationInMyNetworks}
-            mapSearchConversationsText={otherMembersToString}
-          />
-        </div>
-        {this.props.directMessagesList.map(this.renderMember)}
-      </div>
+      <>
+        <div className='messages-list__direct-messages'>{this.renderNewMessageModal()}</div>
+        {this.props.directMessagesList && (
+          <div className='messages-list__items'>
+            <div className='messages-list__items-conversations'>
+              <div className='messages-list__items-conversations-input'>
+                <SearchConversations
+                  className='messages-list__items-conversations-search'
+                  placeholder='Search contacts...'
+                  directMessagesList={this.props.directMessages}
+                  onChange={this.props.conversationInMyNetworks}
+                  mapSearchConversationsText={otherMembersToString}
+                />
+              </div>
+              {this.props.directMessagesList.map(this.renderMember)}
+            </div>
+          </div>
+        )}
+        {/* Note: this does not work. directMessagesList is never null */}
+        {!this.props.directMessagesList && <div className='messages-list__new-messages'>{this.renderNoMessages()}</div>}
+      </>
     );
   }
 }

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -15,9 +15,28 @@ describe('CreateConversationPanel', () => {
     return shallow(<CreateConversationPanel {...allProps} />);
   };
 
-  it('XXX', function () {
-    const wrapper = subject({});
+  it('forwards search function to Autocomplete', function () {
+    const usersInMyNetworks = jest.fn();
+    const wrapper = subject({ usersInMyNetworks });
 
-    expect(wrapper).toHaveElement('.start__chat');
+    expect(wrapper.find('AutocompleteMembers').prop('search')).toBe(usersInMyNetworks);
+  });
+
+  it('fires onCreate when a user is selected', function () {
+    const createOneOnOneConversation = jest.fn();
+    const wrapper = subject({ createOneOnOneConversation });
+
+    wrapper.find('AutocompleteMembers').simulate('select', 'selected-user-id');
+
+    expect(createOneOnOneConversation).toHaveBeenCalledWith('selected-user-id');
+  });
+
+  it('fires onBack when back icon clicked', function () {
+    const toggleConversation = jest.fn();
+    const wrapper = subject({ toggleConversation });
+
+    wrapper.find('.start__chat-return').simulate('click');
+
+    expect(toggleConversation).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -8,9 +8,9 @@ jest.mock('../autocomplete-members');
 describe('CreateConversationPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
-      toggleConversation: () => {},
-      usersInMyNetworks: () => {},
-      createOneOnOneConversation: () => {},
+      onBack: () => {},
+      search: () => {},
+      onCreate: () => {},
       ...props,
     };
 
@@ -18,27 +18,27 @@ describe('CreateConversationPanel', () => {
   };
 
   it('forwards search function to Autocomplete', function () {
-    const usersInMyNetworks = jest.fn();
-    const wrapper = subject({ usersInMyNetworks });
+    const search = jest.fn();
+    const wrapper = subject({ search: search });
 
-    expect(wrapper.find('AutocompleteMembers').prop('search')).toBe(usersInMyNetworks);
+    expect(wrapper.find('AutocompleteMembers').prop('search')).toBe(search);
   });
 
   it('fires onCreate when a user is selected', function () {
-    const createOneOnOneConversation = jest.fn();
-    const wrapper = subject({ createOneOnOneConversation });
+    const onCreate = jest.fn();
+    const wrapper = subject({ onCreate: onCreate });
 
     wrapper.find('AutocompleteMembers').simulate('select', 'selected-user-id');
 
-    expect(createOneOnOneConversation).toHaveBeenCalledWith('selected-user-id');
+    expect(onCreate).toHaveBeenCalledWith('selected-user-id');
   });
 
   it('fires onBack when back icon clicked', function () {
-    const toggleConversation = jest.fn();
-    const wrapper = subject({ toggleConversation });
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack: onBack });
 
     wrapper.find('.start__chat-return').simulate('click');
 
-    expect(toggleConversation).toHaveBeenCalledOnce();
+    expect(onBack).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 
 import CreateConversationPanel, { Properties } from './create-conversation-panel';
 
+jest.mock('../autocomplete-members');
+
 describe('CreateConversationPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import CreateConversationPanel, { Properties } from './create-conversation-panel';
+
+describe('CreateConversationPanel', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      toggleConversation: () => {},
+      usersInMyNetworks: () => {},
+      createOneOnOneConversation: () => {},
+      ...props,
+    };
+
+    return shallow(<CreateConversationPanel {...allProps} />);
+  };
+
+  it('XXX', function () {
+    const wrapper = subject({});
+
+    expect(wrapper).toHaveElement('.start__chat');
+  });
+});

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -11,6 +11,7 @@ describe('CreateConversationPanel', () => {
       onBack: () => {},
       search: () => {},
       onCreate: () => {},
+      onStartGroupChat: () => {},
       ...props,
     };
 
@@ -28,7 +29,7 @@ describe('CreateConversationPanel', () => {
     const onCreate = jest.fn();
     const wrapper = subject({ onCreate: onCreate });
 
-    wrapper.find('AutocompleteMembers').simulate('select', 'selected-user-id');
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'selected-user-id' });
 
     expect(onCreate).toHaveBeenCalledWith('selected-user-id');
   });
@@ -37,8 +38,17 @@ describe('CreateConversationPanel', () => {
     const onBack = jest.fn();
     const wrapper = subject({ onBack: onBack });
 
-    wrapper.find('.start__chat-return').simulate('click');
+    wrapper.find('PanelHeader').simulate('back');
 
     expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('fires onStartGroupChat when the action is clicked', function () {
+    const onStartGroupChat = jest.fn();
+    const wrapper = subject({ onStartGroupChat });
+
+    wrapper.find('.create-conversation__group-button').simulate('click');
+
+    expect(onStartGroupChat).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { AutocompleteMembers } from '../autocomplete-members';
 
-interface Properties {
+export interface Properties {
   toggleConversation: () => void;
   usersInMyNetworks: (input: string) => any;
   createOneOnOneConversation: (id: string) => void;

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -1,32 +1,48 @@
 import * as React from 'react';
 
 import { AutocompleteMembers } from '../autocomplete-members';
+import { PanelHeader } from './panel-header';
+import { IconUsersPlus } from '@zero-tech/zui/icons';
 
 export interface Properties {
   search: (input: string) => any;
 
   onBack: () => void;
   onCreate: (id: string) => void;
+  onStartGroupChat: () => void;
 }
 
 export default class CreateConversationPanel extends React.Component<Properties> {
+  userSelected = (option) => {
+    this.props.onCreate(option.value);
+  };
+
   render() {
     return (
-      <div className='start__chat'>
-        <span className='start__chat-title'>
-          <i
-            className='start__chat-return'
-            onClick={this.props.onBack}
-          />
-          New message
-        </span>
-        <div className='start__chat-search'>
-          <AutocompleteMembers
-            search={this.props.search}
-            onSelect={this.props.onCreate}
-          ></AutocompleteMembers>
+      <>
+        <PanelHeader
+          title='New message'
+          onBack={this.props.onBack}
+        />
+        <div className='start__chat'>
+          <div className='start__chat-search'>
+            <AutocompleteMembers
+              search={this.props.search}
+              onSelect={this.userSelected}
+            >
+              <div
+                className='create-conversation__group-button'
+                onClick={this.props.onStartGroupChat}
+              >
+                <div className='create-conversation__group-icon'>
+                  <IconUsersPlus size={25} />
+                </div>
+                Start a group chat
+              </div>
+            </AutocompleteMembers>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import { AutocompleteMembers } from '../autocomplete-members';
+
+interface Properties {
+  toggleConversation: () => void;
+  usersInMyNetworks: (input: string) => any;
+  createOneOnOneConversation: (id: string) => void;
+}
+
+export default class CreateConversationPanel extends React.Component<Properties> {
+  render() {
+    return (
+      <div className='start__chat'>
+        <span className='start__chat-title'>
+          <i
+            className='start__chat-return'
+            onClick={this.props.toggleConversation}
+          />
+          New message
+        </span>
+        <div className='start__chat-search'>
+          <AutocompleteMembers
+            search={this.props.usersInMyNetworks}
+            onSelect={this.props.createOneOnOneConversation}
+          ></AutocompleteMembers>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { AutocompleteMembers } from '../autocomplete-members';
 
 export interface Properties {
-  toggleConversation: () => void;
-  usersInMyNetworks: (input: string) => any;
-  createOneOnOneConversation: (id: string) => void;
+  onBack: () => void;
+  search: (input: string) => any;
+  onCreate: (id: string) => void;
 }
 
 export default class CreateConversationPanel extends React.Component<Properties> {
@@ -15,14 +15,14 @@ export default class CreateConversationPanel extends React.Component<Properties>
         <span className='start__chat-title'>
           <i
             className='start__chat-return'
-            onClick={this.props.toggleConversation}
+            onClick={this.props.onBack}
           />
           New message
         </span>
         <div className='start__chat-search'>
           <AutocompleteMembers
-            search={this.props.usersInMyNetworks}
-            onSelect={this.props.createOneOnOneConversation}
+            search={this.props.search}
+            onSelect={this.props.onCreate}
           ></AutocompleteMembers>
         </div>
       </div>

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 import { AutocompleteMembers } from '../autocomplete-members';
 
 export interface Properties {
-  onBack: () => void;
   search: (input: string) => any;
+
+  onBack: () => void;
   onCreate: (id: string) => void;
 }
 

--- a/src/components/messenger/list/direct-messages-fixture.json
+++ b/src/components/messenger/list/direct-messages-fixture.json
@@ -48,8 +48,8 @@
     "isVideoEnabled": false
   },
   {
-    "id": "292444273_bd035e84edfbaf11251ffef196de2ab47496439c",
-    "url": "sendbird_group_channel_292444273_bd035e84edfbaf11251ffef196de2ab47496439c",
+    "id": "292444273_bd035e84edfbaf11251ffef196de2ab47496439b",
+    "url": "sendbird_group_channel_292444273_bd035e84edfbaf11251ffef196de2ab47496439b",
     "icon": "https://static.sendbird.com/sample/cover/cover_14.jpg",
     "networkId": "",
     "isChannel": false,

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -1,5 +1,9 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import directMessagesFixture from './direct-messages-fixture.json';
 import Tooltip from '../../tooltip';
@@ -24,7 +28,7 @@ describe('messenger-list', () => {
       ...props,
     };
 
-    return shallow(<DirectMessageChat {...allProps} />);
+    return mount(<DirectMessageChat {...allProps} />);
   };
 
   it('render direct message members', function () {
@@ -56,6 +60,7 @@ describe('messenger-list', () => {
 
     wrapper.setProps({ directMessages: DIRECT_MESSAGES_TEST });
 
+    wrapper.update();
     const displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
 
     expect(displayChatNames).toStrictEqual([
@@ -72,6 +77,7 @@ describe('messenger-list', () => {
     const wrapper = subject({ setActiveMessengerChat: setActiveDirectMessage });
 
     wrapper.setProps({ directMessages: DIRECT_MESSAGES_TEST });
+    wrapper.update();
 
     wrapper.find('.direct-message-members__user').first().simulate('click');
 
@@ -134,6 +140,7 @@ describe('messenger-list', () => {
         ...restOfDirectMessages,
       ],
     });
+    wrapper.update();
     expect(wrapper.find('.direct-message-members__user-unread-count').text()).toEqual(unreadCount.toString());
   });
 
@@ -143,6 +150,7 @@ describe('messenger-list', () => {
     beforeEach(() => {
       wrapper = subject({});
       wrapper.setProps({ directMessages: DIRECT_MESSAGES_TEST });
+      wrapper.update();
     });
 
     afterEach(() => {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import directMessagesFixture from './direct-messages-fixture.json';
 import Tooltip from '../../tooltip';

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -11,10 +11,10 @@ import { Channel } from '../../../store/channels';
 import { normalize } from '../../../store/channels-list';
 import { Dialog } from '@zer0-os/zos-component-library';
 import { SearchConversations } from '../search-conversations';
-import { AutocompleteMembers } from '../autocomplete-members';
 import { RootState } from '../../../store';
 import moment from 'moment';
 import { when } from 'jest-when';
+import CreateConversationPanel from './create-conversation-panel';
 
 export const DIRECT_MESSAGES_TEST = directMessagesFixture as unknown as Channel[];
 
@@ -125,7 +125,7 @@ describe('messenger-list', () => {
     const wrapper = subject({});
     wrapper.find('.header-button__icon').simulate('click');
 
-    const searchResults = await wrapper.find(AutocompleteMembers).prop('search')('jac');
+    const searchResults = await wrapper.find(CreateConversationPanel).prop('search')('jac');
 
     expect(searchResults).toStrictEqual([{ id: 'user-id', image: 'image-url', profileImage: 'image-url' }]);
   });
@@ -136,7 +136,7 @@ describe('messenger-list', () => {
     wrapper.find('.header-button__icon').simulate('click');
 
     // Can't do simulate on custom components when rendering fully?
-    wrapper.find(AutocompleteMembers).prop('onSelect')('selected-user-id');
+    wrapper.find(CreateConversationPanel).prop('onCreate')('selected-user-id');
 
     expect(createDirectMessage).toHaveBeenCalledWith({ userIds: ['selected-user-id'] });
   });
@@ -147,26 +147,27 @@ describe('messenger-list', () => {
     wrapper.find('.header-button__icon').simulate('click');
 
     // Can't do simulate on custom components when rendering fully?
-    wrapper.find(AutocompleteMembers).prop('onSelect')('selected-user-id');
+    wrapper.find(CreateConversationPanel).prop('onCreate')('selected-user-id');
     wrapper.update();
 
-    expect(wrapper.find('.start__chat').exists()).toBeFalse();
-    expect(wrapper.find('.header-button').exists()).toBeTrue();
-    expect(wrapper.find('.messages-list__items-conversations').exists()).toBeTrue();
+    expect(wrapper).not.toHaveElement('CreateConversationPanel');
+    expect(wrapper).toHaveElement('.header-button');
+    expect(wrapper).toHaveElement('.messages-list__items-conversations');
   });
 
   it('returns to conversation list if back button pressed', async function () {
     const wrapper = subject({});
     wrapper.find('.header-button__icon').simulate('click');
-    expect(wrapper.find('.start__chat').exists()).toBeTrue();
-    expect(wrapper.find('.header-button').exists()).toBeFalse();
-    expect(wrapper.find('.messages-list__items-conversations').exists()).toBeFalse();
+    expect(wrapper).toHaveElement('CreateConversationPanel');
+    expect(wrapper).not.toHaveElement('.header-button');
+    expect(wrapper).not.toHaveElement('.messages-list__items-conversations');
 
-    wrapper.find('.start__chat-return').simulate('click');
+    wrapper.find(CreateConversationPanel).prop('onBack')();
+    wrapper.update();
 
-    expect(wrapper.find('.start__chat').exists()).toBeFalse();
-    expect(wrapper.find('.header-button').exists()).toBeTrue();
-    expect(wrapper.find('.messages-list__items-conversations').exists()).toBeTrue();
+    expect(wrapper).not.toHaveElement('CreateConversationPanel');
+    expect(wrapper).toHaveElement('.header-button');
+    expect(wrapper).toHaveElement('.messages-list__items-conversations');
   });
 
   it('should render search conversations', function () {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -170,10 +170,46 @@ describe('messenger-list', () => {
     expect(wrapper).toHaveElement('.messages-list__items-conversations');
   });
 
-  it('should render search conversations', function () {
-    const wrapper = subject({});
+  it('provides the list of conversations to the Search', function () {
+    const conversations = [
+      {
+        id: 'convo-id-1',
+        otherMembers: [],
+      },
+    ];
 
-    expect(wrapper.find(SearchConversations).exists()).toBe(true);
+    const wrapper = subject({ directMessages: conversations as any });
+
+    expect(wrapper.find(SearchConversations).prop('directMessagesList')).toEqual(conversations);
+  });
+
+  it('renders search results', function () {
+    const conversations = [
+      { id: 'convo-id-1', name: 'convo-1', otherMembers: [] },
+      { id: 'convo-id-2', name: 'convo-2', otherMembers: [] },
+      { id: 'convo-id-3', name: 'convo-3', otherMembers: [] },
+    ];
+
+    const wrapper = subject({ directMessages: conversations as any });
+
+    let displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
+    expect(displayChatNames).toStrictEqual([
+      'convo-1',
+      'convo-2',
+      'convo-3',
+    ]);
+
+    wrapper.find(SearchConversations).prop('onChange')([
+      conversations[0],
+      conversations[2],
+    ] as any);
+    wrapper.update();
+
+    displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
+    expect(displayChatNames).toStrictEqual([
+      'convo-1',
+      'convo-3',
+    ]);
   });
 
   it('renders unread messages', function () {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -60,6 +60,8 @@ export class Container extends React.Component<Properties, State> {
   componentDidUpdate(prevProps: Properties): void {
     const { directMessages } = this.props;
 
+    // This might be broken. What happens if you're searching conversations and a real-time update comes in?
+    // Would that break your search results?
     if (directMessages && prevProps.directMessages && directMessages.length !== prevProps.directMessages.length) {
       this.setState({ directMessagesList: directMessages });
     }

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -12,7 +12,6 @@ import { compareDatesDesc } from '../../../lib/date';
 import { MemberNetworks } from '../../../store/users/types';
 import { searchMyNetworksByName } from '../../../platform-apps/channels/util/api';
 import { createDirectMessage } from '../../../store/channels-list';
-import { AutocompleteMembers } from '../autocomplete-members';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
 
 import { IconMessagePlusSquare, IconMessageQuestionSquare, IconXClose } from '@zero-tech/zui/icons';
@@ -20,6 +19,7 @@ import { IconButton } from '../../icon-button';
 import { SearchConversations } from '../search-conversations';
 
 import './styles.scss';
+import CreateConversationPanel from './create-conversation-panel';
 
 export interface PublicProperties {
   onClose: () => void;
@@ -178,26 +178,6 @@ export class Container extends React.Component<Properties, State> {
     this.toggleConversation();
   };
 
-  renderCreateConversation = (): JSX.Element => {
-    return (
-      <div className='start__chat'>
-        <span className='start__chat-title'>
-          <i
-            className='start__chat-return'
-            onClick={this.toggleConversation}
-          />
-          New message
-        </span>
-        <div className='start__chat-search'>
-          <AutocompleteMembers
-            search={this.usersInMyNetworks}
-            onSelect={this.createOneOnOneConversation}
-          ></AutocompleteMembers>
-        </div>
-      </div>
-    );
-  };
-
   renderNoMessages = (): JSX.Element => {
     return (
       <div className='messages-list__start'>
@@ -261,7 +241,13 @@ export class Container extends React.Component<Properties, State> {
                   {this.state.directMessagesList.map(this.renderMember)}
                 </div>
               )}
-              {this.state.showCreateConversation && this.renderCreateConversation()}
+              {this.state.showCreateConversation && (
+                <CreateConversationPanel
+                  toggleConversation={this.toggleConversation}
+                  usersInMyNetworks={this.usersInMyNetworks}
+                  createOneOnOneConversation={this.createOneOnOneConversation}
+                />
+              )}
             </div>
           )}
           {!this.state.directMessagesList && (

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -243,9 +243,9 @@ export class Container extends React.Component<Properties, State> {
               )}
               {this.state.showCreateConversation && (
                 <CreateConversationPanel
-                  toggleConversation={this.toggleConversation}
-                  usersInMyNetworks={this.usersInMyNetworks}
-                  createOneOnOneConversation={this.createOneOnOneConversation}
+                  onBack={this.toggleConversation}
+                  search={this.usersInMyNetworks}
+                  onCreate={this.createOneOnOneConversation}
                 />
               )}
             </div>

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -3,7 +3,6 @@ import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store';
 import { Channel } from '../../../store/channels';
 import { setActiveMessengerId } from '../../../store/chat';
-import Tooltip from '../../tooltip';
 import { denormalizeConversations, fetchDirectMessages } from '../../../store/channels-list';
 import { compareDatesDesc } from '../../../lib/date';
 import { MemberNetworks } from '../../../store/users/types';
@@ -11,8 +10,7 @@ import { searchMyNetworksByName } from '../../../platform-apps/channels/util/api
 import { createDirectMessage } from '../../../store/channels-list';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
 
-import { IconMessagePlusSquare, IconMessageQuestionSquare, IconXClose } from '@zero-tech/zui/icons';
-import { IconButton } from '../../icon-button';
+import { IconXClose } from '@zero-tech/zui/icons';
 
 import './styles.scss';
 import CreateConversationPanel from './create-conversation-panel';
@@ -88,62 +86,9 @@ export class Container extends React.Component<Properties, State> {
     this.setState({ directMessagesList });
   };
 
-  renderNewMessageModal = (): JSX.Element => {
-    return (
-      <Tooltip
-        placement='left'
-        overlay='Create Zero Message'
-        align={{
-          offset: [
-            10,
-            0,
-          ],
-        }}
-        className='direct-message-members__user-tooltip'
-      >
-        <div className='header-button'>
-          <span className='header-button__title'>Conversations</span>
-          <span
-            className='header-button__icon'
-            onClick={this.toggleConversation}
-          >
-            <IconButton
-              onClick={this.toggleConversation}
-              Icon={IconMessagePlusSquare}
-              size={18}
-              className='header-button__icon-plus'
-            />
-          </span>
-        </div>
-      </Tooltip>
-    );
-  };
-
   createOneOnOneConversation = (id: string): void => {
     this.props.createDirectMessage({ userIds: [id] });
     this.toggleConversation();
-  };
-
-  renderNoMessages = (): JSX.Element => {
-    return (
-      <div className='messages-list__start'>
-        <div className='messages-list__start-title'>
-          <span className='messages-list__start-icon'>
-            <IconMessageQuestionSquare
-              size={34}
-              label='You have no messages yet'
-            />
-          </span>
-          You have no messages yet
-        </div>
-        <span
-          className='messages-list__start-conversation'
-          onClick={this.toggleConversation}
-        >
-          Start a Conversation
-        </span>
-      </div>
-    );
   };
 
   renderTitleBar() {
@@ -168,30 +113,21 @@ export class Container extends React.Component<Properties, State> {
       <>
         {this.renderTitleBar()}
         <div className='direct-message-members'>
-          <div className='messages-list__direct-messages'>
-            {!this.state.showCreateConversation && this.renderNewMessageModal()}
-          </div>
-          {this.state.directMessagesList && (
-            <div className='messages-list__items'>
-              {!this.state.showCreateConversation && (
-                <ConversationListPanel
-                  directMessages={this.props.directMessages}
-                  directMessagesList={this.state.directMessagesList}
-                  conversationInMyNetworks={this.conversationInMyNetworks}
-                  handleMemberClick={this.handleMemberClick}
-                />
-              )}
-              {this.state.showCreateConversation && (
-                <CreateConversationPanel
-                  onBack={this.toggleConversation}
-                  search={this.usersInMyNetworks}
-                  onCreate={this.createOneOnOneConversation}
-                />
-              )}
-            </div>
+          {!this.state.showCreateConversation && (
+            <ConversationListPanel
+              directMessages={this.props.directMessages}
+              directMessagesList={this.state.directMessagesList}
+              conversationInMyNetworks={this.conversationInMyNetworks}
+              handleMemberClick={this.handleMemberClick}
+              toggleConversation={this.toggleConversation}
+            />
           )}
-          {!this.state.directMessagesList && (
-            <div className='messages-list__new-messages'>{this.renderNoMessages()}</div>
+          {this.state.showCreateConversation && (
+            <CreateConversationPanel
+              onBack={this.toggleConversation}
+              search={this.usersInMyNetworks}
+              onCreate={this.createOneOnOneConversation}
+            />
           )}
         </div>
       </>

--- a/src/components/messenger/list/panel-header.test.tsx
+++ b/src/components/messenger/list/panel-header.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { PanelHeader, Properties } from './panel-header';
+
+jest.mock('@zero-tech/zui/icons');
+
+describe('PanelHeader', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      title: 'header',
+      onBack: () => {},
+      ...props,
+    };
+
+    return shallow(<PanelHeader {...allProps} />);
+  };
+
+  it('fires onBack when back icon clicked', function () {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    wrapper.find('.messenger-panel__back').simulate('click');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/messenger/list/panel-header.tsx
+++ b/src/components/messenger/list/panel-header.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { IconArrowNarrowLeft } from '@zero-tech/zui/icons';
+
+export interface Properties {
+  title: string;
+  onBack: () => void;
+}
+
+export class PanelHeader extends React.Component<Properties> {
+  render() {
+    return (
+      <div className='messenger-panel__header'>
+        <span
+          className='messenger-panel__back'
+          onClick={this.props.onBack}
+        >
+          <IconArrowNarrowLeft size={24} />
+        </span>
+        {this.props.title}
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { StartGroupPanel, Properties } from './start-group-panel';
+
+jest.mock('../autocomplete-members');
+jest.mock('@zero-tech/zui/components');
+jest.mock('@zero-tech/zui/icons');
+
+describe('StartGroupPanel', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      searchUsers: () => {},
+      onBack: () => {},
+      onContinue: () => {},
+      ...props,
+    };
+
+    return shallow(<StartGroupPanel {...allProps} />);
+  };
+
+  it('forwards search function to Autocomplete', function () {
+    const searchUsers = jest.fn();
+    const wrapper = subject({ searchUsers });
+
+    expect(wrapper.find('AutocompleteMembers').prop('search')).toBe(searchUsers);
+  });
+
+  it('fires onBack when back icon clicked', function () {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    wrapper.find('PanelHeader').simulate('back');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('fires onContinue when continue is clicked', function () {
+    const onContinue = jest.fn();
+    const wrapper = subject({ onContinue });
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2' });
+    wrapper.find('Button').simulate('press');
+
+    expect(onContinue).toHaveBeenCalledWith([
+      'id-1',
+      'id-2',
+    ]);
+  });
+
+  it('enables continue button based on number of users', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find('Button').prop('isDisabled')).toBeTrue();
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
+    expect(wrapper.find('Button').prop('isDisabled')).toBeFalse();
+
+    wrapper
+      .find('.start-group-panel__user-remove')
+      .simulate('click', { currentTarget: { dataset: { value: 'id-1' } } });
+    expect(wrapper.find('Button').prop('isDisabled')).toBeTrue();
+  });
+
+  it('shows selected member count', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('0 members selected');
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
+    expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('1 member selected');
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2' });
+    expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('2 members selected');
+  });
+
+  it('renders selected members', function () {
+    const wrapper = subject({});
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2', label: 'User 2', image: 'url-2' });
+
+    expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual([
+      'User 1',
+      'User 2',
+    ]);
+    expect(wrapper.find('Avatar').map((n) => n.prop('imageURL'))).toEqual([
+      'url-1',
+      'url-2',
+    ]);
+  });
+
+  it('unselects users when X is clicked', function () {
+    const wrapper = subject({});
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2', label: 'User 2', image: 'url-2' });
+
+    wrapper
+      .find('.start-group-panel__user-remove')
+      .first()
+      .simulate('click', { currentTarget: { dataset: { value: 'id-1' } } });
+
+    expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual(['User 2']);
+  });
+
+  it('renders unique list of selected users', function () {
+    const wrapper = subject({});
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    // Select the same option
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+
+    expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual(['User 1']);
+  });
+});

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+
+import { Avatar, Button } from '@zero-tech/zui/components';
+
+import { AutocompleteMembers, Option } from '../autocomplete-members';
+import { IconXClose } from '@zero-tech/zui/icons';
+import { PanelHeader } from './panel-header';
+
+export interface Properties {
+  searchUsers: (input: string) => any;
+
+  onBack: () => void;
+  onContinue: (ids: string[]) => void;
+}
+
+interface State {
+  selectedOptions: Option[];
+}
+
+export class StartGroupPanel extends React.Component<Properties, State> {
+  state = { selectedOptions: [] };
+
+  continue = () => {
+    this.props.onContinue(this.state.selectedOptions.map((o) => o.value));
+  };
+
+  selectOption = (selectedOption) => {
+    if (this.state.selectedOptions.find((o) => o.value === selectedOption.value)) {
+      return;
+    }
+
+    this.setState({
+      selectedOptions: [
+        ...this.state.selectedOptions,
+        selectedOption,
+      ],
+    });
+  };
+
+  unselectOption = (event) => {
+    const clickedValue = event.currentTarget.dataset.value;
+    this.setState({
+      selectedOptions: this.state.selectedOptions.filter((o) => o.value !== clickedValue),
+    });
+  };
+
+  get isContinueDisabled() {
+    return this.state.selectedOptions.length <= 0;
+  }
+
+  render() {
+    return (
+      <>
+        <PanelHeader
+          title='Select members'
+          onBack={this.props.onBack}
+        />
+        <div className='start-group-panel__search'>
+          <AutocompleteMembers
+            search={this.props.searchUsers}
+            onSelect={this.selectOption}
+          >
+            <div className='start-group-panel__selected-count'>
+              <span className='start-group-panel__selected-number'>{this.state.selectedOptions.length}</span> member
+              {this.state.selectedOptions.length === 1 ? '' : 's'} selected
+            </div>
+            <div className='start-group-panel__selected-options'>
+              {this.state.selectedOptions.map((val) => (
+                <div
+                  className='start-group-panel__selected-option'
+                  key={val.value}
+                >
+                  <div className='start-group-panel__selected-tag'>
+                    <Avatar
+                      size={'extra small'}
+                      type={'circle'}
+                      imageURL={val.image}
+                    />
+                    <span className='start-group-panel__user-label'>{val.label}</span>
+                    <button
+                      onClick={this.unselectOption}
+                      data-value={val.value}
+                      className='start-group-panel__user-remove'
+                    >
+                      <IconXClose size={16} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </AutocompleteMembers>
+        </div>
+        <Button
+          className='start-group-panel__continue'
+          onPress={this.continue}
+          isDisabled={this.isContinueDisabled}
+        >
+          Continue
+        </Button>
+      </>
+    );
+  }
+}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -14,9 +14,10 @@
 }
 
 .direct-message-members {
-  overflow-y: scroll;
-  height: 100%;
+  flex-grow: 99;
   padding: 0 16px;
+  display: flex;
+  flex-direction: column;
 
   &__user {
     display: flex;
@@ -91,11 +92,23 @@
       }
     }
     &__items {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+
       animation: conversation-slide-in 600ms ease-in forwards;
 
       &-conversations-input {
         margin-bottom: 18px;
       }
+    }
+
+    &__item-list {
+      flex-grow: 1;
+      // Forcing a height here allows the flex-grow to fill the size without growing too big
+      height: 1px;
+
+      overflow: auto;
     }
   }
 }
@@ -126,6 +139,7 @@
 }
 
 .start__chat {
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   align-content: center;
@@ -154,6 +168,9 @@
   }
 
   &-search {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     text-align: center;
   }
@@ -216,5 +233,116 @@
     & > * {
       margin: auto;
     }
+  }
+}
+
+.messenger-panel {
+  &__header {
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    align-items: center;
+
+    font-style: normal;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 24px;
+    color: theme.$color-greyscale-12;
+
+    padding: 20px 10px;
+  }
+
+  &__back {
+    margin-right: 10px;
+    cursor: pointer;
+  }
+}
+
+.create-conversation {
+  &__group-button {
+    display: flex;
+    align-items: center;
+    margin-top: 16px;
+    gap: 8px;
+    cursor: pointer;
+  }
+
+  &__group-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    background: linear-gradient(223deg, #421349 14.62%, #0d0416 36.73%, #0b060e 59.58%, #2b0659 85.38%);
+    border-radius: 9999px;
+
+    & > * {
+      margin: auto;
+    }
+  }
+}
+
+.start-group-panel {
+  &__selected-count {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+    padding-top: 18px;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__selected-number {
+    color: theme.$color-greyscale-12;
+  }
+
+  &__selected-option {
+    display: inline-block;
+  }
+
+  &__selected-tag {
+    color: theme.$color-greyscale-11;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 4px 8px;
+    gap: 4px;
+    background-color: theme.$color-greyscale-3;
+    border-radius: 8px;
+    border: 1px solid theme.$color-greyscale-5;
+    margin-top: 10px;
+    margin-right: 10px;
+
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+  }
+
+  &__user-remove {
+    cursor: pointer;
+    background: none;
+    border: none;
+    display: inline-block;
+    padding: 0px;
+    margin: 0px;
+  }
+
+  &__content {
+    flex-grow: 99;
+
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__search {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__continue {
+    margin: 16px 0px;
   }
 }

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -27,6 +27,8 @@
 
     &--messages {
       height: 100%;
+      display: flex;
+      flex-direction: column;
     }
   }
 }

--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -1,0 +1,22 @@
+/// <reference types="jest" />
+
+interface ZOSCustomMatchers<R> extends Record<string, any> {
+  toHaveElement<P2>(statelessComponent: FunctionComponent<P2>): ShallowWrapper<P2, never>;
+  toHaveElement<P2>(component: ComponentType<P2>): ShallowWrapper<P2, any>;
+  toHaveElement<C2 extends Component>(
+    componentClass: ComponentClass<C2['props']>
+  ): ShallowWrapper<C2['props'], C2['state'], C2>;
+  toHaveElement(props: EnzymePropSelector): ShallowWrapper<any, any>;
+  toHaveElement(selector: string): R;
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R = void, _T = {}> extends ZOSCustomMatchers<R> {}
+  }
+}
+
+// Not entirely sure why we need to export something but I've found VSCode
+// couldn't autocomplete without this.
+declare const matchers: ZOSCustomMatchers<void>;
+export default matchers;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,3 +14,13 @@ const localStorageMock = {
 };
 
 global.localStorage = localStorageMock;
+
+expect.extend({
+  toHaveElement(actual, finder) {
+    const pass = actual.find(finder).exists();
+    return {
+      pass,
+      message: pass ? () => `expected node [${finder}] not to exist` : () => `expected node [${finder}] to exist`,
+    };
+  },
+});


### PR DESCRIPTION
### What does this do?

Refactors the messenger list into separate panels so we can separate the flow logic from each step of the flow.

### Why are we making this change?

While adding the group conversation functionality this seemed like a good step to make adding the next screens simpler.

### How do I test this?

Verify the messenger list still works as expected with the exception of the existing bugs.
