### PR TITLE
Fix public zOS view

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -24,14 +24,6 @@ export class FeatureFlags {
   set allowInvites(value: boolean) {
     this._setBoolean('allowInvites', value);
   }
-
-  get fullScreenMessenger() {
-    return this._getBoolean('fullScreenMessenger');
-  }
-
-  set fullScreenMessenger(value: boolean) {
-    this._setBoolean('fullScreenMessenger', value);
-  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -200,7 +200,7 @@ describe('authentication saga', () => {
   describe('clearUserState', () => {
     it('resets layout', async () => {
       await expectSaga(clearUserState)
-        .put(update({ isSidekickOpen: false }))
+        .put(update({ isSidekickOpen: false, isMessengerFullScreen: false }))
         .put(receive([]))
         .withReducer(rootReducer)
         .run();

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -4,7 +4,6 @@ import { put, takeLatest, select } from 'redux-saga/effects';
 import { update, SagaActionTypes } from './';
 import { resolveFromLocalStorageAsBoolean } from '../../lib/storage';
 import { User } from '../authentication/types';
-import { featureFlags } from '../../lib/feature-flags';
 
 export const getKeyWithUserId = (key: string) => (state) => {
   const user: User = getDeepProperty(state, 'authentication.user.data', null);
@@ -36,10 +35,7 @@ export function* updateSidekick(action) {
 
 export function* initializeUserLayout(user: { id: string; isAMemberOfWorlds: boolean }) {
   const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE), true);
-  let isMessengerFullScreen = featureFlags.fullScreenMessenger;
-  if (!user.isAMemberOfWorlds) {
-    isMessengerFullScreen = true;
-  }
+  const isMessengerFullScreen = !user.isAMemberOfWorlds;
 
   yield put(
     update({
@@ -53,6 +49,7 @@ export function* clearUserLayout() {
   yield put(
     update({
       isSidekickOpen: false,
+      isMessengerFullScreen: false,
     })
   );
 }


### PR DESCRIPTION
### What does this do?

Public zOS view was broken when logged out because it was forcing you into full screen mode but we don't yet have redirection to the login page. This removes the full screen feature flag and resets the Full Screen mode if a user logs out.

