### PR TITLE
Remove hardcoded timestamp from test, use `moment()`

### DIFF
--- a/src/components/messenger/list/conversation-item.test.tsx
+++ b/src/components/messenger/list/conversation-item.test.tsx
@@ -113,16 +113,17 @@ describe('ConversationItem', () => {
   });
 
   it('renders last message timestamp', function () {
+    const now = moment();
     const wrapper = subject({
       conversation: {
         lastMessage: {
-          createdAt: 1680033123552,
+          createdAt: now.valueOf(),
         },
         otherMembers: [],
       } as any,
     });
 
-    expect(wrapper.find('.conversation-item__timestamp').text()).toEqual('Mar 28');
+    expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(now.format('MMM DD'));
   });
 
   it('renders last message summary', function () {


### PR DESCRIPTION
One test was failing on my local due to timezone issue

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/33264364/234698701-8274ec2c-b4a3-442e-bd2b-f377df7b78d8.png">
