### PR TITLE
Open the rewards popup immediately on first time sign up

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -13,6 +13,7 @@ import { GroupDetailsPanel } from './group-details-panel';
 import { Stage } from '../../../store/create-conversation';
 import { AdminMessageType } from '../../../store/messages';
 import { RewardsPopupContainer } from '../../rewards-popup/container';
+import { RegistrationState } from '../../../store/registration';
 
 const mockSearchMyNetworksByName = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -27,6 +28,7 @@ describe('messenger-list', () => {
       conversations: [],
       isFetchingExistingConversations: false,
       isGroupCreating: false,
+      isFirstTimeLogin: false,
       openConversation: jest.fn(),
       fetchConversations: jest.fn(),
       createConversation: jest.fn(),
@@ -222,6 +224,12 @@ describe('messenger-list', () => {
     expect(wrapper).not.toHaveElement(RewardsPopupContainer);
   });
 
+  it('rewards popup is rendered immediately if first time login', async function () {
+    const wrapper = subject({ isFirstTimeLogin: true });
+
+    expect(wrapper).toHaveElement(RewardsPopupContainer);
+  });
+
   describe('mapState', () => {
     const subject = (channels, createConversationState = {}, currentUser = [{ userId: '', firstName: '' }]) => {
       return DirectMessageChat.mapState(getState(channels, createConversationState, currentUser));
@@ -246,6 +254,7 @@ describe('messenger-list', () => {
           groupDetails: {},
           ...createConversationState,
         },
+        registration: {},
       } as RootState;
     };
 
@@ -343,6 +352,15 @@ describe('messenger-list', () => {
       });
 
       expect(state.isFetchingExistingConversations).toEqual(true);
+    });
+
+    test('isFirstTimeLogin', async () => {
+      const state = DirectMessageChat.mapState({
+        ...getState([]),
+        registration: { isFirstTimeLogin: true } as RegistrationState,
+      });
+
+      expect(state.isFirstTimeLogin).toEqual(true);
     });
   });
 });

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -43,6 +43,7 @@ export interface Properties extends PublicProperties {
   conversations: (Channel & { messagePreview?: string })[];
   isFetchingExistingConversations: boolean;
   isGroupCreating: boolean;
+  isFirstTimeLogin: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -59,7 +60,7 @@ interface State {
 
 export class Container extends React.Component<Properties, State> {
   static mapState(state: RootState): Partial<Properties> {
-    const { createConversation } = state;
+    const { createConversation, registration } = state;
     const conversations = denormalizeConversations(state)
       .sort((messengerA, messengerB) =>
         compareDatesDesc(messengerA.lastMessage?.createdAt, messengerB.lastMessage?.createdAt)
@@ -77,6 +78,7 @@ export class Container extends React.Component<Properties, State> {
       groupUsers: createConversation.groupUsers,
       isGroupCreating: createConversation.groupDetails.isCreating,
       isFetchingExistingConversations: createConversation.startGroupChat.isLoading,
+      isFirstTimeLogin: registration.isFirstTimeLogin,
     };
   }
 
@@ -93,6 +95,11 @@ export class Container extends React.Component<Properties, State> {
   }
 
   state = { isRewardsPopupOpen: false };
+
+  constructor(props: Properties) {
+    super(props);
+    this.state.isRewardsPopupOpen = props.isFirstTimeLogin;
+  }
 
   componentDidMount(): void {
     this.props.fetchConversations();

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -30,6 +30,7 @@ export type RegistrationState = {
   inviteCodeStatus: string;
   userId: string;
   inviteCode: string;
+  isFirstTimeLogin: boolean;
 };
 
 export enum AccountCreationErrors {
@@ -55,6 +56,7 @@ export const initialState: RegistrationState = {
 
   userId: '',
   inviteCode: '',
+  isFirstTimeLogin: false,
 };
 
 export const validateInvite = createAction<{ code: string }>(SagaActionTypes.ValidateInvite);
@@ -83,8 +85,12 @@ const slice = createSlice({
     setInviteCode: (state, action: PayloadAction<RegistrationState['inviteCode']>) => {
       state.inviteCode = action.payload;
     },
+    setFirstTimeLogin: (state, action: PayloadAction<RegistrationState['isFirstTimeLogin']>) => {
+      state.isFirstTimeLogin = action.payload;
+    },
   },
 });
 
-export const { setInviteStatus, setLoading, setStage, setErrors, setUserId, setInviteCode } = slice.actions;
+export const { setInviteStatus, setLoading, setStage, setErrors, setUserId, setInviteCode, setFirstTimeLogin } =
+  slice.actions;
 export const { reducer } = slice;

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -304,6 +304,32 @@ describe('updateProfile', () => {
     ]);
     expect(returnValue).toEqual(false);
   });
+
+  it('updates the first time login status', async () => {
+    const name = 'john';
+
+    const {
+      storeState: { registration },
+    } = await expectSaga(updateProfile, { payload: { name } })
+      .provide([
+        [
+          call(apiCompleteAccount, { userId: 'abc', name, inviteCode: 'INV123' }),
+          { success: true },
+        ],
+      ])
+      .withReducer(
+        rootReducer,
+        initialState({
+          isFirstTimeLogin: false,
+          userId: 'abc',
+          inviteCode: 'INV123',
+          stage: RegistrationStage.ProfileDetails,
+        })
+      )
+      .run();
+
+    expect(registration.isFirstTimeLogin).toEqual(true);
+  });
 });
 
 describe('validateAccountInfo', () => {

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -11,6 +11,7 @@ import {
   setStage,
   setInviteCode,
   setUserId,
+  setFirstTimeLogin,
 } from '.';
 import {
   validateInvite as apiValidateInvite,
@@ -109,6 +110,7 @@ export function* updateProfile(action) {
     const { userId, inviteCode } = yield select((state) => state.registration);
     const response = yield call(apiCompleteAccount, { userId, name, inviteCode });
     if (response.success) {
+      yield put(setFirstTimeLogin(true));
       yield put(setStage(RegistrationStage.Done));
       return true;
     } else {


### PR DESCRIPTION
### What does this do?

Opens the rewards popup when you login immediately on first sign up.

### Why are we making this change?

To show the user the idea of rewards as soon as they enter Messenger.

### How do I test this?

Sign up as a new user and verify the popup is rendered without having to click the button. Refresh and confirm you no longer see the popup immediately.

