### PR TITLE
Zos 307: Fix font issue with messages with links, make links clickable

### DIFF
--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { textToPlainEmojis } from './text-to-emojis';
 
 import './styles.scss';
+import Linkify from 'linkify-react';
+import * as linkifyjs from 'linkifyjs';
 
 export interface Properties {
   message: string;
@@ -45,7 +47,29 @@ export class ContentHighlighter extends React.Component<Properties> {
     });
   }
 
+  renderMessageWithLinks(): React.ReactElement {
+    const { message } = this.props;
+    const hasLinks = linkifyjs.find(message);
+
+    if (hasLinks.length) {
+      return (
+        <Linkify
+          options={{
+            attributes: {
+              target: '_blank',
+              class: 'text-message__link',
+            },
+          }}
+        >
+          {this.renderContent(this.props.message)}
+        </Linkify>
+      );
+    } else {
+      return <div>{this.renderContent(this.props.message)}</div>;
+    }
+  }
+
   render() {
-    return <div>{this.renderContent(this.props.message)}</div>;
+    return this.renderMessageWithLinks();
   }
 }

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Linkify from 'linkify-react';
 import { Message } from '.';
 import { MediaType } from '../../store/messages';
 import { LinkPreview } from '../link-preview';

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -259,7 +259,7 @@ describe('message', () => {
       message: 'http://zos.io',
     });
 
-    expect(wrapper.find(Linkify).exists()).toBe(true);
+    expect(wrapper.find(ContentHighlighter).exists()).toBe(true);
   });
 
   describe('Lightbox', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import Linkify from 'linkify-react';
-import * as linkifyjs from 'linkifyjs';
 import moment from 'moment';
 import { Message as MessageModel, MediaType, EditMessageOptions } from '../../store/messages';
 import { download } from '../../lib/api/attachment';
@@ -157,28 +155,6 @@ export class Message extends React.Component<Properties, State> {
     );
   }
 
-  renderMessageWithLinks(): React.ReactElement {
-    const { message } = this.props;
-    const hasLinks = linkifyjs.find(message);
-
-    if (hasLinks.length) {
-      return (
-        <Linkify
-          options={{
-            attributes: {
-              target: '_blank',
-              class: 'text-message__link',
-            },
-          }}
-        >
-          <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />
-        </Linkify>
-      );
-    } else {
-      return <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />;
-    }
-  }
-
   render() {
     const { message, media, preview, createdAt, sender, isOwner, hidePreview } = this.props;
 
@@ -205,7 +181,7 @@ export class Message extends React.Component<Properties, State> {
                 {sender.firstName} {sender.lastName}
               </div>
               {!this.state.isEditing && (
-                <div className={classNames(preview ? 'message__block-preview' : 'message__block-body')}>
+                <div className={classNames('message__block-body')}>
                   {media && this.renderMedia(media)}
                   {this.props.parentMessageText && (
                     <div className='message__block-reply'>
@@ -217,9 +193,9 @@ export class Message extends React.Component<Properties, State> {
                       </span>
                     </div>
                   )}
-                  {message && this.renderMessageWithLinks()}
+                  {message && <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />}
                   {preview && !hidePreview && (
-                    <div className='message__block-preview-with-remove'>
+                    <div className='message__block-preview'>
                       <LinkPreview url={preview.url} {...preview} />
                       {isOwner && (
                         <IconButton Icon={IconXClose} onClick={this.onRemovePreview} className='remove-preview__icon' />

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -337,14 +337,16 @@ $scrollbar-width: 5px;
         }
 
         &-preview {
-          display: inline-block;
+          display: flex;
+          flex-direction: row;
+          align-items: self-start;
           white-space: pre-wrap;
           word-break: break-word;
           font-size: 13.5px;
           font-weight: 500;
           vertical-align: baseline;
           position: relative;
-          max-width: 600px;
+          max-width: 85%;
 
           .text-message {
             display: inline-block;
@@ -352,13 +354,6 @@ $scrollbar-width: 5px;
             padding: 5px 15px;
             margin-top: 10px;
             border-radius: $border-radius;
-          }
-
-          &-with-remove {
-            display: flex;
-            flex-direction: row;
-            align-items: self-start;
-            max-width: 85%;
           }
         }
 


### PR DESCRIPTION
Messages with links have the same font as messages without links. They're clickable as well now.

![image](https://user-images.githubusercontent.com/33264364/234424762-e4ae553e-afaf-4426-bcaa-60f1cef4caa6.png)


![image](https://user-images.githubusercontent.com/33264364/234424787-285ec2f6-6549-49b8-b2fa-f9186db01d38.png)

![image](https://user-images.githubusercontent.com/33264364/234424811-feb41e5c-b047-45fa-b8af-55c8f9e3e2ab.png)

![image](https://user-images.githubusercontent.com/33264364/234424850-d4546d50-a627-4c10-8d0a-08b90df94566.png)

![image](https://user-images.githubusercontent.com/33264364/234424895-2b729212-e39a-4b5f-b6fe-351d3b8001c7.png)

