### PR TITLE
Manage the create conversation stage in saga

### DIFF
--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -2,12 +2,29 @@ import { PayloadAction, createAction, createSlice } from '@reduxjs/toolkit';
 import { CreateMessengerConversation } from '../channels-list/types';
 
 export enum SagaActionTypes {
+  Start = 'create-conversation/start',
+  Forward = 'create-conversation/forward',
+  Back = 'create-conversation/back',
+  Reset = 'create-conversation/reset',
   CreateConversation = 'create-conversation/create',
 }
 
+export const startCreateConversation = createAction(SagaActionTypes.Start);
+// Temporarily just let the component guide the saga through the stages.
+export const forward = createAction(SagaActionTypes.Forward);
+export const back = createAction(SagaActionTypes.Back);
+export const reset = createAction(SagaActionTypes.Reset);
 export const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
 
+export enum Stage {
+  None = 'none',
+  CreateOneOnOne = 'one_on_one',
+  StartGroupChat = 'start_group',
+  GroupDetails = 'group_details',
+}
+
 type CreateConversationState = {
+  stage: Stage;
   isActive: boolean;
   groupDetails: {
     isCreating: boolean;
@@ -15,6 +32,7 @@ type CreateConversationState = {
 };
 
 const initialState: CreateConversationState = {
+  stage: Stage.None,
   isActive: false,
   groupDetails: {
     isCreating: false,
@@ -25,6 +43,9 @@ const slice = createSlice({
   name: 'createConversation',
   initialState,
   reducers: {
+    setStage: (state, action: PayloadAction<Stage>) => {
+      state.stage = action.payload;
+    },
     setActive: (state, action: PayloadAction<boolean>) => {
       state.isActive = action.payload;
     },
@@ -34,5 +55,5 @@ const slice = createSlice({
   },
 });
 
-export const { setActive, setGroupCreating } = slice.actions;
+export const { setActive, setGroupCreating, setStage } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -1,37 +1,145 @@
-import { testSaga } from 'redux-saga-test-plan';
+import { expectSaga, testSaga } from 'redux-saga-test-plan';
 
-import { createConversation } from './saga';
-import { setGroupCreating, setActive } from '.';
+import { back, createConversation, forward, reset, startConversation } from './saga';
+import { setGroupCreating, setActive, reducer, Stage } from '.';
 
 import { createConversation as performCreateConversation } from '../channels-list/saga';
+import { rootReducer } from '..';
 
 describe('create conversation saga', () => {
-  it('manages the conversation active state', async () => {
-    // Note: temporary during migration
-    return testSaga(createConversation, { payload: {} })
-      .next()
-      .put(setActive(true))
-      .next()
-      .next()
-      .next()
-      .next()
-      .put(setActive(false));
+  describe('startConversation', () => {
+    it('Sets the starting state', async () => {
+      const initialState = {
+        stage: Stage.None,
+        isActive: true,
+        groupDetails: { isCreating: true },
+      };
+
+      const { storeState: state } = await expectSaga(startConversation, { payload: {} })
+        .withReducer(reducer, initialState)
+        .run();
+
+      expect(state).toEqual({ stage: Stage.CreateOneOnOne, isActive: false, groupDetails: { isCreating: false } });
+    });
   });
 
-  it('manages the creating status while performing the actual create', async () => {
-    const testPayload = {
-      userId: 'test',
-      name: 'test name',
-      image: {},
-    };
+  describe('back', () => {
+    it('sets stage to None if moving all the way back', async () => {
+      const initialState = defaultState({ stage: Stage.CreateOneOnOne });
 
-    return testSaga(createConversation, { payload: testPayload })
-      .next()
-      .next()
-      .put(setGroupCreating(true))
-      .next()
-      .call(performCreateConversation, { payload: testPayload })
-      .next()
-      .put(setGroupCreating(false));
+      const {
+        storeState: { createConversation: state },
+      } = await expectSaga(back, { payload: {} })
+        .withReducer(rootReducer, initialState as any)
+        .run();
+
+      expect(state.stage).toEqual(Stage.None);
+    });
+
+    it('sets stage to CreateOneOnOne if moving back from StartGroupChat', async () => {
+      const initialState = defaultState({ stage: Stage.StartGroupChat });
+
+      const {
+        storeState: { createConversation: state },
+      } = await expectSaga(back, { payload: {} })
+        .withReducer(rootReducer, initialState as any)
+        .run();
+
+      expect(state.stage).toEqual(Stage.CreateOneOnOne);
+    });
+
+    it('sets stage to StargGroupChat if moving back from GroupDetails', async () => {
+      const initialState = defaultState({ stage: Stage.GroupDetails });
+
+      const {
+        storeState: { createConversation: state },
+      } = await expectSaga(back, { payload: {} })
+        .withReducer(rootReducer, initialState as any)
+        .run();
+
+      expect(state.stage).toEqual(Stage.StartGroupChat);
+    });
+  });
+
+  describe('forward', () => {
+    it('sets stage to StartGroupChat if moving forward from CreateOneOnOne', async () => {
+      const initialState = defaultState({ stage: Stage.CreateOneOnOne });
+
+      const {
+        storeState: { createConversation: state },
+      } = await expectSaga(forward, { payload: {} })
+        .withReducer(rootReducer, initialState as any)
+        .run();
+
+      expect(state.stage).toEqual(Stage.StartGroupChat);
+    });
+
+    it('sets stage to GroupDetails if moving forward from StartGroupChat', async () => {
+      const initialState = defaultState({ stage: Stage.StartGroupChat });
+
+      const {
+        storeState: { createConversation: state },
+      } = await expectSaga(forward, { payload: {} })
+        .withReducer(rootReducer, initialState as any)
+        .run();
+
+      expect(state.stage).toEqual(Stage.GroupDetails);
+    });
+  });
+
+  describe('reset', () => {
+    it('resets to default state', async () => {
+      const initialState = {
+        stage: Stage.None,
+        isActive: true,
+        groupDetails: { isCreating: true },
+      };
+
+      const { storeState: state } = await expectSaga(reset, { payload: {} }).withReducer(reducer, initialState).run();
+
+      expect(state).toEqual({ stage: Stage.None, isActive: false, groupDetails: { isCreating: false } });
+    });
+  });
+
+  describe('createConversation', () => {
+    it('manages the conversation active state', async () => {
+      // Note: temporary during migration
+      return testSaga(createConversation, { payload: {} })
+        .next()
+        .put(setActive(true))
+        .next()
+        .next()
+        .next()
+        .next()
+        .put(setActive(false));
+    });
+
+    it('manages the creating status while performing the actual create', async () => {
+      const testPayload = {
+        userId: 'test',
+        name: 'test name',
+        image: {},
+      };
+
+      return testSaga(createConversation, { payload: testPayload })
+        .next()
+        .next()
+        .put(setGroupCreating(true))
+        .next()
+        .call(performCreateConversation, { payload: testPayload })
+        .next()
+        .put(setGroupCreating(false));
+    });
   });
 });
+
+function defaultState(attrs = {}) {
+  return {
+    createConversation: {
+      stage: Stage.None,
+      isActive: false,
+      groupDetails: { isCreating: false },
+      ...attrs,
+    },
+  };
+}

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -1,4 +1,5 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { back, createConversation, forward, reset, startConversation } from './saga';
 import { setGroupCreating, setActive, reducer, Stage } from '.';
@@ -129,6 +130,26 @@ describe('create conversation saga', () => {
         .call(performCreateConversation, { payload: testPayload })
         .next()
         .put(setGroupCreating(false));
+    });
+
+    it('resets the conversation saga when complete', async () => {
+      const initialState = {
+        stage: Stage.GroupDetails,
+        isActive: true,
+        groupDetails: { isCreating: true },
+      };
+
+      const { storeState: state } = await expectSaga(createConversation, { payload: {} })
+        .provide([
+          [
+            matchers.call.fn(performCreateConversation),
+            null,
+          ],
+        ])
+        .withReducer(reducer, initialState)
+        .run();
+
+      expect(state).toEqual({ stage: Stage.None, isActive: false, groupDetails: { isCreating: false } });
     });
   });
 });

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -53,8 +53,6 @@ export function* createConversation(action) {
 }
 
 export function* saga() {
-  // XXX: Tweak these. We don't need to listen here and should
-  // listen at the correct moments in the user saga
   yield takeLatest(SagaActionTypes.Start, startConversation);
   yield takeLatest(SagaActionTypes.Back, back);
   yield takeLatest(SagaActionTypes.Forward, forward);

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -49,6 +49,7 @@ export function* createConversation(action) {
   yield call(performCreateConversation, { payload: action.payload });
   yield put(setGroupCreating(false));
   yield put(setActive(false));
+  yield call(reset, {});
 }
 
 export function* saga() {


### PR DESCRIPTION
### What does this do?

Refactors the messenger list to rely on the saga to manage the stage of conversation creation.

This is a step towards having the saga control the entire user flow.

### Why are we making this change?

We believe controlling the user journey via a saga will lead to better control over behaviour and reactions to failures, etc.

### How do I test this?

Test the whole flow of creating a conversation.

