### PR TITLE
Retrieve and pass nonce to Create Account endpoint

### DIFF
--- a/src/store/authentication/api.ts
+++ b/src/store/authentication/api.ts
@@ -7,6 +7,18 @@ export async function nonceOrAuthorize(signedWeb3Token: string): Promise<Authori
   return response.body;
 }
 
+export async function nonce(signedWeb3Token?: string): Promise<AuthorizationResponse> {
+  if (signedWeb3Token) {
+    const response = await post('/authentication/nonce').set('Authorization', `Web3 ${signedWeb3Token}`);
+
+    return response.body;
+  }
+
+  const response = await post('/authentication/nonce');
+
+  return response.body;
+}
+
 export async function fetchCurrentUser(): Promise<User> {
   const response = await get('/api/users/current').catch((err) => console.log(err));
 

--- a/src/store/registration/api.ts
+++ b/src/store/registration/api.ts
@@ -19,15 +19,19 @@ export async function createAccount({
   password,
   handle,
   inviteCode,
+  nonceToken,
 }: {
   email: string;
   password: string;
   handle: string;
   inviteCode: string;
+  nonceToken: string;
 }) {
   const user = { email, password, handle };
   try {
-    const response = await post('/api/v2/accounts/createAndAuthorize').send({ user, inviteSlug: inviteCode });
+    const response = await post('/api/v2/accounts/createAndAuthorize')
+      .set('Authorization', `Nonce ${nonceToken}`)
+      .send({ user, inviteSlug: inviteCode });
     return {
       success: true,
       response: response.body,

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -17,10 +17,11 @@ import {
 } from '.';
 import { rootReducer } from '../reducer';
 import { fetchCurrentUser } from '../authentication/api';
+import { nonce as nonceApi } from '../authentication/api';
 import { throwError } from 'redux-saga-test-plan/providers';
 
 describe('validate invite', () => {
-  it('valites invite code, returns true if VALID', async () => {
+  it('validates invite code, returns true if VALID', async () => {
     const code = '123456';
 
     const {
@@ -42,7 +43,7 @@ describe('validate invite', () => {
     expect(registration.stage).toEqual(RegistrationStage.AccountCreation);
   });
 
-  it('valites invite code, returns false if NOT VALID and stays on invite stage', async () => {
+  it('validates invite code, returns false if NOT VALID and stays on invite stage', async () => {
     const code = '654321';
 
     const {
@@ -70,6 +71,7 @@ describe('createAccount', () => {
     const email = 'john@example.com';
     const password = VALID_PASSWORD;
     const inviteCode = '123987';
+    const nonceToken = 'abc123';
 
     const {
       returnValue,
@@ -77,7 +79,11 @@ describe('createAccount', () => {
     } = await expectSaga(createAccount, { payload: { email, password } })
       .provide([
         [
-          call(apiCreateAccount, { email, password, inviteCode, handle: email }),
+          call(nonceApi),
+          { nonceToken },
+        ],
+        [
+          call(apiCreateAccount, { email, password, inviteCode, handle: email, nonceToken }),
           { success: true, response: {} },
         ],
         [
@@ -117,6 +123,7 @@ describe('createAccount', () => {
     const email = 'john@example.com';
     const password = VALID_PASSWORD;
     const inviteCode = '123987';
+    const nonceToken = 'abc123';
 
     const {
       returnValue,
@@ -124,7 +131,11 @@ describe('createAccount', () => {
     } = await expectSaga(createAccount, { payload: { email, password } })
       .provide([
         [
-          call(apiCreateAccount, { email, password, inviteCode, handle: email }),
+          call(nonceApi),
+          { nonceToken },
+        ],
+        [
+          call(apiCreateAccount, { email, password, inviteCode, handle: email, nonceToken }),
           { success: false, response: 'EMAIL_INVALID' },
         ],
       ])
@@ -140,6 +151,7 @@ describe('createAccount', () => {
     const email = 'john@example.com';
     const password = VALID_PASSWORD;
     const inviteCode = '123987';
+    const nonceToken = 'abc123';
 
     const {
       returnValue,
@@ -147,7 +159,11 @@ describe('createAccount', () => {
     } = await expectSaga(createAccount, { payload: { email, password } })
       .provide([
         [
-          call(apiCreateAccount, { email, password, inviteCode, handle: email }),
+          call(nonceApi),
+          { nonceToken },
+        ],
+        [
+          call(apiCreateAccount, { email, password, inviteCode, handle: email, nonceToken }),
           throwError(new Error('Stub api error')),
         ],
       ])
@@ -163,6 +179,7 @@ describe('createAccount', () => {
     const email = 'john@example.com';
     const password = VALID_PASSWORD;
     const inviteCode = '123987';
+    const nonceToken = 'abc123';
 
     const {
       returnValue,
@@ -170,7 +187,11 @@ describe('createAccount', () => {
     } = await expectSaga(createAccount, { payload: { email, password } })
       .provide([
         [
-          call(apiCreateAccount, { email, password, inviteCode, handle: email }),
+          call(nonceApi),
+          { nonceToken },
+        ],
+        [
+          call(apiCreateAccount, { email, password, inviteCode, handle: email, nonceToken }),
           { success: true, response: {} },
         ],
         [
@@ -190,13 +211,18 @@ describe('createAccount', () => {
     const email = 'john@example.com';
     const password = VALID_PASSWORD;
     const inviteCode = '123987';
+    const nonceToken = 'abc123';
 
     const {
       storeState: { registration },
     } = await expectSaga(createAccount, { payload: { email, password } })
       .provide([
         [
-          call(apiCreateAccount, { email, password, inviteCode, handle: email }),
+          call(nonceApi),
+          { nonceToken },
+        ],
+        [
+          call(apiCreateAccount, { email, password, inviteCode, handle: email, nonceToken }),
           { success: true, response: {} },
         ],
         [

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -18,6 +18,7 @@ import {
   completeAccount as apiCompleteAccount,
 } from './api';
 import { fetchCurrentUser } from '../authentication/api';
+import { nonce as nonceApi } from '../authentication/api';
 import { passwordStrength } from '../../lib/password';
 
 export function* validateInvite(action) {
@@ -50,8 +51,15 @@ export function* createAccount(action) {
       return false;
     }
 
+    const { nonceToken } = yield call(nonceApi);
     // Handle is a required field. To try to ensure uniqueness, we'll use the email address.
-    const result = yield call(apiCreateAccount, { email: email.trim(), password, handle: email, inviteCode });
+    const result = yield call(apiCreateAccount, {
+      email: email.trim(),
+      password,
+      handle: email,
+      inviteCode,
+      nonceToken,
+    });
     if (result.success) {
       const userFetch = yield call(fetchCurrentUser);
       if (userFetch) {


### PR DESCRIPTION
### What does this do?

Looks up a nonce then passes it into the Create Account endpoint.

### How do I test this?

- Open your developer tools
- Create a new user
- Verify that nonce is being called
- Verify that the nonce is passed in the header of the createAndAuthorize endpoint

### Screen capture

https://github.com/zer0-os/zOS/assets/31045/0a83a90a-7d98-41ef-9208-db13e08c9657

