### PR TITLE
Refactor: Move the last message text to messagePreview attribute

### DIFF
--- a/src/components/messenger/list/conversation-item.test.tsx
+++ b/src/components/messenger/list/conversation-item.test.tsx
@@ -126,12 +126,10 @@ describe('ConversationItem', () => {
     expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(now.format('MMM D'));
   });
 
-  it('renders last message summary', function () {
+  it('renders the message preview', function () {
     const wrapper = subject({
       conversation: {
-        lastMessage: {
-          message: 'I said something here',
-        },
+        messagePreview: 'I said something here',
         otherMembers: [],
       } as any,
     });

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -13,7 +13,7 @@ import moment from 'moment';
 const c = bem('conversation-item');
 
 export interface Properties {
-  conversation: Channel;
+  conversation: Channel & { messagePreview?: string };
   onClick: (conversationId: string) => void;
 }
 
@@ -79,8 +79,8 @@ export class ConversationItem extends React.Component<Properties> {
   }
 
   get message() {
-    if (this.props.conversation?.lastMessage?.message) {
-      return this.props.conversation?.lastMessage?.message;
+    if (this.props.conversation?.messagePreview) {
+      return this.props.conversation?.messagePreview;
     }
     return '';
   }

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -260,6 +260,18 @@ describe('messenger-list', () => {
       expect(state.isGroupCreating).toEqual(true);
     });
 
+    test('messagePreview', () => {
+      const state = subject([
+        { id: 'convo-1', lastMessage: { message: 'The last message' }, isChannel: false },
+        { id: 'convo-2', lastMessage: { message: 'Second message last' }, isChannel: false },
+      ]);
+
+      expect(state.conversations.map((c) => c.messagePreview)).toEqual([
+        'The last message',
+        'Second message last',
+      ]);
+    });
+
     test('stage', () => {
       const state = subject([], { stage: Stage.GroupDetails });
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -34,7 +34,7 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   stage: SagaStage;
   groupUsers: Option[];
-  conversations: Channel[];
+  conversations: (Channel & { messagePreview?: string })[];
   isFetchingExistingConversations: boolean;
   isGroupCreating: boolean;
 
@@ -50,9 +50,11 @@ export interface Properties extends PublicProperties {
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const { createConversation } = state;
-    const conversations = denormalizeConversations(state).sort((messengerA, messengerB) =>
-      compareDatesDesc(messengerA.lastMessage?.createdAt, messengerB.lastMessage?.createdAt)
-    );
+    const conversations = denormalizeConversations(state)
+      .sort((messengerA, messengerB) =>
+        compareDatesDesc(messengerA.lastMessage?.createdAt, messengerB.lastMessage?.createdAt)
+      )
+      .map((conversation) => ({ ...conversation, messagePreview: conversation.lastMessage?.message }));
 
     return {
       conversations,


### PR DESCRIPTION
### What does this do?

Maps the last message to a messagePreview attribute when rendering the conversation list.

### Why are we making this change?

Preperatory refactoring for adding in more detailed mapping of the message preview for admin messages, etc.

### How do I test this?

Open the app. Verify that the conversation list still shows the last message in the preview.

