### PR TITLE
Rerender the chat if we switch channels

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -183,6 +183,7 @@ export class Container extends React.Component<Properties, State> {
           </div>
 
           <ChatViewContainer
+            key={this.props.activeMessengerId} // Render new component for a new chat
             channelId={this.props.activeMessengerId}
             className='direct-message-chat__channel'
             isDirectMessage


### PR DESCRIPTION
### What does this do?

Forces a rerender of the component when switching conversations

### Why are we making this change?

This clears out interim state that really shouldn't be maintained when you change conversations. Eg: the message you may have been typing.

