### PR TITLE
Last page of registration flow now calls finalize endpoint

### DIFF
--- a/src/store/registration/api.ts
+++ b/src/store/registration/api.ts
@@ -43,9 +43,9 @@ export async function createAccount({
   }
 }
 
-export async function updateProfile({ id, firstName }: { id: string; firstName: string }) {
+export async function completeAccount({ userId, firstName }: { userId: string; firstName: string }) {
   try {
-    const response = await patch(`/api/profiles/${id}`).send({ firstName: firstName });
+    const response = await post('/api/v2/accounts/finalize').send({ userId, inviteCode: 'code', firstName });
     return {
       success: true,
       response: response.body,

--- a/src/store/registration/api.ts
+++ b/src/store/registration/api.ts
@@ -1,5 +1,5 @@
 import { InviteCodeStatus } from '.';
-import { patch, post } from '../../lib/api/rest';
+import { post } from '../../lib/api/rest';
 
 export async function validateInvite({ code }: { code: string }): Promise<string> {
   try {
@@ -43,9 +43,17 @@ export async function createAccount({
   }
 }
 
-export async function completeAccount({ userId, firstName }: { userId: string; firstName: string }) {
+export async function completeAccount({
+  userId,
+  name,
+  inviteCode,
+}: {
+  userId: string;
+  name: string;
+  inviteCode: string;
+}) {
   try {
-    const response = await post('/api/v2/accounts/finalize').send({ userId, inviteCode: 'code', firstName });
+    const response = await post('/api/v2/accounts/finalize').send({ userId, inviteCode, name });
     return {
       success: true,
       response: response.body,

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -28,7 +28,7 @@ export type RegistrationState = {
   errors: string[];
 
   inviteCodeStatus: string;
-  profileId: string;
+  userId: string;
   inviteCode: string;
 };
 
@@ -53,7 +53,7 @@ export const initialState: RegistrationState = {
   stage: RegistrationStage.ValidateInvite,
   errors: [],
 
-  profileId: '',
+  userId: '',
   inviteCode: '',
 };
 
@@ -77,8 +77,8 @@ const slice = createSlice({
     setErrors: (state, action: PayloadAction<RegistrationState['errors']>) => {
       state.errors = action.payload;
     },
-    setProfileId: (state, action: PayloadAction<RegistrationState['profileId']>) => {
-      state.profileId = action.payload;
+    setUserId: (state, action: PayloadAction<RegistrationState['userId']>) => {
+      state.userId = action.payload;
     },
     setInviteCode: (state, action: PayloadAction<RegistrationState['inviteCode']>) => {
       state.inviteCode = action.payload;
@@ -86,5 +86,5 @@ const slice = createSlice({
   },
 });
 
-export const { setInviteStatus, setLoading, setStage, setErrors, setProfileId, setInviteCode } = slice.actions;
+export const { setInviteStatus, setLoading, setStage, setErrors, setUserId, setInviteCode } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -224,11 +224,14 @@ describe('updateProfile', () => {
     } = await expectSaga(updateProfile, { payload: { name } })
       .provide([
         [
-          call(apiCompleteAccount, { userId: 'abc', firstName: name }),
+          call(apiCompleteAccount, { userId: 'abc', name, inviteCode: 'INV123' }),
           { success: true },
         ],
       ])
-      .withReducer(rootReducer, initialState({ userId: 'abc', stage: RegistrationStage.ProfileDetails }))
+      .withReducer(
+        rootReducer,
+        initialState({ userId: 'abc', inviteCode: 'INV123', stage: RegistrationStage.ProfileDetails })
+      )
       .run();
 
     expect(registration.stage).toEqual(RegistrationStage.Done);
@@ -244,11 +247,14 @@ describe('updateProfile', () => {
     } = await expectSaga(updateProfile, { payload: { name } })
       .provide([
         [
-          call(apiCompleteAccount, { userId: 'abc', firstName: name }),
+          call(apiCompleteAccount, { userId: 'abc', name, inviteCode: 'INV123' }),
           throwError(new Error('Stub api error')),
         ],
       ])
-      .withReducer(rootReducer, initialState({ userId: 'abc', stage: RegistrationStage.ProfileDetails }))
+      .withReducer(
+        rootReducer,
+        initialState({ userId: 'abc', inviteCode: 'INV123', stage: RegistrationStage.ProfileDetails })
+      )
       .run();
 
     expect(registration.stage).toEqual(RegistrationStage.ProfileDetails);

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -4,7 +4,7 @@ import { createAccount, updateProfile, validateAccountInfo, validateInvite } fro
 import {
   validateInvite as apiValidateInvite,
   createAccount as apiCreateAccount,
-  updateProfile as apiUpdateProfile,
+  completeAccount as apiCompleteAccount,
 } from './api';
 import { call } from 'redux-saga/effects';
 import {
@@ -82,13 +82,13 @@ describe('createAccount', () => {
         ],
         [
           call(fetchCurrentUser),
-          { profileSummary: { id: '123' } },
+          { id: '123' },
         ],
       ])
       .withReducer(rootReducer, initialState({ stage: RegistrationStage.AccountCreation, inviteCode }))
       .run();
     expect(registration.stage).toEqual(RegistrationStage.ProfileDetails);
-    expect(registration.profileId).toEqual('123');
+    expect(registration.userId).toEqual('123');
     expect(returnValue).toEqual(true);
   });
 
@@ -201,7 +201,7 @@ describe('createAccount', () => {
         ],
         [
           call(fetchCurrentUser),
-          { profileSummary: { id: '123' } },
+          { id: '123' },
         ],
       ])
       .withReducer(
@@ -224,11 +224,11 @@ describe('updateProfile', () => {
     } = await expectSaga(updateProfile, { payload: { name } })
       .provide([
         [
-          call(apiUpdateProfile, { id: 'abc', firstName: name }),
-          true,
+          call(apiCompleteAccount, { userId: 'abc', firstName: name }),
+          { success: true },
         ],
       ])
-      .withReducer(rootReducer, initialState({ profileId: 'abc', stage: RegistrationStage.ProfileDetails }))
+      .withReducer(rootReducer, initialState({ userId: 'abc', stage: RegistrationStage.ProfileDetails }))
       .run();
 
     expect(registration.stage).toEqual(RegistrationStage.Done);
@@ -244,11 +244,11 @@ describe('updateProfile', () => {
     } = await expectSaga(updateProfile, { payload: { name } })
       .provide([
         [
-          call(apiUpdateProfile, { id: 'abc', firstName: name }),
+          call(apiCompleteAccount, { userId: 'abc', firstName: name }),
           throwError(new Error('Stub api error')),
         ],
       ])
-      .withReducer(rootReducer, initialState({ profileId: 'abc', stage: RegistrationStage.ProfileDetails }))
+      .withReducer(rootReducer, initialState({ userId: 'abc', stage: RegistrationStage.ProfileDetails }))
       .run();
 
     expect(registration.stage).toEqual(RegistrationStage.ProfileDetails);
@@ -263,7 +263,7 @@ describe('updateProfile', () => {
       returnValue,
       storeState: { registration },
     } = await expectSaga(updateProfile, { payload: { name } })
-      .withReducer(rootReducer, initialState({ profileId: 'abc', stage: RegistrationStage.ProfileDetails }))
+      .withReducer(rootReducer, initialState({ userId: 'abc', stage: RegistrationStage.ProfileDetails }))
       .run();
 
     expect(registration.stage).toEqual(RegistrationStage.ProfileDetails);

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -98,8 +98,8 @@ export function* updateProfile(action) {
       return false;
     }
 
-    const userId = yield select((state) => state.registration.userId);
-    const response = yield call(apiCompleteAccount, { userId, firstName: name });
+    const { userId, inviteCode } = yield select((state) => state.registration);
+    const response = yield call(apiCompleteAccount, { userId, name, inviteCode });
     if (response.success) {
       yield put(setStage(RegistrationStage.Done));
       return true;

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -8,14 +8,14 @@ import {
   setInviteStatus,
   setErrors,
   setLoading,
-  setProfileId,
   setStage,
   setInviteCode,
+  setUserId,
 } from '.';
 import {
   validateInvite as apiValidateInvite,
   createAccount as apiCreateAccount,
-  updateProfile as apiUpdateProfile,
+  completeAccount as apiCompleteAccount,
 } from './api';
 import { fetchCurrentUser } from '../authentication/api';
 import { passwordStrength } from '../../lib/password';
@@ -55,7 +55,7 @@ export function* createAccount(action) {
     if (result.success) {
       const userFetch = yield call(fetchCurrentUser);
       if (userFetch) {
-        yield put(setProfileId(userFetch.profileSummary.id));
+        yield put(setUserId(userFetch.id));
         yield put(setStage(RegistrationStage.ProfileDetails));
         yield put(setErrors([]));
         return true;
@@ -98,9 +98,9 @@ export function* updateProfile(action) {
       return false;
     }
 
-    const profileId = yield select((state) => state.registration.profileId);
-    const success = yield call(apiUpdateProfile, { id: profileId, firstName: name });
-    if (success) {
+    const userId = yield select((state) => state.registration.userId);
+    const response = yield call(apiCompleteAccount, { userId, firstName: name });
+    if (response.success) {
       yield put(setStage(RegistrationStage.Done));
       return true;
     } else {


### PR DESCRIPTION
### What does this do?

Switches the last call of the registration page to `finalize` the account creation.

### Why are we making this change?

Rather than raw update profile data we call the business endpoint to finalize the account. This allows us to perform other operations on the back end when a user account is fully created.

### How do I test this?

Perform the registration flow.

