### PR TITLE
Extract ConversationItem component and push tests downward

### DIFF
--- a/src/components/messenger/list/conversation-item.test.tsx
+++ b/src/components/messenger/list/conversation-item.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ConversationItem, Properties } from './conversation-item';
+import moment from 'moment';
+
+describe('ConversationItem', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      conversation: {} as any,
+      onClick: () => null,
+      ...props,
+    };
+
+    return shallow(<ConversationItem {...allProps} />);
+  };
+
+  it('renders conversation title for one on one', function () {
+    const wrapper = subject({
+      conversation: convoWith({ firstName: 'Johnny', lastName: 'Cash' }),
+    });
+
+    const displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
+    expect(displayChatNames).toStrictEqual(['Johnny Cash']);
+  });
+
+  it('renders conversation title for multi-members', function () {
+    const wrapper = subject({
+      conversation: convoWith({ firstName: 'Johnny', lastName: 'Cash' }, { firstName: 'Jackie', lastName: 'Chan' }),
+    });
+
+    expect(title(wrapper)).toStrictEqual('Johnny Cash, Jackie Chan');
+  });
+
+  it('renders conversation title for named conversation', function () {
+    const wrapper = subject({
+      conversation: {
+        ...convoWith({ firstName: 'Johnny', lastName: 'Cash' }),
+        name: 'My Named Conversation',
+      },
+    });
+
+    expect(title(wrapper)).toStrictEqual('My Named Conversation');
+  });
+
+  it('publishes click event', function () {
+    const handleMemberClick = jest.fn();
+    const wrapper = subject({
+      onClick: handleMemberClick,
+      conversation: {
+        ...convoWith(),
+        id: 'test-conversation-id',
+      },
+    });
+
+    wrapper.find('.direct-message-members__user').first().simulate('click');
+
+    expect(handleMemberClick).toHaveBeenCalledWith('test-conversation-id');
+  });
+
+  it('does not show unread count if there are no unread messages', function () {
+    const wrapper = subject({
+      conversation: {
+        id: 'id',
+        unreadCount: 0,
+        otherMembers: [],
+      } as any,
+    });
+
+    expect(wrapper).not.toHaveElement('.direct-message-members__user-unread-count');
+  });
+
+  it('shows unread message count', function () {
+    const wrapper = subject({
+      conversation: {
+        id: 'id',
+        unreadCount: 7,
+        otherMembers: [],
+      } as any,
+    });
+
+    expect(wrapper.find('.direct-message-members__user-unread-count').text()).toEqual('7');
+  });
+
+  describe('status', () => {
+    it('renders inactive if no other members are online', function () {
+      const wrapper = subject({
+        conversation: convoWith({ isOnline: false }, { isOnline: false }),
+      });
+
+      expect(wrapper).not.toHaveElement('.direct-message-members__user-status--active');
+    });
+
+    it('renders active if any other members are online', function () {
+      const wrapper = subject({
+        conversation: convoWith({ isOnline: false }, { isOnline: true }),
+      });
+
+      expect(wrapper).toHaveElement('.direct-message-members__user-status--active');
+    });
+  });
+
+  describe('tooltip', () => {
+    it('renders Online if single member is currently online', function () {
+      const wrapper = subject({
+        conversation: convoWith({ isOnline: true }),
+      });
+
+      expect(wrapper.find('Tooltip').prop('overlay')).toEqual('Online');
+    });
+
+    it('renders last seen time if single member has previously been online', function () {
+      const wrapper = subject({
+        conversation: convoWith({ lastSeenAt: moment().subtract(2, 'days').toISOString() }),
+      });
+
+      expect(wrapper.find('Tooltip').prop('overlay')).toEqual('Last Seen: 2 days ago');
+    });
+
+    it('renders member names when multiple other members', function () {
+      const wrapper = subject({
+        conversation: convoWith({ firstName: 'Johnny', lastName: 'Cash' }, { firstName: 'Jackie', lastName: 'Chan' }),
+      });
+
+      expect(wrapper.find('Tooltip').prop('overlay')).toEqual('Johnny Cash, Jackie Chan');
+    });
+  });
+});
+
+function title(wrapper) {
+  return wrapper.find('.direct-message-members__user-name').text();
+}
+
+function convoWith(...otherMembers): any {
+  return {
+    id: 'convo-id',
+    otherMembers,
+  };
+}

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+import { otherMembersToString } from '../../../platform-apps/channels/util';
+import { lastSeenText } from './utils';
+import { Channel } from '../../../store/channels';
+
+import Tooltip from '../../tooltip';
+
+export interface Properties {
+  conversation: Channel;
+  onClick: (conversationId: string) => void;
+}
+
+export class ConversationItem extends React.Component<Properties> {
+  handleMemberClick = () => {
+    this.props.onClick(this.props.conversation.id);
+  };
+
+  tooltipContent(conversation: Channel) {
+    if (conversation.otherMembers && conversation.otherMembers.length === 1) {
+      return lastSeenText(conversation.otherMembers[0]);
+    }
+
+    return otherMembersToString(conversation.otherMembers);
+  }
+
+  renderStatus(conversation: Channel) {
+    const isAnyUserOnline = conversation.otherMembers.some((user) => user.isOnline);
+
+    return (
+      <div
+        className={classNames('direct-message-members__user-status', {
+          'direct-message-members__user-status--active': isAnyUserOnline,
+        })}
+      ></div>
+    );
+  }
+
+  render() {
+    const { conversation } = this.props;
+    return (
+      <Tooltip
+        placement='left'
+        overlay={this.tooltipContent(conversation)}
+        align={{
+          offset: [
+            10,
+            0,
+          ],
+        }}
+        className='direct-message-members__user-tooltip'
+      >
+        <div className='direct-message-members__user' onClick={this.handleMemberClick}>
+          {this.renderStatus(conversation)}
+          <div className='direct-message-members__user-name'>
+            {conversation.name || otherMembersToString(conversation.otherMembers)}
+          </div>
+          {conversation.unreadCount !== 0 && (
+            <div className='direct-message-members__user-unread-count'>{conversation.unreadCount}</div>
+          )}
+        </div>
+      </Tooltip>
+    );
+  }
+}

