### PR TITLE
Refactor: Move invite toast management to user registration saga

### DIFF
--- a/src/component-mocks.ts
+++ b/src/component-mocks.ts
@@ -53,8 +53,10 @@ jest.mock('@zero-tech/zui/components', () => ({
   Tabs: () => null,
   TabsNav: () => null,
   TextStack: () => null,
+  ToastNotification: () => null,
   ToggleGroup: () => null,
   BASE_CLASSNAME: () => null,
   Tooltip: () => null,
+  Video: () => null,
 }));
 export {};

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -39,6 +39,7 @@ describe('messenger-list', () => {
       zero: '',
       zeroPreviousDay: '',
       isRewardsLoading: false,
+      isInviteNotificationOpen: false,
       openConversation: jest.fn(),
       fetchConversations: jest.fn(),
       createConversation: jest.fn(),
@@ -49,6 +50,7 @@ describe('messenger-list', () => {
       onClose: () => null,
       enterFullScreenMessenger: () => null,
       fetchRewards: () => null,
+      rewardsPopupClosed: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -32,6 +32,7 @@ import { Modal, ToastNotification } from '@zero-tech/zui/components';
 import { InviteDialogContainer } from '../../invite-dialog/container';
 import { fetch as fetchRewards } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
+import { rewardsPopupClosed } from '../../../store/registration';
 
 export interface PublicProperties {
   onClose: () => void;
@@ -53,6 +54,7 @@ export interface Properties extends PublicProperties {
   zeroPreviousDay: string;
   isMessengerFullScreen: boolean;
   isRewardsLoading: boolean;
+  isInviteNotificationOpen: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -63,11 +65,10 @@ export interface Properties extends PublicProperties {
   createConversation: (payload: CreateMessengerConversation) => void;
   enterFullScreenMessenger: () => void;
   fetchRewards: (_obj: any) => void;
+  rewardsPopupClosed: () => void;
 }
 
 interface State {
-  isToastNotificationOpen: boolean;
-  isInviteNotificationComplete: boolean;
   isInviteDialogOpen: boolean;
 }
 
@@ -98,6 +99,7 @@ export class Container extends React.Component<Properties, State> {
       isGroupCreating: createConversation.groupDetails.isCreating,
       isFetchingExistingConversations: createConversation.startGroupChat.isLoading,
       isFirstTimeLogin: registration.isFirstTimeLogin,
+      isInviteNotificationOpen: registration.isInviteToastOpen,
       includeTitleBar: user?.data?.isAMemberOfWorlds,
       allowClose: !layout?.value?.isMessengerFullScreen,
       allowExpand: !layout?.value?.isMessengerFullScreen,
@@ -121,12 +123,11 @@ export class Container extends React.Component<Properties, State> {
       membersSelected,
       fetchRewards,
       enterFullScreenMessenger: () => enterFullScreenMessenger(),
+      rewardsPopupClosed,
     };
   }
 
   state = {
-    isToastNotificationOpen: false,
-    isInviteNotificationComplete: false,
     isInviteDialogOpen: false,
   };
 
@@ -158,22 +159,11 @@ export class Container extends React.Component<Properties, State> {
     this.props.createConversation(conversation);
   };
 
-  onRewardsPopupClose = () => {
-    if (this.props.isFirstTimeLogin && !this.state.isInviteNotificationComplete) {
-      setTimeout(() => {
-        this.setState({ isToastNotificationOpen: true });
-      }, 10000);
-    }
-  };
-
   openInviteDialog = () => {
-    this.setState({ isInviteDialogOpen: true, isToastNotificationOpen: false, isInviteNotificationComplete: true });
+    this.setState({ isInviteDialogOpen: true });
   };
   closeInviteDialog = () => {
     this.setState({ isInviteDialogOpen: false });
-  };
-  closeToastNotification = () => {
-    this.setState({ isToastNotificationOpen: false, isInviteNotificationComplete: true });
   };
 
   renderInviteDialog = (): JSX.Element => {
@@ -192,9 +182,8 @@ export class Container extends React.Component<Properties, State> {
         actionTitle={'Invite Friends'}
         actionAltText={'invite dialog modal call to action'}
         positionVariant='left'
-        openToast={this.state.isToastNotificationOpen}
+        openToast={this.props.isInviteNotificationOpen}
         onClick={this.openInviteDialog}
-        onClose={this.closeToastNotification}
       />
     );
   };
@@ -229,7 +218,7 @@ export class Container extends React.Component<Properties, State> {
           isFirstTimeLogin={this.props.isFirstTimeLogin}
           includeRewardsAvatar={this.props.includeRewardsAvatar}
           userAvatarUrl={this.props.userAvatarUrl}
-          onRewardsPopupClose={this.onRewardsPopupClose}
+          onRewardsPopupClose={this.props.rewardsPopupClosed}
         />
 
         <div className='direct-message-members'>
@@ -266,7 +255,7 @@ export class Container extends React.Component<Properties, State> {
             />
           )}
           {this.state.isInviteDialogOpen && this.renderInviteDialog()}
-          {this.state.isToastNotificationOpen && this.renderToastNotification()}
+          {this.renderToastNotification()}
         </div>
       </>
     );

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -5,6 +5,7 @@ export enum SagaActionTypes {
   CreateAccount = 'registration/createAccount',
   CreateWeb3Account = 'registration/createWeb3Account',
   UpdateProfile = 'registration/updateProfile',
+  RewardsPopupClosed = 'registration/rewardsPopupClosed',
 }
 
 export enum RegistrationStage {
@@ -34,6 +35,7 @@ export type RegistrationState = {
   userId: string;
   inviteCode: string;
   isFirstTimeLogin: boolean;
+  isInviteToastOpen: boolean;
 };
 
 export enum AccountCreationErrors {
@@ -64,12 +66,14 @@ export const initialState: RegistrationState = {
   userId: '',
   inviteCode: '',
   isFirstTimeLogin: false,
+  isInviteToastOpen: false,
 };
 
 export const validateInvite = createAction<{ code: string }>(SagaActionTypes.ValidateInvite);
 export const createAccount = createAction<{ email: string; password: string }>(SagaActionTypes.CreateAccount);
 export const createWeb3Account = createAction<{ token: string }>(SagaActionTypes.CreateWeb3Account);
 export const updateProfile = createAction<{ name: string; image: File | null }>(SagaActionTypes.UpdateProfile);
+export const rewardsPopupClosed = createAction(SagaActionTypes.RewardsPopupClosed);
 
 const slice = createSlice({
   name: 'registration',
@@ -102,6 +106,9 @@ const slice = createSlice({
     registerWithWallet: (state, _action: PayloadAction<null>) => {
       state.stage = RegistrationStage.WalletAccountCreation;
     },
+    setInviteToastOpen: (state, action: PayloadAction<RegistrationState['isInviteToastOpen']>) => {
+      state.isInviteToastOpen = action.payload;
+    },
   },
 });
 
@@ -115,5 +122,6 @@ export const {
   setFirstTimeLogin,
   registerWithEmail,
   registerWithWallet,
+  setInviteToastOpen,
 } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -1,7 +1,15 @@
 import { expectSaga } from 'redux-saga-test-plan';
+import delayP from '@redux-saga/delay-p';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { channelsLoaded, createAccount, updateProfile, validateAccountInfo, validateInvite } from './saga';
+import {
+  channelsLoaded,
+  createAccount,
+  openInviteToastWhenRewardsPopupClosed,
+  updateProfile,
+  validateAccountInfo,
+  validateInvite,
+} from './saga';
 import {
   validateInvite as apiValidateInvite,
   createAccount as apiCreateAccount,
@@ -15,6 +23,7 @@ import {
   ProfileDetailsErrors,
   RegistrationStage,
   RegistrationState,
+  SagaActionTypes,
   initialState as initialRegistrationState,
 } from '.';
 import { RootState, rootReducer } from '../reducer';
@@ -454,6 +463,28 @@ describe('channelsLoaded', () => {
       } as RootState)
       .put(setActiveMessengerId('1234'))
       .run();
+  });
+});
+
+describe('openInviteToastWhenRewardsPopupClosed', () => {
+  it('sets the invite open flag after the rewards propup is closed', async () => {
+    const {
+      storeState: { registration },
+    } = await expectSaga(openInviteToastWhenRewardsPopupClosed)
+      .provide([
+        [
+          matchers.take(SagaActionTypes.RewardsPopupClosed),
+          { type: SagaActionTypes.RewardsPopupClosed },
+        ],
+        [
+          call(delayP, 10000), // delayP is what delay calls behind the scenes. Not ideal but it works.
+          true,
+        ],
+      ])
+      .withReducer(rootReducer, initialState({ isInviteToastOpen: false }))
+      .run();
+
+    expect(registration.isInviteToastOpen).toEqual(true);
   });
 });
 

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -233,7 +233,7 @@ function* openFirstConversation() {
   }
 }
 
-function* openInviteToastWhenRewardsPopupClosed() {
+export function* openInviteToastWhenRewardsPopupClosed() {
   yield take(SagaActionTypes.RewardsPopupClosed);
   yield delay(10000);
   yield put(setInviteToastOpen(true));

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -1,4 +1,4 @@
-import { call, put, race, select, spawn, take } from 'redux-saga/effects';
+import { call, delay, put, race, select, spawn, take } from 'redux-saga/effects';
 import {
   AccountCreationErrors,
   InviteCodeStatus,
@@ -12,6 +12,7 @@ import {
   setInviteCode,
   setUserId,
   setFirstTimeLogin,
+  setInviteToastOpen,
 } from '.';
 import {
   validateInvite as apiValidateInvite,
@@ -214,6 +215,7 @@ export function* saga() {
 
   // After successful registration
   yield spawn(openFirstConversation);
+  yield spawn(openInviteToastWhenRewardsPopupClosed);
 }
 
 export function* channelsLoaded() {
@@ -229,4 +231,10 @@ function* openFirstConversation() {
   if (payload.loaded) {
     yield call(channelsLoaded);
   }
+}
+
+function* openInviteToastWhenRewardsPopupClosed() {
+  yield take(SagaActionTypes.RewardsPopupClosed);
+  yield delay(10000);
+  yield put(setInviteToastOpen(true));
 }


### PR DESCRIPTION
### What does this do?

Pushes the timing logic of when to render the invite toast up to the existing user registration saga.

### Why are we making this change?

Simplification of state management in the component and concentrates the user flow logic in a single place

### How do I test this?

Register a new user and verify that the invite toast is shown 10 seconds after the rewards popup is closed for the first time.

