### PR TITLE
Hit actual api to check for group conversations

### DIFF
--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -17,10 +17,7 @@ export async function createConversation(userIds: string[]): Promise<DirectMessa
   return directMessages.body;
 }
 
-export async function fetchConversationsWithUsers(_userIds: string[]): Promise<any[]> {
-  // Simulate request timing
-  await new Promise((r) => setTimeout(r, 30));
-  return [];
-  // const response = await get<Channel[]>('/conversations', { userIds });
-  // return response.body;
+export async function fetchConversationsWithUsers(userIds: string[]): Promise<any[]> {
+  const response = await get<Channel[]>('/conversations', { userIds });
+  return response.body;
 }


### PR DESCRIPTION
### What does this do?

Removes the stub response and hits the real api when looking for existing group conversations.

### Why are we making this change?

Continuation of the group conversation feature.

### How do I test this?

Start a group conversation with people whom which you already have a group conversation with (exact member list). When you click Continue it should open your existing conversation.

Start a group conversation with people you don't already have one with. Clicking continue should take you to the Group Details panel.

