### PR TITLE
Determine the filtered conversations at render time

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel.test.tsx
@@ -49,7 +49,7 @@ describe('ConversationListPanel', () => {
       'convo-3',
     ]);
 
-    wrapper.find('SearchConversations').simulate('inputChange', 'jac');
+    wrapper.find('SearchConversations').simulate('change', 'jac');
 
     displayChatNames = renderedConversations(wrapper).map((c) => c.name);
     expect(displayChatNames).toStrictEqual([

--- a/src/components/messenger/list/conversation-list-panel.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel.test.tsx
@@ -2,21 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { ConversationListPanel, Properties } from './conversation-list-panel';
-
-// Significant speed improvement by mocking dependencies
-jest.mock('@zero-tech/zui/icons', () => ({}));
-jest.mock('../../icon-button', () => ({ IconButton: () => <></> }));
-jest.mock('../../../store/channels', () => ({}));
-jest.mock('../search-conversations', () => ({ SearchConversations: () => <></> }));
-jest.mock('../../tooltip', () => () => <></>);
-jest.mock('./conversation-item', () => ({ ConversationItem: () => <></> }));
+import { Channel } from '../../../store/channels';
 
 describe('ConversationListPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       directMessages: [],
-      directMessagesList: [],
-      conversationInMyNetworks: () => null,
       handleMemberClick: () => null,
       toggleConversation: () => null,
       ...props,
@@ -29,7 +20,7 @@ describe('ConversationListPanel', () => {
     const handleMemberClick = jest.fn();
     const wrapper = subject({
       handleMemberClick: handleMemberClick,
-      directMessagesList: [
+      directMessages: [
         {
           id: 'test-conversation-id',
           otherMembers: [],
@@ -41,4 +32,33 @@ describe('ConversationListPanel', () => {
 
     expect(handleMemberClick).toHaveBeenCalledWith('test-conversation-id');
   });
+
+  it('renders filtered conversation list', function () {
+    const conversations = [
+      { id: 'convo-id-1', name: 'convo-1', otherMembers: [{ firstName: 'jack' }] },
+      { id: 'convo-id-2', name: 'convo-2', otherMembers: [{ firstName: 'bob' }] },
+      { id: 'convo-id-3', name: 'convo-3', otherMembers: [{ firstName: 'jacklyn' }] },
+    ];
+
+    const wrapper = subject({ directMessages: conversations as any });
+
+    let displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual([
+      'convo-1',
+      'convo-2',
+      'convo-3',
+    ]);
+
+    wrapper.find('SearchConversations').simulate('inputChange', 'jac');
+
+    displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual([
+      'convo-1',
+      'convo-3',
+    ]);
+  });
 });
+
+function renderedConversations(wrapper) {
+  return wrapper.find('ConversationItem').map((node) => node.prop('conversation')) as Channel[];
+}

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -10,16 +10,35 @@ import { ConversationItem } from './conversation-item';
 
 export interface Properties {
   directMessages: Channel[];
-  directMessagesList: Channel[];
-  conversationInMyNetworks: (directMessagesList: Channel[]) => void;
   handleMemberClick: (directMessageId: string) => void;
   toggleConversation: () => void;
 }
 
-export class ConversationListPanel extends React.Component<Properties> {
+interface State {
+  filter: string;
+}
+
+export class ConversationListPanel extends React.Component<Properties, State> {
+  state = { filter: '' };
+
   handleMemberClick = (directMessageId: string) => {
     this.props.handleMemberClick(directMessageId);
   };
+
+  searchChanged = (search: string) => {
+    this.setState({ filter: search });
+  };
+
+  get filteredConversations() {
+    if (this.state.filter === '') {
+      return this.props.directMessages;
+    }
+
+    const searchRegEx = new RegExp(this.state.filter, 'i');
+    return this.props.directMessages.filter((conversation) =>
+      searchRegEx.test(otherMembersToString(conversation.otherMembers))
+    );
+  }
 
   renderNewMessageModal = (): JSX.Element => {
     return (
@@ -69,26 +88,24 @@ export class ConversationListPanel extends React.Component<Properties> {
     return (
       <>
         <div className='messages-list__direct-messages'>{this.renderNewMessageModal()}</div>
-        {this.props.directMessagesList && (
-          <div className='messages-list__items'>
-            <div className='messages-list__items-conversations-input'>
-              <SearchConversations
-                className='messages-list__items-conversations-search'
-                placeholder='Search contacts...'
-                directMessagesList={this.props.directMessages}
-                onChange={this.props.conversationInMyNetworks}
-                mapSearchConversationsText={otherMembersToString}
-              />
-            </div>
-            <div className='messages-list__item-list'>
-              {this.props.directMessagesList.map((dm) => (
-                <ConversationItem key={dm.id} conversation={dm} onClick={this.handleMemberClick} />
-              ))}
-            </div>
+        <div className='messages-list__items'>
+          <div className='messages-list__items-conversations-input'>
+            <SearchConversations
+              className='messages-list__items-conversations-search'
+              placeholder='Search contacts...'
+              directMessagesList={this.props.directMessages}
+              onInputChange={this.searchChanged}
+              mapSearchConversationsText={otherMembersToString}
+            />
           </div>
-        )}
-        {/* Note: this does not work. directMessagesList is never null */}
-        {!this.props.directMessagesList && <div className='messages-list__new-messages'>{this.renderNoMessages()}</div>}
+          <div className='messages-list__item-list'>
+            {this.filteredConversations.map((dm) => (
+              <ConversationItem key={dm.id} conversation={dm} onClick={this.handleMemberClick} />
+            ))}
+          </div>
+        </div>
+        {/* Note: this does not work. directMessages is never null */}
+        {!this.props.directMessages && <div className='messages-list__new-messages'>{this.renderNoMessages()}</div>}
       </>
     );
   }

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -93,9 +93,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             <SearchConversations
               className='messages-list__items-conversations-search'
               placeholder='Search contacts...'
-              directMessagesList={this.props.directMessages}
-              onInputChange={this.searchChanged}
-              mapSearchConversationsText={otherMembersToString}
+              onChange={this.searchChanged}
             />
           </div>
           <div className='messages-list__item-list'>

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -111,24 +111,11 @@ describe('messenger-list', () => {
     expect(wrapper).toHaveElement('.messages-list__items');
   });
 
-  it('provides the list of conversations to the Search', function () {
-    const conversations = [
-      {
-        id: 'convo-id-1',
-        otherMembers: [],
-      },
-    ];
-
-    const wrapper = subject({ directMessages: conversations as any });
-
-    expect(wrapper.find(SearchConversations).prop('directMessagesList')).toEqual(conversations);
-  });
-
   it('renders search results', function () {
     const conversations = [
-      { id: 'convo-id-1', name: 'convo-1', otherMembers: [] },
-      { id: 'convo-id-2', name: 'convo-2', otherMembers: [] },
-      { id: 'convo-id-3', name: 'convo-3', otherMembers: [] },
+      { id: 'convo-id-1', name: 'convo-1', otherMembers: [{ firstName: 'jack' }] },
+      { id: 'convo-id-2', name: 'convo-2', otherMembers: [{ firstName: 'bob' }] },
+      { id: 'convo-id-3', name: 'convo-3', otherMembers: [{ firstName: 'jacklyn' }] },
     ];
 
     const wrapper = subject({ directMessages: conversations as any });
@@ -140,10 +127,7 @@ describe('messenger-list', () => {
       'convo-3',
     ]);
 
-    wrapper.find(SearchConversations).prop('onChange')([
-      conversations[0],
-      conversations[2],
-    ] as any);
+    wrapper.find(SearchConversations).prop('onInputChange')('jac');
     wrapper.update();
 
     displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -8,7 +8,6 @@ import { Container as DirectMessageChat, Properties } from '.';
 import directMessagesFixture from './direct-messages-fixture.json';
 import { Channel } from '../../../store/channels';
 import { normalize } from '../../../store/channels-list';
-import { SearchConversations } from '../search-conversations';
 import { RootState } from '../../../store';
 import moment from 'moment';
 import { when } from 'jest-when';
@@ -109,32 +108,6 @@ describe('messenger-list', () => {
     expect(wrapper).not.toHaveElement('CreateConversationPanel');
     expect(wrapper).toHaveElement('.header-button');
     expect(wrapper).toHaveElement('.messages-list__items');
-  });
-
-  it('renders search results', function () {
-    const conversations = [
-      { id: 'convo-id-1', name: 'convo-1', otherMembers: [{ firstName: 'jack' }] },
-      { id: 'convo-id-2', name: 'convo-2', otherMembers: [{ firstName: 'bob' }] },
-      { id: 'convo-id-3', name: 'convo-3', otherMembers: [{ firstName: 'jacklyn' }] },
-    ];
-
-    const wrapper = subject({ directMessages: conversations as any });
-
-    let displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
-    expect(displayChatNames).toStrictEqual([
-      'convo-1',
-      'convo-2',
-      'convo-3',
-    ]);
-
-    wrapper.find(SearchConversations).prop('onInputChange')('jac');
-    wrapper.update();
-
-    displayChatNames = wrapper.find('.direct-message-members__user-name').map((node) => node.text());
-    expect(displayChatNames).toStrictEqual([
-      'convo-1',
-      'convo-3',
-    ]);
   });
 
   describe('navigation', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -29,7 +29,6 @@ enum Stage {
 
 interface State {
   showCreateConversation: boolean;
-  directMessagesList: Channel[];
   stage: Stage;
 }
 export interface Properties extends PublicProperties {
@@ -42,7 +41,6 @@ export interface Properties extends PublicProperties {
 export class Container extends React.Component<Properties, State> {
   state = {
     showCreateConversation: false,
-    directMessagesList: [],
     stage: Stage.List,
   };
 
@@ -66,17 +64,6 @@ export class Container extends React.Component<Properties, State> {
 
   componentDidMount(): void {
     this.props.fetchDirectMessages();
-    this.setState({ directMessagesList: this.props.directMessages });
-  }
-
-  componentDidUpdate(prevProps: Properties): void {
-    const { directMessages } = this.props;
-
-    // This might be broken. What happens if you're searching conversations and a real-time update comes in?
-    // Would that break your search results?
-    if (directMessages && prevProps.directMessages && directMessages.length !== prevProps.directMessages.length) {
-      this.setState({ directMessagesList: directMessages });
-    }
   }
 
   handleMemberClick = (directMessageId: string) => {
@@ -84,10 +71,7 @@ export class Container extends React.Component<Properties, State> {
   };
 
   reset = (): void => {
-    this.setState({
-      stage: Stage.List,
-      directMessagesList: this.props.directMessages,
-    });
+    this.setState({ stage: Stage.List });
   };
 
   goBack = (): void => {
@@ -99,10 +83,7 @@ export class Container extends React.Component<Properties, State> {
   };
 
   startConversation = (): void => {
-    this.setState({
-      stage: Stage.CreateOneOnOne,
-      directMessagesList: this.props.directMessages,
-    });
+    this.setState({ stage: Stage.CreateOneOnOne });
   };
 
   startGroupChat = (): void => {
@@ -115,10 +96,6 @@ export class Container extends React.Component<Properties, State> {
     const users: MemberNetworks[] = await searchMyNetworksByName(search);
 
     return users.map((user) => ({ ...user, image: user.profileImage }));
-  };
-
-  conversationInMyNetworks = (directMessagesList: Channel[]) => {
-    this.setState({ directMessagesList });
   };
 
   createOneOnOneConversation = (id: string): void => {
@@ -150,8 +127,6 @@ export class Container extends React.Component<Properties, State> {
           {this.state.stage === Stage.List && (
             <ConversationListPanel
               directMessages={this.props.directMessages}
-              directMessagesList={this.state.directMessagesList}
-              conversationInMyNetworks={this.conversationInMyNetworks}
               handleMemberClick={this.handleMemberClick}
               toggleConversation={this.startConversation}
             />

--- a/src/components/messenger/search-conversations/index.test.tsx
+++ b/src/components/messenger/search-conversations/index.test.tsx
@@ -8,9 +8,7 @@ describe('SearchConversations', () => {
     const allProps: Properties = {
       className: '',
       placeholder: '',
-      directMessagesList: [],
-      onInputChange: () => null,
-      mapSearchConversationsText: () => null,
+      onChange: () => null,
       ...props,
     };
 
@@ -38,13 +36,13 @@ describe('SearchConversations', () => {
     expect(wrapper.find('.search_conversation-input').exists()).toBe(true);
   });
 
-  it('publishes onInputChange', async () => {
-    const onInputChange = jest.fn();
+  it('publishes onChange', async () => {
+    const onChange = jest.fn();
     const inputSearch = 'anything';
-    const wrapper = subject({ onInputChange });
+    const wrapper = subject({ onChange });
 
     wrapper.find('.search_conversation-input').simulate('change', { target: { value: inputSearch } });
 
-    expect(onInputChange).toHaveBeenCalledWith(inputSearch);
+    expect(onChange).toHaveBeenCalledWith(inputSearch);
   });
 });

--- a/src/components/messenger/search-conversations/index.test.tsx
+++ b/src/components/messenger/search-conversations/index.test.tsx
@@ -9,8 +9,8 @@ describe('SearchConversations', () => {
       className: '',
       placeholder: '',
       directMessagesList: [],
-      onChange: () => undefined,
-      mapSearchConversationsText: () => undefined,
+      onInputChange: () => null,
+      mapSearchConversationsText: () => null,
       ...props,
     };
 
@@ -38,13 +38,13 @@ describe('SearchConversations', () => {
     expect(wrapper.find('.search_conversation-input').exists()).toBe(true);
   });
 
-  it('should call onChange', async () => {
-    const onChange = jest.fn();
+  it('publishes onInputChange', async () => {
+    const onInputChange = jest.fn();
     const inputSearch = 'anything';
-    const wrapper = subject({ onChange });
+    const wrapper = subject({ onInputChange });
 
     wrapper.find('.search_conversation-input').simulate('change', { target: { value: inputSearch } });
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onInputChange).toHaveBeenCalledWith(inputSearch);
   });
 });

--- a/src/components/messenger/search-conversations/index.tsx
+++ b/src/components/messenger/search-conversations/index.tsx
@@ -1,23 +1,17 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Channel } from '../../../store/channels';
-import { User } from '../../../store/channels';
 
 import './styles.scss';
 export interface Properties {
   className?: string;
   placeholder?: string;
-  directMessagesList?: Channel[];
 
-  onInputChange: (value: string) => void;
-  mapSearchConversationsText: (directMessages: User[]) => string;
+  onChange: (value: string) => void;
 }
 
-interface State {}
-
-export class SearchConversations extends React.Component<Properties, State> {
+export class SearchConversations extends React.Component<Properties> {
   publishSearch = (search) => {
-    this.props.onInputChange(search?.target?.value ?? '');
+    this.props.onChange(search?.target?.value ?? '');
   };
 
   render() {

--- a/src/components/messenger/search-conversations/index.tsx
+++ b/src/components/messenger/search-conversations/index.tsx
@@ -9,22 +9,15 @@ export interface Properties {
   placeholder?: string;
   directMessagesList?: Channel[];
 
-  onChange: (directMessages: Channel[]) => void;
+  onInputChange: (value: string) => void;
   mapSearchConversationsText: (directMessages: User[]) => string;
 }
 
 interface State {}
 
 export class SearchConversations extends React.Component<Properties, State> {
-  searchConversations = (search) => {
-    const expression = search.target.value ? `(${search.target.value})` : '(.*)';
-    const searchRegEx = new RegExp(expression, 'i');
-
-    const directMessagesList = this.props.directMessagesList.filter((conversation) =>
-      searchRegEx.test(this.props.mapSearchConversationsText(conversation.otherMembers))
-    );
-
-    this.props.onChange(directMessagesList);
+  publishSearch = (search) => {
+    this.props.onInputChange(search?.target?.value ?? '');
   };
 
   render() {
@@ -35,7 +28,7 @@ export class SearchConversations extends React.Component<Properties, State> {
           type='search'
           placeholder={this.props.placeholder}
           className='search_conversation-input'
-          onChange={this.searchConversations}
+          onChange={this.publishSearch}
         />
       </div>
     );


### PR DESCRIPTION
### What does this do?

Changes the conversation search to determine the filtered results during render rather than as static state.

### Why are we making this change?

There are numerous bugs related to the user's conversation list changing via external events (eg: real time message received) and the conversation list not updating. An example is the bug where the unread count isn't updating when a new message is received.

### How do I test this?

* Open the conversation list
* Send a message from another user to this user
* Verify that the unread count updates


https://user-images.githubusercontent.com/43770/229908343-0b107c7c-47a0-435d-bce7-7d7dee722732.mp4



