### PR TITLE
Add account creation method selection page

### DIFF
--- a/src/authentication/select-method/container.tsx
+++ b/src/authentication/select-method/container.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
+import { SelectMethod } from '.';
+import { registerWithEmail, registerWithWallet } from '../../store/registration';
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  registerWithEmail: () => void;
+  registerWithWallet: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(_state: RootState) {
+    return {};
+  }
+
+  static mapActions() {
+    return { registerWithEmail, registerWithWallet };
+  }
+
+  render() {
+    return (
+      <SelectMethod onEmailSelected={this.props.registerWithEmail} onWalletSelected={this.props.registerWithWallet} />
+    );
+  }
+}
+
+export const SelectMethodContainer = connectContainer<PublicProperties>(Container);

--- a/src/authentication/select-method/index.test.tsx
+++ b/src/authentication/select-method/index.test.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+
+import { SelectMethod, Properties } from '.';
+
+describe('SelectMethod', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      onEmailSelected: () => null,
+      onWalletSelected: () => null,
+      ...props,
+    };
+
+    return shallow(<SelectMethod {...allProps} />);
+  };
+
+  it('fires email selected', function () {
+    const onEmailSelected = jest.fn();
+    const wrapper = subject({ onEmailSelected });
+
+    wrapper.find({ children: 'Create account with email' }).simulate('press');
+
+    expect(onEmailSelected).toHaveBeenCalledOnce();
+  });
+
+  it('fires wallet selected', function () {
+    const onWalletSelected = jest.fn();
+    const wrapper = subject({ onWalletSelected });
+
+    wrapper.find({ children: 'Create account with wallet' }).simulate('press');
+
+    expect(onWalletSelected).toHaveBeenCalledOnce();
+  });
+});

--- a/src/authentication/select-method/index.tsx
+++ b/src/authentication/select-method/index.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Button } from '@zero-tech/zui/components';
+
+import './styles.scss';
+import { bem } from '../../lib/bem';
+const c = bem('select-method');
+const cn = (m?, s?) => ({ className: c(m, s) });
+
+export interface Properties {
+  onEmailSelected: () => void;
+  onWalletSelected: () => void;
+}
+
+export class SelectMethod extends React.PureComponent<Properties> {
+  render() {
+    return (
+      <div {...cn()}>
+        <h3 {...cn('heading')}>How do you want to create an account?</h3>
+        <form {...cn('form')}>
+          <Button onPress={this.props.onEmailSelected}>Create account with email</Button>
+          <Button onPress={this.props.onWalletSelected}>Create account with wallet</Button>
+          <div {...cn('other-options')}>
+            <span>Already on ZERO? </span>
+            <Link to='/login'>Log in</Link>
+          </div>
+        </form>
+      </div>
+    );
+  }
+}

--- a/src/authentication/select-method/styles.scss
+++ b/src/authentication/select-method/styles.scss
@@ -1,0 +1,22 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../styles';
+
+.select-method {
+  @include base();
+
+  &__heading {
+    @include heading();
+  }
+
+  &__form {
+    @include form();
+
+    padding-top: 32px;
+    gap: 32px;
+  }
+
+  &__other-options {
+    text-align: center;
+    padding-top: 64px;
+  }
+}

--- a/src/invite.tsx
+++ b/src/invite.tsx
@@ -8,8 +8,10 @@ import './invite.scss';
 import { ThemeEngine, Themes } from '@zero-tech/zui/components/ThemeEngine';
 import { RegistrationStage } from './store/registration';
 import { InviteContainer } from './authentication/validate-invite/container';
+import { SelectMethodContainer } from './authentication/select-method/container';
 import { CreateEmailAccountContainer } from './authentication/create-email-account/container';
 import { CreateAccountDetailsContainer } from './authentication/create-account-details/container';
+import { CreateWalletAccount } from './authentication/create-wallet-account';
 
 export interface Properties {
   stage: RegistrationStage;
@@ -34,7 +36,9 @@ export class Container extends React.Component<Properties> {
         <div className='invite-main'>
           <ZeroLogo />
           {this.props.stage === RegistrationStage.ValidateInvite && <InviteContainer />}
-          {this.props.stage === RegistrationStage.AccountCreation && <CreateEmailAccountContainer />}
+          {this.props.stage === RegistrationStage.SelectMethod && <SelectMethodContainer />}
+          {this.props.stage === RegistrationStage.EmailAccountCreation && <CreateEmailAccountContainer />}
+          {this.props.stage === RegistrationStage.WalletAccountCreation && <CreateWalletAccount />}
           {this.props.stage === RegistrationStage.ProfileDetails && <CreateAccountDetailsContainer />}
           {this.props.stage === RegistrationStage.Done && <Redirect to='/' />}
         </div>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -24,6 +24,14 @@ export class FeatureFlags {
   set allowPublicZOS(value: boolean) {
     this._setBoolean('allowPublicZOS', value);
   }
+
+  get allowWeb3Registration() {
+    return this._getBoolean('allowWeb3Registration');
+  }
+
+  set allowWeb3Registration(value: boolean) {
+    this._setBoolean('allowWeb3Registration', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -8,7 +8,9 @@ export enum SagaActionTypes {
 
 export enum RegistrationStage {
   ValidateInvite = 'invite',
-  AccountCreation = 'creation',
+  SelectMethod = 'select-method',
+  EmailAccountCreation = 'email-creation',
+  WalletAccountCreation = 'wallet-creation',
   ProfileDetails = 'details',
   Done = 'done',
 }
@@ -91,9 +93,24 @@ const slice = createSlice({
     setFirstTimeLogin: (state, action: PayloadAction<RegistrationState['isFirstTimeLogin']>) => {
       state.isFirstTimeLogin = action.payload;
     },
+    registerWithEmail: (state, _action: PayloadAction<null>) => {
+      state.stage = RegistrationStage.EmailAccountCreation;
+    },
+    registerWithWallet: (state, _action: PayloadAction<null>) => {
+      state.stage = RegistrationStage.WalletAccountCreation;
+    },
   },
 });
 
-export const { setInviteStatus, setLoading, setStage, setErrors, setUserId, setInviteCode, setFirstTimeLogin } =
-  slice.actions;
+export const {
+  setInviteStatus,
+  setLoading,
+  setStage,
+  setErrors,
+  setUserId,
+  setInviteCode,
+  setFirstTimeLogin,
+  registerWithEmail,
+  registerWithWallet,
+} = slice.actions;
 export const { reducer } = slice;

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -25,6 +25,7 @@ import { passwordStrength } from '../../lib/password';
 import { conversationsChannel } from '../channels-list/channels';
 import { rawConversationsList } from '../channels-list/saga';
 import { setActiveMessengerId } from '../chat';
+import { featureFlags } from '../../lib/feature-flags';
 
 export function* validateInvite(action) {
   const { code } = action.payload;
@@ -34,7 +35,11 @@ export function* validateInvite(action) {
     yield put(setInviteStatus(inviteCodeStatus));
 
     if (inviteCodeStatus === InviteCodeStatus.VALID) {
-      yield put(setStage(RegistrationStage.AccountCreation));
+      if (!featureFlags.allowWeb3Registration) {
+        yield put(setStage(RegistrationStage.EmailAccountCreation));
+      } else {
+        yield put(setStage(RegistrationStage.SelectMethod));
+      }
       yield put(setInviteCode(code));
       return true;
     }


### PR DESCRIPTION
### What does this do?

Registration Flow: Adds the page to select which type of account a user wants to create.

Note: Behind a feature flag for now until the wallet page is completed.

