### PR TITLE
Fix cpu hogging issue: Use Modal open state instead of unmounting

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -87,13 +87,14 @@ export class ConversationListPanel extends React.Component<Properties, State> {
   openInviteDialog = (): void => {
     this.setState({ inviteDialogOpen: true });
   };
+
   closeInviteDialog = (): void => {
     this.setState({ inviteDialogOpen: false });
   };
 
   renderInviteDialog = (): JSX.Element => {
     return (
-      <Modal open={true} onOpenChange={this.closeInviteDialog}>
+      <Modal open={this.state.inviteDialogOpen} onOpenChange={this.closeInviteDialog}>
         <InviteDialogContainer onClose={this.closeInviteDialog} />
       </Modal>
     );
@@ -124,7 +125,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             Invite Friends
           </Button>
         </FeatureFlag>
-        {this.state.inviteDialogOpen && this.renderInviteDialog()}
+        {this.renderInviteDialog()}
       </>
     );
   }


### PR DESCRIPTION
### What does this do?

Rather than control the mounting/unmounting of the Modal just use the `open` property.

### Why are we making this change?

For some reason, unmounting the Modal while it's open causes the app to consume the cpu. There must be some kind of loop in the underlying radix-ui component that goes haywire.

### How do I test this?

Before: Open the chrome task manager and sort by cpu. Open the Invite dialog and click the X to close it. Watch the cpu for that tab spike forever.
After: Repeat. Note the cpu usage drops back down to a normal usage.

