### PR TITLE
Render the admin message when joining Zero

### DIFF
--- a/src/components/admin-message/container.test.tsx
+++ b/src/components/admin-message/container.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { Container, PublicProperties } from './container';
+import { RootState } from '../../store/reducer';
+import { AdminMessageType, Message, normalize } from '../../store/messages';
+
+describe('Container', () => {
+  describe('mapState', () => {
+    const subject = (currentUserId: string, users = {}, publicProps: Partial<PublicProperties> = {}) => {
+      const state = {
+        authentication: {
+          user: {
+            data: { id: currentUserId },
+          },
+        },
+        normalized: {
+          users: {
+            ...users,
+          },
+        } as any,
+      } as RootState;
+      return Container.mapState(state, publicProps as PublicProperties);
+    };
+
+    describe('text', () => {
+      it('returns default message if users not found', () => {
+        const props = subject('current-user', {}, { message: { message: 'some message', admin: {} } as Message });
+
+        expect(props.text).toEqual('some message');
+      });
+
+      it('translates message if current user was invitee', () => {
+        const props = subject(
+          'current-user',
+          { 'inviter-id': { id: 'inviter-id', firstName: 'Courtney' } },
+          {
+            message: {
+              message: 'some message',
+              admin: { type: AdminMessageType.JOINED_ZERO, inviterId: 'inviter-id', inviteeId: 'current-user' },
+            } as Message,
+          }
+        );
+
+        expect(props.text).toEqual('You joined Courtney on Zero');
+      });
+
+      it('translates message if current user was inviter', () => {
+        const props = subject(
+          'current-user',
+          { 'invitee-id': { id: 'invitee-id', firstName: 'Julie' } },
+          {
+            message: {
+              message: 'some message',
+              admin: { type: AdminMessageType.JOINED_ZERO, inviteeId: 'invitee-id', inviterId: 'current-user' },
+            } as Message,
+          }
+        );
+
+        expect(props.text).toEqual('Julie joined you on Zero');
+      });
+    });
+  });
+});

--- a/src/components/admin-message/container.test.tsx
+++ b/src/components/admin-message/container.test.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-
 import { Container, PublicProperties } from './container';
 import { RootState } from '../../store/reducer';
-import { AdminMessageType, Message, normalize } from '../../store/messages';
+import { AdminMessageType, Message } from '../../store/messages';
 
 describe('Container', () => {
   describe('mapState', () => {

--- a/src/components/admin-message/container.tsx
+++ b/src/components/admin-message/container.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { RootState } from '../../store/reducer';
+
+import { AdminMessageType, Message } from '../../store/messages';
+import { AdminMessage } from '.';
+import { denormalize as denormalizeUser } from '../../store/users';
+import { currentUserSelector } from '../../store/authentication/saga';
+import { connectContainer } from '../../store/redux-container';
+
+export interface PublicProperties {
+  message: Message;
+}
+
+export interface Properties extends PublicProperties {
+  text: string;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState, props: PublicProperties): Partial<Properties> {
+    const user = currentUserSelector()(state);
+
+    let text = props.message.message;
+    if (props.message.admin?.type === AdminMessageType.JOINED_ZERO) {
+      if (props.message.admin?.inviteeId === user.id) {
+        const inviter = denormalizeUser(props.message.admin.inviterId, state);
+        text = inviter?.firstName ? `You joined ${inviter.firstName} on Zero` : text;
+      } else {
+        const invitee = denormalizeUser(props.message.admin.inviteeId, state);
+        text = invitee?.firstName ? `${invitee.firstName} joined you on Zero` : text;
+      }
+    }
+
+    return {
+      text,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {};
+  }
+
+  render() {
+    return <AdminMessage message={this.props.text} createdAt={this.props.message.createdAt} />;
+  }
+}
+
+export const AdminMessageContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/admin-message/index.test.tsx
+++ b/src/components/admin-message/index.test.tsx
@@ -1,0 +1,21 @@
+import { shallow } from 'enzyme';
+
+import { AdminMessage, Properties } from '.';
+
+describe('AdminMessage', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      message: '',
+      createdAt: 0,
+      ...props,
+    };
+
+    return shallow(<AdminMessage {...allProps} />);
+  };
+
+  it('renders the date', function () {
+    const wrapper = subject({ message: 'test message', createdAt: 1681745762146 });
+
+    expect(wrapper.find('.admin-message__date').text().trim()).toEqual('17/04/2023');
+  });
+});

--- a/src/components/admin-message/index.tsx
+++ b/src/components/admin-message/index.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import './styles.scss';
+import { bem } from '../../lib/bem';
+import moment from 'moment';
+const c = bem('admin-message');
+
+export interface Properties {
+  message: string;
+  createdAt: number;
+}
+
+export class AdminMessage extends React.PureComponent<Properties> {
+  get formattedDate() {
+    return moment(this.props.createdAt).format('DD/MM/YYYY');
+  }
+
+  render() {
+    return (
+      <div className={c('')}>
+        <span className={c('date')}>{this.formattedDate} </span>
+        {this.props.message}
+      </div>
+    );
+  }
+}

--- a/src/components/admin-message/styles.scss
+++ b/src/components/admin-message/styles.scss
@@ -1,0 +1,10 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.admin-message {
+  margin: 8px 16px;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 15px;
+  color: theme.$color-greyscale-transparency-11;
+  text-align: center;
+}

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -17,6 +17,7 @@ import { Media } from '../message-input/utils';
 import { ParentMessage } from '../../lib/chat/types';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
 import { Message } from '../message';
+import { AdminMessageContainer } from '../admin-message/container';
 
 interface ChatMessageGroups {
   [date: string]: MessageModel[];
@@ -136,25 +137,29 @@ export class ChatView extends React.Component<Properties, State> {
             // eslint-disable-next-line eqeqeq
             this.props.user && message.sender && this.props.user.id == message.sender.userId;
 
-          return (
-            <Message
-              className={classNames('messages__message', {
-                'messages__message--first-in-group': isFirstFromUser && this.props.showSenderAvatar,
-              })}
-              onImageClick={this.openLightbox}
-              key={message.id}
-              messageId={message.id}
-              updatedAt={message.updatedAt}
-              isOwner={isUserOwnerOfTheMessage}
-              onDelete={this.props.deleteMessage}
-              onEdit={this.props.editMessage}
-              onReply={this.props.onReply}
-              parentMessageText={message.parentMessageText}
-              getUsersForMentions={this.searchMentionableUsers}
-              showSenderAvatar={this.props.showSenderAvatar}
-              {...message}
-            />
-          );
+          if (message.isAdmin) {
+            return <AdminMessageContainer key={message.id} message={message} />;
+          } else {
+            return (
+              <Message
+                className={classNames('messages__message', {
+                  'messages__message--first-in-group': isFirstFromUser && this.props.showSenderAvatar,
+                })}
+                onImageClick={this.openLightbox}
+                key={message.id}
+                messageId={message.id}
+                updatedAt={message.updatedAt}
+                isOwner={isUserOwnerOfTheMessage}
+                onDelete={this.props.deleteMessage}
+                onEdit={this.props.editMessage}
+                onReply={this.props.onReply}
+                parentMessageText={message.parentMessageText}
+                getUsersForMentions={this.searchMentionableUsers}
+                showSenderAvatar={this.props.showSenderAvatar}
+                {...message}
+              />
+            );
+          }
         })}
       </div>
     );

