### PR TITLE
Zos 301: Add tooltip popup to display rewards

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -191,6 +191,13 @@ $side-padding: 16px;
     justify-content: center;
     align-items: center;
     color: theme.$color-primary-12;
+
+    &__status {
+      position: absolute;
+      top: 16px;
+      right: 13px;
+      border: 2px solid theme.$color-primary-1;
+    }
   }
 }
 

--- a/src/components/rewards-popup/container.test.tsx
+++ b/src/components/rewards-popup/container.test.tsx
@@ -1,11 +1,5 @@
-import React from 'react';
-
-import { shallow } from 'enzyme';
-
 import { RootState } from '../../store/reducer';
-import { RewardsState } from '../../store/rewards';
-
-import { Container, Properties } from './container';
+import { Container } from './container';
 
 jest.mock('react-dom', () => ({
   createPortal: (node, _portalLocation) => {
@@ -14,67 +8,13 @@ jest.mock('react-dom', () => ({
 }));
 
 describe('Container', () => {
-  const subject = (props: Partial<Properties>) => {
-    const allProps: Properties = {
-      isLoading: false,
-      zero: '0',
-      isFullScreen: false,
-      withTitleBar: false,
-      fetchRewards: () => null,
-      onClose: () => null,
-      openRewardsFAQModal: () => null,
-      ...props,
-    };
-
-    return shallow(<Container {...allProps} />);
-  };
-
-  it('parses token number to renderable string', function () {
-    const wrapper = subject({ zero: '9123456789111315168' });
-    // Note: Temporarily rendering ZERO in the USD field
-    expect(wrapper.find('RewardsPopup').prop('usd')).toEqual('9.1234');
-
-    wrapper.setProps({ zero: '9123000000000000000' });
-    expect(wrapper.find('RewardsPopup').prop('usd')).toEqual('9.123');
-
-    wrapper.setProps({ zero: '23456789111315168' });
-    expect(wrapper.find('RewardsPopup').prop('usd')).toEqual('0.0234');
-
-    wrapper.setProps({ zero: '0' });
-    expect(wrapper.find('RewardsPopup').prop('usd')).toEqual('0');
-  });
-
   describe('mapState', () => {
-    const subject = (rewardsState: Partial<RewardsState> = {}) => {
-      const state = {
-        ...baseState(),
-        rewards: {
-          loading: false,
-          ...rewardsState,
-        },
-      } as RootState;
-      return Container.mapState(state);
-    };
-
     function baseState() {
       return {
         ...authState(),
-        rewards: { loading: false },
         ...layoutState(),
       } as RootState;
     }
-
-    test('isLoading', () => {
-      const props = subject({ loading: true });
-
-      expect(props.isLoading).toEqual(true);
-    });
-
-    test('zero', () => {
-      const props = subject({ zero: '17' });
-
-      expect(props.zero).toEqual('17');
-    });
 
     test('withTitleBar', async () => {
       let state = Container.mapState({ ...baseState(), ...authState({ isAMemberOfWorlds: false }) } as RootState);

--- a/src/components/rewards-popup/container.tsx
+++ b/src/components/rewards-popup/container.tsx
@@ -4,16 +4,17 @@ import { createPortal } from 'react-dom';
 import { connectContainer } from '../../store/redux-container';
 import { RewardsPopup } from '.';
 import { RootState } from '../../store/reducer';
-import { fetch as fetchRewards } from '../../store/rewards';
 
 interface PublicProperties {
   onClose: () => void;
   openRewardsFAQModal: () => void;
+
+  zero: string;
+  isLoading: boolean;
 }
 
 export interface Properties extends PublicProperties {
   isLoading: boolean;
-  zero: string;
   isFullScreen: boolean;
   withTitleBar: boolean;
 
@@ -25,32 +26,15 @@ export class Container extends React.Component<Properties> {
     const {
       authentication: { user },
       layout,
-      rewards,
     } = state;
 
     return {
-      isLoading: rewards.loading,
-      zero: rewards.zero,
       withTitleBar: !!user?.data?.isAMemberOfWorlds,
       isFullScreen: layout.value.isMessengerFullScreen,
     };
   }
   static mapActions() {
-    return {
-      fetchRewards,
-    };
-  }
-
-  componentDidMount() {
-    this.props.fetchRewards();
-  }
-
-  stringifyZero() {
-    const stringValue = this.props.zero.padStart(19, '0');
-    const whole = stringValue.slice(0, -18);
-    const decimal = stringValue.slice(-18).slice(0, 4).replace(/0+$/, '');
-    const decimalString = decimal.length > 0 ? `.${decimal}` : '';
-    return `${whole}${decimalString}`;
+    return {};
   }
 
   render() {
@@ -58,7 +42,7 @@ export class Container extends React.Component<Properties> {
       <>
         {createPortal(
           <RewardsPopup
-            usd={this.stringifyZero()}
+            usd={this.props.zero} // Note: Temporarily rendering ZERO in the USD field
             zero=''
             onClose={this.props.onClose}
             openRewardsFAQModal={this.props.openRewardsFAQModal}

--- a/src/components/tooltip-popup/styles.scss
+++ b/src/components/tooltip-popup/styles.scss
@@ -1,0 +1,48 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@use '~@zero-tech/zui/styles/colors' as colors;
+
+.tooltip-popup {
+  display: block;
+
+  &__trigger {
+    position: relative;
+    margin: unset;
+  }
+
+  &__content {
+    display: flex;
+    padding: 14px;
+    max-width: 32rem;
+    height: 24px;
+    background-color: theme.$color-primary-3;
+    border-radius: 8px;
+    font-weight: 600;
+    line-height: 24px;
+
+    /* Dark/Greyscale/Grey-12 */
+    color: theme.$color-greyscale-12;
+
+    &[data-side='right'][data-align='end'] {
+      border-bottom-left-radius: unset;
+    }
+    &[data-side='right'][data-align='start'] {
+      border-top-left-radius: unset;
+    }
+    &[data-side='left'][data-align='end'] {
+      border-bottom-right-radius: unset;
+    }
+    &[data-side='left'][data-align='start'] {
+      border-top-right-radius: unset;
+    }
+  }
+
+  &__arrow {
+    fill: theme.$color-primary-3;
+    margin-top: -1px;
+    margin-bottom: 3px;
+  }
+
+  &__close {
+    margin-left: 8px;
+  }
+}

--- a/src/components/tooltip-popup/tooltip-popup.tsx
+++ b/src/components/tooltip-popup/tooltip-popup.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import './styles.scss';
+import { bem } from '../../lib/bem';
+import type { ReactNode } from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { IconButton } from '../icon-button';
+import { IconXClose } from '@zero-tech/zui/icons';
+
+const c = bem('tooltip-popup');
+
+export interface Properties {
+  open?: TooltipPrimitive.TooltipProps['open'];
+  onOpenChange?: TooltipPrimitive.TooltipProps['onOpenChange'];
+  side?: TooltipPrimitive.TooltipContentProps['side'];
+  align?: TooltipPrimitive.TooltipContentProps['align'];
+  content?: ReactNode;
+  onClose: () => void;
+}
+
+export class TooltipPopup extends React.Component<Properties> {
+  render() {
+    return (
+      <div className={c('')}>
+        <TooltipPrimitive.Provider>
+          <TooltipPrimitive.Root open={this.props.open} onOpenChange={this.props.onOpenChange} delayDuration={200}>
+            <TooltipPrimitive.Trigger asChild className={c('trigger')}>
+              <span tabIndex={0}>{this.props.children}</span>
+            </TooltipPrimitive.Trigger>
+            <TooltipPrimitive.Content side={this.props.side} align={this.props.align} className={c('content')}>
+              {this.props.content}
+              <TooltipPrimitive.Arrow className={c('arrow')} width={32} height={16} />
+              <IconButton className={c('close')} Icon={IconXClose} onClick={this.props.onClose} />
+            </TooltipPrimitive.Content>
+          </TooltipPrimitive.Root>
+        </TooltipPrimitive.Provider>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
+ Moved saga logic (`fetchRewards`) from rewards popup component to the messenger-list level (since we need to show rewards in the tooltip)
+ added a tooltip-popup component in zOS (TODO: move to zUI)
+ added unit tests

<img width="749" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/98b95f89-0a29-4c95-a882-732e382d8f31">

<img width="413" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/98fc324b-1905-4ba2-a17c-0a51bdbc8680">
