### PR TITLE
Remove fetching of useres when channels are opened

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -7,9 +7,6 @@ import { ChatView } from './chat-view';
 import { Message } from '../../store/messages';
 
 describe('ChannelViewContainer', () => {
-  const USER_DATA = {
-    userId: '12',
-  };
   const subject = (props: any = {}) => {
     const allProps = {
       channel: null,
@@ -23,7 +20,6 @@ describe('ChannelViewContainer', () => {
       activeMessengerId: '',
       sendMessage: () => undefined,
       uploadFileMessage: () => undefined,
-      fetchUsers: () => undefined,
       deleteMessage: () => undefined,
       editMessage: () => undefined,
       markAllMessagesAsReadInChannel: () => undefined,
@@ -115,14 +111,6 @@ describe('ChannelViewContainer', () => {
     expect(fetchMessages).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
   });
 
-  it('fetches users on mount', () => {
-    const fetchUsers = jest.fn();
-
-    subject({ fetchUsers, channelId: 'the-channel-id' });
-
-    expect(fetchUsers).not.toHaveBeenCalledWith({ channelId: 'the-channel-id' });
-  });
-
   it('fetches messages when channel id is set', () => {
     const fetchMessages = jest.fn();
     const stopSyncChannels = jest.fn();
@@ -137,51 +125,6 @@ describe('ChannelViewContainer', () => {
     wrapper.setProps({ channelId: 'the-channel-id' });
 
     expect(fetchMessages).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
-  });
-
-  it('fetches users when users is set', () => {
-    const fetchUsers = jest.fn();
-
-    const wrapper = subject({
-      fetchUsers,
-      channelId: 'the-channel-id',
-      channel: { name: 'first channel', shouldSyncChannels: false },
-      context: {
-        isAuthenticated: true,
-      },
-    });
-
-    wrapper.setProps({
-      user: {
-        isLoading: false,
-        data: USER_DATA,
-      },
-    });
-
-    expect(fetchUsers).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
-  });
-
-  it('fetches users when channel id is updated', () => {
-    const fetchUsers = jest.fn();
-
-    const wrapper = subject({
-      fetchUsers,
-      channelId: 'the-first-channel-id',
-      channel: { name: 'first channel', shouldSyncChannels: false },
-      user: {
-        isLoading: false,
-        data: USER_DATA,
-      },
-      context: {
-        isAuthenticated: true,
-      },
-    });
-
-    wrapper.setProps({
-      channelId: 'the-channel-id',
-    });
-
-    expect(fetchUsers).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
   });
 
   it('fetches messages when channel id is updated', () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -14,13 +14,7 @@ import {
   stopSyncChannels,
   EditMessageOptions,
 } from '../../store/messages';
-import {
-  Channel,
-  denormalize,
-  loadUsers as fetchUsers,
-  joinChannel,
-  markAllMessagesAsReadInChannel,
-} from '../../store/channels';
+import { Channel, denormalize, joinChannel, markAllMessagesAsReadInChannel } from '../../store/channels';
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
 import {
@@ -29,7 +23,6 @@ import {
   SendPayload as PayloadSendMessage,
   MediaPayload,
 } from '../../store/messages/saga';
-import { Payload as PayloadFetchUser } from '../../store/channels-list/types';
 import { Payload as PayloadJoinChannel, MarkAsReadPayload } from '../../store/channels/types';
 import { withContext as withAuthenticationContext } from '../authentication/context';
 import { Media } from '../message-input/utils';
@@ -43,7 +36,6 @@ export interface Properties extends PublicProperties {
   uploadFileMessage: (payload: MediaPayload) => void;
   deleteMessage: (payload: PayloadFetchMessages) => void;
   editMessage: (payload: EditPayload) => void;
-  fetchUsers: (payload: PayloadFetchUser) => void;
   joinChannel: (payload: PayloadJoinChannel) => void;
   markAllMessagesAsReadInChannel: (payload: MarkAsReadPayload) => void;
   startMessageSync: (payload: PayloadFetchMessages) => void;
@@ -86,7 +78,6 @@ export class Container extends React.Component<Properties, State> {
   static mapActions(_props: Properties): Partial<Properties> {
     return {
       fetchMessages,
-      fetchUsers,
       sendMessage,
       uploadFileMessage,
       startMessageSync,
@@ -104,7 +95,6 @@ export class Container extends React.Component<Properties, State> {
     const { channelId } = this.props;
     if (channelId) {
       this.props.fetchMessages({ channelId });
-      this.fetchChannelMembers(channelId);
     }
   }
 
@@ -114,7 +104,6 @@ export class Container extends React.Component<Properties, State> {
     if (channelId && channelId !== prevProps.channelId) {
       this.props.stopSyncChannels(prevProps);
       this.props.fetchMessages({ channelId });
-      this.fetchChannelMembers(channelId);
       this.setState({
         isFirstMessagesFetchDone: false,
         reply: null,
@@ -128,7 +117,6 @@ export class Container extends React.Component<Properties, State> {
       this.props.user.data !== null
     ) {
       this.props.fetchMessages({ channelId });
-      this.fetchChannelMembers(channelId);
       this.setState({
         isFirstMessagesFetchDone: false,
       });
@@ -171,12 +159,6 @@ export class Container extends React.Component<Properties, State> {
   componentWillUnmount() {
     const { channelId } = this.props;
     this.props.stopSyncChannels({ channelId });
-  }
-
-  fetchChannelMembers(channelId: string): void {
-    if (this.props.context.isAuthenticated) {
-      this.props.fetchUsers({ channelId });
-    }
   }
 
   resetCountNewMessage = () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -289,7 +289,6 @@ export class Container extends React.Component<Properties, State> {
           editMessage={this.handleEditMessage}
           sendMessage={this.handleSendMessage}
           joinChannel={this.handleJoinChannel}
-          users={this.channel.users || []}
           hasJoined={this.channel.hasJoined || this.props.isDirectMessage}
           countNewMessages={this.state.countNewMessages}
           resetCountNewMessage={this.resetCountNewMessage}

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -8,7 +8,6 @@ import IndicatorMessage from '../indicator-message';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { getProvider } from '../../lib/cloudinary/provider';
 import { User } from '../../store/authentication/types';
-import { User as UserModel } from '../../store/channels/index';
 import { MessageInput } from '../message-input/container';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { Button as ConnectButton } from '../authentication/button';
@@ -43,7 +42,6 @@ export interface Properties {
   joinChannel: () => void;
   resetCountNewMessage: () => void;
   countNewMessages: number;
-  users: UserModel[];
   className?: string;
   reply?: null | ParentMessage;
   onMessageInputRendered: (ref: RefObject<HTMLTextAreaElement>) => void;
@@ -183,7 +181,7 @@ export class ChatView extends React.Component<Properties, State> {
   }
 
   searchMentionableUsers = async (search: string) => {
-    return await searchMentionableUsersForChannel(this.props.id, search, this.props.users);
+    return await searchMentionableUsersForChannel(this.props.id, search);
   };
 
   render() {

--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -9,10 +9,10 @@ import { ParentMessage } from '../../lib/chat/types';
 
 export interface PublicProperties {
   className?: string;
-  onSubmit: (message: string, mentionedUserIds: User['id'][], media: Media[]) => void;
+  onSubmit: (message: string, mentionedUserIds: User['userId'][], media: Media[]) => void;
   initialValue?: string;
   getUsersForMentions: (search: string) => Promise<UserForMention[]>;
-  renderAfterInput?: (value: string, mentionedUserIds: User['id'][]) => React.ReactNode;
+  renderAfterInput?: (value: string, mentionedUserIds: User['userId'][]) => React.ReactNode;
   onMessageInputRendered?: (textareaRef: RefObject<HTMLTextAreaElement>) => void;
   id?: string;
   reply?: null | ParentMessage;

--- a/src/components/message-input/utils.ts
+++ b/src/components/message-input/utils.ts
@@ -10,7 +10,7 @@ export interface Media {
 }
 export interface UserForMention {
   display: string;
-  id: User['id'];
+  id: User['userId'];
 }
 
 export interface Image {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -23,7 +23,7 @@ interface Properties extends MessageModel {
   onEdit: (
     messageId: number,
     message: string,
-    mentionedUserIds: User['id'][],
+    mentionedUserIds: User['userId'][],
     data?: Partial<EditMessageOptions>
   ) => void;
   onReply: (reply: ParentMessage) => void;

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -277,7 +277,7 @@ describe('messenger-chat', () => {
 
 function stubUser(attrs: Partial<User> = {}): User {
   return {
-    id: 'user-id',
+    userId: 'user-id',
     firstName: 'first-name',
     lastName: 'first-name',
     isOnline: false,

--- a/src/platform-apps/channels/util/api.test.ts
+++ b/src/platform-apps/channels/util/api.test.ts
@@ -5,40 +5,8 @@ describe('userMentionSearch', () => {
     const user1 = { id: 'd-1', name: 'dale' };
     const apiSearch = jest.fn().mockResolvedValue([user1]);
 
-    const searchResults = await searchMentionableUsersForChannel(null, null, [user1] as any, apiSearch);
+    const searchResults = await searchMentionableUsersForChannel(null, null, apiSearch);
 
     expect(searchResults).toEqual([{ id: 'd-1', display: 'dale' }]);
   });
-
-  it('includes only results in the allowedIds', async function () {
-    const user1 = { id: 'd-1', name: 'dale' };
-    const user2 = { id: 'd-2', name: '2-dale' };
-    const user3 = { id: 'd-3', name: '3-dale' };
-    const stubbedResponse = Promise.resolve([
-      user1,
-      user2,
-      user3,
-    ]);
-    const apiSearch = mockForArguments('channel-id', 'da', stubbedResponse);
-    const validUsers = [
-      user1,
-      user3,
-    ] as any;
-
-    const searchResults = await searchMentionableUsersForChannel('channel-id', 'da', validUsers, apiSearch);
-
-    expect(searchResults.map((u) => u.id)).toEqual([
-      'd-1',
-      'd-3',
-    ]);
-  });
 });
-
-function mockForArguments(...mockArgs) {
-  const result = mockArgs.pop();
-  return jest.fn((...actualArgs) => {
-    if (actualArgs.every((element, index) => element === mockArgs[index])) {
-      return result;
-    }
-  });
-}

--- a/src/platform-apps/channels/util/api.ts
+++ b/src/platform-apps/channels/util/api.ts
@@ -1,18 +1,13 @@
 import { searchMentionableUsers } from '../../../store/channels/api';
-import { User } from '../../../store/channels';
 import { searchMyNetworksByName as searchMyNetworksByNameApi } from '../../../store/users/api';
 
 export async function searchMentionableUsersForChannel(
   channelId: string,
   search: string,
-  // When the api is updated to only return channel users we can remove this argument
-  validUsers: Array<User>,
   apiSearch = searchMentionableUsers
 ) {
   const results = await apiSearch(channelId, search);
-  return results
-    .filter((user) => validUsers.find((valid) => user.id === valid.id))
-    .map((u) => ({ id: u.id, display: u.name }));
+  return results.map((u) => ({ id: u.id, display: u.name }));
 }
 
 export async function searchMyNetworksByName(search: string, apiSearch = searchMyNetworksByNameApi) {

--- a/src/store/channels-list/types.ts
+++ b/src/store/channels-list/types.ts
@@ -1,9 +1,5 @@
 import { Channel, User } from '../channels';
 
-export interface Payload {
-  channelId: string;
-}
-
 export enum ChannelType {
   Channel,
   DirectMessage,

--- a/src/store/channels/api.ts
+++ b/src/store/channels/api.ts
@@ -1,15 +1,5 @@
 import { get, post, put } from '../../lib/api/rest';
 
-export async function fetchUsersByChannelId(channelId: string): Promise<any> {
-  return await get<any>(`/chatChannels/${channelId}/members`)
-    .catch((_error) => {
-      return null;
-    })
-    .then((response) => {
-      return response?.body;
-    });
-}
-
 export async function joinChannel(channelId: string): Promise<number> {
   const response = await post<any>(`/chatChannels/${channelId}/join`);
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -24,7 +24,6 @@ export interface Channel {
   id: string;
   name: string;
   messages: Message[];
-  users: User[];
   otherMembers: User[];
   hasMore: boolean;
   countNewMessages: number;

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -40,13 +40,11 @@ export interface Channel {
 }
 
 export enum SagaActionTypes {
-  LoadUsers = 'channels/saga/loadUsers',
   JoinChannel = 'channels/saga/joinChannel',
   MarkAllMessagesAsReadInChannel = 'channels/saga/markAllMessagesAsReadInChannel',
   UnreadCountUpdated = 'channels/saga/unreadCountUpdated',
 }
 
-const loadUsers = createAction<Payload>(SagaActionTypes.LoadUsers);
 const joinChannel = createAction<Payload>(SagaActionTypes.JoinChannel);
 const markAllMessagesAsReadInChannel = createAction<Payload>(SagaActionTypes.MarkAllMessagesAsReadInChannel);
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
@@ -61,4 +59,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { loadUsers, joinChannel, markAllMessagesAsReadInChannel, unreadCountUpdated, removeAll };
+export { joinChannel, markAllMessagesAsReadInChannel, unreadCountUpdated, removeAll };

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -1,7 +1,6 @@
 import { createNormalizedSlice, removeAll } from '../normalized';
 
 import { Message, schema as messageSchema } from '../messages';
-import { schema as usersSchema } from '../users';
 import { createAction } from '@reduxjs/toolkit';
 import { Payload, UnreadCountUpdatedPayload } from './types';
 
@@ -53,7 +52,6 @@ const slice = createNormalizedSlice({
   name: 'channels',
   schemaDefinition: {
     messages: [messageSchema],
-    users: [usersSchema],
   },
 });
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -5,7 +5,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { Payload, UnreadCountUpdatedPayload } from './types';
 
 export interface User {
-  id: string;
+  userId: string;
   firstName: string;
   lastName: string;
   profileId: string;

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -2,40 +2,14 @@ import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import {
-  fetchUsersByChannelId,
   joinChannel as joinChannelAPI,
   markAllMessagesAsReadInChannel as markAllMessagesAsReadInChannelAPI,
 } from './api';
-import { joinChannel, loadUsers, markAllMessagesAsReadInChannel, unreadCountUpdated } from './saga';
+import { joinChannel, markAllMessagesAsReadInChannel, unreadCountUpdated } from './saga';
 
 import { rootReducer } from '../reducer';
 
 describe('channels list saga', () => {
-  const usersResponse = [
-    {
-      id: 'the-first-id',
-      firstName: 'the first name',
-    },
-    {
-      id: 'the-second-id',
-      firstName: 'the second name',
-    },
-  ];
-
-  it('load users', async () => {
-    const channelId = '248576469_9431f1076aa3e08783b2c2cf3b34df143442bc32';
-
-    await expectSaga(loadUsers, { payload: { channelId } })
-      .provide([
-        [
-          matchers.call.fn(fetchUsersByChannelId),
-          usersResponse,
-        ],
-      ])
-      .call(fetchUsersByChannelId, channelId)
-      .run();
-  });
-
   it('join channel and add hasJoined to channel state', async () => {
     const channelId = '248576469_9431f1076aa3e08783b2c2cf3b34df143442bc32';
 
@@ -66,65 +40,6 @@ describe('channels list saga', () => {
       .run();
 
     expect(channels[channelId].hasJoined).toEqual(true);
-  });
-
-  it('adds users ids to channels state', async () => {
-    const channelId = 'channel-id';
-
-    const initialState = {
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            users: [
-              'old-user-id',
-            ],
-          },
-        },
-      },
-    };
-
-    const {
-      storeState: {
-        normalized: { channels },
-      },
-    } = await expectSaga(loadUsers, { payload: { channelId } })
-      .withReducer(rootReducer, initialState as any)
-      .provide([
-        [
-          matchers.call.fn(fetchUsersByChannelId),
-          usersResponse,
-        ],
-      ])
-      .run();
-
-    expect(channels[channelId].users).toStrictEqual([
-      'the-first-id',
-      'the-second-id',
-    ]);
-  });
-
-  it('adds users to normalized state', async () => {
-    const channelId = '248576469_9431f1076aa3e08783b2c2cf3b34df143442bc32';
-
-    const {
-      storeState: {
-        normalized: { users },
-      },
-    } = await expectSaga(loadUsers, { payload: { channelId } })
-      .provide([
-        [
-          matchers.call.fn(fetchUsersByChannelId),
-          usersResponse,
-        ],
-      ])
-      .withReducer(rootReducer)
-      .run();
-
-    expect(users).toMatchObject({
-      'the-first-id': { id: 'the-first-id', firstName: 'the first name' },
-      'the-second-id': { id: 'the-second-id', firstName: 'the second name' },
-    });
   });
 
   it('mark all messages as read', async () => {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -2,35 +2,11 @@ import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, select } from 'redux-saga/effects';
 import { SagaActionTypes, receive, schema, removeAll } from '.';
 
-import {
-  fetchUsersByChannelId,
-  joinChannel as joinChannelAPI,
-  markAllMessagesAsReadInChannel as markAllMessagesAsReadAPI,
-} from './api';
+import { joinChannel as joinChannelAPI, markAllMessagesAsReadInChannel as markAllMessagesAsReadAPI } from './api';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels[${channelId}]`, null);
 };
-
-export function* loadUsers(action) {
-  const { channelId } = action.payload;
-
-  const users = yield call(fetchUsersByChannelId, channelId);
-
-  if (users) {
-    const formatUsers = users.map(({ userId: id, ...rest }) => ({
-      id,
-      ...rest,
-    }));
-
-    yield put(
-      receive({
-        id: channelId,
-        users: formatUsers,
-      })
-    );
-  }
-}
 
 export function* joinChannel(action) {
   const { channelId } = action.payload;
@@ -85,7 +61,6 @@ export function* clearChannels() {
 }
 
 export function* saga() {
-  yield takeLatest(SagaActionTypes.LoadUsers, loadUsers);
   yield takeLatest(SagaActionTypes.JoinChannel, joinChannel);
   yield takeLatest(SagaActionTypes.MarkAllMessagesAsReadInChannel, markAllMessagesAsReadInChannel);
   yield takeLatest(SagaActionTypes.UnreadCountUpdated, unreadCountUpdated);


### PR DESCRIPTION
### What does this do?

This removes code that is no longer necessary that was fetching the channel users every time we rendered a channel/conversation.

### Why are we making this change?

This is no longer required as the mentions search endpoint now filters by channel (and not network).

In addition, the normalization of these users was unconventional and we already have the `otherMembers` list on the channel so it was duplicate information.

### How do I test this?

Verify that you can still mention the appropriate people in channels/conversations.

