### PR TITLE
Render the correct admin message in the conversation list

### DIFF
--- a/src/components/admin-message/container.test.tsx
+++ b/src/components/admin-message/container.test.tsx
@@ -22,7 +22,11 @@ describe('Container', () => {
 
     describe('text', () => {
       it('returns default message if users not found', () => {
-        const props = subject('current-user', {}, { message: { message: 'some message', admin: {} } as Message });
+        const props = subject(
+          'current-user',
+          {},
+          { message: { message: 'some message', isAdmin: true, admin: {} } as Message }
+        );
 
         expect(props.text).toEqual('some message');
       });
@@ -34,6 +38,7 @@ describe('Container', () => {
           {
             message: {
               message: 'some message',
+              isAdmin: true,
               admin: { type: AdminMessageType.JOINED_ZERO, inviterId: 'inviter-id', inviteeId: 'current-user' },
             } as Message,
           }
@@ -49,6 +54,7 @@ describe('Container', () => {
           {
             message: {
               message: 'some message',
+              isAdmin: true,
               admin: { type: AdminMessageType.JOINED_ZERO, inviteeId: 'invitee-id', inviterId: 'current-user' },
             } as Message,
           }

--- a/src/components/admin-message/container.test.tsx
+++ b/src/components/admin-message/container.test.tsx
@@ -21,17 +21,7 @@ describe('Container', () => {
     };
 
     describe('text', () => {
-      it('returns default message if users not found', () => {
-        const props = subject(
-          'current-user',
-          {},
-          { message: { message: 'some message', isAdmin: true, admin: {} } as Message }
-        );
-
-        expect(props.text).toEqual('some message');
-      });
-
-      it('translates message if current user was invitee', () => {
+      it('translates admin messages', () => {
         const props = subject(
           'current-user',
           { 'inviter-id': { id: 'inviter-id', firstName: 'Courtney' } },
@@ -45,22 +35,6 @@ describe('Container', () => {
         );
 
         expect(props.text).toEqual('You joined Courtney on Zero');
-      });
-
-      it('translates message if current user was inviter', () => {
-        const props = subject(
-          'current-user',
-          { 'invitee-id': { id: 'invitee-id', firstName: 'Julie' } },
-          {
-            message: {
-              message: 'some message',
-              isAdmin: true,
-              admin: { type: AdminMessageType.JOINED_ZERO, inviteeId: 'invitee-id', inviterId: 'current-user' },
-            } as Message,
-          }
-        );
-
-        expect(props.text).toEqual('Julie joined you on Zero');
       });
     });
   });

--- a/src/components/admin-message/container.tsx
+++ b/src/components/admin-message/container.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { RootState } from '../../store/reducer';
 
-import { AdminMessageType, Message } from '../../store/messages';
+import { Message } from '../../store/messages';
 import { AdminMessage } from '.';
-import { denormalize as denormalizeUser } from '../../store/users';
-import { currentUserSelector } from '../../store/authentication/saga';
 import { connectContainer } from '../../store/redux-container';
+import { adminMessageText } from '../../lib/chat/chat-message';
 
 export interface PublicProperties {
   message: Message;
@@ -17,22 +16,9 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState, props: PublicProperties): Partial<Properties> {
-    const user = currentUserSelector()(state);
+    let text = props.message.isAdmin ? adminMessageText(props.message, state) : props.message.message;
 
-    let text = props.message.message;
-    if (props.message.admin?.type === AdminMessageType.JOINED_ZERO) {
-      if (props.message.admin?.inviteeId === user.id) {
-        const inviter = denormalizeUser(props.message.admin.inviterId, state);
-        text = inviter?.firstName ? `You joined ${inviter.firstName} on Zero` : text;
-      } else {
-        const invitee = denormalizeUser(props.message.admin.inviteeId, state);
-        text = invitee?.firstName ? `${invitee.firstName} joined you on Zero` : text;
-      }
-    }
-
-    return {
-      text,
-    };
+    return { text };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -26,6 +26,7 @@ import { StartGroupPanel } from './start-group-panel';
 import { GroupDetailsPanel } from './group-details-panel';
 import { Option } from '../autocomplete-members';
 import { MembersSelectedPayload } from '../../../store/create-conversation/types';
+import { adminMessageText } from '../../../lib/chat/chat-message';
 
 export interface PublicProperties {
   onClose: () => void;
@@ -54,7 +55,12 @@ export class Container extends React.Component<Properties> {
       .sort((messengerA, messengerB) =>
         compareDatesDesc(messengerA.lastMessage?.createdAt, messengerB.lastMessage?.createdAt)
       )
-      .map((conversation) => ({ ...conversation, messagePreview: conversation.lastMessage?.message }));
+      .map((conversation) => ({
+        ...conversation,
+        messagePreview: conversation.lastMessage?.isAdmin
+          ? adminMessageText(conversation.lastMessage, state)
+          : conversation.lastMessage?.message,
+      }));
 
     return {
       conversations,

--- a/src/lib/chat/chat-message.test.tsx
+++ b/src/lib/chat/chat-message.test.tsx
@@ -1,35 +1,87 @@
-import { map as mapMessage } from './chat-message';
+import { AdminMessageType, Message } from '../../store/messages';
+import { RootState } from '../../store/reducer';
+import { adminMessageText, map as mapMessage } from './chat-message';
 
 describe('sendbird events', () => {
-  it('maps sendbird channel info received from event', () => {
-    const rawSendbirdResponse = {
-      _iid: 'su-3f487094-5ff1-4e5c-9302-451c622d292e',
-      channelUrl: 'sendbird_group_channel_31029_6f063fff39f551d8ac68fe6d117a52033e292e32',
-      channelType: 'group',
-      messageId: 8728123760,
-      parentMessageId: 8711115337,
-      parentMessage: {
+  describe('mapMessage', () => {
+    it('maps sendbird channel info received from event', () => {
+      const rawSendbirdResponse = {
         _iid: 'su-3f487094-5ff1-4e5c-9302-451c622d292e',
         channelUrl: 'sendbird_group_channel_31029_6f063fff39f551d8ac68fe6d117a52033e292e32',
         channelType: 'group',
-        messageId: 8711115337,
-        parentMessageId: 0,
-        parentMessage: null,
+        messageId: 8728123760,
+        parentMessageId: 8711115337,
+        parentMessage: {
+          _iid: 'su-3f487094-5ff1-4e5c-9302-451c622d292e',
+          channelUrl: 'sendbird_group_channel_31029_6f063fff39f551d8ac68fe6d117a52033e292e32',
+          channelType: 'group',
+          messageId: 8711115337,
+          parentMessageId: 0,
+          parentMessage: null,
+          silent: false,
+          isOperatorMessage: false,
+          messageType: 'user',
+          data: '{"mentionedUsers":[]}',
+          customType: '',
+          mentionType: null,
+          mentionedUsers: null,
+          mentionedUserIds: null,
+          mentionedMessageTemplate: '',
+          threadInfo: null,
+          reactions: [],
+          metaArrays: [],
+          ogMetaData: null,
+          appleCriticalAlertOptions: null,
+          createdAt: 1680168823635,
+          updatedAt: 0,
+          scheduledInfo: null,
+          extendedMessage: {},
+          _isContinuousMessages: false,
+          _scheduledStatus: null,
+          sender: {
+            _iid: 'su-3f487094-5ff1-4e5c-9302-451c622d292e',
+            userId: '1bc08a9b-6f5b-497f-9d0b-3cf47abe426a',
+            nickname: '0x03D3...d161',
+            plainProfileUrl:
+              '{"profileImage":"https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg","firstName":"0x03D3...d161","lastName":"","profileId":"b52d1815-97db-45a7-8477-5b976e9eedde"}',
+            requireAuth: false,
+            metaData: {},
+            connectionStatus: 'nonavailable',
+            isActive: true,
+            lastSeenAt: null,
+            preferredLanguages: null,
+            friendDiscoveryKey: null,
+            friendName: null,
+            role: 'none',
+            isBlockedByMe: false,
+          },
+          reqId: '',
+          replyToChannel: false,
+          sendingStatus: 'succeeded',
+          errorCode: 0,
+          message: 'hi @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) ',
+          messageParams: null,
+          translations: {},
+          translationTargetLanguages: [],
+          messageSurvivalSeconds: -1,
+          plugins: [],
+          _poll: null,
+        },
         silent: false,
         isOperatorMessage: false,
         messageType: 'user',
         data: '{"mentionedUsers":[]}',
         customType: '',
-        mentionType: null,
-        mentionedUsers: null,
-        mentionedUserIds: null,
+        mentionType: 'users',
+        mentionedUsers: [],
+        mentionedUserIds: [],
         mentionedMessageTemplate: '',
         threadInfo: null,
         reactions: [],
         metaArrays: [],
         ogMetaData: null,
         appleCriticalAlertOptions: null,
-        createdAt: 1680168823635,
+        createdAt: 1680691559605,
         updatedAt: 0,
         scheduledInfo: null,
         extendedMessage: {},
@@ -51,114 +103,113 @@ describe('sendbird events', () => {
           friendName: null,
           role: 'none',
           isBlockedByMe: false,
+          profileUrl:
+            '{"profileImage":"https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg","firstName":"0x03D3...d161","lastName":"","profileId":"b52d1815-97db-45a7-8477-5b976e9eedde"}',
         },
         reqId: '',
         replyToChannel: false,
         sendingStatus: 'succeeded',
         errorCode: 0,
-        message: 'hi @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) ',
+        message: 'test mention @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) with image',
         messageParams: null,
         translations: {},
         translationTargetLanguages: [],
         messageSurvivalSeconds: -1,
         plugins: [],
         _poll: null,
-      },
-      silent: false,
-      isOperatorMessage: false,
-      messageType: 'user',
-      data: '{"mentionedUsers":[]}',
-      customType: '',
-      mentionType: 'users',
-      mentionedUsers: [],
-      mentionedUserIds: [],
-      mentionedMessageTemplate: '',
-      threadInfo: null,
-      reactions: [],
-      metaArrays: [],
-      ogMetaData: null,
-      appleCriticalAlertOptions: null,
-      createdAt: 1680691559605,
-      updatedAt: 0,
-      scheduledInfo: null,
-      extendedMessage: {},
-      _isContinuousMessages: false,
-      _scheduledStatus: null,
-      sender: {
-        _iid: 'su-3f487094-5ff1-4e5c-9302-451c622d292e',
-        userId: '1bc08a9b-6f5b-497f-9d0b-3cf47abe426a',
-        nickname: '0x03D3...d161',
-        plainProfileUrl:
-          '{"profileImage":"https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg","firstName":"0x03D3...d161","lastName":"","profileId":"b52d1815-97db-45a7-8477-5b976e9eedde"}',
-        requireAuth: false,
-        metaData: {},
-        connectionStatus: 'nonavailable',
-        isActive: true,
-        lastSeenAt: null,
-        preferredLanguages: null,
-        friendDiscoveryKey: null,
-        friendName: null,
-        role: 'none',
-        isBlockedByMe: false,
-        profileUrl:
-          '{"profileImage":"https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg","firstName":"0x03D3...d161","lastName":"","profileId":"b52d1815-97db-45a7-8477-5b976e9eedde"}',
-      },
-      reqId: '',
-      replyToChannel: false,
-      sendingStatus: 'succeeded',
-      errorCode: 0,
-      message: 'test mention @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) with image',
-      messageParams: null,
-      translations: {},
-      translationTargetLanguages: [],
-      messageSurvivalSeconds: -1,
-      plugins: [],
-      _poll: null,
-    };
+      };
 
-    const mappedMessage = mapMessage(rawSendbirdResponse);
+      const mappedMessage = mapMessage(rawSendbirdResponse);
 
-    expect(mappedMessage).toStrictEqual({
-      id: 8728123760,
-      message: 'test mention @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) with image',
-      parentMessageText: 'hi @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) ',
-      createdAt: 1680691559605,
-      updatedAt: 0,
-      sender: {
-        userId: '1bc08a9b-6f5b-497f-9d0b-3cf47abe426a',
-        firstName: '0x03D3...d161',
-        lastName: '',
-        profileImage: 'https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg',
-        profileId: 'b52d1815-97db-45a7-8477-5b976e9eedde',
-      },
-      mentionedUsers: [],
-      hidePreview: false,
-      image: undefined,
-      media: undefined,
-      isAdmin: false,
-      admin: {},
+      expect(mappedMessage).toStrictEqual({
+        id: 8728123760,
+        message: 'test mention @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) with image',
+        parentMessageText: 'hi @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) ',
+        createdAt: 1680691559605,
+        updatedAt: 0,
+        sender: {
+          userId: '1bc08a9b-6f5b-497f-9d0b-3cf47abe426a',
+          firstName: '0x03D3...d161',
+          lastName: '',
+          profileImage:
+            'https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg',
+          profileId: 'b52d1815-97db-45a7-8477-5b976e9eedde',
+        },
+        mentionedUsers: [],
+        hidePreview: false,
+        image: undefined,
+        media: undefined,
+        isAdmin: false,
+        admin: {},
+      });
+    });
+
+    it('maps an admin message', () => {
+      const adminData = { type: 'some_type', meta: 'some meta' };
+      const rawSendbirdResponse = {
+        channelUrl: 'sendbird_group_channel_31029_6f063fff39f551d8ac68fe6d117a52033e292e32',
+        channelType: 'group',
+        messageId: 8728123760,
+        messageType: 'admin',
+        data: JSON.stringify({ admin: adminData }),
+        message: 'some admin message',
+      };
+
+      const mappedMessage = mapMessage(rawSendbirdResponse);
+
+      expect(mappedMessage).toEqual(
+        expect.objectContaining({
+          id: 8728123760,
+          isAdmin: true,
+          admin: adminData,
+        })
+      );
     });
   });
 
-  it('maps an admin message', () => {
-    const adminData = { type: 'some_type', meta: 'some meta' };
-    const rawSendbirdResponse = {
-      channelUrl: 'sendbird_group_channel_31029_6f063fff39f551d8ac68fe6d117a52033e292e32',
-      channelType: 'group',
-      messageId: 8728123760,
-      messageType: 'admin',
-      data: JSON.stringify({ admin: adminData }),
-      message: 'some admin message',
+  describe('adminMessageText', () => {
+    const getState = (currentUserId: string, users = {}) => {
+      return {
+        authentication: {
+          user: { data: { id: currentUserId } },
+        },
+        normalized: {
+          users: { ...users },
+        } as any,
+      } as RootState;
     };
 
-    const mappedMessage = mapMessage(rawSendbirdResponse);
+    it('returns default message if users not found', () => {
+      const state = getState('current-user', {});
+      const adminText = adminMessageText({ message: 'some message', isAdmin: true, admin: {} } as Message, state);
 
-    expect(mappedMessage).toEqual(
-      expect.objectContaining({
-        id: 8728123760,
+      expect(adminText).toEqual('some message');
+    });
+
+    it('translates message if current user was invitee', () => {
+      const state = getState('current-user', { 'inviter-id': { id: 'inviter-id', firstName: 'Courtney' } });
+      const message = {
+        message: 'some message',
         isAdmin: true,
-        admin: adminData,
-      })
-    );
+        admin: { type: AdminMessageType.JOINED_ZERO, inviterId: 'inviter-id', inviteeId: 'current-user' },
+      } as Message;
+
+      const adminText = adminMessageText(message, state);
+
+      expect(adminText).toEqual('You joined Courtney on Zero');
+    });
+
+    it('translates message if current user was inviter', () => {
+      const state = getState('current-user', { 'invitee-id': { id: 'invitee-id', firstName: 'Julie' } });
+      const message = {
+        message: 'some message',
+        isAdmin: true,
+        admin: { type: AdminMessageType.JOINED_ZERO, inviteeId: 'invitee-id', inviterId: 'current-user' },
+      } as Message;
+
+      const adminText = adminMessageText(message, state);
+
+      expect(adminText).toEqual('Julie joined you on Zero');
+    });
   });
 });


### PR DESCRIPTION
### What does this do?

Adds preprocessing to format admin messages when rendered in the conversation list.

### Why are we making this change?

Accuracy/consistency of the messaging.

### How do I test this?

Invite a user and have them create an account to cause creation of the welcome conversation. Verify that the conversation list now shows the same message as the chat does.

![image](https://user-images.githubusercontent.com/43770/236922476-0e51a592-f22f-4376-88d7-17ba894afc5b.png)
