### PR TITLE
Split reducer from store creation and control store creation

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from './store';
+import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
 import { WalletManager } from './components/wallet-manager';
 import { ViewModeToggle } from './components/view-mode-toggle';

--- a/src/app-sandbox/container.test.tsx
+++ b/src/app-sandbox/container.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Container, Properties } from './container';
-import { RootState } from '../store';
+import { RootState } from '../store/reducer';
 import { AppSandbox } from '.';
 import { Apps, PlatformApp } from '../lib/apps';
 import { Chains, ConnectionStatus, Connectors } from '../lib/web3';

--- a/src/app-sandbox/container.tsx
+++ b/src/app-sandbox/container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../store';
+import { RootState } from '../store/reducer';
 import { setWalletModalOpen } from '../store/web3';
 import { connectContainer } from '../store/redux-container';
 import { AppSandbox } from '.';

--- a/src/app-sandbox/index.tsx
+++ b/src/app-sandbox/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../store';
+import { RootState } from '../store/reducer';
 import { Store } from 'redux';
 
 import { Apps } from '../lib/apps';

--- a/src/components/account/create.tsx
+++ b/src/components/account/create.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FormEvent } from 'react';
 import { Dialog } from '@zer0-os/zos-component-library';
 
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { config } from '../../config';
 import { fetchCurrentUserWithChatAccessToken } from '../../store/authentication';

--- a/src/components/address-bar/container.test.tsx
+++ b/src/components/address-bar/container.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { AddressBar } from '.';
 import { Container } from './container';

--- a/src/components/address-bar/container.tsx
+++ b/src/components/address-bar/container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { History } from 'history';
 import { useHistory } from 'react-router-dom';

--- a/src/components/app-menu/container.test.tsx
+++ b/src/components/app-menu/container.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { Container } from './container';
 import { AppMenu } from './index';

--- a/src/components/app-menu/container.tsx
+++ b/src/components/app-menu/container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { AppMenu } from '.';
 import { Apps, allApps } from '../../lib/apps';

--- a/src/components/authentication/index.test.tsx
+++ b/src/components/authentication/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { ConnectionStatus, Connectors } from '../../lib/web3';
 import { Container } from '.';

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { inject as injectWeb3 } from '../../lib/web3/web3-react';
 import { inject as injectProviderService } from '../../lib/web3/provider-service';

--- a/src/components/chat-connect/chat-connect.tsx
+++ b/src/components/chat-connect/chat-connect.tsx
@@ -9,7 +9,7 @@ import {
   receiveDeleteMessage as receiveDeleteMessageAction,
 } from '../../store/messages';
 import { receiveIsReconnecting } from '../../store/chat';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { unreadCountUpdated } from '../../store/channels';
 import { updateConnector } from '../../store/web3';
 import { Connectors } from '../../lib/web3';

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -1,4 +1,4 @@
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { shallow } from 'enzyme';
 

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -1,6 +1,6 @@
 import React, { RefObject } from 'react';
 import classNames from 'classnames';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { connectContainer } from '../../store/redux-container';
 import {

--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject } from 'react';
 import { User } from '../../store/channels';
 import { UserForMention, Media } from './utils';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { ViewModes } from '../../shared-components/theme-engine';
 import { MessageInput as MessageInputComponent } from './index';

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IconMinus, IconUsers1, IconXClose } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import { setActiveMessengerId } from '../../../store/chat';
-import { RootState } from '../../../store';
+import { RootState } from '../../../store/reducer';
 import { connectContainer } from '../../../store/redux-container';
 import Tooltip from '../../tooltip';
 import { IconButton } from '../../icon-button';

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import { normalize } from '../../../store/channels-list';
-import { RootState } from '../../../store';
+import { RootState } from '../../../store/reducer';
 import moment from 'moment';
 import { when } from 'jest-when';
 import CreateConversationPanel from './create-conversation-panel';

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connectContainer } from '../../../store/redux-container';
-import { RootState } from '../../../store';
+import { RootState } from '../../../store/reducer';
 import { Channel } from '../../../store/channels';
 import { setActiveMessengerId } from '../../../store/chat';
 import { denormalizeConversations, fetchConversations } from '../../../store/channels-list';

--- a/src/components/notification/list/container.test.tsx
+++ b/src/components/notification/list/container.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { RootState } from '../../../store';
+import { RootState } from '../../../store/reducer';
 import { AsyncListStatus } from '../../../store/normalized';
 
 import { Container, Properties } from './container';

