### PR TITLE
Remove prettier config singleAttributePerLine override

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,6 +3,5 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "jsxSingleQuote": true,
-  "printWidth": 120,
-  "singleAttributePerLine": true
+  "printWidth": 120
 }

--- a/src/app-sandbox/index.tsx
+++ b/src/app-sandbox/index.tsx
@@ -91,12 +91,7 @@ export class AppSandbox extends React.Component<Properties> {
     }
 
     if (selectedApp === Apps.Channels) {
-      return (
-        <Channels
-          {...this.appProperties}
-          store={store}
-        />
-      );
+      return <Channels {...this.appProperties} store={store} />;
     }
 
     if (selectedApp === Apps.DAOS) {

--- a/src/components/account/create.tsx
+++ b/src/components/account/create.tsx
@@ -194,11 +194,7 @@ export class Container extends React.Component<Properties, State> {
           </g>
           <defs>
             <clipPath id='clip0_5179_13261'>
-              <rect
-                width='16'
-                height='16'
-                fill='white'
-              />
+              <rect width='16' height='16' fill='white' />
             </clipPath>
           </defs>
         </svg>
@@ -214,10 +210,7 @@ export class Container extends React.Component<Properties, State> {
 
     return (
       <Dialog>
-        <form
-          className='profile-prompt'
-          onSubmit={this.onSubmit}
-        >
+        <form className='profile-prompt' onSubmit={this.onSubmit}>
           <div className='profile-prompt__head'>Create your account</div>
           <div className='profile-prompt__address'>
             <div className='profile-prompt__connection-status'>Connected:</div>
@@ -251,11 +244,7 @@ export class Container extends React.Component<Properties, State> {
           {Boolean(this.state.error) && this.renderError(this.state.error)}
 
           <div className='profile-prompt__submit'>
-            <Button
-              tabIndex={0}
-              onClick={this.onSubmit}
-              onEnterKeyPress={this.onSubmit}
-            >
+            <Button tabIndex={0} onClick={this.onSubmit} onEnterKeyPress={this.onSubmit}>
               Create Account
             </Button>
           </div>

--- a/src/components/address-bar/container.tsx
+++ b/src/components/address-bar/container.tsx
@@ -124,11 +124,5 @@ const ConnectedContainer = injectProviderService<any>(connectContainer<{}>(Conta
 export function AddressBarContainer(props: PublicProperties) {
   const history = useHistory();
 
-  return (
-    <ConnectedContainer
-      {...props}
-      history={history}
-      znsClient={client}
-    />
-  );
+  return <ConnectedContainer {...props} history={history} znsClient={client} />;
 }

--- a/src/components/address-bar/index.tsx
+++ b/src/components/address-bar/index.tsx
@@ -57,10 +57,7 @@ export class AddressBar extends React.Component<Properties, State> {
       ({ elements, route }, segment, index) => {
         if (elements.length) {
           elements.push(
-            <span
-              key={index}
-              className='address-bar__route-seperator'
-            >
+            <span key={index} className='address-bar__route-seperator'>
               .
             </span>
           );
@@ -71,12 +68,7 @@ export class AddressBar extends React.Component<Properties, State> {
         return {
           elements: [
             ...elements,
-            <ZnsLink
-              key={segment}
-              className='address-bar__route-segment'
-              route={route}
-              app={this.app.type}
-            >
+            <ZnsLink key={segment} className='address-bar__route-segment' route={route} app={this.app.type}>
               {segment}
             </ZnsLink>,
           ],
@@ -121,16 +113,8 @@ export class AddressBar extends React.Component<Properties, State> {
     return (
       <div className={classNames('address-bar', this.props.className)}>
         <div className='address-bar__navigation'>
-          <IconButton
-            icon={Icons.ChevronLeft}
-            className={backButtonClass}
-            onClick={this.props.onBack}
-          />
-          <IconButton
-            icon={Icons.ChevronRight}
-            className={forwardButtonClass}
-            onClick={this.props.onForward}
-          />
+          <IconButton icon={Icons.ChevronLeft} className={backButtonClass} onClick={this.props.onBack} />
+          <IconButton icon={Icons.ChevronRight} className={forwardButtonClass} onClick={this.props.onForward} />
         </div>
 
         {AddressBarMode.Display === mode && (
@@ -150,11 +134,7 @@ export class AddressBar extends React.Component<Properties, State> {
             <div className='address-bar__underlay' />
             <div className='address-bar__inner-search-container'>
               <div className='address-bar__inner-search'>
-                <ZNSDropdown
-                  api={this.props.api}
-                  onSelect={this.onSelect}
-                  onCloseBar={this.closeAddressBarMode}
-                />
+                <ZNSDropdown api={this.props.api} onSelect={this.onSelect} onCloseBar={this.closeAddressBarMode} />
               </div>
             </div>
           </>

--- a/src/components/app-menu/container.tsx
+++ b/src/components/app-menu/container.tsx
@@ -39,13 +39,7 @@ export class Container extends React.Component<Properties, {}> {
   render() {
     const { selectedApp } = this.props;
 
-    return (
-      <AppMenu
-        selectedApp={selectedApp}
-        route={this.defaultRoute}
-        apps={this.allApps}
-      />
-    );
+    return <AppMenu selectedApp={selectedApp} route={this.defaultRoute} apps={this.allApps} />;
   }
 }
 

--- a/src/components/app-menu/index.tsx
+++ b/src/components/app-menu/index.tsx
@@ -24,19 +24,9 @@ export class AppMenu extends React.Component<Properties> {
       const { type, name, imageSource } = app;
 
       return (
-        <li
-          key={type}
-          className={className}
-        >
-          <ZnsLink
-            route={this.props.route}
-            app={type}
-          >
-            <img
-              className='app-menu__app-image'
-              src={imageSource}
-              alt={name}
-            />
+        <li key={type} className={className}>
+          <ZnsLink route={this.props.route} app={type}>
+            <img className='app-menu__app-image' src={imageSource} alt={name} />
             <span className='app-menu__app-name'>{name}</span>
           </ZnsLink>
         </li>

--- a/src/components/authentication/button.tsx
+++ b/src/components/authentication/button.tsx
@@ -28,10 +28,7 @@ export class Container extends React.Component<Properties> {
 
   render() {
     return (
-      <div
-        onClick={this.openModal}
-        className={classNames(this.props.className, 'authentication__connect-wrapper')}
-      >
+      <div onClick={this.openModal} className={classNames(this.props.className, 'authentication__connect-wrapper')}>
         <ComponentButton>Connect</ComponentButton>
       </div>
     );

--- a/src/components/authentication/context.tsx
+++ b/src/components/authentication/context.tsx
@@ -9,16 +9,7 @@ export const Context = React.createContext<AuthenticationContext>({
 });
 
 export function withContext<T>(Component: any) {
-  return (props: T) => (
-    <Context.Consumer>
-      {(context) => (
-        <Component
-          {...props}
-          context={context}
-        />
-      )}
-    </Context.Consumer>
-  );
+  return (props: T) => <Context.Consumer>{(context) => <Component {...props} context={context} />}</Context.Consumer>;
 }
 
 export const Provider = Context.Provider;

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -257,10 +257,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
               height: this.state.dropdownHeight,
             }}
           >
-            <div
-              className='autocomplete-dropdown__items'
-              ref={this.itemsElement}
-            >
+            <div className='autocomplete-dropdown__items' ref={this.itemsElement}>
               {this.state.inProgress && (
                 <div className='autocomplete-dropdown-item autocomplete-dropdown__no-results'>Searching...</div>
               )}
@@ -297,12 +294,7 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
       content = <div className='autocomplete-dropdown-item autocomplete-dropdown__no-results'>No results found</div>;
     } else {
       content = items?.map((item) => (
-        <Result
-          isFocused={item.id === focusedItem.id}
-          item={item}
-          onSelect={this.onSelect}
-          key={item.id}
-        />
+        <Result isFocused={item.id === focusedItem.id} item={item} onSelect={this.onSelect} key={item.id} />
       ));
     }
 
@@ -338,10 +330,7 @@ export class Result extends React.Component<ResultProperties, undefined> {
         })}
         onMouseDown={this.onSelect}
       >
-        <div
-          className='autocomplete-dropdown-item__text'
-          title={summary}
-        >
+        <div className='autocomplete-dropdown-item__text' title={summary}>
           <span className='autocomplete-dropdown-item__value'>{value}</span>
           &nbsp;
           <span className='autocomplete-dropdown-item__route'>{route}</span>

--- a/src/components/chat-connect/status-indicator.tsx
+++ b/src/components/chat-connect/status-indicator.tsx
@@ -11,10 +11,7 @@ export class StatusIndicator extends React.Component<Properties> {
     return (
       <div className='status-indicator'>
         <span className='status-indicator__message'>Connection lost, calling the stars...</span>
-        <button
-          className='status-indicator__reconnect-button'
-          onClick={this.props.onForceReconnect}
-        >
+        <button className='status-indicator__reconnect-button' onClick={this.props.onForceReconnect}>
           Try Now
         </button>
       </div>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -126,10 +126,7 @@ export class ChatView extends React.Component<Properties, State> {
     const allMessages = messagesByDay[day];
 
     return (
-      <div
-        className='messages'
-        key={day}
-      >
+      <div className='messages' key={day}>
         <div className='message__header'>
           <div className='message__header-date'>{this.formatDayHeader(day)}</div>
         </div>
@@ -174,10 +171,7 @@ export class ChatView extends React.Component<Properties, State> {
 
   renderJoinButton() {
     return (
-      <div
-        onClick={this.props.joinChannel}
-        className={classNames(this.props.className, 'channel-view__join-wrapper')}
-      >
+      <div onClick={this.props.joinChannel} className={classNames(this.props.className, 'channel-view__join-wrapper')}>
         <ComponentButton>Join Channel</ComponentButton>
       </div>
     );
@@ -194,10 +188,7 @@ export class ChatView extends React.Component<Properties, State> {
     return (
       <div className={classNames('channel-view', this.props.className)}>
         {this.isShowIndicator() && (
-          <IndicatorMessage
-            countNewMessages={this.props.countNewMessages}
-            closeIndicator={this.closeIndicator}
-          />
+          <IndicatorMessage countNewMessages={this.props.countNewMessages} closeIndicator={this.closeIndicator} />
         )}
         {isLightboxOpen && (
           <Lightbox

--- a/src/components/config/index.tsx
+++ b/src/components/config/index.tsx
@@ -7,12 +7,7 @@ import { config } from '../../config';
 export function inject<T>(ChildComponent: any) {
   return class ConfigInjector extends React.Component<T> {
     render() {
-      return (
-        <ChildComponent
-          {...this.props}
-          config={config}
-        />
-      );
+      return <ChildComponent {...this.props} config={config} />;
     }
   };
 }

--- a/src/components/feature-flag/index.tsx
+++ b/src/components/feature-flag/index.tsx
@@ -24,12 +24,7 @@ export const FeatureFlag = inject<PublicProperties>(Component);
 export function inject<T>(ChildComponent: any) {
   return class FeatureFlagInjector extends React.Component<T> {
     render() {
-      return (
-        <ChildComponent
-          {...this.props}
-          featureFlags={featureFlags}
-        />
-      );
+      return <ChildComponent {...this.props} featureFlags={featureFlags} />;
     }
   };
 }

--- a/src/components/icon-button/index.tsx
+++ b/src/components/icon-button/index.tsx
@@ -22,15 +22,8 @@ export class IconButton extends React.Component<Properties> {
 
   render() {
     return (
-      <button
-        className={classNames('icon-button', this.props.className)}
-        onClick={this.handleClick}
-      >
-        <this.props.Icon
-          label={this.props.label}
-          size={this.props.size}
-          isFilled={this.props.isFilled}
-        />
+      <button className={classNames('icon-button', this.props.className)} onClick={this.handleClick}>
+        <this.props.Icon label={this.props.label} size={this.props.size} isFilled={this.props.isFilled} />
       </button>
     );
   }

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -50,13 +50,7 @@ export class ImageUpload extends Component<Properties, State> {
             {this.state.files.length === 0 ? (
               <div {...getRootProps({ className: 'image-upload__dropzone' })}>
                 <input {...getInputProps()} />
-                <svg
-                  width='24'
-                  height='24'
-                  viewBox='0 0 24 24'
-                  fill='none'
-                  xmlns='http://www.w3.org/2000/svg'
-                >
+                <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
                   <path
                     d='M2 3C2 2.44772 2.44772 2 3 2H21C21.5523 2 22 2.44772 22 3C22 3.55228 21.5523 4 21 4H3C2.44772 4 2 3.55228 2 3Z'
                     fill='#EDEDEF'

--- a/src/components/indicator-message/index.tsx
+++ b/src/components/indicator-message/index.tsx
@@ -23,19 +23,9 @@ export class IndicatorMessage extends React.Component<Properties> {
           >
             <span className='indicator__new-message-bar-text'>{this.props.countNewMessages} new messages</span>
           </button>
-          <button
-            type='button'
-            className='indicator__new-message-alt'
-            onClick={this.props.closeIndicator}
-          >
+          <button type='button' className='indicator__new-message-alt' onClick={this.props.closeIndicator}>
             Mark As Read
-            <svg
-              aria-hidden='true'
-              role='img'
-              width='24'
-              height='24'
-              viewBox='0 0 24 24'
-            >
+            <svg aria-hidden='true' role='img' width='24' height='24' viewBox='0 0 24 24'>
               <path
                 fill='currentColor'
                 fill-rule='evenodd'

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -88,10 +88,7 @@ export class InvertedScroll extends React.Component<Properties, undefined> {
 
   render() {
     return (
-      <div
-        className={classNames('scroll-container', this.props.className)}
-        ref={this.setScrollWrapper}
-      >
+      <div className={classNames('scroll-container', this.props.className)} ref={this.setScrollWrapper}>
         <div className='scroll-container__children'>{this.props.children}</div>
       </div>
     );

--- a/src/components/link-preview/index.tsx
+++ b/src/components/link-preview/index.tsx
@@ -111,11 +111,7 @@ export class LinkPreview extends React.Component<Properties, State> {
   renderVideoBanner() {
     return (
       <div className='link-preview__banner'>
-        <VideoPlayer
-          className='link-preview__banner-video'
-          url={this.props.url}
-          autoplay={false}
-        />
+        <VideoPlayer className='link-preview__banner-video' url={this.props.url} autoplay={false} />
       </div>
     );
   }
@@ -167,28 +163,16 @@ export class LinkPreview extends React.Component<Properties, State> {
     const { className, description, url, providerName } = this.props;
 
     return (
-      <div
-        ref={this.ref}
-        className={classNames('link-preview', className)}
-        onClick={this.handleOnClick}
-      >
+      <div ref={this.ref} className={classNames('link-preview', className)} onClick={this.handleOnClick}>
         {this.renderBanner()}
         <div className='link-preview__body'>
-          <ButtonLink
-            url={this.titleUrl}
-            openInNewTab
-            className='link-preview__title'
-          >
+          <ButtonLink url={this.titleUrl} openInNewTab className='link-preview__title'>
             {this.title}
           </ButtonLink>
           <div className='link-preview__description'>{description}</div>
         </div>
         <div className='link-preview__footer'>
-          <ButtonLink
-            className='link-preview__content-link'
-            url={url}
-            openInNewTab
-          >
+          <ButtonLink className='link-preview__content-link' url={url} openInNewTab>
             View this on <span className='link-preview__content-provider'>{providerName}</span>
           </ButtonLink>
         </div>

--- a/src/components/message-audio-recorder/index.tsx
+++ b/src/components/message-audio-recorder/index.tsx
@@ -66,11 +66,7 @@ export default class MessageAudioRecorder extends React.Component<Properties, St
             canvasHeight='20'
           />
           <div className='message-audio-recorder__icons'>
-            <IconButton
-              Icon={IconCheck}
-              onClick={this.stopRecording}
-              className='message-audio-recorder__icons-check'
-            />
+            <IconButton Icon={IconCheck} onClick={this.stopRecording} className='message-audio-recorder__icons-check' />
           </div>
         </div>
       </div>

--- a/src/components/message-input/emoji-picker.tsx
+++ b/src/components/message-input/emoji-picker.tsx
@@ -72,13 +72,6 @@ export class EmojiPicker extends React.Component<Properties> {
       return null;
     }
 
-    return (
-      <Picker
-        theme={this.pickerViewMode}
-        emoji='mechanical_arm'
-        title='ZOS'
-        onSelect={this.insertEmoji}
-      />
-    );
+    return <Picker theme={this.pickerViewMode} emoji='mechanical_arm' title='ZOS' onSelect={this.insertEmoji} />;
   }
 }

--- a/src/components/message-input/giphy.tsx
+++ b/src/components/message-input/giphy.tsx
@@ -10,10 +10,7 @@ export const GiphyComponents = ({ onClickGif }: Properties) => {
   const { fetchGifs, searchKey } = useContext(SearchContext);
   return (
     <div className='giphy__container'>
-      <SearchBar
-        className='giphy__container-search'
-        autoFocus
-      />
+      <SearchBar className='giphy__container-search' autoFocus />
       <div className='giphy__container-grid'>
         <Grid
           key={searchKey}

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -271,19 +271,10 @@ export class MessageInput extends React.Component<Properties, State> {
     return (
       <div className='message-input chat-message__new-message'>
         <div className='message-input__icons'>
-          <IconButton
-            onClick={this.openGiphy}
-            Icon={IconStickerCircle}
-            size={16}
-            className='giphy__icon'
-          />
+          <IconButton onClick={this.openGiphy} Icon={IconStickerCircle} size={16} className='giphy__icon' />
         </div>
         <div className='message-input__icons'>
-          <Menu
-            onSelected={this.mediaSelected}
-            mimeTypes={this.mimeTypes}
-            maxSize={config.cloudinary.max_file_size}
-          />
+          <Menu onSelected={this.mediaSelected} mimeTypes={this.mimeTypes} maxSize={config.cloudinary.max_file_size} />
         </div>
 
         <div className='message-input__input-wrapper'>
@@ -295,21 +286,9 @@ export class MessageInput extends React.Component<Properties, State> {
           >
             {({ getRootProps }) => (
               <div {...getRootProps({ className: 'mentions-text-area' })}>
-                <ImageCards
-                  images={this.images}
-                  onRemoveImage={this.removeMediaPreview}
-                  size='small'
-                />
-                <AudioCards
-                  audios={this.audios}
-                  onRemove={this.removeMediaPreview}
-                />
-                {this.props.reply && (
-                  <ReplyCard
-                    message={this.props.reply.message}
-                    onRemove={this.removeReply}
-                  />
-                )}
+                <ImageCards images={this.images} onRemoveImage={this.removeMediaPreview} size='small' />
+                <AudioCards audios={this.audios} onRemove={this.removeMediaPreview} />
+                {this.props.reply && <ReplyCard message={this.props.reply.message} onRemove={this.removeReply} />}
                 <div className='message-input__emoji-picker'>
                   <EmojiPicker
                     textareaRef={this.textareaRef}
@@ -321,17 +300,9 @@ export class MessageInput extends React.Component<Properties, State> {
                     onSelect={this.onInsertEmoji}
                   />
                 </div>
-                {this.state.isGiphyActive && (
-                  <Giphy
-                    onClickGif={this.onInsertGiphy}
-                    onClose={this.closeGiphy}
-                  />
-                )}
+                {this.state.isGiphyActive && <Giphy onClickGif={this.onInsertGiphy} onClose={this.closeGiphy} />}
                 {this.state.isMicActive && (
-                  <MessageAudioRecorder
-                    onClose={this.cancelRecording}
-                    onMediaSelected={this.createAudioClip}
-                  />
+                  <MessageAudioRecorder onClose={this.cancelRecording} onMediaSelected={this.createAudioClip} />
                 )}
                 <MentionsInput
                   inputRef={this.textareaRef}
@@ -362,12 +333,7 @@ export class MessageInput extends React.Component<Properties, State> {
           </div>
         </div>
         <div className='message-input__icons'>
-          <IconButton
-            onClick={this.startMic}
-            Icon={IconMicrophone2}
-            size={16}
-            className='record-voice__icon'
-          />
+          <IconButton onClick={this.startMic} Icon={IconMicrophone2} size={16} className='record-voice__icon' />
         </div>
       </div>
     );

--- a/src/components/message-input/menu.tsx
+++ b/src/components/message-input/menu.tsx
@@ -21,21 +21,12 @@ export default class Menu extends React.Component<Properties> {
 
   render() {
     return (
-      <Dropzone
-        onDrop={this.imagesSelected}
-        accept={this.props.mimeTypes}
-        maxSize={this.props.maxSize}
-      >
+      <Dropzone onDrop={this.imagesSelected} accept={this.props.mimeTypes} maxSize={this.props.maxSize}>
         {({ getRootProps, getInputProps, open }) => (
           <div className='image-send'>
             <div {...getRootProps({ className: 'image-send__dropzone' })}>
               <input {...getInputProps()} />
-              <IconButton
-                onClick={open}
-                Icon={IconPaperclip}
-                size={16}
-                className='image-send__icon'
-              />
+              <IconButton onClick={open} Icon={IconPaperclip} size={16} className='image-send__icon' />
             </div>
           </div>
         )}

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -54,14 +54,8 @@ export class Message extends React.Component<Properties, State> {
 
   renderAttachment(attachment) {
     return (
-      <div
-        className='message__attachment'
-        onClick={this.openAttachment.bind(this, attachment)}
-      >
-        <AttachmentCards
-          attachments={[attachment]}
-          onAttachmentClicked={this.openAttachment.bind(this, attachment)}
-        />
+      <div className='message__attachment' onClick={this.openAttachment.bind(this, attachment)}>
+        <AttachmentCards attachments={[attachment]} onAttachmentClicked={this.openAttachment.bind(this, attachment)} />
       </div>
     );
   }
@@ -82,14 +76,8 @@ export class Message extends React.Component<Properties, State> {
     const { type, url, name } = media;
     if (MediaType.Image === type) {
       return (
-        <div
-          className='message__block-image'
-          onClick={this.onImageClick(media)}
-        >
-          <img
-            src={url}
-            alt={name}
-          />
+        <div className='message__block-image' onClick={this.onImageClick(media)}>
+          <img src={url} alt={name} />
         </div>
       );
     } else if (MediaType.Video === type) {
@@ -106,10 +94,7 @@ export class Message extends React.Component<Properties, State> {
       return (
         <div className='message__block-audio'>
           <audio controls>
-            <source
-              src={url}
-              type='audio/mpeg'
-            />
+            <source src={url} type='audio/mpeg' />
           </audio>
         </div>
       );
@@ -152,10 +137,7 @@ export class Message extends React.Component<Properties, State> {
 
   editActions = (value: string, mentionedUserIds: string[]) => {
     return (
-      <EditMessageActions
-        onEdit={this.editMessage.bind(this, value, mentionedUserIds)}
-        onCancel={this.toggleEdit}
-      />
+      <EditMessageActions onEdit={this.editMessage.bind(this, value, mentionedUserIds)} onCancel={this.toggleEdit} />
     );
   };
 
@@ -189,19 +171,11 @@ export class Message extends React.Component<Properties, State> {
             },
           }}
         >
-          <ContentHighlighter
-            message={message}
-            mentionedUserIds={this.props.mentionedUserIds}
-          />
+          <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />
         </Linkify>
       );
     } else {
-      return (
-        <ContentHighlighter
-          message={message}
-          mentionedUserIds={this.props.mentionedUserIds}
-        />
-      );
+      return <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />;
     }
   }
 
@@ -246,16 +220,9 @@ export class Message extends React.Component<Properties, State> {
                   {message && this.renderMessageWithLinks()}
                   {preview && !hidePreview && (
                     <div className='message__block-preview-with-remove'>
-                      <LinkPreview
-                        url={preview.url}
-                        {...preview}
-                      />
+                      <LinkPreview url={preview.url} {...preview} />
                       {isOwner && (
-                        <IconButton
-                          Icon={IconXClose}
-                          onClick={this.onRemovePreview}
-                          className='remove-preview__icon'
-                        />
+                        <IconButton Icon={IconXClose} onClick={this.onRemovePreview} className='remove-preview__icon' />
                       )}
                     </div>
                   )}

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -76,16 +76,8 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           {this.state.results && this.state.results.length > 0 && (
             <div className='autocomplete-members__search-results'>
               {this.state.results.map((r) => (
-                <div
-                  key={r.value}
-                  data-id={r.value}
-                  onClick={this.itemClicked}
-                >
-                  <Avatar
-                    size='regular'
-                    type='circle'
-                    imageURL={r.image}
-                  />
+                <div key={r.value} data-id={r.value} onClick={this.itemClicked}>
+                  <Avatar size='regular' type='circle' imageURL={r.image} />
                   <div>{r.label}</div>
                 </div>
               ))}

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -139,20 +139,9 @@ export class Container extends React.Component<Properties, State> {
         })}
       >
         <div className='direct-message-chat__content'>
-          <div
-            className='direct-message-chat__title-bar'
-            onClick={this.handleHeaderClick}
-          >
-            <IconButton
-              onClick={this.handleMinimizeClick}
-              Icon={IconMinus}
-              size={12}
-            />
-            <IconButton
-              onClick={this.handleClose}
-              Icon={IconXClose}
-              size={12}
-            />
+          <div className='direct-message-chat__title-bar' onClick={this.handleHeaderClick}>
+            <IconButton onClick={this.handleMinimizeClick} Icon={IconMinus} size={12} />
+            <IconButton onClick={this.handleClose} Icon={IconXClose} size={12} />
           </div>
 
           <div className='direct-message-chat__header'>

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -88,10 +88,7 @@ export class ConversationListPanel extends React.Component<ConversationListPanel
       >
         <div className='header-button'>
           <span className='header-button__title'>Conversations</span>
-          <span
-            className='header-button__icon'
-            onClick={this.props.toggleConversation}
-          >
+          <span className='header-button__icon' onClick={this.props.toggleConversation}>
             <IconButton
               onClick={this.props.toggleConversation}
               Icon={IconMessagePlusSquare}
@@ -109,17 +106,11 @@ export class ConversationListPanel extends React.Component<ConversationListPanel
       <div className='messages-list__start'>
         <div className='messages-list__start-title'>
           <span className='messages-list__start-icon'>
-            <IconMessageQuestionSquare
-              size={34}
-              label='You have no messages yet'
-            />
+            <IconMessageQuestionSquare size={34} label='You have no messages yet' />
           </span>
           You have no messages yet
         </div>
-        <span
-          className='messages-list__start-conversation'
-          onClick={this.props.toggleConversation}
-        >
+        <span className='messages-list__start-conversation' onClick={this.props.toggleConversation}>
           Start a Conversation
         </span>
       </div>

--- a/src/components/messenger/list/create-conversation-panel.tsx
+++ b/src/components/messenger/list/create-conversation-panel.tsx
@@ -20,20 +20,12 @@ export default class CreateConversationPanel extends React.Component<Properties>
   render() {
     return (
       <>
-        <PanelHeader
-          title='New message'
-          onBack={this.props.onBack}
-        />
+        <PanelHeader title='New message' onBack={this.props.onBack} />
+
         <div className='start__chat'>
           <div className='start__chat-search'>
-            <AutocompleteMembers
-              search={this.props.search}
-              onSelect={this.userSelected}
-            >
-              <div
-                className='create-conversation__group-button'
-                onClick={this.props.onStartGroupChat}
-              >
+            <AutocompleteMembers search={this.props.search} onSelect={this.userSelected}>
+              <div className='create-conversation__group-button' onClick={this.props.onStartGroupChat}>
                 <div className='create-conversation__group-icon'>
                   <IconUsersPlus size={25} />
                 </div>

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -135,15 +135,8 @@ export class Container extends React.Component<Properties, State> {
   renderTitleBar() {
     return (
       <div className='messenger-list__header'>
-        <button
-          className='messenger-list__icon-button'
-          onClick={this.props.onClose}
-        >
-          <IconXClose
-            label='Close Messenger'
-            size={12}
-            isFilled={false}
-          />
+        <button className='messenger-list__icon-button' onClick={this.props.onClose}>
+          <IconXClose label='Close Messenger' size={12} isFilled={false} />
         </button>
       </div>
     );

--- a/src/components/messenger/list/panel-header.tsx
+++ b/src/components/messenger/list/panel-header.tsx
@@ -11,10 +11,7 @@ export class PanelHeader extends React.Component<Properties> {
   render() {
     return (
       <div className='messenger-panel__header'>
-        <span
-          className='messenger-panel__back'
-          onClick={this.props.onBack}
-        >
+        <span className='messenger-panel__back' onClick={this.props.onBack}>
           <IconArrowNarrowLeft size={24} />
         </span>
         {this.props.title}

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -51,31 +51,18 @@ export class StartGroupPanel extends React.Component<Properties, State> {
   render() {
     return (
       <>
-        <PanelHeader
-          title='Select members'
-          onBack={this.props.onBack}
-        />
+        <PanelHeader title='Select members' onBack={this.props.onBack} />
         <div className='start-group-panel__search'>
-          <AutocompleteMembers
-            search={this.props.searchUsers}
-            onSelect={this.selectOption}
-          >
+          <AutocompleteMembers search={this.props.searchUsers} onSelect={this.selectOption}>
             <div className='start-group-panel__selected-count'>
               <span className='start-group-panel__selected-number'>{this.state.selectedOptions.length}</span> member
               {this.state.selectedOptions.length === 1 ? '' : 's'} selected
             </div>
             <div className='start-group-panel__selected-options'>
               {this.state.selectedOptions.map((val) => (
-                <div
-                  className='start-group-panel__selected-option'
-                  key={val.value}
-                >
+                <div className='start-group-panel__selected-option' key={val.value}>
                   <div className='start-group-panel__selected-tag'>
-                    <Avatar
-                      size={'extra small'}
-                      type={'circle'}
-                      imageURL={val.image}
-                    />
+                    <Avatar size={'extra small'} type={'circle'} imageURL={val.image} />
                     <span className='start-group-panel__user-label'>{val.label}</span>
                     <button
                       onClick={this.unselectOption}
@@ -90,11 +77,7 @@ export class StartGroupPanel extends React.Component<Properties, State> {
             </div>
           </AutocompleteMembers>
         </div>
-        <Button
-          className='start-group-panel__continue'
-          onPress={this.continue}
-          isDisabled={this.isContinueDisabled}
-        >
+        <Button className='start-group-panel__continue' onPress={this.continue} isDisabled={this.isContinueDisabled}>
           Continue
         </Button>
       </>

--- a/src/components/notification/item/index.tsx
+++ b/src/components/notification/item/index.tsx
@@ -40,10 +40,7 @@ export class NotificationItem extends React.Component<Properties> {
         </div>
         {this.props.isUnread && (
           <div className='notification-item__right'>
-            <Status
-              type='unread'
-              className='notification-item__status'
-            />
+            <Status type='unread' className='notification-item__status' />
           </div>
         )}
       </div>

--- a/src/components/notification/popup/index.tsx
+++ b/src/components/notification/popup/index.tsx
@@ -41,10 +41,7 @@ export class NotificationPopup extends React.Component<Properties> {
 
   renderPopup() {
     return (
-      <div
-        className='notification-popup'
-        ref={this.notificationPopupRef}
-      >
+      <div className='notification-popup' ref={this.notificationPopupRef}>
         <div className='notification-popup_title-bar'>
           <h3>Notifications</h3>
         </div>

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -24,10 +24,7 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
           <div className='reply-card__message'>
             <ContentHighlighter message={message} />
           </div>
-          <span
-            className='reply-card__icon-close'
-            onClick={this.itemRemoved}
-          />
+          <span className='reply-card__icon-close' onClick={this.itemRemoved} />
         </div>
       </div>
     );

--- a/src/components/user-actions/index.tsx
+++ b/src/components/user-actions/index.tsx
@@ -65,10 +65,7 @@ export class UserActions extends React.Component<Properties, State> {
     return (
       <>
         <div className='user-actions'>
-          <button
-            className='user-actions__icon-button'
-            onClick={this.toggleConversationListState}
-          >
+          <button className='user-actions__icon-button' onClick={this.toggleConversationListState}>
             <IconMessageSquare2 isFilled={this.props.isConversationListOpen} />
             {this.props.unreadConversationMessageCount > 0 && (
               <div className='user-actions__badge'>{this.unreadConversationCount}</div>
@@ -85,12 +82,7 @@ export class UserActions extends React.Component<Properties, State> {
             )}
           </button>
           <button onClick={this.toggleUserPopupState}>
-            <Avatar
-              type='circle'
-              size='regular'
-              imageURL={this.props.userImageUrl}
-              statusType={this.userStatus}
-            />
+            <Avatar type='circle' size='regular' imageURL={this.props.userImageUrl} statusType={this.userStatus} />
           </button>
         </div>
         {this.state.isNotificationPopupOpen && (

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -39,15 +39,8 @@ export class UserMenuPopup extends React.Component<PopupProperties> {
 
     return (
       <>
-        <div
-          className='user-menu-popup__underlay'
-          onClick={this.props.onAbort}
-        >
-          <div
-            className='user-menu-popup__content'
-            style={{ top: y, left: x }}
-            onClick={this.blockClick}
-          >
+        <div className='user-menu-popup__underlay' onClick={this.props.onAbort}>
+          <div className='user-menu-popup__content' style={{ top: y, left: x }} onClick={this.blockClick}>
             <UserMenuPopupContent {...this.props} />
           </div>
         </div>
@@ -68,19 +61,13 @@ export class UserMenuPopupContent extends React.Component<Properties> {
     return (
       <div className='user-menu-popup'>
         <h3>
-          <span
-            title={address}
-            className='user-menu-popup__address'
-          >
+          <span title={address} className='user-menu-popup__address'>
             <span>{address.slice(0, 6)}</span>
             <span>...</span>
             <span className='eth-address__address-last-four'>{address.slice(-4)}</span>
           </span>
         </h3>
-        <Button
-          variant='primary'
-          onPress={this.props.onDisconnect}
-        >
+        <Button variant='primary' onPress={this.props.onDisconnect}>
           Disconnect
         </Button>
       </div>

--- a/src/components/view-mode-toggle/index.tsx
+++ b/src/components/view-mode-toggle/index.tsx
@@ -58,13 +58,7 @@ export class Container extends React.Component<Properties> {
   };
 
   render() {
-    return (
-      <IconButton
-        className={this.className}
-        icon={this.icon}
-        onClick={this.handleClick}
-      />
-    );
+    return <IconButton className={this.className} icon={this.icon} onClick={this.handleClick} />;
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,15 +37,8 @@ ReactDOM.render(
         <EscapeManagerProvider>
           <Router history={history}>
             <Web3ReactContextProvider>
-              <Route
-                path='/:znsRoute?/'
-                exact
-                render={redirectToDefaults}
-              />
-              <Route
-                path='/:znsRoute/:app'
-                component={ZnsRouteConnect}
-              />
+              <Route path='/:znsRoute?/' exact render={redirectToDefaults} />
+              <Route path='/:znsRoute/:app' component={ZnsRouteConnect} />
             </Web3ReactContextProvider>
           </Router>
         </EscapeManagerProvider>

--- a/src/lib/web3/provider-service.tsx
+++ b/src/lib/web3/provider-service.tsx
@@ -16,12 +16,7 @@ export const service = new ProviderService();
 export function inject<T>(ChildComponent: any) {
   return class ProviderServiceInjector extends React.Component<T> {
     render() {
-      return (
-        <ChildComponent
-          {...this.props}
-          providerService={service}
-        />
-      );
+      return <ChildComponent {...this.props} providerService={service} />;
     }
   };
 }

--- a/src/lib/web3/web3-react.tsx
+++ b/src/lib/web3/web3-react.tsx
@@ -28,13 +28,7 @@ export function inject<T>(ChildComponent: any) {
     static contextType = getWeb3ReactContext();
 
     render() {
-      return (
-        <ChildComponent
-          {...this.props}
-          connectors={{ get: getConnector }}
-          web3={this.context}
-        />
-      );
+      return <ChildComponent {...this.props} connectors={{ get: getConnector }} web3={this.context} />;
     }
   };
 }

--- a/src/platform-apps/channels/attachment-cards/attachment-card.tsx
+++ b/src/platform-apps/channels/attachment-cards/attachment-card.tsx
@@ -32,12 +32,7 @@ export default class AttachmentCard extends React.Component<Properties, undefine
     const color = '#ffffff';
 
     return (
-      <svg
-        width={size}
-        height={size}
-        viewBox='0 0 24 24'
-        fill='none'
-      >
+      <svg width={size} height={size} viewBox='0 0 24 24' fill='none'>
         <path
           d='M21.4398 11.05L12.2498 20.24C11.124 21.3659 9.59699 21.9984 8.0048 21.9984C6.41262 21.9984 4.88565 21.3659 3.7598 20.24C2.63396 19.1142 2.00146 17.5872 2.00146 15.995C2.00146 14.4029 2.63396 12.8759 3.7598 11.75L12.9498 2.56004C13.7004 1.80948 14.7183 1.38782 15.7798 1.38782C16.8413 1.38782 17.8592 1.80948 18.6098 2.56004C19.3604 3.3106 19.782 4.32859 19.782 5.39004C19.782 6.4515 19.3604 7.46948 18.6098 8.22004L9.4098 17.41C9.03452 17.7853 8.52553 17.9962 7.9948 17.9962C7.46407 17.9962 6.95508 17.7853 6.5798 17.41C6.20452 17.0348 5.99369 16.5258 5.99369 15.995C5.99369 15.4643 6.20452 14.9553 6.5798 14.58L15.0698 6.10004'
           stroke={color}
@@ -59,10 +54,7 @@ export default class AttachmentCard extends React.Component<Properties, undefine
 
     if (this.hasOnClick()) {
       return (
-        <button
-          className='attachment-card__info'
-          onClick={this.download}
-        >
+        <button className='attachment-card__info' onClick={this.download}>
           {content}
         </button>
       );

--- a/src/platform-apps/channels/audio-cards/audio-card.tsx
+++ b/src/platform-apps/channels/audio-cards/audio-card.tsx
@@ -15,12 +15,7 @@ export default class AudioCard extends React.Component<Properties> {
     if (onRemove) {
       return (
         <div className='audio__cards-card__actions'>
-          <IconButton
-            onClick={onRemove}
-            Icon={IconTrash4}
-            size={20}
-            className='audio__cards-card__actions-delete'
-          />
+          <IconButton onClick={onRemove} Icon={IconTrash4} size={20} className='audio__cards-card__actions-delete' />
         </div>
       );
     }
@@ -33,11 +28,7 @@ export default class AudioCard extends React.Component<Properties> {
       <div className='audio__cards-card'>
         {this.deleteIcon()}
         <span className='audio__cards-card__preview'>
-          <audio
-            controls
-            controlsList='nodownload nofullscreen noremoteplayback'
-            className='audio__cards-card__audio'
-          >
+          <audio controls controlsList='nodownload nofullscreen noremoteplayback' className='audio__cards-card__audio'>
             <source src={audio.url} />
           </audio>
         </span>

--- a/src/platform-apps/channels/audio-cards/index.tsx
+++ b/src/platform-apps/channels/audio-cards/index.tsx
@@ -31,11 +31,7 @@ export default class AudioCards extends React.Component<Properties, undefined> {
     return (
       <div className='audio__cards'>
         {audios.map((a) => (
-          <AudioCard
-            key={a.id}
-            audio={a}
-            onRemove={this.itemRemoved(a)}
-          />
+          <AudioCard key={a.id} audio={a} onRemove={this.itemRemoved(a)} />
         ))}
       </div>
     );

--- a/src/platform-apps/channels/channel-list.tsx
+++ b/src/platform-apps/channels/channel-list.tsx
@@ -36,10 +36,7 @@ export class ChannelList extends React.Component<Properties> {
           }
 
           return (
-            <div
-              key={channel.id}
-              className='channel-list__channel-info'
-            >
+            <div key={channel.id} className='channel-list__channel-info'>
               <ZnsLink
                 className={classNames('channel-list__channel', {
                   active: channel.id === this.props.currentChannelId,
@@ -88,10 +85,7 @@ export class ChannelList extends React.Component<Properties> {
       <div className='channel-list__category'>
         {Object.keys(channelsByCategory).map((category) => {
           return (
-            <div
-              key={category}
-              className='channel-list__category-channel'
-            >
+            <div key={category} className='channel-list__category-channel'>
               <Collapsible
                 className='channel-list__category-channel-name'
                 openedClassName='channel-list__category-channel-name'

--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -117,10 +117,7 @@ export class Container extends React.Component<Properties> {
       <Provider store={this.props.store}>
         <AppLayout className='channels'>
           <AppContextPanel>
-            <ChannelList
-              channels={this.props.channels}
-              currentChannelId={this.props.channelId}
-            />
+            <ChannelList channels={this.props.channels} currentChannelId={this.props.channelId} />
           </AppContextPanel>
           <AppContent className='channel-app'>{this.renderChannelView()}</AppContent>
         </AppLayout>

--- a/src/platform-apps/channels/image-cards/image-card.tsx
+++ b/src/platform-apps/channels/image-cards/image-card.tsx
@@ -18,10 +18,7 @@ export default class ImageCard extends React.Component<Properties, undefined> {
 
     if (onRemoveImage) {
       return (
-        <button
-          className='image-card__delete button-reset'
-          onClick={this.props.onRemoveImage}
-        >
+        <button className='image-card__delete button-reset' onClick={this.props.onRemoveImage}>
           <IconTrash4 size={20} />
         </button>
       );
@@ -42,13 +39,7 @@ export default class ImageCard extends React.Component<Properties, undefined> {
       <div className={cardClass}>
         <div className={'image-card__image-wrap'}>
           <div className='image-card__image'>
-            {size !== 'full-width' && (
-              <img
-                src={image.url}
-                title={image.name}
-                alt='preview'
-              />
-            )}
+            {size !== 'full-width' && <img src={image.url} title={image.name} alt='preview' />}
           </div>
           {this.deleteIcon()}
         </div>

--- a/src/platform-apps/channels/image-cards/index.tsx
+++ b/src/platform-apps/channels/image-cards/index.tsx
@@ -32,13 +32,7 @@ export default class ImageCards extends React.Component<Properties, undefined> {
 
     const imageCards = images.map((image) => {
       return (
-        <ImageCard
-          border={border}
-          key={image.id}
-          image={image}
-          size={size}
-          onRemoveImage={this.imageRemoved(image)}
-        />
+        <ImageCard border={border} key={image.id} image={image} size={size} onRemoveImage={this.imageRemoved(image)} />
       );
     });
 

--- a/src/platform-apps/channels/index.tsx
+++ b/src/platform-apps/channels/index.tsx
@@ -16,12 +16,7 @@ interface Properties {
 
 export class Component extends React.Component<Properties> {
   renderChild = ({ match }) => {
-    return (
-      <ChannelsContainer
-        channelId={match.params.channelId || ''}
-        {...this.props}
-      />
-    );
+    return <ChannelsContainer channelId={match.params.channelId || ''} {...this.props} />;
   };
 
   get rootUrl() {
@@ -29,12 +24,7 @@ export class Component extends React.Component<Properties> {
   }
 
   render() {
-    return (
-      <Route
-        path={`${this.rootUrl}/:channelId?`}
-        render={this.renderChild}
-      />
-    );
+    return <Route path={`${this.rootUrl}/:channelId?`} render={this.renderChild} />;
   }
 }
 

--- a/src/platform-apps/channels/messages-menu/edit-message-actions.tsx
+++ b/src/platform-apps/channels/messages-menu/edit-message-actions.tsx
@@ -10,10 +10,7 @@ export default class EditMessageActions extends React.Component<Properties> {
   render() {
     return (
       <div className='edit-message__actions'>
-        <button
-          className='icon-button address-bar__navigation-button'
-          onClick={this.props.onEdit}
-        >
+        <button className='icon-button address-bar__navigation-button' onClick={this.props.onEdit}>
           <svg
             xmlns='http://www.w3.org/2000/svg'
             width='24px'
@@ -32,10 +29,7 @@ export default class EditMessageActions extends React.Component<Properties> {
             <title id='okIconTitle'>Ok</title> <polyline points='4 13 9 18 20 7' />{' '}
           </svg>
         </button>
-        <button
-          className='icon-button address-bar__navigation-button'
-          onClick={this.props.onCancel}
-        >
+        <button className='icon-button address-bar__navigation-button' onClick={this.props.onCancel}>
           <svg
             xmlns='http://www.w3.org/2000/svg'
             width='24px'

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -34,33 +34,21 @@ export class MessageMenu extends React.Component<Properties, State> {
 
     if (this.props.onReply && this.props.canReply && !this.props.isMediaMessage) {
       menuItems.push(
-        <li
-          className='menu-button reply-item'
-          key='reply'
-          onClick={this.props.onReply}
-        >
+        <li className='menu-button reply-item' key='reply' onClick={this.props.onReply}>
           <span>Reply</span>
         </li>
       );
     }
     if (this.props.onDelete && this.props.canEdit) {
       menuItems.push(
-        <li
-          className='menu-button delete-item'
-          key='delete'
-          onClick={this.toggleDeleteDialog}
-        >
+        <li className='menu-button delete-item' key='delete' onClick={this.toggleDeleteDialog}>
           <span>Delete</span>
         </li>
       );
     }
     if (this.props.onEdit && this.props.canEdit && !this.props.isMediaMessage) {
       menuItems.push(
-        <li
-          className='menu-button edit-item'
-          key='edit'
-          onClick={this.props.onEdit}
-        >
+        <li className='menu-button edit-item' key='edit' onClick={this.props.onEdit}>
           <span>Edit</span>
         </li>
       );
@@ -116,16 +104,8 @@ export class MessageMenu extends React.Component<Properties, State> {
 
     return (
       <div className={this.props.className}>
-        <IconButton
-          onClick={this.open}
-          Icon={IconDotsVertical}
-          size={20}
-        />
-        <PortalMenu
-          className='portal-menu'
-          onClose={this.close}
-          isOpen={this.state.isOpen}
-        >
+        <IconButton onClick={this.open} Icon={IconDotsVertical} size={20} />
+        <PortalMenu className='portal-menu' onClose={this.close} isOpen={this.state.isOpen}>
           {menuItems}
         </PortalMenu>
         {this.showDeleteModal && this.renderDeleteModal()}

--- a/src/platform-apps/channels/messages-menu/portal-menu.tsx
+++ b/src/platform-apps/channels/messages-menu/portal-menu.tsx
@@ -19,18 +19,11 @@ export default class PortalMenu extends React.Component<Properties> {
 
     const { x, y } = this.ref.getBoundingClientRect();
     return (
-      <div
-        className={classNames(this.props.className)}
-        onClick={this.close}
-        style={{ top: y, left: x }}
-      >
+      <div className={classNames(this.props.className)} onClick={this.close} style={{ top: y, left: x }}>
         <div className='portal-menu__content'>
           <ul>{this.props.children}</ul>
         </div>
-        <div
-          className='portal-menu__underlay'
-          onClick={this.close}
-        />
+        <div className='portal-menu__underlay' onClick={this.close} />
       </div>
     );
   }

--- a/src/shared-components/theme-engine/index.tsx
+++ b/src/shared-components/theme-engine/index.tsx
@@ -39,11 +39,5 @@ export class Component extends React.Component<Properties> {
 }
 
 export function ThemeEngine(props: Partial<Properties>) {
-  return (
-    <Component
-      viewMode={props.viewMode}
-      theme={theme}
-      element={document.documentElement}
-    />
-  );
+  return <Component viewMode={props.viewMode} theme={theme} element={document.documentElement} />;
 }


### PR DESCRIPTION
### What does this do?

Removes the singleAttributePerLine override in the prettier config. Formatting will now split to multi-line based on the line length parameter which we have set at 120.

### Why are we making this change?

The default setting for prettier is to not enable this. I prefer the compactness of the default setting and the team didn't strongly oppose.

