### PR TITLE
Move management of full create conversation flow into saga

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -24,12 +24,12 @@ describe('messenger-list', () => {
       conversations: [],
       isFetchingExistingConversations: false,
       isGroupCreating: false,
-      setActiveMessengerChat: jest.fn(),
+      openConversation: jest.fn(),
       fetchConversations: jest.fn(),
       createConversation: jest.fn(),
       startCreateConversation: () => null,
       membersSelected: () => null,
-      forward: () => null,
+      startGroup: () => null,
       back: () => null,
       onClose: () => null,
       ...props,
@@ -98,13 +98,13 @@ describe('messenger-list', () => {
     expect(wrapper).toHaveElement(GroupDetailsPanel);
   });
 
-  it('moves forward when group chat started', async function () {
-    const forward = jest.fn();
-    const wrapper = subject({ stage: Stage.CreateOneOnOne, forward });
+  it('moves starts group when group chat started', async function () {
+    const startGroup = jest.fn();
+    const wrapper = subject({ stage: Stage.CreateOneOnOne, startGroup });
 
     wrapper.find(CreateConversationPanel).simulate('startGroupChat');
 
-    expect(forward).toHaveBeenCalledOnce();
+    expect(startGroup).toHaveBeenCalledOnce();
   });
 
   it('moves back from CreateConversationPanel', async function () {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -11,7 +11,7 @@ import {
   Stage as SagaStage,
   back,
   createConversation,
-  forward,
+  startGroup,
   membersSelected,
   startCreateConversation,
 } from '../../../store/create-conversation';
@@ -39,9 +39,7 @@ export interface Properties extends PublicProperties {
   isGroupCreating: boolean;
 
   startCreateConversation: () => void;
-  // Temporarily just advance through the stages until each one
-  // does the appropriate step
-  forward: () => void;
+  startGroup: () => void;
   back: () => void;
   setActiveMessengerChat: (channelId: string) => void;
   fetchConversations: () => void;
@@ -72,7 +70,7 @@ export class Container extends React.Component<Properties> {
       createConversation,
       startCreateConversation,
       back,
-      forward,
+      startGroup,
       membersSelected,
     };
   }
@@ -94,7 +92,7 @@ export class Container extends React.Component<Properties> {
   };
 
   startGroupChat = (): void => {
-    this.props.forward();
+    this.props.startGroup();
   };
 
   usersInMyNetworks = async (search: string) => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -41,7 +41,7 @@ export interface Properties extends PublicProperties {
   startCreateConversation: () => void;
   startGroup: () => void;
   back: () => void;
-  setActiveMessengerChat: (channelId: string) => void;
+  openConversation: (channelId: string) => void;
   fetchConversations: () => void;
   membersSelected: (payload: MembersSelectedPayload) => void;
   createConversation: (payload: CreateMessengerConversation) => void;
@@ -65,7 +65,7 @@ export class Container extends React.Component<Properties> {
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
-      setActiveMessengerChat: setActiveMessengerId,
+      openConversation: setActiveMessengerId,
       fetchConversations,
       createConversation,
       startCreateConversation,
@@ -78,22 +78,6 @@ export class Container extends React.Component<Properties> {
   componentDidMount(): void {
     this.props.fetchConversations();
   }
-
-  openConversation = (id: string) => {
-    this.props.setActiveMessengerChat(id);
-  };
-
-  goBack = (): void => {
-    this.props.back();
-  };
-
-  startConversation = (): void => {
-    this.props.startCreateConversation();
-  };
-
-  startGroupChat = (): void => {
-    this.props.startGroup();
-  };
 
   usersInMyNetworks = async (search: string) => {
     const users: MemberNetworks[] = await searchMyNetworksByName(search);
@@ -136,23 +120,23 @@ export class Container extends React.Component<Properties> {
           {this.props.stage === SagaStage.None && (
             <ConversationListPanel
               conversations={this.props.conversations}
-              onConversationClick={this.openConversation}
-              startConversation={this.startConversation}
+              onConversationClick={this.props.openConversation}
+              startConversation={this.props.startCreateConversation}
             />
           )}
           {this.props.stage === SagaStage.CreateOneOnOne && (
             <CreateConversationPanel
-              onBack={this.goBack}
+              onBack={this.props.back}
               search={this.usersInMyNetworks}
               onCreate={this.createOneOnOneConversation}
-              onStartGroupChat={this.startGroupChat}
+              onStartGroupChat={this.props.startGroup}
             />
           )}
           {this.props.stage === SagaStage.StartGroupChat && (
             <StartGroupPanel
               initialSelections={this.props.groupUsers}
               isContinuing={this.props.isFetchingExistingConversations}
-              onBack={this.goBack}
+              onBack={this.props.back}
               onContinue={this.groupMembersSelected}
               searchUsers={this.usersInMyNetworks}
             />
@@ -161,7 +145,7 @@ export class Container extends React.Component<Properties> {
             <GroupDetailsPanel
               users={this.props.groupUsers}
               onCreate={this.createGroup}
-              onBack={this.goBack}
+              onBack={this.props.back}
               isCreating={this.props.isGroupCreating}
             />
           )}

--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -4,16 +4,15 @@ import { MembersSelectedPayload } from './types';
 
 export enum SagaActionTypes {
   Start = 'create-conversation/start',
-  Forward = 'create-conversation/forward',
   Back = 'create-conversation/back',
   Cancel = 'create-conversation/cancel',
+  StartGroup = 'create-conversation/start-group',
   MembersSelected = 'create-conversation/members-selected',
   CreateConversation = 'create-conversation/create',
 }
 
 export const startCreateConversation = createAction(SagaActionTypes.Start);
-// Temporarily just let the component guide the saga through the stages.
-export const forward = createAction(SagaActionTypes.Forward);
+export const startGroup = createAction(SagaActionTypes.StartGroup);
 export const back = createAction(SagaActionTypes.Back);
 export const membersSelected = createAction<MembersSelectedPayload>(SagaActionTypes.MembersSelected);
 export const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);

--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -6,6 +6,7 @@ export enum SagaActionTypes {
   Start = 'create-conversation/start',
   Forward = 'create-conversation/forward',
   Back = 'create-conversation/back',
+  Cancel = 'create-conversation/cancel',
   MembersSelected = 'create-conversation/members-selected',
   CreateConversation = 'create-conversation/create',
 }

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -1,7 +1,7 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { back, createConversation, forward, groupMembersSelected, reset, startConversation } from './saga';
+import { createConversation, groupMembersSelected, reset, startConversation } from './saga';
 import { setGroupCreating, reducer, Stage, setFetchingConversations } from '.';
 
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
@@ -39,7 +39,7 @@ describe('create conversation saga', () => {
 
       const {
         storeState: { createConversation: state },
-      } = await expectSaga(back, { payload: {} })
+      } = await expectSaga(goBack, { payload: {} })
         .withReducer(rootReducer, initialState as any)
         .run();
 
@@ -51,7 +51,7 @@ describe('create conversation saga', () => {
 
       const {
         storeState: { createConversation: state },
-      } = await expectSaga(back, { payload: {} })
+      } = await expectSaga(goBack, { payload: {} })
         .withReducer(rootReducer, initialState as any)
         .run();
 
@@ -63,7 +63,7 @@ describe('create conversation saga', () => {
 
       const {
         storeState: { createConversation: state },
-      } = await expectSaga(back, { payload: {} })
+      } = await expectSaga(goBack, { payload: {} })
         .withReducer(rootReducer, initialState as any)
         .run();
 
@@ -77,7 +77,7 @@ describe('create conversation saga', () => {
 
       const {
         storeState: { createConversation: state },
-      } = await expectSaga(forward, { payload: {} })
+      } = await expectSaga(goForward, { payload: {} })
         .withReducer(rootReducer, initialState as any)
         .run();
 
@@ -89,7 +89,7 @@ describe('create conversation saga', () => {
 
       const {
         storeState: { createConversation: state },
-      } = await expectSaga(forward, { payload: {} })
+      } = await expectSaga(goForward, { payload: {} })
         .withReducer(rootReducer, initialState as any)
         .run();
 

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -54,8 +54,10 @@ export function* createConversation(action) {
 }
 
 export function* saga() {
-  yield take(SagaActionTypes.Start);
-  yield startConversation();
+  while (true) {
+    yield take(SagaActionTypes.Start);
+    yield startConversation();
+  }
 }
 
 export function* startConversation() {

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,15 +1,9 @@
-import { takeLatest, put, call, select } from 'redux-saga/effects';
+import { put, call, select, race, take } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, setGroupUsers, setStage } from '.';
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
 import { fetchConversationsWithUsers } from '../channels-list/api';
 import { setActiveMessengerId } from '../chat';
 import { currentUserSelector } from '../authentication/saga';
-
-export function* startConversation(_action) {
-  yield put(setGroupCreating(false));
-  yield put(setGroupUsers([]));
-  yield put(setStage(Stage.CreateOneOnOne));
-}
 
 export function* reset(_action) {
   yield put(setGroupUsers([]));
@@ -20,37 +14,25 @@ export function* reset(_action) {
 
 export const getStage = (state) => state.createConversation.stage;
 
-export function* back(_action) {
-  const currentStage = yield select(getStage);
+export function previousStage(currentStage: Stage) {
   switch (currentStage) {
     case Stage.CreateOneOnOne:
-      yield put(setStage(Stage.None));
-      break;
+      return Stage.None;
     case Stage.StartGroupChat:
-      yield put(setStage(Stage.CreateOneOnOne));
-      break;
+      return Stage.CreateOneOnOne;
     case Stage.GroupDetails:
-      yield put(setStage(Stage.StartGroupChat));
-      break;
+      return Stage.StartGroupChat;
   }
-}
-
-export function* forward(_action) {
-  const currentStage = yield select(getStage);
-  switch (currentStage) {
-    case Stage.CreateOneOnOne:
-      yield put(setStage(Stage.StartGroupChat));
-      break;
-    case Stage.StartGroupChat:
-      yield put(setStage(Stage.GroupDetails));
-      break;
-  }
+  return Stage.None;
 }
 
 export function* groupMembersSelected(action) {
-  yield put(setFetchingConversations(true));
-  yield call(performGroupMembersSelected, action);
-  yield put(setFetchingConversations(false));
+  try {
+    yield put(setFetchingConversations(true));
+    return yield call(performGroupMembersSelected, action);
+  } finally {
+    yield put(setFetchingConversations(false));
+  }
 }
 
 export function* performGroupMembersSelected(action) {
@@ -65,26 +47,81 @@ export function* performGroupMembersSelected(action) {
 
   if (existingConversations.length === 0) {
     yield put(setGroupUsers(users));
-    yield put(setStage(Stage.GroupDetails));
+    return Stage.GroupDetails;
   } else {
     const selectedConversation = existingConversations[0];
     yield call(channelsReceived, { payload: { channels: [selectedConversation] } });
     yield put(setActiveMessengerId(selectedConversation.id));
-    yield call(reset, {});
+    return Stage.None;
   }
 }
 
 export function* createConversation(action) {
-  yield put(setGroupCreating(true));
-  yield call(performCreateConversation, { payload: action.payload });
-  yield put(setGroupCreating(false));
-  yield call(reset, {});
+  try {
+    yield put(setGroupCreating(true));
+    yield call(performCreateConversation, { payload: action.payload });
+  } finally {
+    yield put(setGroupCreating(false));
+  }
 }
 
 export function* saga() {
-  yield takeLatest(SagaActionTypes.Start, startConversation);
-  yield takeLatest(SagaActionTypes.Back, back);
-  yield takeLatest(SagaActionTypes.Forward, forward);
-  yield takeLatest(SagaActionTypes.MembersSelected, groupMembersSelected);
-  yield takeLatest(SagaActionTypes.CreateConversation, createConversation);
+  yield take(SagaActionTypes.Start);
+  yield startConversation();
+}
+
+// XXX: handle cancellations for slow things... like...pressing back while a request is running?..
+// XXX: Also handle logout / full cancellations...any others besides logout?
+export function* startConversation() {
+  try {
+    yield call(reset, {});
+    yield put(setStage(Stage.CreateOneOnOne));
+
+    let currentStage = Stage.CreateOneOnOne;
+    while (currentStage !== Stage.None) {
+      const { back, handlerResult } = yield race({
+        back: take(SagaActionTypes.Back),
+        handlerResult: call(STAGE_HANDLERS[currentStage]),
+      });
+
+      let nextStage = handlerResult;
+      if (back) {
+        nextStage = previousStage(currentStage);
+      }
+
+      yield put(setStage(nextStage));
+      currentStage = nextStage;
+    }
+  } finally {
+    yield call(reset, {});
+  }
+}
+
+const STAGE_HANDLERS = {
+  [Stage.CreateOneOnOne]: handleOneOnOne,
+  [Stage.StartGroupChat]: handleStartGroup,
+  [Stage.GroupDetails]: handleGroupDetails,
+};
+
+function* handleOneOnOne() {
+  const action = yield take([
+    SagaActionTypes.Forward,
+    SagaActionTypes.CreateConversation,
+  ]);
+  if (action.type === SagaActionTypes.Forward) {
+    return Stage.StartGroupChat;
+  }
+  yield call(createConversation, action);
+  return Stage.None;
+}
+
+function* handleStartGroup() {
+  const action = yield take(SagaActionTypes.MembersSelected);
+  return yield call(groupMembersSelected, action);
+}
+
+function* handleGroupDetails() {
+  const action = yield take(SagaActionTypes.CreateConversation);
+  yield call(createConversation, action);
+  return Stage.None;
 }

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -100,10 +100,10 @@ const PREVIOUS_STAGES = {
 
 function* handleOneOnOne() {
   const action = yield take([
-    SagaActionTypes.Forward,
+    SagaActionTypes.StartGroup,
     SagaActionTypes.CreateConversation,
   ]);
-  if (action.type === SagaActionTypes.Forward) {
+  if (action.type === SagaActionTypes.StartGroup) {
     return Stage.StartGroupChat;
   }
   yield call(createConversation, action);

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -106,6 +106,7 @@ function* handleOneOnOne() {
     SagaActionTypes.CreateConversation,
   ]);
   if (action.type === SagaActionTypes.StartGroup) {
+    yield put(setGroupUsers([]));
     return Stage.StartGroupChat;
   }
   yield call(createConversation, action);


### PR DESCRIPTION
### What does this do?

Pushes the management of the entire user journey of creating a new conversation into a saga.

### Why are we making this change?

Attempting a new pattern for managing a user journey.

### How do I test this?

Test the entire flow of creating various types of conversations.