--- a/src/components/notification/list/container.tsx
+++ b/src/components/notification/list/container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { connectContainer } from '../../../store/redux-container';
-import { RootState } from '../../../store';
+import { RootState } from '../../../store/reducer';
 import { fetch as fetchNotifications, denormalizeNotifications } from '../../../store/notifications';
 import { denormalize as denormalizeChannel } from '../../../store/channels';
 

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import classNames from 'classnames';

--- a/src/components/theme-engine/index.test.tsx
+++ b/src/components/theme-engine/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { ThemeEngine, ViewModes } from '../../shared-components/theme-engine';
 import { Container } from '.';

--- a/src/components/theme-engine/index.tsx
+++ b/src/components/theme-engine/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 
 import { ThemeEngine as ThemeEngineComponentDeprecated, ViewModes } from '../../shared-components/theme-engine';

--- a/src/components/user-actions/container.test.tsx
+++ b/src/components/user-actions/container.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { Container, Properties } from './container';
 import { normalize as normalizeChannelList } from '../../store/channels-list';

--- a/src/components/user-actions/container.tsx
+++ b/src/components/user-actions/container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { connectContainer } from '../../store/redux-container';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { denormalizeConversations } from '../../store/channels-list';
 
 import { UserActions } from '.';

--- a/src/components/view-mode-toggle/index.test.tsx
+++ b/src/components/view-mode-toggle/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { Container } from '.';
 import { ViewModes } from '../../shared-components/theme-engine';

--- a/src/components/view-mode-toggle/index.tsx
+++ b/src/components/view-mode-toggle/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { setViewMode } from '../../store/theme';
 import { connectContainer } from '../../store/redux-container';
 

