### PR TITLE
Add a full screen messenger mode via feature flag

### DIFF
--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -139,5 +139,22 @@ describe('Main', () => {
 
       expect(state.isMessengerFullScreen).toBeTrue();
     });
+
+    test('other layout state when messenger is fullscreen', () => {
+      const state = subject({
+        layout: {
+          value: {
+            isContextPanelOpen: true,
+            hasContextPanel: true,
+            isSidekickopen: false,
+            isMessengerFullScreen: true,
+          },
+        } as any,
+      });
+
+      expect(state.isContextPanelOpen).toBeFalse();
+      expect(state.hasContextPanel).toBeFalse();
+      expect(state.isSidekickOpen).toBeTrue();
+    });
   });
 });

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -14,6 +14,7 @@ describe('Main', () => {
       isSidekickOpen: false,
       hasContextPanel: false,
       isContextPanelOpen: false,
+      isMessengerFullScreen: false,
       context: {
         isAuthenticated: false,
       },
@@ -77,6 +78,18 @@ describe('Main', () => {
     expect(wrapper).toHaveElement(MessengerChat);
   });
 
+  it('does not render platform navigation if chat is full screen', () => {
+    const wrapper = subject({ isMessengerFullScreen: true });
+
+    expect(wrapper).not.toHaveElement('.main__navigation-platform');
+  });
+
+  it('does not render main header if chat is full screen', () => {
+    const wrapper = subject({ isMessengerFullScreen: true });
+
+    expect(wrapper).not.toHaveElement('.main__header');
+  });
+
   describe('mapState', () => {
     const subject = (state: any) =>
       Main.mapState({
@@ -107,6 +120,16 @@ describe('Main', () => {
       });
 
       expect(state.isContextPanelOpen).toBeTrue();
+    });
+
+    test('isMessengerFullScreen', () => {
+      const state = subject({
+        layout: {
+          value: { isMessengerFullScreen: true },
+        } as any,
+      });
+
+      expect(state.isMessengerFullScreen).toBeTrue();
     });
   });
 });

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -52,12 +52,14 @@ describe('Main', () => {
     const wrapper = subject({
       hasContextPanel: false,
       isContextPanelOpen: false,
+      isMessengerFullScreen: false,
     });
 
     const main = wrapper.find('.main');
 
     expect(main.hasClass('has-context-panel')).toBe(false);
     expect(main.hasClass('context-panel-open')).toBe(false);
+    expect(main.hasClass('messenger-full-screen')).toBe(false);
   });
 
   it('adds class when hasContextPanel is true', () => {
@@ -70,6 +72,12 @@ describe('Main', () => {
     const wrapper = subject({ isContextPanelOpen: true });
 
     expect(wrapper.find('.main').hasClass('context-panel-open')).toBe(true);
+  });
+
+  it('adds class when isMessengerFullScreen is true', () => {
+    const wrapper = subject({ isMessengerFullScreen: true });
+
+    expect(wrapper.find('.main').hasClass('messenger-full-screen')).toBe(true);
   });
 
   it('renders direct message chat component', () => {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -45,6 +45,7 @@ export class Container extends React.Component<Properties> {
       'context-panel-open': this.props.isContextPanelOpen,
       'sidekick-panel-open': this.props.isSidekickOpen && this.props.context.isAuthenticated,
       'has-context-panel': this.props.hasContextPanel,
+      'messenger-full-screen': this.props.isMessengerFullScreen,
     });
 
     return (

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -18,6 +18,7 @@ export interface Properties {
   hasContextPanel: boolean;
   isContextPanelOpen: boolean;
   isSidekickOpen: boolean;
+  isMessengerFullScreen: boolean;
   context: {
     isAuthenticated: boolean;
   };
@@ -31,6 +32,7 @@ export class Container extends React.Component<Properties> {
       hasContextPanel: layout.hasContextPanel,
       isContextPanelOpen: layout.isContextPanelOpen,
       isSidekickOpen: layout.isSidekickOpen,
+      isMessengerFullScreen: layout.isMessengerFullScreen,
     };
   }
 
@@ -55,27 +57,31 @@ export class Container extends React.Component<Properties> {
               <ViewModeToggle className='main__view-mode-toggle' />
             </div>
           </div>
-          <div className='main__navigation-platform'>
-            <div>
-              <div className='main__network'>
-                <Logo className={'main__network__logo'} />
-                <span>Wilder World</span>
+          {!this.props.isMessengerFullScreen && (
+            <div className='main__navigation-platform'>
+              <div>
+                <div className='main__network'>
+                  <Logo className={'main__network__logo'} />
+                  <span>Wilder World</span>
+                </div>
               </div>
+              <div className='main__app-menu-container'>
+                <AppMenuContainer />
+              </div>
+              <div></div>
             </div>
-            <div className='main__app-menu-container'>
-              <AppMenuContainer />
+          )}
+        </div>
+        {!this.props.isMessengerFullScreen && (
+          <div className='main__header'>
+            <div className='main__address-bar-wrapper'>
+              <AddressBarContainer className='main__address-bar' />
             </div>
-            <div></div>
+            <div className='main__wallet-manager-wrapper'>
+              <WalletManager className='main__wallet-manager' />
+            </div>
           </div>
-        </div>
-        <div className='main__header'>
-          <div className='main__address-bar-wrapper'>
-            <AddressBarContainer className='main__address-bar' />
-          </div>
-          <div className='main__wallet-manager-wrapper'>
-            <WalletManager className='main__wallet-manager' />
-          </div>
-        </div>
+        )}
 
         {this.props.context.isAuthenticated && <Sidekick className='main__sidekick' />}
 

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -28,11 +28,20 @@ export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const layout = state.layout.value;
 
+    if (layout.isMessengerFullScreen) {
+      return {
+        hasContextPanel: false,
+        isContextPanelOpen: false,
+        isSidekickOpen: true,
+        isMessengerFullScreen: true,
+      };
+    }
+
     return {
       hasContextPanel: layout.hasContextPanel,
       isContextPanelOpen: layout.isContextPanelOpen,
       isSidekickOpen: layout.isSidekickOpen,
-      isMessengerFullScreen: layout.isMessengerFullScreen,
+      isMessengerFullScreen: false,
     };
   }
 

--- a/src/app-sandbox/index.test.tsx
+++ b/src/app-sandbox/index.test.tsx
@@ -199,4 +199,10 @@ describe('AppSandbox', () => {
     expect(sandbox.hasClass('context-panel-open')).toBe(true);
     expect(sandbox.hasClass('has-context-panel')).toBe(true);
   });
+
+  it('does not render if messenger is full screen', () => {
+    const wrapper = subject({ layout: { isMessengerFullScreen: true } });
+
+    expect(wrapper.isEmptyRender()).toBeTrue();
+  });
 });

--- a/src/app-sandbox/index.tsx
+++ b/src/app-sandbox/index.tsx
@@ -102,7 +102,11 @@ export class AppSandbox extends React.Component<Properties> {
   }
 
   render() {
-    const { hasContextPanel, isContextPanelOpen, isSidekickOpen } = this.props.layout;
+    const { hasContextPanel, isContextPanelOpen, isSidekickOpen, isMessengerFullScreen } = this.props.layout;
+
+    if (isMessengerFullScreen) {
+      return null;
+    }
 
     const className = classNames('app-sandbox', {
       'context-panel-open': isContextPanelOpen,

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -24,6 +24,14 @@ export class FeatureFlags {
   set allowInvites(value: boolean) {
     this._setBoolean('allowInvites', value);
   }
+
+  get fullScreenMessenger() {
+    return this._getBoolean('fullScreenMessenger');
+  }
+
+  set fullScreenMessenger(value: boolean) {
+    this._setBoolean('fullScreenMessenger', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/main.scss
+++ b/src/main.scss
@@ -32,6 +32,10 @@ $border-color-hover: theme-zui.$color-primary-7;
 
   pointer-events: none;
 
+  &.messenger-full-screen {
+    justify-content: start;
+  }
+
   &__navigation {
     box-sizing: border-box;
     display: flex;

--- a/src/store/layout/index.test.ts
+++ b/src/store/layout/index.test.ts
@@ -6,6 +6,7 @@ describe('layout reducer', () => {
       isContextPanelOpen: false,
       isSidekickOpen: false,
       hasContextPanel: false,
+      isMessengerFullScreen: false,
     },
   };
 
@@ -15,6 +16,7 @@ describe('layout reducer', () => {
         isContextPanelOpen: false,
         isSidekickOpen: false,
         hasContextPanel: false,
+        isMessengerFullScreen: true,
       },
     });
   });

--- a/src/store/layout/index.ts
+++ b/src/store/layout/index.ts
@@ -12,6 +12,7 @@ const initialState: LayoutState = {
     isContextPanelOpen: false,
     hasContextPanel: false,
     isSidekickOpen: false,
+    isMessengerFullScreen: true,
   },
 };
 

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -4,6 +4,7 @@ import { put, takeLatest, select } from 'redux-saga/effects';
 import { update, SagaActionTypes } from './';
 import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
 import { User } from '../authentication/types';
+import { featureFlags } from '../../lib/feature-flags';
 
 export const getKeyWithUserId = (key: string) => (state) => {
   const user: User = getDeepProperty(state, 'authentication.user.data', null);
@@ -35,7 +36,7 @@ export function* updateSidekick(action) {
 
 export function* initializeUserLayout(user: { id: string }) {
   const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE), true);
-  const isMessengerFullScreen = (window as any).FEATURE_FLAGS.fullScreenMessenger;
+  const isMessengerFullScreen = featureFlags.fullScreenMessenger;
 
   yield put(
     update({

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -35,10 +35,12 @@ export function* updateSidekick(action) {
 
 export function* initializeUserLayout(user: { id: string }) {
   const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE), true);
+  const isMessengerFullScreen = (window as any).FEATURE_FLAGS.fullScreenMessenger;
 
   yield put(
     update({
       isSidekickOpen,
+      isMessengerFullScreen,
     })
   );
 }

--- a/src/store/layout/types.ts
+++ b/src/store/layout/types.ts
@@ -2,6 +2,7 @@ export interface AppLayout {
   hasContextPanel: boolean;
   isContextPanelOpen: boolean;
   isSidekickOpen: boolean;
+  isMessengerFullScreen: boolean;
 }
 
 export interface LayoutState {


### PR DESCRIPTION
### What does this do?

Adds a feature flag (`fullScreenMessenger`) to render the app in full screen messenger mode

### Why are we making this change?

First step towards networkless Messenger users and full screen mode in zOS. This allows UI to be built in full screen mode while the rest of the full screen styling is completed.

### How do I test this?

Set the feature flag to true and refresh the page: `window.FEATURE_FLAGS.fullScreenMessenger = true`


![image](https://github.com/zer0-os/zOS/assets/43770/2640f804-e0c8-4e9a-8b5b-2f39bcd0672d)
