### PR TITLE
Convert the registration/login pages to use forms

### DIFF
--- a/src/authentication/create-account-details/index.test.tsx
+++ b/src/authentication/create-account-details/index.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { CreateAccountDetails, Properties } from '.';
+import { inputEvent } from '../../test/utils';
 
 describe('CreateAccountDetails', () => {
   const subject = (props: Partial<Properties>) => {
@@ -21,7 +22,7 @@ describe('CreateAccountDetails', () => {
     const wrapper = subject({ onCreate });
 
     wrapper.find('Input[name="name"]').simulate('change', 'Jack Black');
-    wrapper.find('Button').simulate('press');
+    wrapper.find('form').simulate('submit', inputEvent());
 
     expect(onCreate).toHaveBeenCalledWith({ name: 'Jack Black' });
   });

--- a/src/authentication/create-account-details/index.tsx
+++ b/src/authentication/create-account-details/index.tsx
@@ -23,7 +23,8 @@ interface State {
 export class CreateAccountDetails extends React.Component<Properties, State> {
   state = { name: '' };
 
-  publishOnCreate = () => {
+  publishOnCreate = (e) => {
+    e.preventDefault();
     this.props.onCreate({ name: this.state.name });
   };
 
@@ -49,7 +50,7 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
       <div className={c('')}>
         <h3 className={c('heading')}>CREATE YOUR ACCOUNT</h3>
         <div className={c('sub-heading')}>Step 2 of 2: What should we call you?</div>
-        <form className={c('form')}>
+        <form className={c('form')} onSubmit={this.publishOnCreate}>
           <Input
             label='What is your name?'
             helperText='This will be your name that is visible to others on Zero'
@@ -60,7 +61,7 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
             alert={this.nameError}
           />
           {this.generalError && <Alert variant='error'>{this.generalError}</Alert>}
-          <Button className={c('button')} onPress={this.publishOnCreate} isLoading={this.props.isLoading}>
+          <Button className={c('button')} isLoading={this.props.isLoading} isSubmit>
             Create Account
           </Button>
         </form>

--- a/src/authentication/create-email-account/index.test.tsx
+++ b/src/authentication/create-email-account/index.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 
 import { CreateEmailAccount, Properties } from '.';
 import { passwordStrength } from '../../lib/password';
+import { inputEvent } from '../../test/utils';
 
 describe('CreateEmailAccount', () => {
   const subject = (props: Partial<Properties>) => {
@@ -23,7 +24,7 @@ describe('CreateEmailAccount', () => {
 
     wrapper.find('Input[name="email"]').simulate('change', 'jack@example.com');
     wrapper.find('PasswordInput').simulate('change', 'abcd9876');
-    wrapper.find('Button').simulate('press');
+    wrapper.find('form').simulate('submit', inputEvent());
 
     expect(onNext).toHaveBeenCalledWith({ email: 'jack@example.com', password: 'abcd9876' });
   });

--- a/src/authentication/create-email-account/index.tsx
+++ b/src/authentication/create-email-account/index.tsx
@@ -38,7 +38,8 @@ function unorderedList(arr) {
 export class CreateEmailAccount extends React.Component<Properties, State> {
   state = { email: '', password: '', strength: 0 };
 
-  publishOnNext = () => {
+  publishOnNext = (e) => {
+    e.preventDefault();
     this.props.onNext({ email: this.state.email, password: this.state.password });
   };
 
@@ -78,7 +79,7 @@ export class CreateEmailAccount extends React.Component<Properties, State> {
       <div className={c('')}>
         <h3 className={c('heading')}>CREATE YOUR ACCOUNT</h3>
         <div className={c('sub-heading')}>Step 1 of 2: Enter your details</div>
-        <div className={c('form')}>
+        <form className={c('form')} onSubmit={this.publishOnNext}>
           <Input
             label='Email Address'
             name='email'
@@ -98,10 +99,10 @@ export class CreateEmailAccount extends React.Component<Properties, State> {
           <PasswordStrength strength={this.state.strength} />
           {this.generalError && <Alert variant='error'>{this.generalError}</Alert>}
 
-          <Button className={c('button')} onPress={this.publishOnNext} isLoading={this.props.isLoading}>
+          <Button className={c('button')} isLoading={this.props.isLoading} isSubmit>
             Next
           </Button>
-        </div>
+        </form>
       </div>
     );
   }

--- a/src/authentication/email-login/index.test.tsx
+++ b/src/authentication/email-login/index.test.tsx
@@ -16,13 +16,13 @@ describe('EmailLogin', () => {
     return shallow(<EmailLogin {...allProps} />);
   };
 
-  it('publishes form data when button is clicked', function () {
+  it('publishes form data when form is submitted', function () {
     const onSubmit = jest.fn();
     const wrapper = subject({ onSubmit });
 
     wrapper.find('Input[name="email"]').simulate('change', 'jack@example.com');
     wrapper.find('PasswordInput').simulate('change', 'abcd9876');
-    wrapper.find('Button').simulate('press');
+    wrapper.find('form').simulate('submit', inputEvent());
 
     expect(onSubmit).toHaveBeenCalledWith({ email: 'jack@example.com', password: 'abcd9876' });
   });
@@ -53,3 +53,11 @@ describe('EmailLogin', () => {
     expect(wrapper.find('Alert').prop('children')).toEqual('invalid');
   });
 });
+
+function inputEvent(attrs = {}) {
+  return {
+    preventDefault: () => {},
+    stopPropagation: () => {},
+    ...attrs,
+  };
+}

--- a/src/authentication/email-login/index.test.tsx
+++ b/src/authentication/email-login/index.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { EmailLogin, Properties } from '.';
+import { inputEvent } from '../../test/utils';
 
 describe('EmailLogin', () => {
   const subject = (props: Partial<Properties>) => {
@@ -53,11 +54,3 @@ describe('EmailLogin', () => {
     expect(wrapper.find('Alert').prop('children')).toEqual('invalid');
   });
 });
-
-function inputEvent(attrs = {}) {
-  return {
-    preventDefault: () => {},
-    stopPropagation: () => {},
-    ...attrs,
-  };
-}

--- a/src/authentication/email-login/index.tsx
+++ b/src/authentication/email-login/index.tsx
@@ -29,7 +29,8 @@ export class EmailLogin extends React.Component<Properties, State> {
   trackEmail = (value) => this.setState({ email: value });
   trackPassword = (value) => this.setState({ password: value });
 
-  publishOnSubmit = () => {
+  publishOnSubmit = (e) => {
+    e.preventDefault();
     this.props.onSubmit({ email: this.state.email, password: this.state.password });
   };
 
@@ -56,7 +57,7 @@ export class EmailLogin extends React.Component<Properties, State> {
       <div className={c('')}>
         <h3 className={c('heading')}>LOG IN</h3>
         <div className={c('sub-heading')}>Join us!</div>
-        <div className={c('form')}>
+        <form className={c('form')} onSubmit={this.publishOnSubmit}>
           <Input
             label='Email Address'
             name='email'
@@ -74,12 +75,12 @@ export class EmailLogin extends React.Component<Properties, State> {
             alert={this.passwordError}
           />
           {this.generalError && <Alert variant='error'>{this.generalError}</Alert>}
-          <Button className={c('button')} onPress={this.publishOnSubmit} isLoading={this.props.isLoading}>
+          <Button className={c('button')} isLoading={this.props.isLoading} isSubmit>
             Login
           </Button>
-          <div className={c('other-options')}>
-            New to ZERO? <Link to='/get-access'>Create an account</Link>
-          </div>
+        </form>
+        <div className={c('other-options')}>
+          New to ZERO? <Link to='/get-access'>Create an account</Link>
         </div>
       </div>
     );

--- a/src/authentication/validate-invite/index.test.tsx
+++ b/src/authentication/validate-invite/index.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 
 import { Invite, Properties } from '.';
 import { InviteCodeStatus } from '../../store/registration';
+import { inputEvent } from '../../test/utils';
 
 describe('Invite', () => {
   const subject = (props: Partial<Properties>) => {
@@ -53,7 +54,7 @@ describe('Invite', () => {
     const wrapper = subject({ validateInvite });
 
     wrapper.find('Input').simulate('change', code);
-    wrapper.find('Button').simulate('press');
+    wrapper.find('form').simulate('submit', inputEvent());
 
     wrapper.setProps({ isLoading: false });
     expect(validateInvite).toHaveBeenCalledWith({ code });
@@ -62,7 +63,7 @@ describe('Invite', () => {
   it('shows alert if invite is not valid', function () {
     const wrapper = subject({});
 
-    wrapper.find('Button').simulate('press');
+    wrapper.find('form').simulate('submit', inputEvent());
 
     wrapper.setProps({ inviteCodeStatus: InviteCodeStatus.INVITE_CODE_USED });
     expect(wrapper.find('Alert').prop('children')).toEqual(

--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -28,7 +28,8 @@ export class Invite extends React.Component<Properties, State> {
     this.setState({ inviteCode: code });
   };
 
-  onClick = async () => {
+  submitForm = async (e) => {
+    e.preventDefault();
     this.setState({ renderAlert: true });
     this.props.validateInvite({ code: this.state.inviteCode });
   };
@@ -73,27 +74,29 @@ export class Invite extends React.Component<Properties, State> {
         <h3 className='invite__title'>Add your invite code</h3>
         <p className='invite__text'>This is the 6 digit code you received in your invite</p>
 
-        <Input
-          onChange={this.onInviteCodeChanged}
-          placeholder='E.g. 123456'
-          value={this.state.inviteCode}
-          className='invite__input'
-          type='text'
-        />
+        <form onSubmit={this.submitForm}>
+          <Input
+            onChange={this.onInviteCodeChanged}
+            placeholder='E.g. 123456'
+            value={this.state.inviteCode}
+            className='invite__input'
+            type='text'
+          />
 
-        {this.state.renderAlert &&
-          this.props.inviteCodeStatus !== InviteCodeStatus.VALID &&
-          this.renderAlert(this.props.inviteCodeStatus)}
+          {this.state.renderAlert &&
+            this.props.inviteCodeStatus !== InviteCodeStatus.VALID &&
+            this.renderAlert(this.props.inviteCodeStatus)}
 
-        <Button
-          variant='primary'
-          className='invite__button'
-          onPress={this.onClick}
-          isDisabled={!this.state.inviteCode.length || this.state.inviteCode.length > MAX_INVITE_CODE_LENGTH}
-          isLoading={this.props.isLoading}
-        >
-          Get access
-        </Button>
+          <Button
+            variant='primary'
+            className='invite__button'
+            isDisabled={!this.state.inviteCode.length || this.state.inviteCode.length > MAX_INVITE_CODE_LENGTH}
+            isLoading={this.props.isLoading}
+            isSubmit
+          >
+            Get access
+          </Button>
+        </form>
 
         {/* TODO: hyperlink the second texts */}
         <div className='invite__subtext1'>

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,7 @@
+export function inputEvent(attrs = {}) {
+  return {
+    preventDefault: () => {},
+    stopPropagation: () => {},
+    ...attrs,
+  };
+}


### PR DESCRIPTION
### What does this do?

Converts the recent registration and login pages to use forms. This allows a user to hit enter when in the form and it'll do what you'd expect.

### Why are we making this change?

UX

### How do I test this?

On any of the pages, enter information into one of the input boxes and, while still there, hit Enter. Verify the correct behaviour occurs.