--- a/src/components/wallet-manager/index.test.tsx
+++ b/src/components/wallet-manager/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 import { Button, WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
 import { ConnectionStatus, Connectors } from '../../lib/web3';

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { config } from '../../config';
 import { ConnectionStatus, Connectors } from '../../lib/web3';
 import { getChainNameFromId } from '../../lib/web3/chains';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { updateConnector, Web3State, setWalletModalOpen } from '../../store/web3';
 import { isElectron } from '../../utils';

--- a/src/components/web3-connect/index.test.tsx
+++ b/src/components/web3-connect/index.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { Container, Properties } from '.';
 
 import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 
 const getWeb3 = (web3 = {}) => ({
   activate: () => undefined,

--- a/src/components/web3-connect/index.tsx
+++ b/src/components/web3-connect/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { providers } from 'ethers';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ReactDOM from 'react-dom';
 import { ZnsRouteConnect } from './zns-route-connect';
-import { store } from './store';
+import { store, runSagas } from './store';
 import { Provider } from 'react-redux';
 import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
@@ -17,6 +17,8 @@ import { AppSandboxContainer } from './app-sandbox/container';
 
 import '../node_modules/@zer0-os/zos-component-library/dist/index.css';
 import './index.scss';
+
+runSagas();
 
 initializeErrorBoundary();
 

--- a/src/platform-apps/channels/container.test.tsx
+++ b/src/platform-apps/channels/container.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { Redirect } from 'react-router-dom';
 
 import { shallow } from 'enzyme';

--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import getDeepProperty from 'lodash.get';
 
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { Store } from 'redux';
 
 import { connectContainer } from '../../store/redux-container';

--- a/src/platform-apps/channels/index.tsx
+++ b/src/platform-apps/channels/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 import { Route } from 'react-router-dom';
 
-import { RootState } from '../../store';
+import { RootState } from '../../store/reducer';
 import { Store } from 'redux';
 
 import { ChannelsContainer } from './container';

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -21,7 +21,7 @@ import { setChatAccessToken } from '../chat';
 import { fetch as fetchNotifications } from '../notifications';
 import { receive, SagaActionTypes as ChannelsListSagaActionTypes } from '../channels-list';
 import { update } from '../layout';
-import { rootReducer } from '../index';
+import { rootReducer } from '../reducer';
 import { clearNotifications } from '../notifications/saga';
 import { clearChannelsAndConversations } from '../channels-list/saga';
 import { clearUserLayout } from '../layout/saga';

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -21,7 +21,7 @@ import {
 } from './saga';
 
 import { SagaActionTypes, setStatus } from '.';
-import { rootReducer } from '..';
+import { rootReducer } from '../reducer';
 import { AsyncListStatus } from '../normalized';
 
 const MOCK_CHANNELS = [

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -8,7 +8,7 @@ import {
 } from './api';
 import { joinChannel, loadUsers, markAllMessagesAsReadInChannel, unreadCountUpdated } from './saga';
 
-import { rootReducer } from '..';
+import { rootReducer } from '../reducer';
 
 describe('channels list saga', () => {
   const usersResponse = [

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,20 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import createSagaMiddleware from 'redux-saga';
-import { combineReducers } from 'redux';
 
 import { rootSaga } from './saga';
-
-import { reducer as layout } from './layout';
-import { reducer as channelsList } from './channels-list';
-import { reducer as web3 } from './web3';
-import { reducer as zns } from './zns';
-import { reducer as theme } from './theme';
-import { reducer as apps } from './apps';
-import { reducer as normalized } from './normalized';
-import { reducer as authentication } from './authentication';
-import { reducer as chat } from './chat';
-import { reducer as notificationsList } from './notifications';
-import { reducer as createConversation } from './create-conversation';
+import { rootReducer } from './reducer';
 
 const sagaMiddleware = createSagaMiddleware({
   onError: (e) => {
@@ -22,25 +10,11 @@ const sagaMiddleware = createSagaMiddleware({
   },
 });
 
-export const rootReducer = combineReducers({
-  layout,
-  channelsList,
-  web3,
-  zns,
-  theme,
-  apps,
-  normalized,
-  authentication,
-  chat,
-  notificationsList,
-  createConversation,
-});
-
-export type RootState = ReturnType<typeof rootReducer>;
-
 export const store = configureStore({
   reducer: rootReducer,
   middleware: (defaults) => defaults({ thunk: false }).concat(sagaMiddleware),
 });
 
-sagaMiddleware.run(rootSaga);
+export function runSagas() {
+  sagaMiddleware.run(rootSaga);
+}

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -23,7 +23,7 @@ import {
   clearMessages,
 } from './saga';
 
-import { rootReducer } from '..';
+import { rootReducer } from '../reducer';
 
 describe('messages saga', () => {
   const MESSAGES_RESPONSE = {

--- a/src/store/notifications/saga.test.ts
+++ b/src/store/notifications/saga.test.ts
@@ -3,7 +3,7 @@ import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { AsyncListStatus } from '../normalized';
-import { rootReducer } from '..';
+import { rootReducer } from '../reducer';
 
 import {
   addNotification,

--- a/src/store/notifications/saga.ts
+++ b/src/store/notifications/saga.ts
@@ -14,7 +14,7 @@ import {
 import { fetchNotifications } from './api';
 import PusherClient from '../../lib/pusher';
 import { authChannel } from '../authentication/saga';
-import { store } from '../';
+import { store } from '..';
 
 export interface Payload {
   userId: string;

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,0 +1,29 @@
+import { combineReducers } from 'redux';
+
+import { reducer as layout } from './layout';
+import { reducer as channelsList } from './channels-list';
+import { reducer as web3 } from './web3';
+import { reducer as zns } from './zns';
+import { reducer as theme } from './theme';
+import { reducer as apps } from './apps';
+import { reducer as normalized } from './normalized';
+import { reducer as authentication } from './authentication';
+import { reducer as chat } from './chat';
+import { reducer as notificationsList } from './notifications';
+import { reducer as createConversation } from './create-conversation';
+
+export const rootReducer = combineReducers({
+  layout,
+  channelsList,
+  web3,
+  zns,
+  theme,
+  apps,
+  normalized,
+  authentication,
+  chat,
+  notificationsList,
+  createConversation,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/redux-container.ts
+++ b/src/store/redux-container.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect, ConnectedComponent } from 'react-redux';
-import { RootState } from '.';
+import { RootState } from './reducer';
 
 // XXX
 // interface IContainerComponent<TPublicProps, TContainerProps> {

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -1,7 +1,7 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import { clearUsers } from './saga';
 
-import { rootReducer } from '..';
+import { rootReducer } from '../reducer';
 
 describe('users saga', () => {
   it('removes the users', async () => {

--- a/src/store/zns/saga.test.ts
+++ b/src/store/zns/saga.test.ts
@@ -2,7 +2,7 @@ import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { setRoute } from './saga';
-import { rootReducer, RootState } from '..';
+import { rootReducer, RootState } from '../reducer';
 import { get as getResolver } from '../../lib/zns/domain-resolver';
 
 describe('zns saga', () => {

--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from './store';
+import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
 import { History } from 'history';
 


### PR DESCRIPTION
### What does this do?

* Splits the combined reducer creation into its own loadable file
* Wraps the actual middleware registration into a function so we can control when it occurs

### Why are we making this change?

Tests were starting up the entire middleware when all we needed were the reducers

### How do I test this?

Run the app. Smoke test.

