### PR TITLE
Add Group Details panel to Conversation pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "linkifyjs": "^4.0.2",
         "lodash.get": "^4.4.2",
         "lodash.kebabcase": "^4.1.1",
+        "lodash.uniqby": "^4.7.0",
         "moment": "^2.29.4",
         "normalizr": "^3.6.2",
         "rc-tooltip": "^5.3.1",
@@ -23251,6 +23252,11 @@
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "license": "MIT"
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
     },
     "node_modules/loglevel": {
       "version": "1.7.1",
@@ -50139,6 +50145,11 @@
     },
     "lodash.uniq": {
       "version": "4.5.0"
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
     },
     "loglevel": {
       "version": "1.7.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "linkifyjs": "^4.0.2",
     "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
+    "lodash.uniqby": "^4.7.0",
     "moment": "^2.29.4",
     "normalizr": "^3.6.2",
     "rc-tooltip": "^5.3.1",

--- a/src/components/messenger/list/group-details-panel.test.tsx
+++ b/src/components/messenger/list/group-details-panel.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { GroupDetailsPanel, Properties } from './group-details-panel';
+import { SelectedUserTag } from './selected-user-tag';
+
+describe('GroupDetailsPanel', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      users: [],
+      onBack: () => null,
+      onCreate: () => null,
+      ...props,
+    };
+
+    return shallow(<GroupDetailsPanel {...allProps} />);
+  };
+
+  it('fires onBack when back icon clicked', function () {
+    const onBack = jest.fn();
+
+    const wrapper = subject({ onBack });
+
+    wrapper.find('PanelHeader').simulate('back');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('shows selected member count', function () {
+    let wrapper = subject({ users: [] });
+
+    expect(wrapper.find('.group-details-panel__selected-count').text()).toEqual('0 members selected');
+
+    wrapper = subject({ users: [stubUser()] });
+    expect(wrapper.find('.group-details-panel__selected-count').text()).toEqual('1 member selected');
+
+    wrapper = subject({
+      users: [
+        stubUser(),
+        stubUser(),
+      ],
+    });
+    expect(wrapper.find('.group-details-panel__selected-count').text()).toEqual('2 members selected');
+  });
+
+  it('shows selected users', function () {
+    const wrapper = subject({
+      users: [
+        stubUser({ value: 'user-1' }),
+        stubUser({ value: 'user-2' }),
+      ],
+    });
+
+    expect(wrapper.find(SelectedUserTag).length).toEqual(2);
+    expect(wrapper.find(SelectedUserTag).at(0).prop('userOption').value).toEqual('user-1');
+    expect(wrapper.find(SelectedUserTag).at(1).prop('userOption').value).toEqual('user-2');
+  });
+
+  it('fires onCreate when create group is clicked', function () {
+    const onCreate = jest.fn();
+    const users = [
+      stubUser({ value: 'u-1' }),
+      stubUser({ value: 'u-2' }),
+    ];
+    const wrapper = subject({ onCreate, users });
+
+    wrapper.find('Button').simulate('press');
+
+    expect(onCreate).toHaveBeenCalledWith({ users: users });
+  });
+});
+
+function stubUser(props = {}): any {
+  return { value: 'id-1', label: 'User 1', image: 'url-1', ...props };
+}

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { Button } from '@zero-tech/zui/components';
+
+import { Option } from '../autocomplete-members';
+import { PanelHeader } from './panel-header';
+import { SelectedUserTag } from './selected-user-tag';
+
+import { bem } from '../../../lib/bem';
+const c = bem('group-details-panel');
+
+export interface Properties {
+  users: Option[];
+
+  onBack: () => void;
+  onCreate: (data: { users: Option[] }) => void;
+}
+
+export class GroupDetailsPanel extends React.Component<Properties> {
+  createGroup = () => {
+    this.props.onCreate({ users: this.props.users });
+  };
+
+  render() {
+    return (
+      <>
+        <PanelHeader title='Group details' onBack={this.props.onBack} />
+        <div className={c('selected-count')}>
+          <span className={c('selected-number')}>{this.props.users.length}</span> member
+          {this.props.users.length === 1 ? '' : 's'} selected
+        </div>
+        {this.props.users.map((u) => (
+          <SelectedUserTag userOption={u} key={u.value}></SelectedUserTag>
+        ))}
+        <Button onPress={this.createGroup}>Create Group</Button>
+      </>
+    );
+  }
+}

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -29,10 +29,14 @@ export class GroupDetailsPanel extends React.Component<Properties> {
           <span className={c('selected-number')}>{this.props.users.length}</span> member
           {this.props.users.length === 1 ? '' : 's'} selected
         </div>
-        {this.props.users.map((u) => (
-          <SelectedUserTag userOption={u} key={u.value}></SelectedUserTag>
-        ))}
-        <Button onPress={this.createGroup}>Create Group</Button>
+        <div>
+          {this.props.users.map((u) => (
+            <SelectedUserTag userOption={u} key={u.value}></SelectedUserTag>
+          ))}
+        </div>
+        <Button onPress={this.createGroup} className={c('create')}>
+          Create Group
+        </Button>
       </>
     );
   }

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -112,9 +112,9 @@ describe('messenger-list', () => {
 
   it('creates a group conversation when users selected and conversation already exists', async function () {
     const setActiveMessengerChat = jest.fn();
-    // XXX: add current user id
     when(mockFetchConversationsWithUsers)
       .calledWith([
+        'current-user-id',
         'selected-id-1',
         'selected-id-2',
       ])
@@ -122,7 +122,7 @@ describe('messenger-list', () => {
         { id: 'convo-1' },
         { id: 'convo-2' },
       ]);
-    const wrapper = subject({ setActiveMessengerChat });
+    const wrapper = subject({ userId: 'current-user-id', setActiveMessengerChat });
     openCreateConversation(wrapper);
     openStartGroup(wrapper);
 
@@ -221,6 +221,7 @@ describe('messenger-list', () => {
     const getState = (channels) => {
       const channelData = normalize(channels);
       return {
+        authentication: {},
         channelsList: { value: channelData.result },
         normalized: channelData.entities,
       } as RootState;

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -129,6 +129,17 @@ describe('messenger-list', () => {
     expect(setActiveMessengerChat).toHaveBeenCalledWith('convo-1');
   });
 
+  it('sets StartGroupPanel to Continuing while data is loading', async function () {
+    const fetchPromise = new Promise((_r) => null); // Never resolve
+    when(mockFetchConversationsWithUsers).mockReturnValue(fetchPromise);
+    const wrapper = subject({});
+    openCreateConversation(wrapper);
+    openStartGroup(wrapper);
+
+    wrapper.find(StartGroupPanel).prop('onContinue')([{} as any]);
+    expect(wrapper.find(StartGroupPanel).prop('isContinuing')).toBeTrue();
+  });
+
   it('adds the existing conversations to the store if there are any', async function () {
     const channelsReceived = jest.fn();
     when(mockFetchConversationsWithUsers).mockResolvedValue([{ id: 'convo-1' }]);

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -29,8 +29,9 @@ jest.mock('../../../store/channels-list/api', () => {
 describe('messenger-list', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
-      setActiveMessengerChat: jest.fn(),
+      userId: '',
       conversations: [],
+      setActiveMessengerChat: jest.fn(),
       fetchConversations: jest.fn(),
       createConversation: jest.fn(),
       channelsReceived: jest.fn(),
@@ -161,15 +162,15 @@ describe('messenger-list', () => {
   });
 
   it('creates a group conversation when details submitted', async function () {
-    const createDirectMessage = jest.fn();
-    const wrapper = subject({ createDirectMessage });
+    const createConversation = jest.fn();
+    const wrapper = subject({ createConversation });
     openCreateConversation(wrapper);
     openStartGroup(wrapper);
     await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'id-1' } as any]);
 
     wrapper.find(GroupDetailsPanel).simulate('create', { users: [{ value: 'id-1' }] });
 
-    expect(createDirectMessage).toHaveBeenCalledWith({ userIds: ['id-1'] });
+    expect(createConversation).toHaveBeenCalledWith({ userIds: ['id-1'] });
   });
 
   describe('navigation', () => {
@@ -225,9 +226,9 @@ describe('messenger-list', () => {
     });
 
     it('returns to conversation list when group conversation created from GroupDetails stage', async function () {
-      const createDirectMessage = jest.fn();
+      const createConversation = jest.fn();
       when(mockFetchConversationsWithUsers).mockResolvedValue([]);
-      const wrapper = subject({ createDirectMessage });
+      const wrapper = subject({ createConversation });
       openCreateConversation(wrapper);
       openStartGroup(wrapper);
       await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'selected-id-1' } as any]);

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -167,6 +167,34 @@ describe('messenger-list', () => {
     expect(createConversation).toHaveBeenCalledWith({ userIds: ['id-1'] });
   });
 
+  it('maintains the selected users on StartGroup phase if back button pressed on group details panel', async function () {
+    const wrapper = subject({});
+    openCreateConversation(wrapper);
+    openStartGroup(wrapper);
+    await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'user-id' } as any]);
+
+    wrapper.find(GroupDetailsPanel).simulate('back');
+
+    expect(wrapper.find(StartGroupPanel).prop('initialSelections')).toEqual([{ value: 'user-id' }]);
+  });
+
+  it('clears the selected users if moving back from StartGroup', async function () {
+    const wrapper = subject({});
+    openCreateConversation(wrapper);
+    openStartGroup(wrapper);
+
+    // Select some users
+    await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'user-id' } as any]);
+    // Navigate back to the Create panel
+    wrapper.find(GroupDetailsPanel).simulate('back');
+    wrapper.find(StartGroupPanel).simulate('back');
+
+    // Open the start group again
+    openStartGroup(wrapper);
+
+    expect(wrapper.find(StartGroupPanel).prop('initialSelections')).toEqual([]);
+  });
+
   describe('navigation', () => {
     it('moves to the group conversation creation phase', function () {
       const wrapper = subject({});

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -12,18 +12,12 @@ import { GroupDetailsPanel } from './group-details-panel';
 
 const mockSearchMyNetworksByName = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
-  return {
-    searchMyNetworksByName: async (...args) => {
-      return await mockSearchMyNetworksByName(...args);
-    },
-  };
+  return { searchMyNetworksByName: async (...args) => await mockSearchMyNetworksByName(...args) };
 });
 
 const mockFetchConversationsWithUsers = jest.fn();
 jest.mock('../../../store/channels-list/api', () => {
-  return {
-    fetchConversationsWithUsers: async (...args) => mockFetchConversationsWithUsers(...args),
-  };
+  return { fetchConversationsWithUsers: async (...args) => mockFetchConversationsWithUsers(...args) };
 });
 
 describe('messenger-list', () => {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -127,8 +127,8 @@ describe('messenger-list', () => {
     openStartGroup(wrapper);
 
     await wrapper.find(StartGroupPanel).prop('onContinue')([
-      'selected-id-1',
-      'selected-id-2',
+      { value: 'selected-id-1' } as any,
+      { value: 'selected-id-2' } as any,
     ]);
 
     expect(setActiveMessengerChat).toHaveBeenCalledWith('convo-1');
@@ -141,7 +141,7 @@ describe('messenger-list', () => {
     openCreateConversation(wrapper);
     openStartGroup(wrapper);
 
-    await wrapper.find(StartGroupPanel).prop('onContinue')(['selected-id-1']);
+    await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'selected-id-1' } as any]);
 
     expect(channelsReceived).toHaveBeenCalledWith({ channels: [{ id: 'convo-1' }] });
   });
@@ -152,12 +152,24 @@ describe('messenger-list', () => {
 
     openCreateConversation(wrapper);
     openStartGroup(wrapper);
-    await wrapper.find(StartGroupPanel).prop('onContinue')(['id-1']);
+    await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'id-1' } as any]);
 
     expect(wrapper).not.toHaveElement(ConversationListPanel);
     expect(wrapper).not.toHaveElement(CreateConversationPanel);
     expect(wrapper).not.toHaveElement(StartGroupPanel);
     expect(wrapper).toHaveElement('GroupDetailsPanel');
+  });
+
+  it('creates a group conversation when details submitted', async function () {
+    const createDirectMessage = jest.fn();
+    const wrapper = subject({ createDirectMessage });
+    openCreateConversation(wrapper);
+    openStartGroup(wrapper);
+    await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'id-1' } as any]);
+
+    wrapper.find(GroupDetailsPanel).simulate('create', { users: [{ value: 'id-1' }] });
+
+    expect(createDirectMessage).toHaveBeenCalledWith({ userIds: ['id-1'] });
   });
 
   describe('navigation', () => {
@@ -191,7 +203,7 @@ describe('messenger-list', () => {
       openCreateConversation(wrapper);
       openStartGroup(wrapper);
 
-      await wrapper.find(StartGroupPanel).prop('onContinue')(['selected-id-1']);
+      await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'selected-id-1' } as any]);
 
       expect(wrapper).toHaveElement(ConversationListPanel);
       expect(wrapper).not.toHaveElement(CreateConversationPanel);
@@ -210,6 +222,21 @@ describe('messenger-list', () => {
       expect(wrapper).not.toHaveElement(CreateConversationPanel);
       expect(wrapper).toHaveElement('StartGroupPanel');
       expect(wrapper).not.toHaveElement('GroupDetailsPanel');
+    });
+
+    it('returns to conversation list when group conversation created from GroupDetails stage', async function () {
+      const createDirectMessage = jest.fn();
+      when(mockFetchConversationsWithUsers).mockResolvedValue([]);
+      const wrapper = subject({ createDirectMessage });
+      openCreateConversation(wrapper);
+      openStartGroup(wrapper);
+      await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'selected-id-1' } as any]);
+      wrapper.find(GroupDetailsPanel).simulate('create', { users: [{ value: 'id-1' }] });
+
+      expect(wrapper).toHaveElement(ConversationListPanel);
+      expect(wrapper).not.toHaveElement(CreateConversationPanel);
+      expect(wrapper).not.toHaveElement(StartGroupPanel);
+      expect(wrapper).not.toHaveElement(GroupDetailsPanel);
     });
   });
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -121,14 +121,11 @@ export class Container extends React.Component<Properties, State> {
     this.reset();
   };
 
