### PR TITLE
Push selecting members for group chat into saga

### DIFF
--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -1,11 +1,13 @@
 import { PayloadAction, createAction, createSlice } from '@reduxjs/toolkit';
 import { CreateMessengerConversation } from '../channels-list/types';
+import { MembersSelectedPayload } from './types';
 
 export enum SagaActionTypes {
   Start = 'create-conversation/start',
   Forward = 'create-conversation/forward',
   Back = 'create-conversation/back',
   Reset = 'create-conversation/reset',
+  MembersSelected = 'create-conversation/members-selected',
   CreateConversation = 'create-conversation/create',
 }
 
@@ -14,6 +16,7 @@ export const startCreateConversation = createAction(SagaActionTypes.Start);
 export const forward = createAction(SagaActionTypes.Forward);
 export const back = createAction(SagaActionTypes.Back);
 export const reset = createAction(SagaActionTypes.Reset);
+export const membersSelected = createAction<MembersSelectedPayload>(SagaActionTypes.MembersSelected);
 export const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
 
 export enum Stage {
@@ -26,6 +29,10 @@ export enum Stage {
 type CreateConversationState = {
   stage: Stage;
   isActive: boolean;
+  groupUsers: [];
+  startGroupChat: {
+    isLoading: boolean;
+  };
   groupDetails: {
     isCreating: boolean;
   };
@@ -34,6 +41,10 @@ type CreateConversationState = {
 const initialState: CreateConversationState = {
   stage: Stage.None,
   isActive: false,
+  groupUsers: [],
+  startGroupChat: {
+    isLoading: false,
+  },
   groupDetails: {
     isCreating: false,
   },
@@ -49,11 +60,17 @@ const slice = createSlice({
     setActive: (state, action: PayloadAction<boolean>) => {
       state.isActive = action.payload;
     },
+    setFetchingConversations: (state, action: PayloadAction<boolean>) => {
+      state.startGroupChat.isLoading = action.payload;
+    },
     setGroupCreating: (state, action: PayloadAction<boolean>) => {
       state.groupDetails.isCreating = action.payload;
+    },
+    setGroupUsers: (state, action: PayloadAction<[]>) => {
+      state.groupUsers = action.payload;
     },
   },
 });
 
-export const { setActive, setGroupCreating, setStage } = slice.actions;
+export const { setActive, setGroupCreating, setStage, setGroupUsers, setFetchingConversations } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -1,32 +1,43 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { back, createConversation, forward, reset, startConversation } from './saga';
-import { setGroupCreating, setActive, reducer, Stage } from '.';
+import { back, createConversation, forward, groupMembersSelected, reset, startConversation } from './saga';
+import { setGroupCreating, setActive, reducer, Stage, setFetchingConversations } from '.';
 
-import { createConversation as performCreateConversation } from '../channels-list/saga';
+import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
 import { rootReducer } from '..';
+import { fetchConversationsWithUsers } from '../channels-list/api';
+import { setActiveMessengerId } from '../chat';
+import { select } from 'redux-saga/effects';
+import { currentUserSelector } from '../authentication/saga';
 
 describe('create conversation saga', () => {
   describe('startConversation', () => {
     it('Sets the starting state', async () => {
-      const initialState = {
-        stage: Stage.None,
+      const initialState = defaultState({
+        stage: Stage.StartGroupChat, // Arbitrary non-starting state
         isActive: true,
+        groupUsers: [{ things: 'loaded' }],
         groupDetails: { isCreating: true },
-      };
+      });
 
       const { storeState: state } = await expectSaga(startConversation, { payload: {} })
         .withReducer(reducer, initialState)
         .run();
 
-      expect(state).toEqual({ stage: Stage.CreateOneOnOne, isActive: false, groupDetails: { isCreating: false } });
+      expect(state).toEqual({
+        stage: Stage.CreateOneOnOne,
+        isActive: false,
+        groupUsers: [],
+        startGroupChat: { isLoading: false },
+        groupDetails: { isCreating: false },
+      });
     });
   });
 
   describe('back', () => {
     it('sets stage to None if moving all the way back', async () => {
-      const initialState = defaultState({ stage: Stage.CreateOneOnOne });
+      const initialState = fullState({ stage: Stage.CreateOneOnOne });
 
       const {
         storeState: { createConversation: state },
@@ -38,7 +49,7 @@ describe('create conversation saga', () => {
     });
 
     it('sets stage to CreateOneOnOne if moving back from StartGroupChat', async () => {
-      const initialState = defaultState({ stage: Stage.StartGroupChat });
+      const initialState = fullState({ stage: Stage.StartGroupChat });
 
       const {
         storeState: { createConversation: state },
@@ -50,7 +61,7 @@ describe('create conversation saga', () => {
     });
 
     it('sets stage to StargGroupChat if moving back from GroupDetails', async () => {
-      const initialState = defaultState({ stage: Stage.GroupDetails });
+      const initialState = fullState({ stage: Stage.GroupDetails });
 
       const {
         storeState: { createConversation: state },
@@ -64,7 +75,7 @@ describe('create conversation saga', () => {
 
   describe('forward', () => {
     it('sets stage to StartGroupChat if moving forward from CreateOneOnOne', async () => {
-      const initialState = defaultState({ stage: Stage.CreateOneOnOne });
+      const initialState = fullState({ stage: Stage.CreateOneOnOne });
 
       const {
         storeState: { createConversation: state },
@@ -76,7 +87,7 @@ describe('create conversation saga', () => {
     });
 
     it('sets stage to GroupDetails if moving forward from StartGroupChat', async () => {
-      const initialState = defaultState({ stage: Stage.StartGroupChat });
+      const initialState = fullState({ stage: Stage.StartGroupChat });
 
       const {
         storeState: { createConversation: state },
@@ -88,17 +99,124 @@ describe('create conversation saga', () => {
     });
   });
 
+  describe('groupMembersSelected', () => {
+    function expectWithExistingChannels(channels = [{ id: 'stub-convo' }], payload = { users: [] }) {
+      return expectSaga(groupMembersSelected, { payload }).provide([
+        [
+          matchers.call.fn(fetchConversationsWithUsers),
+          channels,
+        ],
+        [
+          matchers.call.fn(channelsReceived),
+          null,
+        ],
+      ]);
+    }
+
+    it('includes current user when fetching conversations', async () => {
+      return expectSaga(groupMembersSelected, { payload: { users: [{ value: 'other-user-id' }] } })
+        .provide([
+          [
+            select(currentUserSelector),
+            { id: 'current-user-id' },
+          ],
+          [
+            matchers.call.fn(fetchConversationsWithUsers),
+            [],
+          ],
+        ])
+        .call(fetchConversationsWithUsers, [
+          'current-user-id',
+          'other-user-id',
+        ])
+        .run();
+    });
+
+    it('saves first existing conversation', async () => {
+      await expectWithExistingChannels([
+        { id: 'convo-1' },
+        { id: 'convo-2' },
+      ])
+        .call(channelsReceived, { payload: { channels: [{ id: 'convo-1' }] } })
+        .run();
+    });
+
+    it('opens the existing conversation', async () => {
+      await expectWithExistingChannels([{ id: 'convo-1' }])
+        .put(setActiveMessengerId('convo-1'))
+        .run();
+    });
+
+    it('returns to initial state when existing conversation selected', async () => {
+      const initialState = defaultState({ stage: Stage.StartGroupChat });
+
+      const { storeState: state } = await expectWithExistingChannels([{ id: 'convo-1' }])
+        .withReducer(reducer, initialState)
+        .run();
+
+      expect(state).toEqual(expect.objectContaining({ stage: Stage.None }));
+    });
+
+    it('manages loading state', async () => {
+      return testSaga(groupMembersSelected, { payload: {} })
+        .next()
+        .put(setFetchingConversations(true))
+        .next()
+        .next()
+        .put(setFetchingConversations(false));
+    });
+
+    it('moves to group details stage if no existing conversations found', async () => {
+      const initialState = defaultState({ stage: Stage.StartGroupChat });
+
+      const { storeState: state } = await expectSaga(groupMembersSelected, {
+        payload: {
+          users: [
+            { value: 'user-1' },
+            { value: 'user-2' },
+          ],
+        },
+      })
+        .provide([
+          [
+            matchers.call.fn(fetchConversationsWithUsers),
+            [],
+          ],
+        ])
+        .withReducer(reducer, initialState)
+        .run();
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          stage: Stage.GroupDetails,
+          groupUsers: [
+            { value: 'user-1' },
+            { value: 'user-2' },
+          ],
+        })
+      );
+    });
+  });
+
   describe('reset', () => {
     it('resets to default state', async () => {
-      const initialState = {
+      const initialState = defaultState({
         stage: Stage.None,
         isActive: true,
+        groupUsers: [{ things: 'loaded' }],
+        startGroupChat: { isLoading: true },
         groupDetails: { isCreating: true },
-      };
+      });
 
       const { storeState: state } = await expectSaga(reset, { payload: {} }).withReducer(reducer, initialState).run();
 
-      expect(state).toEqual({ stage: Stage.None, isActive: false, groupDetails: { isCreating: false } });
+      expect(state).toEqual({
+        stage: Stage.None,
+        isActive: false,
+        groupUsers: [],
+        startGroupChat: { isLoading: false },
+        groupDetails: { isCreating: false },
+      });
     });
   });
 
@@ -133,11 +251,7 @@ describe('create conversation saga', () => {
     });
 
     it('resets the conversation saga when complete', async () => {
-      const initialState = {
-        stage: Stage.GroupDetails,
-        isActive: true,
-        groupDetails: { isCreating: true },
-      };
+      const initialState = defaultState({ stage: Stage.GroupDetails });
 
       const { storeState: state } = await expectSaga(createConversation, { payload: {} })
         .provide([
@@ -149,18 +263,24 @@ describe('create conversation saga', () => {
         .withReducer(reducer, initialState)
         .run();
 
-      expect(state).toEqual({ stage: Stage.None, isActive: false, groupDetails: { isCreating: false } });
+      expect(state.stage).toEqual(Stage.None);
     });
   });
 });
 
+function fullState(attrs = {}) {
+  return {
+    createConversation: defaultState(attrs),
+  };
+}
+
 function defaultState(attrs = {}) {
   return {
-    createConversation: {
-      stage: Stage.None,
-      isActive: false,
-      groupDetails: { isCreating: false },
-      ...attrs,
-    },
+    stage: Stage.None,
+    isActive: false,
+    groupUsers: [] as any,
+    startGroupChat: { isLoading: false },
+    groupDetails: { isCreating: false },
+    ...attrs,
   };
 }

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,15 +1,29 @@
 import { takeLatest, put, call, select } from 'redux-saga/effects';
-import { SagaActionTypes, Stage, setActive, setGroupCreating, setStage } from '.';
-import { createConversation as performCreateConversation } from '../channels-list/saga';
+import {
+  SagaActionTypes,
+  Stage,
+  setActive,
+  setFetchingConversations,
+  setGroupCreating,
+  setGroupUsers,
+  setStage,
+} from '.';
+import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
+import { fetchConversationsWithUsers } from '../channels-list/api';
+import { setActiveMessengerId } from '../chat';
+import { currentUserSelector } from '../authentication/saga';
 
 export function* startConversation(_action) {
   yield put(setActive(false));
   yield put(setGroupCreating(false));
+  yield put(setGroupUsers([]));
   yield put(setStage(Stage.CreateOneOnOne));
 }
 
 export function* reset(_action) {
   yield put(setActive(false));
+  yield put(setGroupUsers([]));
+  yield put(setFetchingConversations(false));
   yield put(setGroupCreating(false));
   yield put(setStage(Stage.None));
 }
@@ -43,6 +57,33 @@ export function* forward(_action) {
   }
 }
 
+export function* groupMembersSelected(action) {
+  yield put(setFetchingConversations(true));
+  yield call(performGroupMembersSelected, action);
+  yield put(setFetchingConversations(false));
+}
+
+export function* performGroupMembersSelected(action) {
+  const { users } = action.payload;
+
+  const currentUser = yield select(currentUserSelector);
+  const userIds = [
+    currentUser.id,
+    ...users.map((o) => o.value),
+  ];
+  const existingConversations = yield call(fetchConversationsWithUsers, userIds);
+
+  if (existingConversations.length === 0) {
+    yield put(setGroupUsers(users));
+    yield put(setStage(Stage.GroupDetails));
+  } else {
+    const selectedConversation = existingConversations[0];
+    yield call(channelsReceived, { payload: { channels: [selectedConversation] } });
+    yield put(setActiveMessengerId(selectedConversation.id));
+    yield call(reset, {});
+  }
+}
+
 export function* createConversation(action) {
   yield put(setActive(true));
   yield put(setGroupCreating(true));
@@ -57,5 +98,6 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.Back, back);
   yield takeLatest(SagaActionTypes.Forward, forward);
   yield takeLatest(SagaActionTypes.Reset, reset);
+  yield takeLatest(SagaActionTypes.MembersSelected, groupMembersSelected);
   yield takeLatest(SagaActionTypes.CreateConversation, createConversation);
 }

--- a/src/store/create-conversation/types.ts
+++ b/src/store/create-conversation/types.ts
@@ -1,0 +1,3 @@
+export interface MembersSelectedPayload {
+  users: any[];
+}


### PR DESCRIPTION
### What does this do?

Moves selecting of group chat members into saga

### Why are we making this change?

Continuation of moving Create Conversation user flow into saga.

### How do I test this?

Verify all functionality of creating a new conversation.
