### PR TITLE
Cancel a create conversation saga when user logs out

### DIFF
--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -16,6 +16,7 @@ import { clearChannelsAndConversations } from '../channels-list/saga';
 import { clearNotifications } from '../notifications/saga';
 import { clearUsers } from '../users/saga';
 import { clearMessages } from '../messages/saga';
+import { multicastChannel } from 'redux-saga';
 
 export interface Payload {
   signedWeb3Token: string;
@@ -102,6 +103,10 @@ export function* processUserAccount(params: {
   } else {
     yield spawn(clearUserState);
   }
+
+  // Publish a message across the authChannel
+  const channel = yield call(authChannel);
+  yield put(channel, { userId: user?.id });
 }
 
 export function* initializeUserState(user: User) {
@@ -128,4 +133,12 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.NonceOrAuthorize, nonceOrAuthorize);
   yield takeLatest(SagaActionTypes.Terminate, terminate);
   yield takeLatest(SagaActionTypes.FetchCurrentUserWithChatAccessToken, getCurrentUserWithChatAccessToken);
+}
+
+let theChannel;
+export function* authChannel() {
+  if (!theChannel) {
+    theChannel = yield call(multicastChannel);
+  }
+  return theChannel;
 }


### PR DESCRIPTION
### What does this do?

Adds an auth channel to announce login/logout events and listens to that channel to cancel in-progress conversation creation.

### Why are we making this change?

Tightening up the flow of creating a conversation.

### How do I test this?

Before: Note that the conversation flow is still in progress when logging back in.

https://user-images.githubusercontent.com/43770/231522934-e6cbf62d-794c-45eb-80fb-9073fcb5474f.mp4

After: Note that the conversation flow has been cancelled

https://user-images.githubusercontent.com/43770/231523000-482eb317-58e3-4d57-8463-599cb55ea9fc.mp4

