### PR TITLE
Update sendbird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@giphy/js-fetch-api": "^4.7.1",
         "@giphy/react-components": "^6.5.2",
         "@reduxjs/toolkit": "^1.7.1",
-        "@sendbird/chat": "^4.6.0",
+        "@sendbird/chat": "^4.8.1",
         "@sentry/react": "^7.13.0",
         "@types/jest": "^24.9.1",
         "@types/node": "^12.20.37",
@@ -29,9 +29,9 @@
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-feed": "^1.29.2",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zapp-buy-domains": "*",
-        "@zero-tech/zapp-daos": "*",
-        "@zero-tech/zapp-nfts": "*",
+        "@zero-tech/zapp-buy-domains": "latest",
+        "@zero-tech/zapp-daos": "latest",
+        "@zero-tech/zapp-nfts": "latest",
         "@zero-tech/zapp-staking": "latest",
         "@zero-tech/zui": "^0.20.2",
         "audio-react-recorder-fixed": "^1.0.3",
@@ -6366,9 +6366,9 @@
       }
     },
     "node_modules/@sendbird/chat": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.6.0.tgz",
-      "integrity": "sha512-Q8sfuSgI7NbR950111yasZwycK3vMrqb2IQWKoMN7/AVrDSOSUMDMBR2hfSCHOZaJwz7vtMnj4l9oWY3Sk8zuw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.8.1.tgz",
+      "integrity": "sha512-UnrTqtxHVrrxJIWbz4uIptGBCmgxuzJ5ELA+2WdsMj+33j5skXE1UVYXhnJ3FT3aYJhwr+mSxy+jSj9u9/KP6Q==",
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "^1.17.6"
       },
@@ -39552,9 +39552,9 @@
       }
     },
     "@sendbird/chat": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.6.0.tgz",
-      "integrity": "sha512-Q8sfuSgI7NbR950111yasZwycK3vMrqb2IQWKoMN7/AVrDSOSUMDMBR2hfSCHOZaJwz7vtMnj4l9oWY3Sk8zuw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.8.1.tgz",
+      "integrity": "sha512-UnrTqtxHVrrxJIWbz4uIptGBCmgxuzJ5ELA+2WdsMj+33j5skXE1UVYXhnJ3FT3aYJhwr+mSxy+jSj9u9/KP6Q==",
       "requires": {}
     },
     "@sentry/browser": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@giphy/js-fetch-api": "^4.7.1",
     "@giphy/react-components": "^6.5.2",
     "@reduxjs/toolkit": "^1.7.1",
-    "@sendbird/chat": "^4.6.0",
+    "@sendbird/chat": "^4.8.1",
     "@sentry/react": "^7.13.0",
     "@types/jest": "^24.9.1",
     "@types/node": "^12.20.37",


### PR DESCRIPTION
### What does this do?

Upgrading to Sendbird 4.8.1 resolves a bug where the session handler fails to refresh a key. Exception (Failed to refresh the session key). We initially reached out to Sendbird support in late March, they confirmed it was a bug in late April, then confirmed the bug was resolved in version 4.8.1 on May 10th.

### How do I test this?

- Log out / log in to zOS
- Open your Developer Tools
- Send a conversation message, verify the message sends
- Wait 10minutes for the session refresh to be triggered by the Sendbird library, verify that there are no Sendbird exceptions within the console 

### Previous Sendbird errors signature were as follows
![Screen Shot 2023-05-11 at 12 27 45 PM](https://github.com/zer0-os/zOS/assets/31045/2ce5a9c0-8411-4601-b099-ca0fe8d616f4)