--- a/src/components/messenger/list/conversation-list-panel.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ConversationListPanel, Properties } from './conversation-list-panel';
+
+// Significant speed improvement by mocking dependencies
+jest.mock('@zero-tech/zui/icons', () => ({}));
+jest.mock('../../icon-button', () => ({ IconButton: () => <></> }));
+jest.mock('../../../store/channels', () => ({}));
+jest.mock('../search-conversations', () => ({ SearchConversations: () => <></> }));
+jest.mock('../../tooltip', () => () => <></>);
+jest.mock('./conversation-item', () => ({ ConversationItem: () => <></> }));
+
+describe('ConversationListPanel', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      directMessages: [],
+      directMessagesList: [],
+      conversationInMyNetworks: () => null,
+      handleMemberClick: () => null,
+      toggleConversation: () => null,
+      ...props,
+    };
+
+    return shallow(<ConversationListPanel {...allProps} />);
+  };
+
+  it('handle member click', function () {
+    const handleMemberClick = jest.fn();
+    const wrapper = subject({
+      handleMemberClick: handleMemberClick,
+      directMessagesList: [
+        {
+          id: 'test-conversation-id',
+          otherMembers: [],
+        } as any,
+      ],
+    });
+
+    wrapper.find('ConversationItem').simulate('click', 'test-conversation-id');
+
+    expect(handleMemberClick).toHaveBeenCalledWith('test-conversation-id');
+  });
+});

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
-import classNames from 'classnames';
 
 import Tooltip from '../../tooltip';
-import { lastSeenText } from './utils';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { SearchConversations } from '../search-conversations';
 import { Channel } from '../../../store/channels';
 import { IconMessagePlusSquare, IconMessageQuestionSquare } from '@zero-tech/zui/icons';
 import { IconButton } from '../../icon-button';
+import { ConversationItem } from './conversation-item';
 
