### PR TITLE
Implement Create Group Chat functionality

### DIFF
--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -45,16 +45,6 @@ describe('autocomplete-members', () => {
     expect(wrapper.find('.autocomplete-members__search-results').exists()).toBeFalse();
   });
 
-  it('renders empty result message', async () => {
-    const search = jest.fn();
-    when(search).mockResolvedValue([]);
-    const wrapper = subject({ search });
-
-    await searchFor(wrapper, 'name');
-
-    expect(wrapper.find('.autocomplete-members__empty-results').exists()).toBeTrue();
-  });
-
   it('fires onSelect when result is clicked', async () => {
     const search = jest.fn();
     when(search).mockResolvedValue([

--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -68,7 +68,7 @@ describe('autocomplete-members', () => {
       .find('.autocomplete-members__search-results > div')
       .simulate('click', { currentTarget: { dataset: { id: 'result-1' } } });
 
-    expect(onSelect).toHaveBeenCalledWith('result-1');
+    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1' });
   });
 });
 

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -68,7 +68,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           onChange={this.searchChanged}
           value={this.state.searchString}
           startEnhancer={<IconSearchMd size={18} />}
-          wrapperClassName={'autocomplete-members__search-wrapper'}
+          wrapperClassName={'autocomplete-members__search-wrapper force-extra-specificity'}
           inputClassName={'autocomplete-members__search-input'}
         />
         {this.props.children}

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -60,7 +60,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
 
   render() {
     return (
-      <>
+      <div className='autocomplete-members'>
         <Input
           autoFocus
           type='search'
@@ -91,11 +91,8 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
               ))}
             </div>
           )}
-          {this.state.results && this.state.results.length === 0 && (
-            <div className='autocomplete-members__empty-results'>No citizens found</div>
-          )}
         </div>
-      </>
+      </div>
     );
   }
 }

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -8,7 +8,7 @@ import { IconSearchMd } from '@zero-tech/zui/components/Icons/icons/IconSearchMd
 
 export interface Properties {
   search: (query: string) => Promise<Item[]>;
-  onSelect: (id: string) => void;
+  onSelect: (selected: Option) => void;
 }
 
 interface State {
@@ -51,7 +51,11 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
   };
 
   itemClicked = (event: any) => {
-    this.props.onSelect(event.currentTarget.dataset.id);
+    const clickedId = event.currentTarget.dataset.id;
+    const selectedUser = this.state.results.find((r) => r.value === clickedId);
+    if (selectedUser) {
+      this.props.onSelect(selectedUser);
+    }
   };
 
   render() {

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -6,7 +6,8 @@
   }
 
   &__content {
-    padding-top: 16px;
+    margin-top: 16px;
+    border-top: 1px solid theme.$color-primary-4;
   }
 
   &__search-results {

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -31,6 +31,6 @@
   }
 }
 
