### PR TITLE
Move conversation padding to internal components to allow for better scrollbar positioning

### DIFF
--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -6,6 +6,11 @@
   display: flex;
   flex-direction: column;
 
+  & > * {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
   &__search-input {
     width: 100%;
   }

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -63,9 +63,11 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
             <SelectedUserTag userOption={u} key={u.value}></SelectedUserTag>
           ))}
         </div>
-        <Button onPress={this.createGroup} className={c('create')} isLoading={this.props.isCreating}>
-          Create Group
-        </Button>
+        <div>
+          <Button onPress={this.createGroup} className={c('create')} isLoading={this.props.isCreating}>
+            Create Group
+          </Button>
+        </div>
       </div>
     );
   }

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -13,9 +13,10 @@
   }
 }
 
+$side-padding: 16px;
+
 .direct-message-members {
   flex-grow: 99;
-  padding: 0 16px;
   display: flex;
   flex-direction: column;
 
@@ -53,6 +54,7 @@
 
       &-conversations-input {
         margin-bottom: 18px;
+        padding: 0px $side-padding;
       }
     }
 
@@ -62,6 +64,7 @@
       height: 1px;
 
       overflow: auto;
+      padding: 0px $side-padding;
     }
   }
 }
@@ -70,6 +73,7 @@
   font-size: 16px;
   font-weight: 700;
   line-height: 14px;
+  padding: 0px $side-padding;
   color: themeDeprecated.$font-color-primary;
   background-color: transparent;
   transition: background-color animation.$animation-duration ease-out;
@@ -218,11 +222,16 @@
   }
 
   &__continue {
-    margin: 16px 0px;
+    margin: 16px $side-padding;
   }
 }
 
 .group-details-panel {
+  & > * {
+    padding-right: $side-padding;
+    padding-left: $side-padding;
+  }
+
   &__selected-count {
     font-style: normal;
     font-weight: 400;
@@ -237,6 +246,7 @@
   }
 
   &__create {
+    width: 100%;
     margin: 16px 0px;
   }
 


### PR DESCRIPTION
### What does this do?

Moves the conversation panel padding down the stack to allow for better scrollbar location.

Before:
![image](https://user-images.githubusercontent.com/43770/231536987-1e760bd3-4094-40ec-8ca8-df594957f5ad.png)

After:
![image](https://user-images.githubusercontent.com/43770/231536876-f3021508-3b87-4569-840e-d08f396d60e3.png)
