### PR TITLE
Add name field to group creation

### DIFF
--- a/src/components/messenger/list/group-details-panel.test.tsx
+++ b/src/components/messenger/list/group-details-panel.test.tsx
@@ -67,7 +67,18 @@ describe('GroupDetailsPanel', () => {
 
     wrapper.find('Button').simulate('press');
 
-    expect(onCreate).toHaveBeenCalledWith({ users: users });
+    expect(onCreate).toHaveBeenCalledWith({ users: users, name: '' });
+  });
+
+  it('includes group name onCreate', function () {
+    const onCreate = jest.fn();
+    const users = [stubUser({ value: 'u-1' })];
+    const wrapper = subject({ onCreate, users });
+
+    wrapper.find('Input').simulate('change', 'group name');
+    wrapper.find('Button').simulate('press');
+
+    expect(onCreate).toHaveBeenCalledWith({ name: 'group name', users: users });
   });
 });
 

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button } from '@zero-tech/zui/components';
+import { Button, Input } from '@zero-tech/zui/components';
 
 import { Option } from '../autocomplete-members';
 import { PanelHeader } from './panel-header';
@@ -13,18 +13,35 @@ export interface Properties {
   users: Option[];
 
   onBack: () => void;
-  onCreate: (data: { users: Option[] }) => void;
+  onCreate: (data: { name: string; users: Option[] }) => void;
 }
 
-export class GroupDetailsPanel extends React.Component<Properties> {
+interface State {
+  name: string;
+}
+
+export class GroupDetailsPanel extends React.Component<Properties, State> {
+  state = { name: '' };
+
   createGroup = () => {
-    this.props.onCreate({ users: this.props.users });
+    this.props.onCreate({ name: this.state.name, users: this.props.users });
+  };
+
+  nameChanged = (value) => {
+    this.setState({ name: value });
   };
 
   render() {
     return (
       <>
         <PanelHeader title='Group details' onBack={this.props.onBack} />
+        <div>
+          <div className={c('field-info')}>
+            <span className={c('label')}>Group name</span>
+            <span className={c('optional')}>Optional</span>
+          </div>
+          <Input value={this.state.name} onChange={this.nameChanged} />
+        </div>
         <div className={c('selected-count')}>
           <span className={c('selected-number')}>{this.props.users.length}</span> member
           {this.props.users.length === 1 ? '' : 's'} selected

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -173,9 +173,9 @@ describe('messenger-list', () => {
     openStartGroup(wrapper);
     await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'id-1' } as any]);
 
-    wrapper.find(GroupDetailsPanel).simulate('create', { users: [{ value: 'id-1' }] });
+    wrapper.find(GroupDetailsPanel).simulate('create', { name: 'group name', users: [{ value: 'id-1' }] });
 
-    expect(createConversation).toHaveBeenCalledWith({ userIds: ['id-1'] });
+    expect(createConversation).toHaveBeenCalledWith({ name: 'group name', userIds: ['id-1'] });
   });
 
   it('maintains the selected users on StartGroup phase if back button pressed on group details panel', async function () {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -143,7 +143,7 @@ export class Container extends React.Component<Properties, State> {
   };
 
   createGroup = async (details) => {
-    const conversation = { userIds: details.users.map((u) => u.value) };
+    const conversation = { name: details.name, userIds: details.users.map((u) => u.value) };
     this.props.createConversation(conversation);
     this.reset();
   };

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -239,6 +239,30 @@
   &__create {
     margin: 16px 0px;
   }
+
+  &__field-info {
+    display: flex;
+    align-content: stretch;
+    line-height: 24px;
+    margin-bottom: 12px;
+  }
+
+  &__label {
+    flex-grow: 1;
+
+    color: theme.$color-greyscale-12;
+    font-weight: 400;
+    font-size: 16px;
+  }
+
+  &__optional {
+    flex-grow: 0;
+    flex-shrink: 0;
+
+    color: theme.$color-greyscale-11;
+    font-family: 'SF Pro Text';
+    font-size: 12px;
+  }
 }
 
 .selected-user-tag {

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -12,8 +12,8 @@ export async function fetchConversations(): Promise<Channel[]> {
   return directMessages.body;
 }
 
-export async function createConversation(userIds: string[]): Promise<DirectMessage[]> {
-  const directMessages = await post<Channel[]>('/directMessages').send({ userIds });
+export async function createConversation(userIds: string[], name: string = ''): Promise<DirectMessage[]> {
+  const directMessages = await post<Channel[]>('/directMessages').send({ name, userIds });
   return directMessages.body;
 }
 

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -68,8 +68,9 @@ describe('channels list saga', () => {
   });
 
   it('create direct messages', async () => {
+    const name = 'group';
     const userIds = ['7867766_7876Z2'];
-    await expectSaga(createConversation, { payload: { userIds } })
+    await expectSaga(createConversation, { payload: { userIds, name } })
       .provide([
         [
           matchers.call.fn(createConversationApi),
@@ -77,15 +78,16 @@ describe('channels list saga', () => {
         ],
       ])
       .withReducer(rootReducer)
-      .call(createConversationApi, userIds)
+      .call(createConversationApi, userIds, name)
       .run();
   });
 
   it('handle existing chat direct messages creation', async () => {
+    const name = 'group';
     const userIds = ['7867766_7876Z2'];
     const {
       storeState: { channelsList, chat },
-    } = await expectSaga(createConversation, { payload: { userIds } })
+    } = await expectSaga(createConversation, { payload: { userIds, name } })
       .withReducer(rootReducer)
       .provide([
         [
@@ -94,7 +96,7 @@ describe('channels list saga', () => {
         ],
       ])
       .withReducer(rootReducer)
-      .call(createConversationApi, userIds)
+      .call(createConversationApi, userIds, name)
       .run();
 
     expect(channelsList.value).toStrictEqual([MOCK_CREATE_DIRECT_MESSAGE_RESPONSE.id]);

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -54,8 +54,8 @@ export function* fetchConversations() {
 }
 
 export function* createConversation(action) {
-  const { userIds } = action.payload;
-  const response: DirectMessage = yield call(createConversationMessageApi, userIds);
+  const { name, userIds } = action.payload;
+  const response: DirectMessage = yield call(createConversationMessageApi, userIds, name);
 
   const conversation = channelMapper(response);
   const existingConversationsList = yield select(rawConversationsList());

--- a/src/store/channels-list/types.ts
+++ b/src/store/channels-list/types.ts
@@ -14,6 +14,7 @@ export interface DirectMessage extends Channel {
 }
 
 export interface CreateMessengerConversation {
+  name?: string;
   userIds: string[];
 }
 


### PR DESCRIPTION
### What does this do?

Adds the Name field to group conversation creation.

### Why are we making this change?

So we can name group convos!

### How do I test this?

Create a group conversation. Set a name. Verify it shows up in the conversation list with the name and the name renders in the chat window.

![image](https://user-images.githubusercontent.com/43770/230485175-aeaeec05-99a4-4ff3-b0e6-66401a8f239e.png)