--- a/src/lib/chat/chat-message.test.tsx
+++ b/src/lib/chat/chat-message.test.tsx
@@ -135,6 +135,8 @@ describe('sendbird events', () => {
       hidePreview: false,
       image: undefined,
       media: undefined,
+      isAdmin: false,
+      admin: {},
     });
   });
 });

--- a/src/lib/chat/chat-message.test.tsx
+++ b/src/lib/chat/chat-message.test.tsx
@@ -139,4 +139,26 @@ describe('sendbird events', () => {
       admin: {},
     });
   });
+
+  it('maps an admin message', () => {
+    const adminData = { type: 'some_type', meta: 'some meta' };
+    const rawSendbirdResponse = {
+      channelUrl: 'sendbird_group_channel_31029_6f063fff39f551d8ac68fe6d117a52033e292e32',
+      channelType: 'group',
+      messageId: 8728123760,
+      messageType: 'admin',
+      data: JSON.stringify({ admin: adminData }),
+      message: 'some admin message',
+    };
+
+    const mappedMessage = mapMessage(rawSendbirdResponse);
+
+    expect(mappedMessage).toEqual(
+      expect.objectContaining({
+        id: 8728123760,
+        isAdmin: true,
+        admin: adminData,
+      })
+    );
+  });
 });

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -86,6 +86,7 @@ function extractMessageData(jsonData, isMediaMessage) {
   let mentionedUsers = [];
   let hidePreview = false;
   let media;
+  let admin;
 
   try {
     const data = jsonData ? JSON.parse(jsonData) : {};
@@ -96,9 +97,10 @@ function extractMessageData(jsonData, isMediaMessage) {
 
     mentionedUsers = data.mentionedUsers || [];
     hidePreview = data.hidePreview || false;
+    admin = data.admin || {};
   } catch (e) {}
 
-  return { mentionedUsers, hidePreview, media, image: media };
+  return { mentionedUsers, hidePreview, media, image: media, admin };
 }
 
 export function map(sendbirdMessage) {
@@ -111,6 +113,7 @@ export function map(sendbirdMessage) {
     createdAt,
     updatedAt,
     sender: getSender(sender),
-    ...extractMessageData(data, messageType === 'file'),
+    ...extractMessageData(data, messageType.toLowerCase() === 'file'),
+    isAdmin: messageType.toLowerCase() === 'admin',
   } as unknown as Message;
 }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -43,10 +43,16 @@ export interface InfoUploadResponse {
   apiUrl: string;
   query: QueryUploadPayload;
 }
+
+export enum AdminMessageType {
+  JOINED_ZERO = 'JOINED_ZERO',
+}
+
 export interface Message {
   id: number;
   message?: string;
   parentMessageText?: string;
+  isAdmin: boolean;
   createdAt: number;
   updatedAt: number;
   sender: Sender;
@@ -55,6 +61,11 @@ export interface Message {
   hidePreview: boolean;
   preview: LinkPreview;
   media?: Media;
+  admin?: {
+    type: AdminMessageType;
+    inviterId?: string;
+    inviteeId?: string;
+  };
 }
 
 export interface EditMessageOptions {

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -19,6 +19,7 @@ export function messageFactory(messageText: string, user: User, parentMessage: P
     id: Date.now(),
     mentionedUserIds: [],
     message: messageText,
+    isAdmin: false,
     parentMessageText: parentMessage ? parentMessage.message : '',
     sender: {
       userId: user.id,


### PR DESCRIPTION
### What does this do?

This renders the JOINED_ZERO admin message in the chat.

### Why are we making this change?

When a new user joins we send an admin message to the conversation between the inviter and the invitee. This renders that admin message in the format we want.

### How do I test this?

Using an invite code, join Zero. Verify that you are automatically put in a conversation with the inviter and that you can see the admin message.

