### PR TITLE
Hide cloudinary provider creation behind a function

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -6,7 +6,7 @@ import { Message as MessageModel, MediaType, EditMessageOptions } from '../../st
 import InvertedScroll from '../inverted-scroll';
 import IndicatorMessage from '../indicator-message';
 import { Lightbox } from '@zer0-os/zos-component-library';
-import { provider as cloudinaryProvider } from '../../lib/cloudinary/provider';
+import { getProvider } from '../../lib/cloudinary/provider';
 import { User } from '../../store/authentication/types';
 import { User as UserModel } from '../../store/channels/index';
 import { MessageInput } from '../message-input/container';
@@ -192,7 +192,7 @@ export class ChatView extends React.Component<Properties, State> {
         )}
         {isLightboxOpen && (
           <Lightbox
-            provider={cloudinaryProvider}
+            provider={getProvider()}
             items={lightboxMedia}
             startingIndex={lightboxStartIndex}
             onClose={this.closeLightBox}

--- a/src/components/link-preview/index.tsx
+++ b/src/components/link-preview/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { BackgroundImage, BackgroundImageProperties, VideoPlayer, ButtonLink } from '@zer0-os/zos-component-library';
 import { LinkPreviewType } from '../../lib/link-preview';
-import { provider as cloudinaryProvider } from '../../lib/cloudinary/provider';
+import { getProvider } from '../../lib/cloudinary/provider';
 
 require('./styles.scss');
 
@@ -25,7 +25,13 @@ interface State {
   width: number;
 }
 
-const TWITTER_LOGO = cloudinaryProvider.getSource({ src: 'twitter-logo.png', local: false, options: {} });
+let twitterLogo;
+function getTwitterLogo() {
+  if (!twitterLogo) {
+    twitterLogo = getProvider().getSource({ src: 'twitter-logo.png', local: false, options: {} });
+  }
+  return twitterLogo;
+}
 
 export class LinkPreview extends React.Component<Properties, State> {
   state = { width: 0 };
@@ -131,14 +137,14 @@ export class LinkPreview extends React.Component<Properties, State> {
 
     if (providerName === 'Twitter') {
       options.background = 'transparent';
-      source = TWITTER_LOGO;
+      source = getTwitterLogo();
     }
 
     const props: BackgroundImageProperties = {
       source,
       options,
       className: 'link-preview__banner-image',
-      provider: cloudinaryProvider,
+      provider: getProvider(),
     };
 
     const ratio = this.bannerRatio;

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -4,8 +4,7 @@ import moment from 'moment';
 import { Message as MessageModel, MediaType, EditMessageOptions } from '../../store/messages';
 import { download } from '../../lib/api/attachment';
 import { LinkPreview } from '../link-preview';
-import { CloudinaryProvider } from '@zer0-os/zos-component-library';
-import { provider } from '../../lib/cloudinary/provider';
+import { getProvider } from '../../lib/cloudinary/provider';
 import { MessageInput } from '../message-input/container';
 import { User } from '../../store/channels';
 import { ParentMessage } from '../../lib/chat/types';
@@ -28,7 +27,6 @@ interface Properties extends MessageModel {
     data?: Partial<EditMessageOptions>
   ) => void;
   onReply: (reply: ParentMessage) => void;
-  cloudinaryProvider: CloudinaryProvider;
   isOwner?: boolean;
   messageId?: number;
   updatedAt: number;
@@ -41,7 +39,6 @@ export interface State {
   isEditing: boolean;
 }
 export class Message extends React.Component<Properties, State> {
-  static defaultProps = { cloudinaryProvider: provider };
   state = {
     isEditing: false,
   } as State;
@@ -169,7 +166,7 @@ export class Message extends React.Component<Properties, State> {
         {this.props.showSenderAvatar && (
           <div className='message__left'>
             <div
-              style={{ backgroundImage: `url(${provider.getSourceUrl(sender.profileImage)})` }}
+              style={{ backgroundImage: `url(${getProvider().getSourceUrl(sender.profileImage)})` }}
               className='message__author-avatar'
             />
           </div>

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -8,7 +8,7 @@ import Tooltip from '../../tooltip';
 import { IconButton } from '../../icon-button';
 import { Channel, denormalize } from '../../../store/channels';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
-import { provider as imageProvider } from '../../../lib/cloudinary/provider';
+import { getProvider } from '../../../lib/cloudinary/provider';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 
 import './styles.scss';
@@ -148,7 +148,7 @@ export class Container extends React.Component<Properties, State> {
             <span>
               <div
                 style={{
-                  backgroundImage: `url(${imageProvider.getSourceUrl(this.avatarUrl())})`,
+                  backgroundImage: `url(${getProvider().getSourceUrl(this.avatarUrl())})`,
                 }}
                 className={classNames(
                   'direct-message-chat__header-avatar',

--- a/src/lib/browser/index.ts
+++ b/src/lib/browser/index.ts
@@ -1,4 +1,4 @@
-import { provider } from '../../lib/cloudinary/provider';
+import { getProvider } from '../../lib/cloudinary/provider';
 import { Message } from '../../store/messages';
 
 const DEFAULT_HEADING = 'Chat message received';
@@ -9,7 +9,7 @@ export const send = (options: { body; heading; tag }) => {
   new Notification(heading, {
     tag: tag,
     body,
-    icon: provider.getSource({ src: 'v1681525214/zero-logo-round.png', local: false, options: {} }),
+    icon: getProvider().getSource({ src: 'v1681525214/zero-logo-round.png', local: false, options: {} }),
   });
 };
 

--- a/src/lib/cloudinary/provider.tsx
+++ b/src/lib/cloudinary/provider.tsx
@@ -1,7 +1,17 @@
 import { CloudinaryProvider } from '@zer0-os/zos-component-library';
 import { config } from '../../config';
 
-export const provider = new CloudinaryProvider({
-  cloud_name: config.cloudinary.cloud_name,
-  max_file_size: config.cloudinary.max_file_size,
-});
+let provider;
+export function getProvider() {
+  if (!provider) {
+    provider = createProvider();
+  }
+  return provider;
+}
+
+function createProvider() {
+  return new CloudinaryProvider({
+    cloud_name: config.cloudinary.cloud_name,
+    max_file_size: config.cloudinary.max_file_size,
+  });
+}

--- a/src/lib/cloudinary/provider.tsx
+++ b/src/lib/cloudinary/provider.tsx
@@ -3,9 +3,7 @@ import { config } from '../../config';
 
 let provider;
 export function getProvider() {
-  if (!provider) {
-    provider = createProvider();
-  }
+  provider = provider ?? createProvider();
   return provider;
 }
 

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -6,7 +6,7 @@ import { SagaActionTypes } from '.';
 import { dynamic, throwError } from 'redux-saga-test-plan/providers';
 import { call } from 'redux-saga/effects';
 
-jest.mock('../../config', () => ({ config: { inviteUrl: 'https://www.example.com/invite', cloudinary: {} } }));
+jest.mock('../../config', () => ({ config: { inviteUrl: 'https://www.example.com/invite' } }));
 
 describe('fetchInvite', () => {
   describe('fetchInvite', () => {


### PR DESCRIPTION
### What does this do?

This hides the singleton cloudinary provider behind a getter function.

### Why are we making this change?

Previously, this object was instantiated as soon as the file was loaded. This is a side-effect we'd like to avoid.

### How do I test this?

Run the tests
Smoke test the app where we have images displayed

