### PR TITLE
Consider an admin message to be always from a different user in the conversation list

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -130,14 +130,17 @@ export class ChatView extends React.Component<Properties, State> {
           <div className='message__header-date'>{this.formatDayHeader(day)}</div>
         </div>
         {allMessages.map((message, index) => {
-          const isFirstFromUser = index === 0 || message.sender.userId !== allMessages[index - 1].sender.userId;
-          const isUserOwnerOfTheMessage =
-            // eslint-disable-next-line eqeqeq
-            this.props.user && message.sender && this.props.user.id == message.sender.userId;
-
           if (message.isAdmin) {
             return <AdminMessageContainer key={message.id} message={message} />;
           } else {
+            const isFirstFromUser =
+              index === 0 ||
+              allMessages[index - 1].isAdmin ||
+              message.sender.userId !== allMessages[index - 1].sender.userId;
+            const isUserOwnerOfTheMessage =
+              // eslint-disable-next-line eqeqeq
+              this.props.user && message.sender && this.props.user.id == message.sender.userId;
+
             return (
               <div key={message.id} className='messages__message-row'>
                 <Message


### PR DESCRIPTION
### What does this do?

Fixes a bug where a brand new user conversation with the admin "welcome" message crashed the first time you open it.
