### PR TITLE
Add schema options to override the id attribute when normalizing

### DIFF
--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -1,6 +1,7 @@
 import { createNormalizedSlice, removeAll } from '../normalized';
 
 import { Message, schema as messageSchema } from '../messages';
+import { schema as userSchema } from '../users';
 import { createAction } from '@reduxjs/toolkit';
 import { Payload, UnreadCountUpdatedPayload } from './types';
 
@@ -52,6 +53,7 @@ const slice = createNormalizedSlice({
   name: 'channels',
   schemaDefinition: {
     messages: [messageSchema],
+    otherMembers: [userSchema],
   },
 });
 

--- a/src/store/normalized/creators.ts
+++ b/src/store/normalized/creators.ts
@@ -62,7 +62,7 @@ export class Creators {
   public createNormalizedSlice = (config: NormalizedSliceConfig) => {
     const { receive: receiveNormalized } = this.normalizedSlice.actions;
 
-    const schema = new nSchema.Entity(config.name, config.schemaDefinition);
+    const schema = new nSchema.Entity(config.name, config.schemaDefinition, config.options ?? {});
 
     const normalizer = new Normalizer(schema);
 

--- a/src/store/normalized/index.ts
+++ b/src/store/normalized/index.ts
@@ -20,9 +20,14 @@ export interface NormalizedListSliceConfig {
   schema: nSchema.Entity;
 }
 
+export interface SchemaOptions {
+  idAttribute: string;
+}
+
 export interface NormalizedSliceConfig {
   name: string;
   schemaDefinition?: Schema;
+  options?: SchemaOptions;
 }
 
 const receiveNormalized = (state, action: PayloadAction<any>) => {

--- a/src/store/users/index.ts
+++ b/src/store/users/index.ts
@@ -2,6 +2,9 @@ import { createNormalizedSlice, removeAll } from '../normalized';
 
 const slice = createNormalizedSlice({
   name: 'users',
+  options: {
+    idAttribute: 'userId',
+  },
 });
 
 export const { receiveNormalized, receive } = slice.actions;


### PR DESCRIPTION
### What does this do?

Adds the ability to use a different attribute for the id in the normalizer and uses that for `otherMembers` in the channels

### Why are we making this change?

So that we have easy access to all the users across the app.

### How do I test this?

Load up the app and verify that the conversation list shows the other member's names correctly.

