### PR TITLE
Add loading state when creating group conversation

### DIFF
--- a/src/components/messenger/list/group-details-panel.test.tsx
+++ b/src/components/messenger/list/group-details-panel.test.tsx
@@ -9,6 +9,7 @@ describe('GroupDetailsPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       users: [],
+      isCreating: false,
       onBack: () => null,
       onCreate: () => null,
       ...props,
@@ -89,6 +90,12 @@ describe('GroupDetailsPanel', () => {
     wrapper.find('Button').simulate('press');
 
     expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ image }));
+  });
+
+  it('sets button to loading state if creating', function () {
+    const wrapper = subject({ isCreating: true });
+
+    expect(wrapper.find('Button').prop('isLoading')).toBeTrue();
   });
 });
 

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -12,6 +12,7 @@ const c = bem('group-details-panel');
 
 export interface Properties {
   users: Option[];
+  isCreating: boolean;
 
   onBack: () => void;
   onCreate: (data: { name: string; users: Option[]; image: File }) => void;
@@ -62,7 +63,7 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
             <SelectedUserTag userOption={u} key={u.value}></SelectedUserTag>
           ))}
         </div>
-        <Button onPress={this.createGroup} className={c('create')}>
+        <Button onPress={this.createGroup} className={c('create')} isLoading={this.props.isCreating}>
           Create Group
         </Button>
       </>

--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -1,0 +1,38 @@
+import { PayloadAction, createAction, createSlice } from '@reduxjs/toolkit';
+import { CreateMessengerConversation } from '../channels-list/types';
+
+export enum SagaActionTypes {
+  CreateConversation = 'create-conversation/create',
+}
+
+export const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
+
+type CreateConversationState = {
+  isActive: boolean;
+  groupDetails: {
+    isCreating: boolean;
+  };
+};
+
+const initialState: CreateConversationState = {
+  isActive: false,
+  groupDetails: {
+    isCreating: false,
+  },
+};
+
+const slice = createSlice({
+  name: 'createConversation',
+  initialState,
+  reducers: {
+    setActive: (state, action: PayloadAction<boolean>) => {
+      state.isActive = action.payload;
+    },
+    setGroupCreating: (state, action: PayloadAction<boolean>) => {
+      state.groupDetails.isCreating = action.payload;
+    },
+  },
+});
+
+export const { setActive, setGroupCreating } = slice.actions;
+export const { reducer } = slice;

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -1,0 +1,37 @@
+import { testSaga } from 'redux-saga-test-plan';
+
+import { createConversation } from './saga';
+import { setGroupCreating, setActive } from '.';
+
+import { createConversation as performCreateConversation } from '../channels-list/saga';
+
+describe('create conversation saga', () => {
+  it('manages the conversation active state', async () => {
+    // Note: temporary during migration
+    return testSaga(createConversation, { payload: {} })
+      .next()
+      .put(setActive(true))
+      .next()
+      .next()
+      .next()
+      .next()
+      .put(setActive(false));
+  });
+
+  it('manages the creating status while performing the actual create', async () => {
+    const testPayload = {
+      userId: 'test',
+      name: 'test name',
+      image: {},
+    };
+
+    return testSaga(createConversation, { payload: testPayload })
+      .next()
+      .next()
+      .put(setGroupCreating(true))
+      .next()
+      .call(performCreateConversation, { payload: testPayload })
+      .next()
+      .put(setGroupCreating(false));
+  });
+});

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,0 +1,15 @@
+import { takeLatest, put, call } from 'redux-saga/effects';
+import { SagaActionTypes, setActive, setGroupCreating } from '.';
+import { createConversation as performCreateConversation } from '../channels-list/saga';
+
+export function* createConversation(action) {
+  yield put(setActive(true));
+  yield put(setGroupCreating(true));
+  yield call(performCreateConversation, { payload: action.payload });
+  yield put(setGroupCreating(false));
+  yield put(setActive(false));
+}
+
+export function* saga() {
+  yield takeLatest(SagaActionTypes.CreateConversation, createConversation);
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,6 +14,7 @@ import { reducer as normalized } from './normalized';
 import { reducer as authentication } from './authentication';
 import { reducer as chat } from './chat';
 import { reducer as notificationsList } from './notifications';
+import { reducer as createConversation } from './create-conversation';
 
 const sagaMiddleware = createSagaMiddleware({
   onError: (e) => {
@@ -32,6 +33,7 @@ export const rootReducer = combineReducers({
   authentication,
   chat,
   notificationsList,
+  createConversation,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -11,6 +11,7 @@ import { saga as chat } from './chat/saga';
 import { saga as theme } from './theme/saga';
 import { saga as layout } from './layout/saga';
 import { saga as notificationsList } from './notifications/saga';
+import { saga as createConversation } from './create-conversation/saga';
 
 export function* rootSaga() {
   const allSagas = {
@@ -25,6 +26,7 @@ export function* rootSaga() {
     theme,
     layout,
     notificationsList,
+    createConversation,
   };
 
   yield all(


### PR DESCRIPTION
### What does this do?

Puts the Create Group button into loading state while the group is being created.

Note: This also prepares a createConversation saga which will evolve into managing the whole user flow as a saga. It includes some temporary hacks to ensure the flow still continues to work in both modes for now. These will disappear over the next few PRs.

### Why are we making this change?

User experience

### How do I test this?

Create a group conversation and see the loading indicator. Adding an image will make it slower which may help.