-interface ConversationListPanelProperties {
+export interface Properties {
   directMessages: Channel[];
   directMessagesList: Channel[];
   conversationInMyNetworks: (directMessagesList: Channel[]) => void;
@@ -17,60 +16,9 @@ interface ConversationListPanelProperties {
   toggleConversation: () => void;
 }
 
-export class ConversationListPanel extends React.Component<ConversationListPanelProperties> {
-  handleMemberClick(directMessageId: string) {
+export class ConversationListPanel extends React.Component<Properties> {
+  handleMemberClick = (directMessageId: string) => {
     this.props.handleMemberClick(directMessageId);
-  }
-
-  renderStatus(directMessage: Channel) {
-    const isAnyUserOnline = directMessage.otherMembers.some((user) => user.isOnline);
-
-    return (
-      <div
-        className={classNames('direct-message-members__user-status', {
-          'direct-message-members__user-status--active': isAnyUserOnline,
-        })}
-      ></div>
-    );
-  }
-
-  tooltipContent(directMessage: Channel) {
-    if (directMessage.otherMembers && directMessage.otherMembers.length === 1) {
-      return lastSeenText(directMessage.otherMembers[0]);
-    }
-
-    return otherMembersToString(directMessage.otherMembers);
-  }
-
-  renderMember = (directMessage: Channel) => {
-    return (
-      <Tooltip
-        placement='left'
-        overlay={this.tooltipContent(directMessage)}
-        align={{
-          offset: [
-            10,
-            0,
-          ],
-        }}
-        className='direct-message-members__user-tooltip'
-        key={directMessage.id}
-      >
-        <div
-          className='direct-message-members__user'
-          onClick={this.handleMemberClick.bind(this, directMessage.id)}
-          key={directMessage.id}
-        >
-          {this.renderStatus(directMessage)}
-          <div className='direct-message-members__user-name'>
-            {directMessage.name || otherMembersToString(directMessage.otherMembers)}
-          </div>
-          {directMessage.unreadCount !== 0 && (
-            <div className='direct-message-members__user-unread-count'>{directMessage.unreadCount}</div>
-          )}
-        </div>
-      </Tooltip>
-    );
   };
 
   renderNewMessageModal = (): JSX.Element => {
@@ -132,7 +80,11 @@ export class ConversationListPanel extends React.Component<ConversationListPanel
                 mapSearchConversationsText={otherMembersToString}
               />
             </div>
-            <div className='messages-list__item-list'>{this.props.directMessagesList.map(this.renderMember)}</div>
+            <div className='messages-list__item-list'>
+              {this.props.directMessagesList.map((dm) => (
+                <ConversationItem key={dm.id} conversation={dm} onClick={this.handleMemberClick} />
+              ))}
+            </div>
           </div>
         )}
         {/* Note: this does not work. directMessagesList is never null */}

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -6,10 +6,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import directMessagesFixture from './direct-messages-fixture.json';
-import Tooltip from '../../tooltip';
 import { Channel } from '../../../store/channels';
 import { normalize } from '../../../store/channels-list';
-import { Dialog } from '@zer0-os/zos-component-library';
 import { SearchConversations } from '../search-conversations';
 import { RootState } from '../../../store';
 import moment from 'moment';
@@ -43,12 +41,6 @@ describe('messenger-list', () => {
     return mount(<DirectMessageChat {...allProps} />);
   };
 
-  it('render direct message members', function () {
-    const wrapper = subject({});
-
-    expect(wrapper.find('.direct-message-members').exists()).toBe(true);
-  });
-
   it('start sync direct messages', function () {
     const fetchDirectMessages = jest.fn();
 
@@ -67,63 +59,10 @@ describe('messenger-list', () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
-  it('render members name', function () {
-    const wrapper = subject({});
-
-    wrapper.setProps({ directMessages: DIRECT_MESSAGES_TEST });
-
-    wrapper.update();
-    const displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
-
-    expect(displayChatNames).toStrictEqual([
-      'Charles Diya, Eric',
-      'James Diya, Laz',
-      'daily chat',
-      'Eric',
-    ]);
-  });
-
-  it('handle member click', function () {
-    const setActiveDirectMessage = jest.fn();
-
-    const wrapper = subject({ setActiveMessengerChat: setActiveDirectMessage });
-
-    wrapper.setProps({ directMessages: DIRECT_MESSAGES_TEST });
-    wrapper.update();
-
-    wrapper.find('.direct-message-members__user').first().simulate('click');
-
-    expect(setActiveDirectMessage).toHaveBeenCalledWith('292444273_bd035e84edfbaf11251ffef196de2ab47496439c');
-  });
-
-  it('should not render read messages', function () {
-    const wrapper = subject({});
-
-    expect(wrapper.find('.direct-message-members__user-unread-count').exists()).toBe(false);
-  });
-
-  it('should render create direct messsages button', function () {
-    const wrapper = subject({});
-
-    expect(wrapper.find('.messages-list__direct-messages').exists()).toBe(true);
-  });
-
-  it('should render direct messsages dialog when DMs button is clicked', function () {
-    const wrapper = subject({});
-    wrapper.find('.messages-list__direct-messages').simulate('click');
-
-    expect(wrapper.find(Dialog).exists()).toBe(false);
-  });
-
   it('searches for citizens when creating a new conversation', async function () {
     when(mockSearchMyNetworksByName)
       .calledWith('jac')
-      .mockResolvedValue([
-        {
-          id: 'user-id',
-          profileImage: 'image-url',
-        },
-      ]);
+      .mockResolvedValue([{ id: 'user-id', profileImage: 'image-url' }]);
     const wrapper = subject({});
     wrapper.find('.header-button__icon').simulate('click');
 
@@ -214,30 +153,7 @@ describe('messenger-list', () => {
     ]);
   });
 
-  it('renders unread messages', function () {
-    const [
-      firstDirectMessage,
-      ...restOfDirectMessages
-    ] = DIRECT_MESSAGES_TEST;
-
-    const unreadCount = 10;
-
-    const wrapper = subject({});
-
-    wrapper.setProps({
-      directMessages: [
-        {
-          ...firstDirectMessage,
-          unreadCount,
-        },
-        ...restOfDirectMessages,
-      ],
-    });
-    wrapper.update();
-    expect(wrapper.find('.direct-message-members__user-unread-count').text()).toEqual(unreadCount.toString());
-  });
-
-  describe('tooltip', () => {
+  describe('navigation', () => {
     it('moves to the group conversation creation phase', function () {
       const wrapper = subject({});
 
@@ -301,74 +217,6 @@ describe('messenger-list', () => {
       expect(wrapper).not.toHaveElement(CreateConversationPanel);
       expect(wrapper).toHaveElement('.header-button');
       expect(wrapper).toHaveElement('.messages-list__items');
-    });
-  });
-
-  describe('tooltip', () => {
-    let wrapper;
-
-    beforeEach(() => {
-      wrapper = subject({});
-      wrapper.setProps({ directMessages: DIRECT_MESSAGES_TEST });
-      wrapper.update();
-    });
-
-    afterEach(() => {
-      wrapper = null;
-    });
-
-    const tooltipList = () => {
-      return wrapper.find(Tooltip);
-    };
-
-    it('renders', function () {
-      expect(tooltipList().first().exists()).toBe(true);
-    });
-
-    it('renders placement to left', function () {
-      const placementLeft = 'left';
-
-      expect(tooltipList().map((tooltip) => tooltip.prop('placement'))).toEqual(Array(5).fill(placementLeft));
-    });
-
-    it('renders class name', function () {
-      const className = 'direct-message-members__user-tooltip';
-
-      expect(tooltipList().map((tooltip) => tooltip.prop('className'))).toEqual(Array(5).fill(className));
-    });
-
-    it('renders align prop', function () {
-      const align = {
-        offset: [
-          10,
-          0,
-        ],
-      };
-
-      expect(tooltipList().map((tooltip) => tooltip.prop('align'))).toEqual(Array(5).fill(align));
-    });
-
-    it('renders content', function () {
-      expect(tooltipList().map((tooltip) => tooltip.prop('overlay'))).toEqual([
-        'Create Zero Message',
-        'Charles Diya, Eric',
-        'James Diya, Laz',
-        'Online',
-        'Last Seen: Never',
-      ]);
-    });
-
-    it('renders status', function () {
-      expect(
-        tooltipList()
-          .find('.direct-message-members__user-status')
-          .map((tooltip) => tooltip.prop('className'))
-      ).toEqual([
-        'direct-message-members__user-status direct-message-members__user-status--active',
-        'direct-message-members__user-status direct-message-members__user-status--active',
-        'direct-message-members__user-status direct-message-members__user-status--active',
-        'direct-message-members__user-status',
-      ]);
     });
   });
 


### PR DESCRIPTION
### What does this do?

Refactor: Extract a component for rendering the conversation item in the conversation list.

### Why are we making this change?

Tidying up. More focused tests and simpler components.

### How do I test this?

* Automated tests
* Open the conversation list and view it. Verify it appears and behaves as expected

