### PR TITLE
Use saga effects rather than dispatching to the store directly

### DIFF
--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -4,7 +4,6 @@ import { channelsReceived, createConversation as performCreateConversation } fro
 import { fetchConversationsWithUsers } from '../channels-list/api';
 import { setActiveMessengerId } from '../chat';
 import { authChannel, currentUserSelector } from '../authentication/saga';
-import { store } from '../';
 
 export function* reset() {
   yield put(setGroupUsers([]));
@@ -132,7 +131,7 @@ function* authWatcher() {
   while (true) {
     const payload = yield take(channel, '*');
     if (!payload.userId) {
-      store.dispatch({ type: SagaActionTypes.Cancel });
+      yield put({ type: SagaActionTypes.Cancel });
     }
   }
 }

--- a/src/store/notifications/saga.test.ts
+++ b/src/store/notifications/saga.test.ts
@@ -221,9 +221,7 @@ describe('notifications list saga', () => {
       })
 
       .next({ userId: undefined })
-      .inspect((action) => {
-        expect(action).toEqual({ type: SagaActionTypes.CancelEventWatch });
-      });
+      .put({ type: SagaActionTypes.CancelEventWatch });
   });
 
   describe('createEventChannel', () => {

--- a/src/store/notifications/saga.ts
+++ b/src/store/notifications/saga.ts
@@ -14,7 +14,6 @@ import {
 import { fetchNotifications } from './api';
 import PusherClient from '../../lib/pusher';
 import { authChannel } from '../authentication/saga';
-import { store } from '..';
 
 export interface Payload {
   userId: string;
@@ -101,7 +100,7 @@ export function* authWatcher() {
     if (userId) {
       yield spawn(watchForChannelEvent, userId);
     } else {
-      yield store.dispatch({ type: SagaActionTypes.CancelEventWatch });
+      yield put({ type: SagaActionTypes.CancelEventWatch });
     }
   }
 }


### PR DESCRIPTION
### What does this do?

Changes some direct references to the store in sagas to use the proper saga effect instead.

### Why are we making this change?

Cleanliness

### How do I test this?

* Start creating a conversation and then logout/login. Verify you're not still creating a conversation in the sidekick.
* Verify realtime notifications are being received while logged in then log out and confirm the connection is no longer listening.

