### PR TITLE
fix: messenger-panel header back arrow (conversation flow)

### DIFF
--- a/src/components/messenger/list/panel-header.tsx
+++ b/src/components/messenger/list/panel-header.tsx
@@ -12,7 +12,7 @@ export class PanelHeader extends React.Component<Properties> {
     return (
       <div className='messenger-panel__header'>
         <span className='messenger-panel__back' onClick={this.props.onBack}>
-          <IconArrowNarrowLeft size={24} />
+          <IconArrowNarrowLeft size={24} isFilled />
         </span>
         {this.props.title}
       </div>

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -217,6 +217,11 @@ $side-padding: 16px;
     height: 32px;
     width: 32px;
     cursor: pointer;
+    border-radius: 50%;
+
+    &:hover {
+      background-color: theme.$color-greyscale-transparency-3;
+    }
   }
 }
 

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -207,11 +207,15 @@ $side-padding: 16px;
     line-height: 24px;
     color: theme.$color-greyscale-12;
 
-    padding: 20px 10px;
+    padding: 16px;
   }
 
   &__back {
-    margin-right: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    width: 32px;
     cursor: pointer;
   }
 }


### PR DESCRIPTION
[Design feedback Jira task](https://wilderworld.atlassian.net/jira/software/c/projects/ZOS/boards/33?modal=detail&selectedIssue=ZOS-316)

[Jira Subtask](https://wilderworld.atlassian.net/jira/software/c/projects/ZOS/boards/33?modal=detail&selectedIssue=ZOS-354)

**What I’ve changed**:

- The messenger panel title with back arrow (.messenger-panel__header) needs the padding adjusted slightly to match the designs. Should be 16px vertical and horizontal. 

- Set svg container size so margin-right can be removed for gap between arrow and text. No margin required with correct container size and svg alignment.

- add isFilled prop to Icon to be aligned with design

- add background colour on hover of back button

<img width="362" alt="Screenshot 2023-05-24 at 12 21 03" src="https://github.com/zer0-os/zOS/assets/39112648/f655defd-5f1e-427c-9852-f787841c0f92">

*On Hover*
<img width="362" alt="Screenshot 2023-05-24 at 12 35 10" src="https://github.com/zer0-os/zOS/assets/39112648/3f1802c4-1453-442d-9b9c-17c1dc80403f">