-.start__chat-search .autocomplete-members__search-wrapper {
+.force-extra-specificity.autocomplete-members__search-wrapper {
   border-radius: 9999px;
 }

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -1,6 +1,11 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .autocomplete-members {
+  flex-grow: 1;
+
+  display: flex;
+  flex-direction: column;
+
   &__search-input {
     width: 100%;
   }
@@ -8,6 +13,10 @@
   &__content {
     margin-top: 16px;
     border-top: 1px solid theme.$color-primary-4;
+    flex-grow: 1;
+    overflow-y: auto;
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
   }
 
   &__search-results {

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -132,18 +132,16 @@ export class ConversationListPanel extends React.Component<ConversationListPanel
         <div className='messages-list__direct-messages'>{this.renderNewMessageModal()}</div>
         {this.props.directMessagesList && (
           <div className='messages-list__items'>
-            <div className='messages-list__items-conversations'>
-              <div className='messages-list__items-conversations-input'>
-                <SearchConversations
-                  className='messages-list__items-conversations-search'
-                  placeholder='Search contacts...'
-                  directMessagesList={this.props.directMessages}
-                  onChange={this.props.conversationInMyNetworks}
-                  mapSearchConversationsText={otherMembersToString}
-                />
-              </div>
-              {this.props.directMessagesList.map(this.renderMember)}
+            <div className='messages-list__items-conversations-input'>
+              <SearchConversations
+                className='messages-list__items-conversations-search'
+                placeholder='Search contacts...'
+                directMessagesList={this.props.directMessages}
+                onChange={this.props.conversationInMyNetworks}
+                mapSearchConversationsText={otherMembersToString}
+              />
             </div>
+            <div className='messages-list__item-list'>{this.props.directMessagesList.map(this.renderMember)}</div>
           </div>
         )}
         {/* Note: this does not work. directMessagesList is never null */}

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -38,7 +38,7 @@ describe('CreateConversationPanel', () => {
     const onBack = jest.fn();
     const wrapper = subject({ onBack: onBack });
 
-    wrapper.find('.start__chat-return').simulate('click');
+    wrapper.find('PanelHeader').simulate('back');
 
     expect(onBack).toHaveBeenCalledOnce();
   });

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -11,6 +11,7 @@ describe('CreateConversationPanel', () => {
       onBack: () => {},
       search: () => {},
       onCreate: () => {},
+      onStartGroupChat: () => {},
       ...props,
     };
 
@@ -40,5 +41,14 @@ describe('CreateConversationPanel', () => {
     wrapper.find('.start__chat-return').simulate('click');
 
     expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('fires onStartGroupChat when the action is clicked', function () {
+    const onStartGroupChat = jest.fn();
+    const wrapper = subject({ onStartGroupChat });
+
+    wrapper.find('.create-conversation__group-button').simulate('click');
+
+    expect(onStartGroupChat).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/messenger/list/create-conversation-panel.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel.test.tsx
@@ -28,7 +28,7 @@ describe('CreateConversationPanel', () => {
     const onCreate = jest.fn();
     const wrapper = subject({ onCreate: onCreate });
 
-    wrapper.find('AutocompleteMembers').simulate('select', 'selected-user-id');
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'selected-user-id' });
 
     expect(onCreate).toHaveBeenCalledWith('selected-user-id');
   });

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -7,6 +7,7 @@ export interface Properties {
 
   onBack: () => void;
   onCreate: (id: string) => void;
+  onStartGroupChat: () => void;
 }
 
 export default class CreateConversationPanel extends React.Component<Properties> {

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -11,6 +11,10 @@ export interface Properties {
 }
 
 export default class CreateConversationPanel extends React.Component<Properties> {
+  userSelected = (option) => {
+    this.props.onCreate(option.value);
+  };
+
   render() {
     return (
       <div className='start__chat'>
@@ -24,8 +28,15 @@ export default class CreateConversationPanel extends React.Component<Properties>
         <div className='start__chat-search'>
           <AutocompleteMembers
             search={this.props.search}
-            onSelect={this.props.onCreate}
-          ></AutocompleteMembers>
+            onSelect={this.userSelected}
+          >
+            <div
+              className='create-conversation__group-button'
+              onClick={this.props.onStartGroupChat}
+            >
+              Start a group chat
+            </div>
+          </AutocompleteMembers>
         </div>
       </div>
     );

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { AutocompleteMembers } from '../autocomplete-members';
 import { PanelHeader } from './panel-header';
+import { IconUsersPlus } from '@zero-tech/zui/icons';
 
 export interface Properties {
   search: (input: string) => any;
@@ -33,6 +34,9 @@ export default class CreateConversationPanel extends React.Component<Properties>
                 className='create-conversation__group-button'
                 onClick={this.props.onStartGroupChat}
               >
+                <div className='create-conversation__group-icon'>
+                  <IconUsersPlus size={25} />
+                </div>
                 Start a group chat
               </div>
             </AutocompleteMembers>

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { AutocompleteMembers } from '../autocomplete-members';
+import { PanelHeader } from './panel-header';
 
 export interface Properties {
   search: (input: string) => any;
@@ -17,28 +18,27 @@ export default class CreateConversationPanel extends React.Component<Properties>
 
   render() {
     return (
-      <div className='start__chat'>
-        <span className='start__chat-title'>
-          <i
-            className='start__chat-return'
-            onClick={this.props.onBack}
-          />
-          New message
-        </span>
-        <div className='start__chat-search'>
-          <AutocompleteMembers
-            search={this.props.search}
-            onSelect={this.userSelected}
-          >
-            <div
-              className='create-conversation__group-button'
-              onClick={this.props.onStartGroupChat}
+      <>
+        <PanelHeader
+          title='New message'
+          onBack={this.props.onBack}
+        />
+        <div className='start__chat'>
+          <div className='start__chat-search'>
+            <AutocompleteMembers
+              search={this.props.search}
+              onSelect={this.userSelected}
             >
-              Start a group chat
-            </div>
-          </AutocompleteMembers>
+              <div
+                className='create-conversation__group-button'
+                onClick={this.props.onStartGroupChat}
+              >
+                Start a group chat
+              </div>
+            </AutocompleteMembers>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -154,7 +154,7 @@ describe('messenger-list', () => {
 
     expect(wrapper).not.toHaveElement('CreateConversationPanel');
     expect(wrapper).toHaveElement('.header-button');
-    expect(wrapper).toHaveElement('.messages-list__items-conversations');
+    expect(wrapper).toHaveElement('.messages-list__items');
   });
 
   it('returns to conversation list if back button pressed', async function () {
@@ -162,14 +162,14 @@ describe('messenger-list', () => {
     wrapper.find('.header-button__icon').simulate('click');
     expect(wrapper).toHaveElement('CreateConversationPanel');
     expect(wrapper).not.toHaveElement('.header-button');
-    expect(wrapper).not.toHaveElement('.messages-list__items-conversations');
+    expect(wrapper).not.toHaveElement('.messages-list__items');
 
     wrapper.find(CreateConversationPanel).prop('onBack')();
     wrapper.update();
 
     expect(wrapper).not.toHaveElement('CreateConversationPanel');
     expect(wrapper).toHaveElement('.header-button');
-    expect(wrapper).toHaveElement('.messages-list__items-conversations');
+    expect(wrapper).toHaveElement('.messages-list__items');
   });
 
   it('provides the list of conversations to the Search', function () {
@@ -300,7 +300,7 @@ describe('messenger-list', () => {
       expect(wrapper).not.toHaveElement(StartGroupPanel);
       expect(wrapper).not.toHaveElement(CreateConversationPanel);
       expect(wrapper).toHaveElement('.header-button');
-      expect(wrapper).toHaveElement('.messages-list__items-conversations');
+      expect(wrapper).toHaveElement('.messages-list__items');
     });
   });
 

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -16,6 +16,7 @@ import moment from 'moment';
 import { when } from 'jest-when';
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
+import { StartGroupPanel } from './start-group-panel';
 
 export const DIRECT_MESSAGES_TEST = directMessagesFixture as unknown as Channel[];
 
@@ -236,17 +237,71 @@ describe('messenger-list', () => {
     expect(wrapper.find('.direct-message-members__user-unread-count').text()).toEqual(unreadCount.toString());
   });
 
-  it('moves to the group conversation creation phase', function () {
-    const wrapper = subject({});
+  describe('tooltip', () => {
+    it('moves to the group conversation creation phase', function () {
+      const wrapper = subject({});
 
-    wrapper.find('.header-button__icon').simulate('click');
+      wrapper.find('.header-button__icon').simulate('click');
 
-    wrapper.find(CreateConversationPanel).prop('onStartGroupChat')();
-    wrapper.update();
+      wrapper.find(CreateConversationPanel).prop('onStartGroupChat')();
+      wrapper.update();
 
-    expect(wrapper).not.toHaveElement(ConversationListPanel);
-    expect(wrapper).not.toHaveElement(CreateConversationPanel);
-    expect(wrapper).toHaveElement('StartGroupPanel');
+      expect(wrapper).not.toHaveElement(ConversationListPanel);
+      expect(wrapper).not.toHaveElement(CreateConversationPanel);
+      expect(wrapper).toHaveElement('StartGroupPanel');
+    });
+
+    it('returns to one on one conversation panel if back button pressed on start group panel', async function () {
+      const wrapper = subject({});
+      wrapper.find('.header-button__icon').simulate('click');
+      wrapper.find(CreateConversationPanel).prop('onStartGroupChat')();
+      wrapper.update();
+
+      wrapper.find(StartGroupPanel).prop('onBack')();
+      wrapper.update();
+
+      expect(wrapper).not.toHaveElement(StartGroupPanel);
+      expect(wrapper).toHaveElement(CreateConversationPanel);
+      expect(wrapper).not.toHaveElement(ConversationListPanel);
+    });
+
+    it('creates a group conversation when users selected', async function () {
+      const createDirectMessage = jest.fn();
+      const wrapper = subject({ createDirectMessage });
+      wrapper.find('.header-button__icon').simulate('click');
+      wrapper.find(CreateConversationPanel).prop('onStartGroupChat')();
+      wrapper.update();
+
+      // Can't do simulate on custom components when rendering fully. Convert to simulate after.
+      wrapper.find(StartGroupPanel).prop('onContinue')([
+        'selected-id-1',
+        'selected-id-2',
+      ]);
+
+      expect(createDirectMessage).toHaveBeenCalledWith({
+        userIds: [
+          'selected-id-1',
+          'selected-id-2',
+        ],
+      });
+    });
+
+    it('returns to conversation list when one on one conversation created', async function () {
+      const createDirectMessage = jest.fn();
+      const wrapper = subject({ createDirectMessage });
+      wrapper.find('.header-button__icon').simulate('click');
+      wrapper.find(CreateConversationPanel).prop('onStartGroupChat')();
+      wrapper.update();
+
+      // Can't do simulate on custom components when rendering fully. Convert to simulate after.
+      wrapper.find(StartGroupPanel).prop('onContinue')(['id-1']);
+      wrapper.update();
+
+      expect(wrapper).not.toHaveElement(StartGroupPanel);
+      expect(wrapper).not.toHaveElement(CreateConversationPanel);
+      expect(wrapper).toHaveElement('.header-button');
+      expect(wrapper).toHaveElement('.messages-list__items-conversations');
+    });
   });
 
   describe('tooltip', () => {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -15,6 +15,7 @@ import { RootState } from '../../../store';
 import moment from 'moment';
 import { when } from 'jest-when';
 import CreateConversationPanel from './create-conversation-panel';
+import { ConversationListPanel } from './conversation-list-panel';
 
 export const DIRECT_MESSAGES_TEST = directMessagesFixture as unknown as Channel[];
 
@@ -233,6 +234,19 @@ describe('messenger-list', () => {
     });
     wrapper.update();
     expect(wrapper.find('.direct-message-members__user-unread-count').text()).toEqual(unreadCount.toString());
+  });
+
+  it('moves to the group conversation creation phase', function () {
+    const wrapper = subject({});
+
+    wrapper.find('.header-button__icon').simulate('click');
+
+    wrapper.find(CreateConversationPanel).prop('onStartGroupChat')();
+    wrapper.update();
+
+    expect(wrapper).not.toHaveElement(ConversationListPanel);
+    expect(wrapper).not.toHaveElement(CreateConversationPanel);
+    expect(wrapper).toHaveElement('StartGroupPanel');
   });
 
   describe('tooltip', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,7 +15,7 @@ import { IconXClose } from '@zero-tech/zui/icons';
 import './styles.scss';
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
-import StartGroupPanel from './start-group-panel';
+import { StartGroupPanel } from './start-group-panel';
 
 export interface PublicProperties {
   onClose: () => void;
@@ -93,6 +93,8 @@ export class Container extends React.Component<Properties, State> {
   goBack = (): void => {
     if (this.state.stage === Stage.CreateOneOnOne) {
       this.setState({ stage: Stage.List });
+    } else if (this.state.stage === Stage.StartGroupChat) {
+      this.setState({ stage: Stage.CreateOneOnOne });
     }
   };
 
@@ -121,6 +123,12 @@ export class Container extends React.Component<Properties, State> {
 
   createOneOnOneConversation = (id: string): void => {
     this.props.createDirectMessage({ userIds: [id] });
+    this.reset();
+  };
+
+  groupMembersSelected = (userIds: string[]): void => {
+    // For now, we just create the message. Adding group details to come in the future.
+    this.props.createDirectMessage({ userIds });
     this.reset();
   };
 
@@ -163,7 +171,13 @@ export class Container extends React.Component<Properties, State> {
               onStartGroupChat={this.startGroupChat}
             />
           )}
-          {this.state.stage === Stage.StartGroupChat && <StartGroupPanel />}
+          {this.state.stage === Stage.StartGroupChat && (
+            <StartGroupPanel
+              onBack={this.goBack}
+              onContinue={this.groupMembersSelected}
+              searchUsers={this.usersInMyNetworks}
+            />
+          )}
         </div>
       </>
     );

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,6 +15,7 @@ import { IconXClose } from '@zero-tech/zui/icons';
 import './styles.scss';
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
+import StartGroupPanel from './start-group-panel';
 
 export interface PublicProperties {
   onClose: () => void;
@@ -23,6 +24,7 @@ export interface PublicProperties {
 enum Stage {
   List = 'list',
   CreateOneOnOne = 'one_on_one',
+  StartGroupChat = 'start_group',
 }
 
 interface State {
@@ -101,6 +103,12 @@ export class Container extends React.Component<Properties, State> {
     });
   };
 
+  startGroupChat = (): void => {
+    this.setState({
+      stage: Stage.StartGroupChat,
+    });
+  };
+
   usersInMyNetworks = async (search: string) => {
     const users: MemberNetworks[] = await searchMyNetworksByName(search);
 
@@ -152,8 +160,10 @@ export class Container extends React.Component<Properties, State> {
               onBack={this.goBack}
               search={this.usersInMyNetworks}
               onCreate={this.createOneOnOneConversation}
+              onStartGroupChat={this.startGroupChat}
             />
           )}
+          {this.state.stage === Stage.StartGroupChat && <StartGroupPanel />}
         </div>
       </>
     );

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -20,9 +20,15 @@ export interface PublicProperties {
   onClose: () => void;
 }
 
+enum Stage {
+  List = 'list',
+  CreateOneOnOne = 'one_on_one',
+}
+
 interface State {
   showCreateConversation: boolean;
   directMessagesList: Channel[];
+  stage: Stage;
 }
 export interface Properties extends PublicProperties {
   setActiveMessengerChat: (channelId: string) => void;
@@ -32,7 +38,11 @@ export interface Properties extends PublicProperties {
 }
 
 export class Container extends React.Component<Properties, State> {
-  state = { showCreateConversation: false, directMessagesList: [] };
+  state = {
+    showCreateConversation: false,
+    directMessagesList: [],
+    stage: Stage.List,
+  };
 
   static mapState(state: RootState): Partial<Properties> {
     const messengerList = denormalizeConversations(state).sort((messengerA, messengerB) =>
@@ -71,9 +81,22 @@ export class Container extends React.Component<Properties, State> {
     this.props.setActiveMessengerChat(directMessageId);
   };
 
-  toggleConversation = (): void => {
+  reset = (): void => {
     this.setState({
-      showCreateConversation: !this.state.showCreateConversation,
+      stage: Stage.List,
+      directMessagesList: this.props.directMessages,
+    });
+  };
+
+  goBack = (): void => {
+    if (this.state.stage === Stage.CreateOneOnOne) {
+      this.setState({ stage: Stage.List });
+    }
+  };
+
+  startConversation = (): void => {
+    this.setState({
+      stage: Stage.CreateOneOnOne,
       directMessagesList: this.props.directMessages,
     });
   };
@@ -90,7 +113,7 @@ export class Container extends React.Component<Properties, State> {
 
   createOneOnOneConversation = (id: string): void => {
     this.props.createDirectMessage({ userIds: [id] });
-    this.toggleConversation();
+    this.reset();
   };
 
   renderTitleBar() {
@@ -115,18 +138,18 @@ export class Container extends React.Component<Properties, State> {
       <>
         {this.renderTitleBar()}
         <div className='direct-message-members'>
-          {!this.state.showCreateConversation && (
+          {this.state.stage === Stage.List && (
             <ConversationListPanel
               directMessages={this.props.directMessages}
               directMessagesList={this.state.directMessagesList}
               conversationInMyNetworks={this.conversationInMyNetworks}
               handleMemberClick={this.handleMemberClick}
-              toggleConversation={this.toggleConversation}
+              toggleConversation={this.startConversation}
             />
           )}
-          {this.state.showCreateConversation && (
+          {this.state.stage === Stage.CreateOneOnOne && (
             <CreateConversationPanel
-              onBack={this.toggleConversation}
+              onBack={this.goBack}
               search={this.usersInMyNetworks}
               onCreate={this.createOneOnOneConversation}
             />

--- a/src/components/messenger/list/panel-header.test.tsx
+++ b/src/components/messenger/list/panel-header.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { PanelHeader, Properties } from './panel-header';
+
+jest.mock('@zero-tech/zui/icons');
+
+describe('PanelHeader', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      title: 'header',
+      onBack: () => {},
+      ...props,
+    };
+
+    return shallow(<PanelHeader {...allProps} />);
+  };
+
+  it('fires onBack when back icon clicked', function () {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    wrapper.find('.messenger-panel__back').simulate('click');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/messenger/list/panel-header.tsx
+++ b/src/components/messenger/list/panel-header.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { IconArrowNarrowLeft } from '@zero-tech/zui/icons';
+
+export interface Properties {
+  title: string;
+  onBack: () => void;
+}
+
+export class PanelHeader extends React.Component<Properties> {
+  render() {
+    return (
+      <div className='messenger-panel__header'>
+        <span
+          className='messenger-panel__back'
+          onClick={this.props.onBack}
+        >
+          <IconArrowNarrowLeft size={24} />
+        </span>
+        {this.props.title}
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { StartGroupPanel, Properties } from './start-group-panel';
+
+jest.mock('../autocomplete-members');
+jest.mock('@zero-tech/zui/components');
+
+describe('StartGroupPanel', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      searchUsers: () => {},
+      onBack: () => {},
+      onContinue: () => {},
+      ...props,
+    };
+
+    return shallow(<StartGroupPanel {...allProps} />);
+  };
+
+  it('forwards search function to Autocomplete', function () {
+    const searchUsers = jest.fn();
+    const wrapper = subject({ searchUsers });
+
+    expect(wrapper.find('AutocompleteMembers').prop('search')).toBe(searchUsers);
+  });
+
+  it('fires onBack when back icon clicked', function () {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    wrapper.find('.start-group-panel__back').simulate('click');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('fires onContinue when continue is clicked', function () {
+    const onContinue = jest.fn();
+    const wrapper = subject({ onContinue });
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2' });
+    wrapper.find('.start-group-panel__continue').simulate('click');
+
+    expect(onContinue).toHaveBeenCalledWith([
+      'id-1',
+      'id-2',
+    ]);
+  });
+
+  it('enables continue button based on number of users', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find('.start-group-panel__continue').prop('disabled')).toBeTrue();
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
+    expect(wrapper.find('.start-group-panel__continue').prop('disabled')).toBeFalse();
+
+    // XXX: remove the selection
+    // expect(wrapper.find('.start-group-panel__continue').prop('disabled')).toBeTrue();
+  });
+
+  it('shows selected member count', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('0 members selected');
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
+    expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('1 member selected');
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2' });
+    expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('2 members selected');
+  });
+
+  it('renders selected members', function () {
+    const wrapper = subject({});
+
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2', label: 'User 2', image: 'url-2' });
+
+    expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual([
+      'User 1',
+      'User 2',
+    ]);
+    expect(wrapper.find('Avatar').map((n) => n.prop('imageURL'))).toEqual([
+      'url-1',
+      'url-2',
+    ]);
+  });
+
+  it('unselects users when X is clicked', function () {
+    const wrapper = subject({});
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2', label: 'User 2', image: 'url-2' });
+
+    wrapper
+      .find('.start-group-panel__user-remove')
+      .first()
+      .simulate('click', { currentTarget: { dataset: { value: 'id-1' } } });
+
+    expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual(['User 2']);
+  });
+
+  it('renders unique list of selected users', function () {
+    const wrapper = subject({});
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    // Select the same option
+    wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+
+    expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual(['User 1']);
+  });
+
+  xit('unselects users when autocomplete remove clicked', function () {});
+});

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -41,7 +41,7 @@ describe('StartGroupPanel', () => {
 
     wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
     wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2' });
-    wrapper.find('.start-group-panel__continue').simulate('click');
+    wrapper.find('Button').simulate('press');
 
     expect(onContinue).toHaveBeenCalledWith([
       'id-1',
@@ -52,13 +52,15 @@ describe('StartGroupPanel', () => {
   it('enables continue button based on number of users', function () {
     const wrapper = subject({});
 
-    expect(wrapper.find('.start-group-panel__continue').prop('disabled')).toBeTrue();
+    expect(wrapper.find('Button').prop('isDisabled')).toBeTrue();
 
     wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-1' });
-    expect(wrapper.find('.start-group-panel__continue').prop('disabled')).toBeFalse();
+    expect(wrapper.find('Button').prop('isDisabled')).toBeFalse();
 
-    // XXX: remove the selection
-    // expect(wrapper.find('.start-group-panel__continue').prop('disabled')).toBeTrue();
+    wrapper
+      .find('.start-group-panel__user-remove')
+      .simulate('click', { currentTarget: { dataset: { value: 'id-1' } } });
+    expect(wrapper.find('Button').prop('isDisabled')).toBeTrue();
   });
 
   it('shows selected member count', function () {
@@ -110,6 +112,4 @@ describe('StartGroupPanel', () => {
 
     expect(wrapper.find('.start-group-panel__user-label').map((n) => n.text())).toEqual(['User 1']);
   });
-
-  xit('unselects users when autocomplete remove clicked', function () {});
 });

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -5,6 +5,7 @@ import { StartGroupPanel, Properties } from './start-group-panel';
 
 jest.mock('../autocomplete-members');
 jest.mock('@zero-tech/zui/components');
+jest.mock('@zero-tech/zui/icons');
 
 describe('StartGroupPanel', () => {
   const subject = (props: Partial<Properties>) => {
@@ -29,7 +30,7 @@ describe('StartGroupPanel', () => {
     const onBack = jest.fn();
     const wrapper = subject({ onBack });
 
-    wrapper.find('.start-group-panel__back').simulate('click');
+    wrapper.find('PanelHeader').simulate('back');
 
     expect(onBack).toHaveBeenCalledOnce();
   });

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@zero-tech/zui/components';
 
 import { AutocompleteMembers, Option } from '../autocomplete-members';
 import { IconXClose } from '@zero-tech/zui/icons';
+import { PanelHeader } from './panel-header';
 
 export interface Properties {
   searchUsers: (input: string) => any;
@@ -50,15 +51,10 @@ export class StartGroupPanel extends React.Component<Properties, State> {
   render() {
     return (
       <>
-        <div className='start-group-panel'>
-          <span>
-            <i
-              className='start-group-panel__back'
-              onClick={this.props.onBack}
-            />
-            Select members
-          </span>
-        </div>
+        <PanelHeader
+          title='Select members'
+          onBack={this.props.onBack}
+        />
         <AutocompleteMembers
           search={this.props.searchUsers}
           onSelect={this.selectOption}

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -59,27 +59,32 @@ export class StartGroupPanel extends React.Component<Properties, State> {
           search={this.props.searchUsers}
           onSelect={this.selectOption}
         >
-          <div className=''>
-            <span className='start-group-panel__selected-count'>
-              {this.state.selectedOptions.length} member{this.state.selectedOptions.length === 1 ? '' : 's'} selected
-            </span>
-            {this.state.selectedOptions.map((val) => (
-              <div key={val.value}>
+          <div className='start-group-panel__selected-count'>
+            <span className='start-group-panel__selected-number'>{this.state.selectedOptions.length}</span> member
+            {this.state.selectedOptions.length === 1 ? '' : 's'} selected
+          </div>
+          {this.state.selectedOptions.map((val) => (
+            <div
+              className='start-group-panel__selected-option'
+              key={val.value}
+            >
+              <div className='start-group-panel__selected-tag'>
                 <Avatar
-                  size={'small'}
+                  size={'extra small'}
                   type={'circle'}
                   imageURL={val.image}
                 />
                 <span className='start-group-panel__user-label'>{val.label}</span>
                 <button
                   onClick={this.unselectOption}
+                  data-value={val.value}
                   className='start-group-panel__user-remove'
                 >
-                  <IconXClose data-value={val.value} />
+                  <IconXClose size={16} />
                 </button>
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </AutocompleteMembers>
         <button
           className='start-group-panel__continue'

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -1,11 +1,98 @@
 import * as React from 'react';
 
-// import { AutocompleteMembers } from '../autocomplete-members';
+import { Avatar } from '@zero-tech/zui/components';
 
-export interface Properties {}
+import { AutocompleteMembers, Option } from '../autocomplete-members';
+import { IconXClose } from '@zero-tech/zui/icons';
 
-export default class StartGroupPanel extends React.Component<Properties> {
+export interface Properties {
+  searchUsers: (input: string) => any;
+
+  onBack: () => void;
+  onContinue: (ids: string[]) => void;
+}
+
+interface State {
+  selectedOptions: Option[];
+}
+
+export class StartGroupPanel extends React.Component<Properties, State> {
+  state = { selectedOptions: [] };
+
+  continue = () => {
+    this.props.onContinue(this.state.selectedOptions.map((o) => o.value));
+  };
+
+  selectOption = (selectedOption) => {
+    if (this.state.selectedOptions.find((o) => o.value === selectedOption.value)) {
+      return;
+    }
+
+    this.setState({
+      selectedOptions: [
+        ...this.state.selectedOptions,
+        selectedOption,
+      ],
+    });
+  };
+
+  unselectOption = (event) => {
+    const clickedValue = event.currentTarget.dataset.value;
+    this.setState({
+      selectedOptions: this.state.selectedOptions.filter((o) => o.value !== clickedValue),
+    });
+  };
+
+  get isContinueDisabled() {
+    return this.state.selectedOptions.length <= 0;
+  }
+
   render() {
-    return <div className='start-group-panel'></div>;
+    return (
+      <>
+        <div className='start-group-panel'>
+          <span>
+            <i
+              className='start-group-panel__back'
+              onClick={this.props.onBack}
+            />
+            Select members
+          </span>
+        </div>
+        <AutocompleteMembers
+          search={this.props.searchUsers}
+          onSelect={this.selectOption}
+        >
+          <div className=''>
+            <span className='start-group-panel__selected-count'>
+              {this.state.selectedOptions.length} member{this.state.selectedOptions.length === 1 ? '' : 's'} selected
+            </span>
+            {this.state.selectedOptions.map((val) => (
+              <div key={val.value}>
+                <Avatar
+                  size={'small'}
+                  type={'circle'}
+                  imageURL={val.image}
+                />
+                <span className='start-group-panel__user-label'>{val.label}</span>
+                <button
+                  onClick={this.unselectOption}
+                  className='start-group-panel__user-remove'
+                >
+                  <IconXClose data-value={val.value} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </AutocompleteMembers>
+        <button
+          className='start-group-panel__continue'
+          onClick={this.continue}
+          disabled={this.isContinueDisabled}
+        >
+          Continue
+        </button>
+      </>
+    );
   }
 }

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Avatar } from '@zero-tech/zui/components';
+import { Avatar, Button } from '@zero-tech/zui/components';
 
 import { AutocompleteMembers, Option } from '../autocomplete-members';
 import { IconXClose } from '@zero-tech/zui/icons';
@@ -55,44 +55,48 @@ export class StartGroupPanel extends React.Component<Properties, State> {
           title='Select members'
           onBack={this.props.onBack}
         />
-        <AutocompleteMembers
-          search={this.props.searchUsers}
-          onSelect={this.selectOption}
-        >
-          <div className='start-group-panel__selected-count'>
-            <span className='start-group-panel__selected-number'>{this.state.selectedOptions.length}</span> member
-            {this.state.selectedOptions.length === 1 ? '' : 's'} selected
-          </div>
-          {this.state.selectedOptions.map((val) => (
-            <div
-              className='start-group-panel__selected-option'
-              key={val.value}
-            >
-              <div className='start-group-panel__selected-tag'>
-                <Avatar
-                  size={'extra small'}
-                  type={'circle'}
-                  imageURL={val.image}
-                />
-                <span className='start-group-panel__user-label'>{val.label}</span>
-                <button
-                  onClick={this.unselectOption}
-                  data-value={val.value}
-                  className='start-group-panel__user-remove'
-                >
-                  <IconXClose size={16} />
-                </button>
-              </div>
+        <div className='start-group-panel__search'>
+          <AutocompleteMembers
+            search={this.props.searchUsers}
+            onSelect={this.selectOption}
+          >
+            <div className='start-group-panel__selected-count'>
+              <span className='start-group-panel__selected-number'>{this.state.selectedOptions.length}</span> member
+              {this.state.selectedOptions.length === 1 ? '' : 's'} selected
             </div>
-          ))}
-        </AutocompleteMembers>
-        <button
+            <div className='start-group-panel__selected-options'>
+              {this.state.selectedOptions.map((val) => (
+                <div
+                  className='start-group-panel__selected-option'
+                  key={val.value}
+                >
+                  <div className='start-group-panel__selected-tag'>
+                    <Avatar
+                      size={'extra small'}
+                      type={'circle'}
+                      imageURL={val.image}
+                    />
+                    <span className='start-group-panel__user-label'>{val.label}</span>
+                    <button
+                      onClick={this.unselectOption}
+                      data-value={val.value}
+                      className='start-group-panel__user-remove'
+                    >
+                      <IconXClose size={16} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </AutocompleteMembers>
+        </div>
+        <Button
           className='start-group-panel__continue'
-          onClick={this.continue}
-          disabled={this.isContinueDisabled}
+          onPress={this.continue}
+          isDisabled={this.isContinueDisabled}
         >
           Continue
-        </button>
+        </Button>
       </>
     );
   }

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+// import { AutocompleteMembers } from '../autocomplete-members';
+
+export interface Properties {}
+
+export default class StartGroupPanel extends React.Component<Properties> {
+  render() {
+    return <div className='start-group-panel'></div>;
+  }
+}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -14,9 +14,10 @@
 }
 
 .direct-message-members {
-  overflow-y: scroll;
-  height: 100%;
+  flex-grow: 99;
   padding: 0 16px;
+  display: flex;
+  flex-direction: column;
 
   &__user {
     display: flex;
@@ -126,6 +127,7 @@
 }
 
 .start__chat {
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   align-content: center;
@@ -154,6 +156,9 @@
   }
 
   &-search {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     text-align: center;
   }
@@ -285,5 +290,22 @@
     display: inline-block;
     padding: 0px;
     margin: 0px;
+  }
+
+  &__content {
+    flex-grow: 99;
+
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__search {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__continue {
+    margin: 16px 0px;
   }
 }

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -92,11 +92,23 @@
       }
     }
     &__items {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+
       animation: conversation-slide-in 600ms ease-in forwards;
 
       &-conversations-input {
         margin-bottom: 18px;
       }
+    }
+
+    &__item-list {
+      flex-grow: 1;
+      // Forcing a height here allows the flex-grow to fill the size without growing too big
+      height: 1px;
+
+      overflow: auto;
     }
   }
 }

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -258,6 +258,31 @@
   }
 }
 
+.create-conversation {
+  &__group-button {
+    display: flex;
+    align-items: center;
+    margin-top: 16px;
+    gap: 8px;
+    cursor: pointer;
+  }
+
+  &__group-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    background: linear-gradient(223deg, #421349 14.62%, #0d0416 36.73%, #0b060e 59.58%, #2b0659 85.38%);
+    border-radius: 9999px;
+
+    & > * {
+      margin: auto;
+    }
+  }
+}
+
 .start-group-panel {
   &__selected-count {
     font-style: normal;

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -247,10 +247,43 @@
     font-weight: 400;
     font-size: 12px;
     line-height: 15px;
+    padding-top: 18px;
     color: theme.$color-greyscale-11;
   }
 
   &__selected-number {
     color: theme.$color-greyscale-12;
+  }
+
+  &__selected-option {
+    display: inline-block;
+  }
+
+  &__selected-tag {
+    color: theme.$color-greyscale-11;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 4px 8px;
+    gap: 4px;
+    background-color: theme.$color-greyscale-3;
+    border-radius: 8px;
+    border: 1px solid theme.$color-greyscale-5;
+    margin-top: 10px;
+    margin-right: 10px;
+
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+  }
+
+  &__user-remove {
+    cursor: pointer;
+    background: none;
+    border: none;
+    display: inline-block;
+    padding: 0px;
+    margin: 0px;
   }
 }

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -218,3 +218,39 @@
     }
   }
 }
+
+.messenger-panel {
+  &__header {
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    align-items: center;
+
+    font-style: normal;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 24px;
+    color: theme.$color-greyscale-12;
+
+    padding: 20px 10px;
+  }
+
+  &__back {
+    margin-right: 10px;
+    cursor: pointer;
+  }
+}
+
+.start-group-panel {
+  &__selected-count {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__selected-number {
+    color: theme.$color-greyscale-12;
+  }
+}

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -27,6 +27,8 @@
 
     &--messages {
       height: 100%;
+      display: flex;
+      flex-direction: column;
     }
   }
 }


### PR DESCRIPTION
### What does this do?

This re-implements the Create Group Chat functionality. This will create a new group chat as it was previously.

To follow up afterwards with the new group chat screen (i.e., name and image).

### Why are we making this change?

To get the app back to the previous state but matching the designs.

### How do I test this?

Go through all the variations of creating conversations.

