### PR TITLE
Add a simple template script to generate components and store/saga files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "husky": "^8.0.1",
         "jest-extended": "^1.2.0",
         "jest-when": "^3.5.2",
+        "mustache": "^4.2.0",
         "prettier": "^2.7.1",
         "prettier-plugin-multiline-arrays": "^1.0.0",
         "pretty-quick": "^3.1.3",
@@ -24706,6 +24707,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/nan": {
@@ -51064,6 +51074,12 @@
         "arrify": "^2.0.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true
     },
     "nan": {
       "version": "2.15.0"

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "husky": "^8.0.1",
     "jest-extended": "^1.2.0",
     "jest-when": "^3.5.2",
+    "mustache": "^4.2.0",
     "prettier": "^2.7.1",
     "prettier-plugin-multiline-arrays": "^1.0.0",
     "pretty-quick": "^3.1.3",

--- a/templates/component/index.test.tsx.mustache
+++ b/templates/component/index.test.tsx.mustache
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+
+import { {{ componentName }}, Properties } from '.';
+
+describe('{{ componentName }}', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      ...props,
+    };
+
+    return shallow(<{{componentName}} {...allProps} />);
+  };
+
+  it('TODO renders', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.exists()).toBeTrue();
+  });
+});

--- a/templates/component/index.tsx.mustache
+++ b/templates/component/index.tsx.mustache
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export interface Properties {
+}
+
+export class {{componentName}} extends React.Component <Properties> {
+  render() {
+    return (
+      <div />
+    );
+  }
+}

--- a/templates/generate.js
+++ b/templates/generate.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const mustache = require('mustache');
+const readline = require('readline');
+
+const destinationPath = process.argv[2];
+const componentName = path
+  .basename(destinationPath)
+  .split('-')
+  .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+  .join('');
+
+console.log(`Generating component ${componentName} in ${destinationPath}`);
+
+const files = [
+  { template: path.join('templates', 'component', 'index.tsx.mustache'), filename: 'index.tsx' },
+  { template: path.join('templates', 'component', 'index.test.tsx.mustache'), filename: 'index.test.tsx' },
+];
+
+// Check if folder exists
+if (fs.existsSync(destinationPath)) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  rl.question(`The folder ${destinationPath} already exists. Do you want to overwrite it? (y/n): `, (answer) => {
+    rl.close();
+    if (answer === 'y') {
+      fs.rmSync(destinationPath, { recursive: true });
+      createComponent();
+    } else {
+      console.log('Aborting component creation.');
+    }
+  });
+} else {
+  createComponent();
+}
+
+function createComponent() {
+  // Create folder
+  fs.mkdirSync(destinationPath);
+
+  // Generate files from templates
+  files.forEach((file) => {
+    const templatePath = path.join('.', file.template);
+    const template = fs.readFileSync(templatePath, 'utf8');
+    const output = mustache.render(template, { componentName });
+    const filePath = path.join(destinationPath, file.filename);
+    fs.writeFileSync(filePath, output);
+  });
+
+  console.log(`Component ${componentName} created at ${destinationPath}.`);
+}

--- a/templates/saga/api.ts.mustache
+++ b/templates/saga/api.ts.mustache
@@ -1,0 +1,4 @@
+export async function apiCall(_obj: any) {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return { success: true, response: {} };
+}

--- a/templates/saga/index.ts.mustache
+++ b/templates/saga/index.ts.mustache
@@ -1,0 +1,31 @@
+import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+// TODO: Add reducer to ../reducer.ts
+// TODO: Add saga to ../saga.ts
+
+export enum SagaActionTypes {
+  Start = '{{sagaName}}/start',
+}
+
+export type {{sagaName}}State = {
+  loading: boolean;
+};
+
+export const initialState: {{sagaName}}State = {
+  loading: false,
+};
+
+export const start = createAction<{}>(SagaActionTypes.Start);
+
+const slice = createSlice({
+  name: '{{sagaNameLower}}',
+  initialState,
+  reducers: {
+    setLoading: (state, action: PayloadAction<{{sagaName}}State['loading']>) => {
+      state.loading = action.payload;
+    },
+  },
+});
+
+export const { setLoading } = slice.actions;
+export const { reducer } = slice;

--- a/templates/saga/saga.test.ts.mustache
+++ b/templates/saga/saga.test.ts.mustache
@@ -1,0 +1,33 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { call } from 'redux-saga/effects';
+import { throwError } from 'redux-saga-test-plan/providers';
+
+import { start } from './saga';
+import { apiCall } from './api';
+import { {{sagaName}}State, initialState as initial{{sagaName}}State } from '.';
+
+import { rootReducer } from '../reducer';
+
+describe('start', () => {
+  it('makes api call', async () => {
+    await expectSaga(start, { payload: {} })
+      .provide([
+        [
+          call(apiCall, {}),
+          { success: true, response: {} },
+        ],
+      ])
+      .withReducer(rootReducer, initialState({}))
+      .call(apiCall, {})
+      .run();
+  });
+});
+
+function initialState(attrs: Partial<{{sagaName}}State> = {}) {
+  return {
+    {{sagaNameLower}}: {
+      ...initial{{sagaName}}State,
+      ...attrs,
+    },
+  } as any;
+}

--- a/templates/saga/saga.ts.mustache
+++ b/templates/saga/saga.ts.mustache
@@ -1,0 +1,21 @@
+import { call, put, take } from 'redux-saga/effects';
+
+import { SagaActionTypes, setLoading } from '.';
+import { apiCall } from './api';
+
+// TODO: add to ../saga.ts
+
+export function* start(action) {
+  yield put(setLoading(true));
+  try {
+    yield call(apiCall, {});
+  } catch (e) {
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+export function* saga() {
+  const action = yield take(SagaActionTypes.Start);
+  yield call(start, action);
+}


### PR DESCRIPTION
### What does this do?

Adds a script so you can run `node ./templates/generate.js component src/components/funny-button` and `node ./templates/generate.js saga src/store/interesting-saga`

### Why are we making this change?

I find I always create the same few files with a boilerplate starting point. This makes that slightly quicker.

