### PR TITLE
Pull wallet select component in from zos-component-library

### DIFF
--- a/src/components/wallet-manager/index.test.tsx
+++ b/src/components/wallet-manager/index.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { RootState } from '../../store/reducer';
 
-import { Button, WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
 import { ConnectionStatus, Connectors } from '../../lib/web3';
 import { Container } from '.';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { Button as ConnectButton } from '../../components/authentication/button';
 import { UserActionsContainer } from '../user-actions/container';
+import { WalletType } from '../wallet-select/wallets';
 
 describe('WalletManager', () => {
   const subject = (props: any = {}) => {
@@ -47,7 +47,7 @@ describe('WalletManager', () => {
       isAuthenticated: true,
     });
 
-    expect(wrapper.find(Button).exists()).toBe(false);
+    expect(wrapper.find('Button').exists()).toBe(false);
   });
 
   it('renders user actions when set', () => {
@@ -86,13 +86,13 @@ describe('WalletManager', () => {
   it('does not render wallet select modal', () => {
     const wrapper = subject();
 
-    expect(wrapper.find(WalletSelectModal).exists()).toBe(false);
+    expect(wrapper.find('WalletSelectModal').exists()).toBe(false);
   });
 
   it('should render all available wallets', () => {
     const wrapper = subject({ isWalletModalOpen: true });
 
-    expect(wrapper.find(WalletSelectModal).prop('wallets')).toStrictEqual([
+    expect(wrapper.find('WalletSelectModal').prop('wallets')).toStrictEqual([
       WalletType.Metamask,
       WalletType.WalletConnect,
       WalletType.Coinbase,
@@ -106,7 +106,7 @@ describe('WalletManager', () => {
 
     wrapper.setProps({ connectionStatus: ConnectionStatus.Connecting });
 
-    expect(wrapper.find(WalletSelectModal).prop('isConnecting')).toBe(true);
+    expect(wrapper.find('WalletSelectModal').prop('isConnecting')).toBe(true);
   });
 
   it('passes isConnecting of true when wallet selected', () => {
@@ -115,34 +115,34 @@ describe('WalletManager', () => {
       isWalletModalOpen: true,
     });
 
-    wrapper.find(WalletSelectModal).simulate('select', Connectors.Metamask);
+    wrapper.find('WalletSelectModal').simulate('select', Connectors.Metamask);
 
-    expect(wrapper.find(WalletSelectModal).prop('isConnecting')).toBe(true);
+    expect(wrapper.find('WalletSelectModal').prop('isConnecting')).toBe(true);
   });
 
   it('passes isConnecting of false when wallet selected and status becomes connected', () => {
     const wrapper = subject({ connectionStatus: ConnectionStatus.Connected, isWalletModalOpen: true });
 
-    wrapper.find(WalletSelectModal).simulate('select', Connectors.Metamask);
+    wrapper.find('WalletSelectModal').simulate('select', Connectors.Metamask);
 
     wrapper.setProps({ connectionStatus: ConnectionStatus.Connecting });
 
     // assert pre-condition
-    expect(wrapper.find(WalletSelectModal).prop('isConnecting')).toBe(true);
+    expect(wrapper.find('WalletSelectModal').prop('isConnecting')).toBe(true);
 
     wrapper.setProps({ connectionStatus: ConnectionStatus.Connected });
 
     // re-open modal, as it will be closed at this point
     wrapper.find(ConnectButton).simulate('click');
 
-    expect(wrapper.find(WalletSelectModal).prop('isConnecting')).toBe(false);
+    expect(wrapper.find('WalletSelectModal').prop('isConnecting')).toBe(false);
   });
 
   it('closes wallet select modal onClose', () => {
     const setWalletModalOpen = jest.fn();
     const wrapper = subject({ isWalletModalOpen: true, setWalletModalOpen });
 
-    wrapper.find(WalletSelectModal).simulate('close');
+    wrapper.find('WalletSelectModal').simulate('close');
 
     expect(setWalletModalOpen).toHaveBeenCalledWith(false);
   });
@@ -165,13 +165,13 @@ describe('WalletManager', () => {
   it('should show list of wallet when status is disconnected', () => {
     const wrapper = subject({ connectionStatus: ConnectionStatus.Connected, isWalletModalOpen: true });
 
-    wrapper.find(WalletSelectModal).simulate('select', Connectors.Metamask);
+    wrapper.find('WalletSelectModal').simulate('select', Connectors.Metamask);
 
-    expect(wrapper.find(WalletSelectModal).prop('isConnecting')).toBe(true);
+    expect(wrapper.find('WalletSelectModal').prop('isConnecting')).toBe(true);
 
     wrapper.setProps({ connectionStatus: ConnectionStatus.Disconnected });
 
-    expect(wrapper.find(WalletSelectModal).prop('isConnecting')).toBe(false);
+    expect(wrapper.find('WalletSelectModal').prop('isConnecting')).toBe(false);
   });
 
   it('calls update connector when wallet selected', () => {
@@ -179,7 +179,7 @@ describe('WalletManager', () => {
 
     const wrapper = subject({ updateConnector, isWalletModalOpen: true });
 
-    wrapper.find(WalletSelectModal).simulate('select', Connectors.Metamask);
+    wrapper.find('WalletSelectModal').simulate('select', Connectors.Metamask);
 
     expect(updateConnector).toHaveBeenCalledWith(Connectors.Metamask);
   });
@@ -191,7 +191,7 @@ describe('WalletManager', () => {
       connectionStatus: ConnectionStatus.NetworkNotSupported,
     });
 
-    expect(wrapper.find(WalletSelectModal).prop('isNotSupportedNetwork')).toBe(true);
+    expect(wrapper.find('WalletSelectModal').prop('isNotSupportedNetwork')).toBe(true);
   });
 
   describe('mapState', () => {

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -1,4 +1,3 @@
-import { WalletSelectModal, WalletType } from '@zer0-os/zos-component-library';
 import classNames from 'classnames';
 import React from 'react';
 import { config } from '../../config';
@@ -13,6 +12,9 @@ import './styles.scss';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { updateSidekick } from '../../store/layout';
 import { UserActionsContainer } from '../user-actions/container';
+
+import { WalletSelectModal } from '../wallet-select/modal';
+import { WalletType } from '../wallet-select/wallets';
 
 interface PublicProperties {
   className?: string;

--- a/src/components/wallet-select/error-network/index.test.tsx
+++ b/src/components/wallet-select/error-network/index.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ErrorNetwork } from '../error-network';
+
+describe('ErrorNetwork', () => {
+  const subject = (props: any = {}) => {
+    const allProps = {
+      supportedNetwork: '',
+      ...props,
+    };
+    return shallow(<ErrorNetwork {...allProps} />);
+  };
+
+  it('it displays error network', () => {
+    const supportedNetwork = 'Rinkeby';
+
+    const wrapper = subject({ supportedNetwork });
+
+    expect(wrapper.find('.error-network__chainId').text().trim()).toBe(
+      'Please switch to supported Network Rinkeby in your wallet before connecting'
+    );
+  });
+
+  it('it adds supportedChainId as title', () => {
+    const supportedNetwork = 'Kovan';
+
+    const wrapper = subject({ supportedNetwork });
+
+    expect(wrapper.find('.error-network__chainId').prop('title')).toBe(supportedNetwork);
+  });
+});

--- a/src/components/wallet-select/error-network/index.tsx
+++ b/src/components/wallet-select/error-network/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import './styles.scss';
+
+export interface Properties {
+  supportedNetwork: string;
+}
+
+export class ErrorNetwork extends React.Component<Properties> {
+  render() {
+    const supportedNetwork = this.props.supportedNetwork;
+
+    return (
+      <div className='error-network'>
+        <span title={supportedNetwork} className='error-network__chainId'>
+          Please switch to supported Network {supportedNetwork} in your wallet before connecting
+        </span>
+      </div>
+    );
+  }
+}

--- a/src/components/wallet-select/error-network/styles.scss
+++ b/src/components/wallet-select/error-network/styles.scss
@@ -1,0 +1,10 @@
+.error-network {
+  padding: 10px 10px;
+  text-align: center;
+}
+
+.error-network span {
+  font-size: 16px;
+  font-weight: normal;
+  color: rgb(196 14 14);
+}

--- a/src/components/wallet-select/index.test.tsx
+++ b/src/components/wallet-select/index.test.tsx
@@ -22,19 +22,19 @@ describe('WalletSelect', () => {
   it('does not render wallets when connecting', () => {
     const wrapper = subject({ isConnecting: true, wallets: [WalletType.Metamask] });
 
-    expect(wrapper.find('.wallet-select__wallet').exists()).toBe(false);
+    expect(wrapper.find('.zos-wallet-select__wallet').exists()).toBe(false);
   });
 
   it('does renders connecting indicator when connecting', () => {
     const wrapper = subject({ isConnecting: true, wallets: [WalletType.Metamask] });
 
-    expect(wrapper.find('.wallet-select__connecting-indicator').exists()).toBe(true);
+    expect(wrapper.find('.zos-wallet-select__connecting-indicator').exists()).toBe(true);
   });
 
   it('renders a single wallet', () => {
     const wrapper = subject({ wallets: [WalletType.Metamask] });
 
-    const renderedName = wrapper.find('.wallet-select__wallet-name').at(0);
+    const renderedName = wrapper.find('.zos-wallet-select__wallet-name').at(0);
 
     expect(renderedName.text().trim()).toBe('Metamask');
   });
@@ -42,7 +42,7 @@ describe('WalletSelect', () => {
   it('defaults to all wallets', () => {
     const wrapper = subject();
 
-    const renderedNames = wrapper.find('.wallet-select__wallet-name').map((element) => element.text().trim());
+    const renderedNames = wrapper.find('.zos-wallet-select__wallet-name').map((element) => element.text().trim());
 
     expect(renderedNames).toIncludeSameMembers([
       'Wallet Connect',
@@ -59,7 +59,7 @@ describe('WalletSelect', () => {
 
     const wrapper = subject({ wallets, onSelect });
 
-    wrapper.find('.wallet-select__wallet-provider').at(0).simulate('click');
+    wrapper.find('.zos-wallet-select__wallet-provider').at(0).simulate('click');
 
     expect(onSelect).toHaveBeenCalledWith(WalletType.Metamask);
   });

--- a/src/components/wallet-select/index.test.tsx
+++ b/src/components/wallet-select/index.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { WalletSelect } from '.';
+import { WalletType } from './wallets';
+
+describe('WalletSelect', () => {
+  const subject = (props: any = {}) => {
+    const allProps = {
+      ...props,
+    };
+
+    return shallow(<WalletSelect {...allProps} />);
+  };
+
+  it('adds className', () => {
+    const wrapper = subject({ className: 'taco-launcher' });
+
+    expect(wrapper.hasClass('taco-launcher')).toBe(true);
+  });
+
+  it('does not render wallets when connecting', () => {
+    const wrapper = subject({ isConnecting: true, wallets: [WalletType.Metamask] });
+
+    expect(wrapper.find('.wallet-select__wallet').exists()).toBe(false);
+  });
+
+  it('does renders connecting indicator when connecting', () => {
+    const wrapper = subject({ isConnecting: true, wallets: [WalletType.Metamask] });
+
+    expect(wrapper.find('.wallet-select__connecting-indicator').exists()).toBe(true);
+  });
+
+  it('renders a single wallet', () => {
+    const wrapper = subject({ wallets: [WalletType.Metamask] });
+
+    const renderedName = wrapper.find('.wallet-select__wallet-name').at(0);
+
+    expect(renderedName.text().trim()).toBe('Metamask');
+  });
+
+  it('defaults to all wallets', () => {
+    const wrapper = subject();
+
+    const renderedNames = wrapper.find('.wallet-select__wallet-name').map((element) => element.text().trim());
+
+    expect(renderedNames).toIncludeSameMembers([
+      'Wallet Connect',
+      'Metamask',
+      'Coinbase Wallet',
+      'Fortmatic',
+      'Portis',
+    ]);
+  });
+
+  it('fires onSelect when wallet clicked', () => {
+    const onSelect = jest.fn();
+    const wallets = [WalletType.Metamask];
+
+    const wrapper = subject({ wallets, onSelect });
+
+    wrapper.find('.wallet-select__wallet-provider').at(0).simulate('click');
+
+    expect(onSelect).toHaveBeenCalledWith(WalletType.Metamask);
+  });
+});

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -4,6 +4,12 @@ import classNames from 'classnames';
 import { wallets, WalletType } from './wallets';
 import { Button } from '@zero-tech/zui/components';
 
+import './styles.scss';
+import { bem } from '../../lib/bem';
+import { IconLinkExternal1 } from '@zero-tech/zui/icons';
+// Temporarily use different base class name to avoid conflicts with zos-component-library
+const c = bem('zos-wallet-select');
+
 export interface Properties {
   isConnecting: boolean;
   className?: string;
@@ -30,8 +36,8 @@ export class WalletSelect extends React.Component<Properties> {
   renderContent() {
     if (this.props.isConnecting) {
       return (
-        <div className='wallet-select__connecting-indicator'>
-          <Button>Connecting...</Button>
+        <div className={c('connecting-indicator')}>
+          <Button isDisabled={true}>Connecting...</Button>
         </div>
       );
     }
@@ -44,10 +50,10 @@ export class WalletSelect extends React.Component<Properties> {
       const { type, name, imageSource } = wallets[walletType];
 
       return (
-        <li key={type} className='wallet-select__wallet-provider' onClick={this.getClickHandler(type)}>
-          <span className='wallet-select__wallet-name'>{name}</span>
+        <li key={type} className={c('wallet-provider')} onClick={this.getClickHandler(type)}>
+          <span className={c('wallet-name')}>{name}</span>
           <div>
-            <div className='wallet-select__wallet-provider-logo'>
+            <div className={c('wallet-provider-logo')}>
               <img src={imageSource} alt={name} />
             </div>
           </div>
@@ -58,19 +64,18 @@ export class WalletSelect extends React.Component<Properties> {
 
   render() {
     return (
-      <div className={classNames('wallet-select', 'border-primary', this.props.className)}>
-        <div className='wallet-select__header'>
-          <h3 className='glow-text'>Connect To A Wallet</h3>
+      <div className={classNames(c(''), this.props.className)}>
+        <div className={c('title-bar')}>
+          <h3 className={c('title')}>Connect To A Wallet</h3>
         </div>
-        <hr className='glow' />
         {this.renderContent()}
-        <hr className='glow' />
-        <div className='wallet-select__footer'>
+        <div className={c('footer')}>
           New to Ethereum?
-          <br />
-          <a href='https://ethereum.org/en/wallets/' target='_blank' rel='noreferrer'>
-            Learn more about wallets
-          </a>
+          <div className={c('footer-link')}>
+            <a href='https://ethereum.org/en/wallets/' target='_blank' rel='noreferrer'>
+              Learn more about wallets <IconLinkExternal1 className={c('external-icon')} size={12} />
+            </a>
+          </div>
         </div>
       </div>
     );

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { wallets, WalletType } from './wallets';
+import { Button } from '@zero-tech/zui/components';
+
+export interface Properties {
+  isConnecting: boolean;
+  className?: string;
+  wallets?: WalletType[];
+
+  onSelect?: (connector: WalletType) => void;
+}
+
+export class WalletSelect extends React.Component<Properties> {
+  private clickHandlers: any = {};
+
+  getClickHandler = (walletType: WalletType) => {
+    if (!this.clickHandlers[walletType]) {
+      this.clickHandlers[walletType] = () => this.props.onSelect(walletType);
+    }
+
+    return this.clickHandlers[walletType];
+  };
+
+  get wallets() {
+    return this.props.wallets || Object.values(WalletType);
+  }
+
+  renderContent() {
+    if (this.props.isConnecting) {
+      return (
+        <div className='wallet-select__connecting-indicator'>
+          <Button>Connecting...</Button>
+        </div>
+      );
+    }
+
+    return <ul>{this.renderWallets()}</ul>;
+  }
+
+  renderWallets() {
+    return this.wallets.map((walletType) => {
+      const { type, name, imageSource } = wallets[walletType];
+
+      return (
+        <li key={type} className='wallet-select__wallet-provider' onClick={this.getClickHandler(type)}>
+          <span className='wallet-select__wallet-name'>{name}</span>
+          <div>
+            <div className='wallet-select__wallet-provider-logo'>
+              <img src={imageSource} alt={name} />
+            </div>
+          </div>
+        </li>
+      );
+    });
+  }
+
+  render() {
+    return (
+      <div className={classNames('wallet-select', 'border-primary', this.props.className)}>
+        <div className='wallet-select__header'>
+          <h3 className='glow-text'>Connect To A Wallet</h3>
+        </div>
+        <hr className='glow' />
+        {this.renderContent()}
+        <hr className='glow' />
+        <div className='wallet-select__footer'>
+          New to Ethereum?
+          <br />
+          <a href='https://ethereum.org/en/wallets/' target='_blank' rel='noreferrer'>
+            Learn more about wallets
+          </a>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/wallet-select/modal.test.tsx
+++ b/src/components/wallet-select/modal.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { WalletSelect } from '.';
+import { WalletSelectModal } from './modal';
+import { WalletType } from './wallets';
+
+describe('WalletSelect/Modal', () => {
+  const subject = (props: any = {}) => {
+    const allProps = {
+      isConnecting: false,
+      networkName: '',
+      isNotSupportedNetwork: false,
+      ...props,
+    };
+
+    return shallow(<WalletSelectModal {...allProps} />);
+  };
+
+  it('adds className', () => {
+    const wrapper = subject({ className: 'taco-launcher' });
+
+    expect(wrapper.hasClass('taco-launcher')).toBe(true);
+  });
+
+  it('renders child', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find(WalletSelect).exists()).toBe(true);
+  });
+
+  it('propagates onClose from Modal', () => {
+    const onClose = jest.fn();
+
+    const wrapper = subject({ onClose });
+
+    wrapper.find('Modal').simulate('openChange', false);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('passes wallets to child', () => {
+    const wallets = [WalletType.Portis];
+
+    const wrapper = subject({ wallets });
+
+    expect(wrapper.find(WalletSelect).prop('wallets')).toStrictEqual(wallets);
+  });
+
+  it('passes onSelect to child', () => {
+    const onSelect = () => undefined;
+
+    const wrapper = subject({ onSelect });
+
+    expect(wrapper.find(WalletSelect).prop('onSelect')).toStrictEqual(onSelect);
+  });
+
+  it('passes isConnecting to child', () => {
+    const wrapper = subject({ isConnecting: true });
+
+    expect(wrapper.find(WalletSelect).prop('isConnecting')).toBe(true);
+  });
+
+  it('passes supportedNetwork to errorNetwork', () => {
+    const wrapper = subject({ networkName: 'MainNet', isNotSupportedNetwork: true });
+
+    expect(wrapper.find('ErrorNetwork').prop('supportedNetwork')).toBe('MainNet');
+  });
+});

--- a/src/components/wallet-select/modal.tsx
+++ b/src/components/wallet-select/modal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { WalletSelect, Properties as WalletSelectProperties } from '.';
+import { WalletType } from './wallets';
+import { ErrorNetwork } from './error-network';
+import { Modal } from '@zero-tech/zui/components';
+
+export interface Properties extends WalletSelectProperties {
+  isConnecting: boolean;
+  isNotSupportedNetwork: boolean;
+  wallets: WalletType[];
+  className?: string;
+  networkName: string;
+  onClose?: () => void;
+  onSelect?: (connector: WalletType) => void;
+}
+
+export class WalletSelectModal extends React.Component<Properties> {
+  openChanged = (isOpen: boolean) => {
+    if (!isOpen) {
+      this.props.onClose && this.props.onClose();
+    }
+  };
+
+  get supportedNetwork() {
+    return this.props.isNotSupportedNetwork;
+  }
+
+  render() {
+    return (
+      <Modal
+        open={true}
+        className={classNames('wallet-select-modal', this.props.className)}
+        onOpenChange={this.openChanged}
+      >
+        <WalletSelect
+          wallets={this.props.wallets}
+          isConnecting={this.props.isConnecting}
+          onSelect={this.props.onSelect}
+        />
+        {this.supportedNetwork && <ErrorNetwork supportedNetwork={this.props.networkName} />}
+      </Modal>
+    );
+  }
+}

--- a/src/components/wallet-select/modal.tsx
+++ b/src/components/wallet-select/modal.tsx
@@ -31,7 +31,7 @@ export class WalletSelectModal extends React.Component<Properties> {
     return (
       <Modal
         open={true}
-        className={classNames('wallet-select-modal', this.props.className)}
+        className={classNames('zos-wallet-select-modal', this.props.className)}
         onOpenChange={this.openChanged}
       >
         <WalletSelect

--- a/src/components/wallet-select/styles.scss
+++ b/src/components/wallet-select/styles.scss
@@ -1,0 +1,93 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+$left-padding: 12px;
+
+.zos-wallet-select {
+  color: theme.$color-greyscale-12;
+
+  &__title-bar {
+    border-bottom: 1px solid theme.$color-primary-4;
+    padding-bottom: 16px;
+    padding-left: $left-padding;
+  }
+
+  &__title {
+    margin: 0px;
+    padding: 0px;
+
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  ul {
+    margin: 0px;
+    padding: 0px;
+  }
+
+  &__wallet-provider {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 7px $left-padding;
+    height: 56px;
+    cursor: pointer;
+    border-radius: 8px;
+
+    &:hover {
+      background-color: theme.$color-primary-4;
+    }
+  }
+
+  &__wallet-provider-logo {
+    box-sizing: border-box;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 28px;
+    width: 28px;
+    background-color: theme.$color-primary-1;
+    padding: 2px;
+  }
+
+  &__wallet-provider-logo img {
+    width: 24px;
+    height: 24px;
+    transition: opacity var(--animation-time-medium) ease-in-out;
+    vertical-align: middle;
+  }
+
+  &__footer {
+    border-top: 1px solid theme.$color-primary-4;
+    padding-top: 16px;
+    padding-left: $left-padding;
+
+    color: theme.$color-greyscale-11;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 17px;
+
+    a {
+      color: theme.$color-greyscale-12;
+      border-bottom: 1px solid theme.$color-greyscale-12;
+    }
+  }
+
+  &__footer-link {
+    margin-top: 12px;
+  }
+  &__external-icon {
+    height: 6px;
+    width: 6px;
+    display: inline-block;
+    color: theme.$color-greyscale-12;
+    text-decoration: underline;
+  }
+
+  &__connecting-indicator {
+    display: flex;
+    justify-content: center;
+    padding: 18px;
+  }
+}

--- a/src/components/wallet-select/styles.scss
+++ b/src/components/wallet-select/styles.scss
@@ -2,6 +2,10 @@
 
 $left-padding: 12px;
 
+.zos-wallet-select-modal {
+  outline: none;
+}
+
 .zos-wallet-select {
   color: theme.$color-greyscale-12;
 

--- a/src/components/wallet-select/wallets.ts
+++ b/src/components/wallet-select/wallets.ts
@@ -1,0 +1,51 @@
+export enum WalletType {
+  Metamask = 'metamask',
+  WalletConnect = 'wallet-connect',
+  Coinbase = 'coinbase',
+  Fortmatic = 'fortmatic',
+  Portis = 'portis',
+}
+
+export interface Wallet {
+  type: WalletType;
+  name: string;
+  imageSource: string;
+}
+
+const wallets: { [walletType: string]: Wallet } = {
+  [WalletType.Metamask]: {
+    type: WalletType.Metamask,
+    name: 'Metamask',
+    imageSource: 'metamask.svg',
+  },
+  [WalletType.WalletConnect]: {
+    type: WalletType.WalletConnect,
+    name: 'Wallet Connect',
+    imageSource: 'walletconnect.svg',
+  },
+  [WalletType.Coinbase]: {
+    type: WalletType.Coinbase,
+    name: 'Coinbase Wallet',
+    imageSource: 'coinbasewallet.svg',
+  },
+  [WalletType.Fortmatic]: {
+    type: WalletType.Fortmatic,
+    name: 'Fortmatic',
+    imageSource: 'fortmatic.svg',
+  },
+  [WalletType.Portis]: {
+    type: WalletType.Portis,
+    name: 'Portis',
+    imageSource: 'portis.svg',
+  },
+};
+
+for (const wallet in wallets) {
+  // XXX: factory-dev?!!!... move to production
+  wallets[wallet].imageSource = [
+    'https://res.cloudinary.com/fact0ry-dev/image/upload/v1637005920/zero-assets/wallet-providers',
+    wallets[wallet].imageSource,
+  ].join('/');
+}
+
+export { wallets };

--- a/src/components/wallet-select/wallets.ts
+++ b/src/components/wallet-select/wallets.ts
@@ -41,7 +41,6 @@ const wallets: { [walletType: string]: Wallet } = {
 };
 
 for (const wallet in wallets) {
-  // XXX: factory-dev?!!!... move to production
   wallets[wallet].imageSource = [
     'https://res.cloudinary.com/fact0ry-dev/image/upload/v1637005920/zero-assets/wallet-providers',
     wallets[wallet].imageSource,


### PR DESCRIPTION
### What does this do?

Copies the wallet-select component in from the zos-component-library and styles it to match current designs

### Why are we making this change?

Since we're moving towards zUI we're deprecating the zos-component-library. In this case I figured we'd really only be using this component in zOS core so I pulled it into zOS rather than zUI.


https://github.com/zer0-os/zOS/assets/43770/f325f6a2-d940-4c80-b60b-9b5fcaf8f03c