-  // XXX: The StartGroup stage needs to return the options. I actually think we want to refactor
-  // the Option type to some root place rather than source it from the autocomplete. Does it even
-  // need to be its own type or can it be a user?
-  groupMembersSelected = async (userIds: string[]) => {
+  groupMembersSelected = async (selectedOptions: Option[]) => {
     // XXX: loading state for the continue button
     const existingConversations = await fetchConversationsWithUsers([
       this.props.userId,
-      ...userIds,
+      ...selectedOptions.map((o) => o.value),
     ]);
 
     if (existingConversations?.length > 0) {
@@ -138,15 +135,15 @@ export class Container extends React.Component<Properties, State> {
     } else {
       this.setState({
         stage: Stage.GroupDetails,
-        groupUsers: userIds.map((uId) => ({ vale: uId, label: 'aha' } as any)),
+        groupUsers: selectedOptions,
       });
     }
   };
 
   createGroup = async (details) => {
-    // XXX: test this.
     const conversation = { userIds: details.users.map((u) => u.value) };
     this.props.createConversation(conversation);
+    this.reset();
   };
 
   renderTitleBar() {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -85,17 +85,15 @@ export class Container extends React.Component<Properties, State> {
   };
 
   reset = (): void => {
-    this.setState({ stage: Stage.List });
+    this.setState({ stage: Stage.List, groupUsers: [] });
   };
 
   goBack = (): void => {
     if (this.state.stage === Stage.CreateOneOnOne) {
       this.setState({ stage: Stage.List });
     } else if (this.state.stage === Stage.StartGroupChat) {
-      this.setState({ stage: Stage.CreateOneOnOne });
+      this.setState({ stage: Stage.CreateOneOnOne, groupUsers: [] });
     } else if (this.state.stage === Stage.GroupDetails) {
-      // XXX: What about resetting the current selected users?
-      // We should probably render the existing selection list
       this.setState({ stage: Stage.StartGroupChat });
     }
   };
@@ -178,6 +176,7 @@ export class Container extends React.Component<Properties, State> {
           )}
           {this.state.stage === Stage.StartGroupChat && (
             <StartGroupPanel
+              initialSelections={this.state.groupUsers}
               onBack={this.goBack}
               onContinue={this.groupMembersSelected}
               searchUsers={this.usersInMyNetworks}

--- a/src/components/messenger/list/selected-user-tag.test.tsx
+++ b/src/components/messenger/list/selected-user-tag.test.tsx
@@ -36,4 +36,12 @@ describe('SelectedUserTag', () => {
 
     expect(onRemove).toHaveBeenCalledWith('id-1');
   });
+
+  it('does not render remove button if no handler provided', function () {
+    const userOption = { value: 'id-1', label: 'User 1', image: 'url-1' };
+
+    const wrapper = subject({ userOption, onRemove: null });
+
+    expect(wrapper).not.toHaveElement('button');
+  });
 });

--- a/src/components/messenger/list/selected-user-tag.test.tsx
+++ b/src/components/messenger/list/selected-user-tag.test.tsx
@@ -22,7 +22,7 @@ describe('SelectedUserTag', () => {
 
     const wrapper = subject({ userOption });
 
-    expect(wrapper.find('.start-group-panel__user-label').text()).toEqual('User 1');
+    expect(wrapper.find('.selected-user-tag__user-label').text()).toEqual('User 1');
     expect(wrapper.find('Avatar').prop('imageURL')).toEqual('url-1');
   });
 

--- a/src/components/messenger/list/selected-user-tag.tsx
+++ b/src/components/messenger/list/selected-user-tag.tsx
@@ -22,9 +22,8 @@ export class SelectedUserTag extends React.Component<Properties> {
   render() {
     const { userOption: option } = this.props;
 
-    // XXX: move the key up the stack
     return (
-      <div className={c('selected-option')} key={option.value}>
+      <div className={c('selected-option')}>
         <div className={c('selected-tag')}>
           <Avatar size={'extra small'} type={'circle'} imageURL={option.image} />
           <span className={c('user-label')}>{option.label}</span>

--- a/src/components/messenger/list/selected-user-tag.tsx
+++ b/src/components/messenger/list/selected-user-tag.tsx
@@ -8,7 +8,7 @@ import { IconXClose } from '@zero-tech/zui/icons';
 export interface Properties {
   userOption: Option;
 
-  onRemove: (id: string) => void;
+  onRemove?: (id: string) => void;
 }
 
 export class SelectedUserTag extends React.Component<Properties> {
@@ -24,9 +24,11 @@ export class SelectedUserTag extends React.Component<Properties> {
         <div className='start-group-panel__selected-tag'>
           <Avatar size={'extra small'} type={'circle'} imageURL={option.image} />
           <span className='start-group-panel__user-label'>{option.label}</span>
-          <button onClick={this.publishRemove} data-value={option.value} className='start-group-panel__user-remove'>
-            <IconXClose size={16} />
-          </button>
+          {this.props.onRemove && (
+            <button onClick={this.publishRemove} data-value={option.value} className='start-group-panel__user-remove'>
+              <IconXClose size={16} />
+            </button>
+          )}
         </div>
       </div>
     );

--- a/src/components/messenger/list/selected-user-tag.tsx
+++ b/src/components/messenger/list/selected-user-tag.tsx
@@ -5,6 +5,9 @@ import { Option } from '../autocomplete-members';
 import { Avatar } from '@zero-tech/zui/components';
 import { IconXClose } from '@zero-tech/zui/icons';
 
+import { bem } from '../../../lib/bem';
+const c = bem('selected-user-tag');
+
 export interface Properties {
   userOption: Option;
 
@@ -19,13 +22,14 @@ export class SelectedUserTag extends React.Component<Properties> {
   render() {
     const { userOption: option } = this.props;
 
+    // XXX: move the key up the stack
     return (
-      <div className='start-group-panel__selected-option' key={option.value}>
-        <div className='start-group-panel__selected-tag'>
+      <div className={c('selected-option')} key={option.value}>
+        <div className={c('selected-tag')}>
           <Avatar size={'extra small'} type={'circle'} imageURL={option.image} />
-          <span className='start-group-panel__user-label'>{option.label}</span>
+          <span className={c('user-label')}>{option.label}</span>
           {this.props.onRemove && (
-            <button onClick={this.publishRemove} data-value={option.value} className='start-group-panel__user-remove'>
+            <button onClick={this.publishRemove} data-value={option.value} className={c('user-remove')}>
               <IconXClose size={16} />
             </button>
           )}

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -9,6 +9,7 @@ jest.mock('@zero-tech/zui/components');
 describe('StartGroupPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
+      isContinuing: false,
       initialSelections: [],
       searchUsers: () => {},
       onBack: () => {},
@@ -47,6 +48,12 @@ describe('StartGroupPanel', () => {
       { value: 'id-1' },
       { value: 'id-2' },
     ]);
+  });
+
+  it('sets button to loading state if loading', function () {
+    const wrapper = subject({ isContinuing: true });
+
+    expect(wrapper.find('Button').prop('isLoading')).toBeTrue();
   });
 
   it('enables continue button based on number of users', function () {

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -9,6 +9,7 @@ jest.mock('@zero-tech/zui/components');
 describe('StartGroupPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
+      initialSelections: [],
       searchUsers: () => {},
       onBack: () => {},
       onContinue: () => {},
@@ -70,6 +71,20 @@ describe('StartGroupPanel', () => {
 
     wrapper.find('AutocompleteMembers').simulate('select', { value: 'id-2' });
     expect(wrapper.find('.start-group-panel__selected-count').text()).toEqual('2 members selected');
+  });
+
+  it('renders initialSelected members', function () {
+    const wrapper = subject({
+      initialSelections: [
+        { value: 'id-1', label: 'User 1', image: 'url-1' },
+        { value: 'id-2', label: 'User 2', image: 'url-2' },
+      ],
+    });
+
+    expect(wrapper.find('SelectedUserTag').map(userLabel)).toEqual([
+      'User 1',
+      'User 2',
+    ]);
   });
 
   it('renders selected members', function () {

--- a/src/components/messenger/list/start-group-panel.test.tsx
+++ b/src/components/messenger/list/start-group-panel.test.tsx
@@ -43,8 +43,8 @@ describe('StartGroupPanel', () => {
     wrapper.find('Button').simulate('press');
 
     expect(onContinue).toHaveBeenCalledWith([
-      'id-1',
-      'id-2',
+      { value: 'id-1' },
+      { value: 'id-2' },
     ]);
   });
 

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -65,7 +65,7 @@ export class StartGroupPanel extends React.Component<Properties, State> {
               <span className='start-group-panel__selected-number'>{this.state.selectedOptions.length}</span> member
               {this.state.selectedOptions.length === 1 ? '' : 's'} selected
             </div>
-            <div className='start-group-panel__selected-options'>
+            <div>
               {this.state.selectedOptions.map((option) => (
                 <SelectedUserTag key={option.value} userOption={option} onRemove={this.unselectOption} />
               ))}

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -8,6 +8,8 @@ import { SelectedUserTag } from './selected-user-tag';
 
 export interface Properties {
   initialSelections: Option[];
+  isContinuing: boolean;
+
   searchUsers: (input: string) => any;
 
   onBack: () => void;
@@ -70,7 +72,12 @@ export class StartGroupPanel extends React.Component<Properties, State> {
             </div>
           </AutocompleteMembers>
         </div>
-        <Button className='start-group-panel__continue' onPress={this.continue} isDisabled={this.isContinueDisabled}>
+        <Button
+          className='start-group-panel__continue'
+          onPress={this.continue}
+          isDisabled={this.isContinueDisabled}
+          isLoading={this.props.isContinuing}
+        >
           Continue
         </Button>
       </>

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -7,6 +7,7 @@ import { PanelHeader } from './panel-header';
 import { SelectedUserTag } from './selected-user-tag';
 
 export interface Properties {
+  initialSelections: Option[];
   searchUsers: (input: string) => any;
 
   onBack: () => void;
@@ -19,6 +20,11 @@ interface State {
 
 export class StartGroupPanel extends React.Component<Properties, State> {
   state = { selectedOptions: [] };
+
+  constructor(props) {
+    super(props);
+    this.state = { selectedOptions: [...props.initialSelections] };
+  }
 
   continue = () => {
     this.props.onContinue(this.state.selectedOptions);

--- a/src/components/messenger/list/start-group-panel.tsx
+++ b/src/components/messenger/list/start-group-panel.tsx
@@ -10,7 +10,7 @@ export interface Properties {
   searchUsers: (input: string) => any;
 
   onBack: () => void;
-  onContinue: (ids: string[]) => void;
+  onContinue: (options: Option[]) => void;
 }
 
 interface State {
@@ -21,7 +21,7 @@ export class StartGroupPanel extends React.Component<Properties, State> {
   state = { selectedOptions: [] };
 
   continue = () => {
-    this.props.onContinue(this.state.selectedOptions.map((o) => o.value));
+    this.props.onContinue(this.state.selectedOptions);
   };
 
   selectOption = (selectedOption) => {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -251,6 +251,44 @@
     color: theme.$color-greyscale-12;
   }
 
+  &__content {
+    flex-grow: 99;
+
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__search {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__continue {
+    margin: 16px 0px;
+  }
+}
+
+.group-details-panel {
+  &__selected-count {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+    padding-top: 18px;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__selected-number {
+    color: theme.$color-greyscale-12;
+  }
+
+  &__create {
+    margin: 16px 0px;
+  }
+}
+
+.selected-user-tag {
   &__selected-option {
     display: inline-block;
   }
@@ -281,22 +319,5 @@
     display: inline-block;
     padding: 0px;
     margin: 0px;
-  }
-
-  &__content {
-    flex-grow: 99;
-
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__search {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__continue {
-    margin: 16px 0px;
   }
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -20,10 +20,16 @@ expect.extend({
     const pass = actual.find(finder).exists();
     return {
       pass,
-      message: pass ? () => `expected node [${finder}] not to exist` : () => `expected node [${finder}] to exist`,
+      message: pass
+        ? () => `expected node [${printable(finder)}] not to exist`
+        : () => `expected node [${printable(finder)}] to exist`,
     };
   },
 });
+
+function printable(finder) {
+  return finder.name ?? finder;
+}
 
 // Hack to allow us to dynamically regenerate the mock files for zUI
 // Running a single test with this env var set will recreate the files.

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -16,3 +16,9 @@ export async function createConversation(userIds: string[]): Promise<DirectMessa
   const directMessages = await post<Channel[]>('/directMessages').send({ userIds });
   return directMessages.body;
 }
+
+export async function fetchConversationsWithUsers(_userIds: string[]): Promise<any[]> {
+  return [];
+  // const response = await get<Channel[]>('/conversations', { userIds });
+  // return response.body;
+}

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -18,6 +18,8 @@ export async function createConversation(userIds: string[]): Promise<DirectMessa
 }
 
 export async function fetchConversationsWithUsers(_userIds: string[]): Promise<any[]> {
+  // Simulate request timing
+  await new Promise((r) => setTimeout(r, 30));
   return [];
   // const response = await get<Channel[]>('/conversations', { userIds });
   // return response.body;

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -5,33 +5,18 @@ import { schema } from '../channels';
 import { ChannelsReceivedPayload, CreateMessengerConversation } from './types';
 
 export enum SagaActionTypes {
-<<<<<<< HEAD
   FetchChannels = 'channelsList/saga/fetchChannels',
   FetchConversations = 'channelsList/saga/fetchConversations',
   CreateConversation = 'channelsList/saga/createConversations',
   StartChannelsAndConversationsAutoRefresh = 'channelsList/saga/startChannelsAndConversationsAutoRefresh',
   StopChannelsAndConversationsAutoRefresh = 'channelsList/saga/stopChannelsAndConversationsAutoRefresh',
+  ChannelsReceived = 'channelsList/saga/received',
 }
 
 const fetchChannels = createAction<string>(SagaActionTypes.FetchChannels);
 const fetchConversations = createAction<string>(SagaActionTypes.FetchConversations);
 const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
-=======
-  Fetch = 'channelsList/saga/fetch',
-  CreateDirectMessage = 'directMessages/saga/createDirectMessage',
-  ReceiveUnreadCount = 'channelsList/saga/receiveUnreadCount',
-  StopSyncChannels = 'channelsList/saga/stopSyncChannels',
-  FetchDirectMessages = 'channelsList/saga/fetchDirectMessages',
-  ChannelsReceived = 'channelsList/saga/received',
-}
-
-const fetch = createAction<string>(SagaActionTypes.Fetch);
-const createDirectMessage = createAction<CreateMessengerConversation>(SagaActionTypes.CreateDirectMessage);
-const receiveUnreadCount = createAction<string>(SagaActionTypes.ReceiveUnreadCount);
-const stopSyncChannels = createAction<string>(SagaActionTypes.StopSyncChannels);
-const fetchDirectMessages = createAction<string>(SagaActionTypes.FetchDirectMessages);
 const channelsReceived = createAction<ChannelsReceivedPayload>(SagaActionTypes.ChannelsReceived);
->>>>>>> d7e0235 (Add the existing channels to the redux store)
 
 const slice = createNormalizedListSlice({
   name: 'channelsList',
@@ -40,11 +25,7 @@ const slice = createNormalizedListSlice({
 
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
-<<<<<<< HEAD
-export { fetchChannels, fetchConversations, createConversation };
-=======
-export { fetch, receiveUnreadCount, stopSyncChannels, fetchDirectMessages, createDirectMessage, channelsReceived };
->>>>>>> d7e0235 (Add the existing channels to the redux store)
+export { fetchChannels, fetchConversations, createConversation, channelsReceived };
 
 export function denormalizeChannels(state) {
   return denormalize(state.channelsList.value, state).filter((c) => c.isChannel);

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -2,9 +2,10 @@ import { createAction } from '@reduxjs/toolkit';
 import { createNormalizedListSlice } from '../normalized';
 
 import { schema } from '../channels';
-import { CreateMessengerConversation } from './types';
+import { ChannelsReceivedPayload, CreateMessengerConversation } from './types';
 
 export enum SagaActionTypes {
+<<<<<<< HEAD
   FetchChannels = 'channelsList/saga/fetchChannels',
   FetchConversations = 'channelsList/saga/fetchConversations',
   CreateConversation = 'channelsList/saga/createConversations',
@@ -15,6 +16,22 @@ export enum SagaActionTypes {
 const fetchChannels = createAction<string>(SagaActionTypes.FetchChannels);
 const fetchConversations = createAction<string>(SagaActionTypes.FetchConversations);
 const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
+=======
+  Fetch = 'channelsList/saga/fetch',
+  CreateDirectMessage = 'directMessages/saga/createDirectMessage',
+  ReceiveUnreadCount = 'channelsList/saga/receiveUnreadCount',
+  StopSyncChannels = 'channelsList/saga/stopSyncChannels',
+  FetchDirectMessages = 'channelsList/saga/fetchDirectMessages',
+  ChannelsReceived = 'channelsList/saga/received',
+}
+
+const fetch = createAction<string>(SagaActionTypes.Fetch);
+const createDirectMessage = createAction<CreateMessengerConversation>(SagaActionTypes.CreateDirectMessage);
+const receiveUnreadCount = createAction<string>(SagaActionTypes.ReceiveUnreadCount);
+const stopSyncChannels = createAction<string>(SagaActionTypes.StopSyncChannels);
+const fetchDirectMessages = createAction<string>(SagaActionTypes.FetchDirectMessages);
+const channelsReceived = createAction<ChannelsReceivedPayload>(SagaActionTypes.ChannelsReceived);
+>>>>>>> d7e0235 (Add the existing channels to the redux store)
 
 const slice = createNormalizedListSlice({
   name: 'channelsList',
@@ -23,7 +40,11 @@ const slice = createNormalizedListSlice({
 
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
+<<<<<<< HEAD
 export { fetchChannels, fetchConversations, createConversation };
+=======
+export { fetch, receiveUnreadCount, stopSyncChannels, fetchDirectMessages, createDirectMessage, channelsReceived };
+>>>>>>> d7e0235 (Add the existing channels to the redux store)
 
 export function denormalizeChannels(state) {
   return denormalize(state.channelsList.value, state).filter((c) => c.isChannel);

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -1,6 +1,11 @@
 import { ChannelType, DirectMessage } from './types';
 import getDeepProperty from 'lodash.get';
+<<<<<<< HEAD
 import { takeLatest, put, call, take, race } from 'redux-saga/effects';
+=======
+import uniqBy from 'lodash.uniqby';
+import { takeLatest, put, call, delay } from 'redux-saga/effects';
+>>>>>>> d7e0235 (Add the existing channels to the redux store)
 import { SagaActionTypes, setStatus, receive } from '.';
 
 import {
@@ -100,9 +105,39 @@ export function* startChannelsAndConversationsRefresh() {
   }
 }
 
+export function* channelsReceived(action) {
+  const { channels } = action.payload;
+
+  const newChannels = channels.map(channelMapper);
+
+  // Silly to get theme separately but we'll be splitting these anyway
+  const existingDirectMessages = yield select(rawDirectMessages());
+  const existingChannels = yield select(rawChannelsList());
+
+  const newChannelList = uniqBy(
+    [
+      ...existingChannels,
+      ...existingDirectMessages,
+      ...newChannels,
+    ],
+    (c) => c.id ?? c
+  );
+
+  yield put(receive(newChannelList));
+}
+
 export function* saga() {
+<<<<<<< HEAD
   yield takeLatest(SagaActionTypes.FetchChannels, fetchChannels);
   yield takeLatest(SagaActionTypes.StartChannelsAndConversationsAutoRefresh, startChannelsAndConversationsRefresh);
   yield takeLatest(SagaActionTypes.FetchConversations, fetchConversations);
   yield takeLatest(SagaActionTypes.CreateConversation, createConversation);
+=======
+  yield takeLatest(SagaActionTypes.Fetch, fetch);
+  yield takeLatest(SagaActionTypes.ReceiveUnreadCount, syncUnreadCount);
+  yield takeLatest(SagaActionTypes.StopSyncChannels, stopSyncChannels);
+  yield takeLatest(SagaActionTypes.FetchDirectMessages, fetchDirectMessages);
+  yield takeLatest(SagaActionTypes.CreateDirectMessage, createDirectMessage);
+  yield takeLatest(SagaActionTypes.ChannelsReceived, channelsReceived);
+>>>>>>> d7e0235 (Add the existing channels to the redux store)
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -1,11 +1,7 @@
 import { ChannelType, DirectMessage } from './types';
 import getDeepProperty from 'lodash.get';
-<<<<<<< HEAD
-import { takeLatest, put, call, take, race } from 'redux-saga/effects';
-=======
 import uniqBy from 'lodash.uniqby';
-import { takeLatest, put, call, delay } from 'redux-saga/effects';
->>>>>>> d7e0235 (Add the existing channels to the redux store)
+import { takeLatest, put, call, take, race } from 'redux-saga/effects';
 import { SagaActionTypes, setStatus, receive } from '.';
 
 import {
@@ -110,8 +106,8 @@ export function* channelsReceived(action) {
 
   const newChannels = channels.map(channelMapper);
 
-  // Silly to get theme separately but we'll be splitting these anyway
-  const existingDirectMessages = yield select(rawDirectMessages());
+  // Silly to get them separately but we'll be splitting these anyway
+  const existingDirectMessages = yield select(rawConversationsList());
   const existingChannels = yield select(rawChannelsList());
 
   const newChannelList = uniqBy(
@@ -127,17 +123,9 @@ export function* channelsReceived(action) {
 }
 
 export function* saga() {
-<<<<<<< HEAD
   yield takeLatest(SagaActionTypes.FetchChannels, fetchChannels);
   yield takeLatest(SagaActionTypes.StartChannelsAndConversationsAutoRefresh, startChannelsAndConversationsRefresh);
   yield takeLatest(SagaActionTypes.FetchConversations, fetchConversations);
   yield takeLatest(SagaActionTypes.CreateConversation, createConversation);
-=======
-  yield takeLatest(SagaActionTypes.Fetch, fetch);
-  yield takeLatest(SagaActionTypes.ReceiveUnreadCount, syncUnreadCount);
-  yield takeLatest(SagaActionTypes.StopSyncChannels, stopSyncChannels);
-  yield takeLatest(SagaActionTypes.FetchDirectMessages, fetchDirectMessages);
-  yield takeLatest(SagaActionTypes.CreateDirectMessage, createDirectMessage);
   yield takeLatest(SagaActionTypes.ChannelsReceived, channelsReceived);
->>>>>>> d7e0235 (Add the existing channels to the redux store)
 }

--- a/src/store/channels-list/types.ts
+++ b/src/store/channels-list/types.ts
@@ -16,3 +16,7 @@ export interface DirectMessage extends Channel {
 export interface CreateMessengerConversation {
   userIds: string[];
 }
+
+export interface ChannelsReceivedPayload {
+  channels: Channel[];
+}


### PR DESCRIPTION
### What does this do?

Adds the Group Details panel into the group conversation flow.

Note: For now, this just interjects the second panel in the flow always. Once the endpoint is built to search for pre-existing conversations with the same users we can skip the second step if possible.

### Why are we making this change?

A step towards allowing users to set the name and image for a group conversation.

### How do I test this?

Create group conversations


https://user-images.githubusercontent.com/43770/230182486-c19cebb8-1bbb-49c6-950f-bbe3e69db189.mp4

