### PR TITLE
Fetch a real invite code

### DIFF
--- a/src/store/create-invitation/api.ts
+++ b/src/store/create-invitation/api.ts
@@ -1,6 +1,6 @@
-// import { get } from '../../lib/api/rest';
+import { post } from '../../lib/api/rest';
 
 export async function getInvite() {
-  return '1234598';
-  // return await get('/api/invite').then((response) => response?.body || {});
+  const response = await post('/invite');
+  return response.body;
 }


### PR DESCRIPTION
### What does this do?

1. Fetches real invite codes from the actual endpoint
2. Handles errors somewhat cleanly when fetching the invite code (no user feedback)

