### PR TITLE
Fix error when logged in without a wallet address

### DIFF
--- a/src/components/user-actions/user-menu-popup.test.tsx
+++ b/src/components/user-actions/user-menu-popup.test.tsx
@@ -20,6 +20,22 @@ describe('UserActions', () => {
     expect(wrapper.find('.user-menu-popup__address').text()).toEqual('0x1234...9876');
   });
 
+  it('does not render address if user does not have one', () => {
+    const wrapper = subject({ address: '' });
+
+    expect(wrapper).not.toHaveElement('.user-menu-popup__address');
+  });
+
+  it('button text renders depending on address', () => {
+    const wrapper = subject({ address: '' });
+
+    expect(wrapper.find('Button').children().text()).toEqual('Logout');
+
+    wrapper.setProps({ address: '0x1234000000000000000000000000000000009876' });
+
+    expect(wrapper.find('Button').children().text()).toEqual('Disconnect');
+  });
+
   it('publishes disconnect', () => {
     const onDisconnect = jest.fn();
 

--- a/src/components/user-actions/user-menu-popup.tsx
+++ b/src/components/user-actions/user-menu-popup.tsx
@@ -60,15 +60,17 @@ export class UserMenuPopupContent extends React.Component<Properties> {
 
     return (
       <div className='user-menu-popup'>
-        <h3>
-          <span title={address} className='user-menu-popup__address'>
-            <span>{address.slice(0, 6)}</span>
-            <span>...</span>
-            <span className='eth-address__address-last-four'>{address.slice(-4)}</span>
-          </span>
-        </h3>
+        {address && (
+          <h3>
+            <span title={address} className='user-menu-popup__address'>
+              <span>{address.slice(0, 6)}</span>
+              <span>...</span>
+              <span className='eth-address__address-last-four'>{address.slice(-4)}</span>
+            </span>
+          </h3>
+        )}
         <Button variant='primary' onPress={this.props.onDisconnect}>
-          Disconnect
+          {address ? 'Disconnect' : 'Logout'}
         </Button>
       </div>
     );


### PR DESCRIPTION
### What does this do?

The logout popup was referencing the wallet `address`. This adds detection to prevent failure in the case the address does not exist.

### Why are we making this change?

Given the new login flows of creating accounts without a wallet, we need to ensure the app can still render if a user logs in this way.

