### PR TITLE
Remove allowInvites feature flag

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -9,7 +9,6 @@ import { IconButton } from '../../icon-button';
 import { ConversationItem } from './conversation-item';
 import { InviteDialogContainer } from '../../invite-dialog/container';
 import { Button, Modal } from '@zero-tech/zui/components';
-import { FeatureFlag } from '../../feature-flag';
 
 export interface Properties {
   conversations: Channel[];
@@ -120,11 +119,9 @@ export class ConversationListPanel extends React.Component<Properties, State> {
         </div>
         {/* Note: this does not work. directMessages is never null */}
         {!this.props.conversations && <div className='messages-list__new-messages'>{this.renderNoMessages()}</div>}
-        <FeatureFlag featureFlag={'allowInvites'}>
-          <Button variant={'text'} onPress={this.openInviteDialog}>
-            Invite Friends
-          </Button>
-        </FeatureFlag>
+        <Button variant={'text'} onPress={this.openInviteDialog}>
+          Invite Friends
+        </Button>
         {this.renderInviteDialog()}
       </>
     );

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -17,14 +17,6 @@ export class FeatureFlags {
     this._setBoolean('channelsApp', value);
   }
 
-  get allowInvites() {
-    return this._getBoolean('allowInvites');
-  }
-
-  set allowInvites(value: boolean) {
-    this._setBoolean('allowInvites', value);
-  }
-
   get allowPublicZOS() {
     return this._getBoolean('allowPublicZOS');
   }


### PR DESCRIPTION
### What does this do?

Removes the allowInvites feature flag now that they are usable.

