### PR TITLE
Refactor web3 registration to saga

### DIFF
--- a/src/authentication/create-wallet-account/container.test.tsx
+++ b/src/authentication/create-wallet-account/container.test.tsx
@@ -20,7 +20,7 @@ describe('Container', () => {
       test('web3 connection error', () => {
         let props = subject({ web3: { value: { error: 'Web3 Error' } } as Web3State });
 
-        expect(props.errors).toEqual({ general: 'Web3 Error' });
+        expect(props.error).toEqual('Web3 Error');
       });
 
       test('registration error: address already exists', () => {
@@ -28,7 +28,7 @@ describe('Container', () => {
           registration: { errors: [AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS] } as RegistrationState,
         });
 
-        expect(props.errors).toEqual({ general: 'This address has already been registered' });
+        expect(props.error).toEqual('This address has already been registered');
       });
     });
 

--- a/src/authentication/create-wallet-account/container.test.tsx
+++ b/src/authentication/create-wallet-account/container.test.tsx
@@ -1,8 +1,6 @@
 import { Container } from './container';
 import { AccountCreationErrors, RegistrationState } from '../../store/registration';
 import { RootState } from '../../store/reducer';
-import { Web3State } from '../../store/web3';
-import { ConnectionStatus } from '../../lib/web3';
 
 describe('Container', () => {
   describe('mapState', () => {
@@ -17,12 +15,6 @@ describe('Container', () => {
     };
 
     describe('errors', () => {
-      test('web3 connection error', () => {
-        let props = subject({ web3: { value: { error: 'Web3 Error' } } as Web3State });
-
-        expect(props.error).toEqual('Web3 Error');
-      });
-
       test('registration error: address already exists', () => {
         const props = subject({
           registration: { errors: [AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS] } as RegistrationState,
@@ -33,14 +25,6 @@ describe('Container', () => {
     });
 
     describe('isConnecting', () => {
-      it('is true when web3 is connecting', () => {
-        const props = subject({
-          web3: { status: ConnectionStatus.Connecting, value: {} } as Web3State,
-        });
-
-        expect(props.isConnecting).toEqual(true);
-      });
-
       it('is true when registration is pending', () => {
         const props = subject({
           registration: { loading: true } as RegistrationState,

--- a/src/authentication/create-wallet-account/container.tsx
+++ b/src/authentication/create-wallet-account/container.tsx
@@ -25,7 +25,7 @@ export class Container extends React.Component<Properties> {
     } = state;
 
     return {
-      errors: { general: value.error || Container.mapErrors(errors || []).general },
+      errors: { general: value.error || Container.mapErrors(errors) },
       isConnecting: status === ConnectionStatus.Connecting || loading,
     };
   }
@@ -35,21 +35,15 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapErrors(errors: string[]) {
-    const errorObject = {} as Properties['errors'];
-
-    errors.forEach((error) => {
-      switch (error) {
-        case AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS:
-          errorObject.general = 'This address has already been registered';
-          break;
-        default:
-          // XXX: debugging - render the error message raw
-          errorObject.general = error;
-          break;
-      }
-    });
-
-    return errorObject;
+    if (!errors) {
+      return '';
+    }
+    const error = errors[0];
+    if (error === AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS) {
+      return 'This address has already been registered';
+    }
+    // XXX: debugging - render the error message raw
+    return error;
   }
 
   connectorSelected = async (connector) => {

--- a/src/authentication/create-wallet-account/container.tsx
+++ b/src/authentication/create-wallet-account/container.tsx
@@ -9,10 +9,7 @@ import { RootState } from '../../store/reducer';
 import { Web3Connect } from '../../components/web3-connect';
 
 export interface Properties {
-  // XXX: simplify even further to just a single error
-  errors: {
-    general: string;
-  };
+  error: string;
   isConnecting: boolean;
 
   createWeb3Account: (payload: { connector: Connectors }) => void;
@@ -26,7 +23,7 @@ export class Container extends React.Component<Properties> {
     } = state;
 
     return {
-      errors: { general: value.error || Container.mapErrors(errors) },
+      error: value.error || Container.mapErrors(errors),
       isConnecting: loading,
     };
   }
@@ -43,8 +40,7 @@ export class Container extends React.Component<Properties> {
     if (error === AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS) {
       return 'This address has already been registered';
     }
-    // XXX: debugging - render the error message raw
-    return error;
+    return 'An error has occurred';
   }
 
   connectorSelected = async (connector) => {
@@ -57,7 +53,7 @@ export class Container extends React.Component<Properties> {
         <Web3Connect>
           <CreateWalletAccount
             onSelect={this.connectorSelected}
-            error={this.props.errors.general}
+            error={this.props.error}
             isConnecting={this.props.isConnecting}
           />
         </Web3Connect>

--- a/src/authentication/create-wallet-account/container.tsx
+++ b/src/authentication/create-wallet-account/container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { connectContainer } from '../../store/redux-container';
-import { ConnectionStatus, Connectors } from '../../lib/web3';
+import { Connectors } from '../../lib/web3';
 import { AccountCreationErrors, createWeb3Account } from '../../store/registration';
 
 import { CreateWalletAccount } from '.';
@@ -9,6 +9,7 @@ import { RootState } from '../../store/reducer';
 import { Web3Connect } from '../../components/web3-connect';
 
 export interface Properties {
+  // XXX: simplify even further to just a single error
   errors: {
     general: string;
   };
@@ -20,13 +21,13 @@ export interface Properties {
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const {
-      web3: { status, value },
+      web3: { value },
       registration: { errors, loading },
     } = state;
 
     return {
       errors: { general: value.error || Container.mapErrors(errors) },
-      isConnecting: status === ConnectionStatus.Connecting || loading,
+      isConnecting: loading,
     };
   }
 

--- a/src/authentication/create-wallet-account/container.tsx
+++ b/src/authentication/create-wallet-account/container.tsx
@@ -17,14 +17,11 @@ export interface Properties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
-    const {
-      web3: { value },
-      registration: { errors, loading },
-    } = state;
+    const { registration } = state;
 
     return {
-      error: value.error || Container.mapErrors(errors),
-      isConnecting: loading,
+      error: Container.mapErrors(registration.errors),
+      isConnecting: registration.loading,
     };
   }
 
@@ -40,7 +37,7 @@ export class Container extends React.Component<Properties> {
     if (error === AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS) {
       return 'This address has already been registered';
     }
-    return 'An error has occurred';
+    return error;
   }
 
   connectorSelected = async (connector) => {

--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -25,7 +25,7 @@ interface State {
 
 export class Invite extends React.Component<Properties, State> {
   state: State = {
-    inviteCode: '67E44B', // XXX
+    inviteCode: '',
     renderAlert: false,
   };
 

--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -25,7 +25,7 @@ interface State {
 
 export class Invite extends React.Component<Properties, State> {
   state: State = {
-    inviteCode: '',
+    inviteCode: '67E44B', // XXX
     renderAlert: false,
   };
 

--- a/src/components/web3-connect/index.test.tsx
+++ b/src/components/web3-connect/index.test.tsx
@@ -365,36 +365,6 @@ describe('Web3Connect', () => {
     expect(component.hasClass('the-cat-parade')).toBe(true);
   });
 
-  it('clears localstorage & reloads if connectionStatus is Connecting and has been connected but web3 account is not null', () => {
-    const component = subject(
-      {
-        connectionStatus: ConnectionStatus.Disconnected,
-        web3: getWeb3({
-          active: false,
-        }),
-      },
-      <div className='the-cat-parade' />
-    );
-
-    const reload = jest.fn();
-    global.window = Object.create({
-      location: {
-        reload,
-      },
-    });
-
-    // recreate the buggy state, where we have a web3 account but no connection
-    component.setProps({
-      connectionStatus: ConnectionStatus.Connecting,
-      web3: getWeb3({ account: '0x0000000000000000000000000000000000000009', chainId: Chains.Goerli }),
-    });
-    component.setProps({ connectionStatus: ConnectionStatus.Connected });
-    component.setProps({ connectionStatus: ConnectionStatus.Connecting });
-
-    expect(localStorage.getItem('previousConnector')).toBe('none');
-    expect(reload).toHaveBeenCalled();
-  });
-
   describe('mapState', () => {
     const subject = (state: RootState) => Container.mapState(state);
     const getState = (state: any = {}) =>

--- a/src/components/web3-connect/index.tsx
+++ b/src/components/web3-connect/index.tsx
@@ -167,16 +167,6 @@ export class Container extends React.Component<Properties, State> {
     if (web3.account !== previouslyAccount) {
       this.props.setAddress(web3.account);
     }
-
-    if (
-      connectionStatus === ConnectionStatus.Connecting &&
-      previousConnectionStatus === ConnectionStatus.Connected &&
-      web3.account
-    ) {
-      localStorage.removeItem('previousConnector');
-      window.location.reload();
-      this.reconnectPreviousConnector();
-    }
   }
 
   get shouldRender() {

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -1,4 +1,5 @@
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Connectors } from '../../lib/web3';
 
 export enum SagaActionTypes {
   ValidateInvite = 'registration/validateInvite',
@@ -71,7 +72,7 @@ export const initialState: RegistrationState = {
 
 export const validateInvite = createAction<{ code: string }>(SagaActionTypes.ValidateInvite);
 export const createAccount = createAction<{ email: string; password: string }>(SagaActionTypes.CreateAccount);
-export const createWeb3Account = createAction<{ token: string }>(SagaActionTypes.CreateWeb3Account);
+export const createWeb3Account = createAction<{ connector: Connectors }>(SagaActionTypes.CreateWeb3Account);
 export const updateProfile = createAction<{ name: string; image: File | null }>(SagaActionTypes.UpdateProfile);
 export const rewardsPopupClosed = createAction(SagaActionTypes.RewardsPopupClosed);
 

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -503,7 +503,7 @@ describe('authorizeAndCreateWeb3Account', () => {
       .provide([
         [
           call(getSignedToken, Connectors.Metamask),
-          signedToken,
+          { success: true, token: signedToken },
         ],
         [
           call(apiCreateWeb3Account, { inviteCode, web3Token: signedToken }),

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -3,6 +3,7 @@ import delayP from '@redux-saga/delay-p';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import {
+  authorizeAndCreateWeb3Account,
   channelsLoaded,
   createAccount,
   openInviteToastWhenRewardsPopupClosed,
@@ -13,6 +14,7 @@ import {
 import {
   validateInvite as apiValidateInvite,
   createAccount as apiCreateAccount,
+  createWeb3Account as apiCreateWeb3Account,
   completeAccount as apiCompleteAccount,
   uploadImage,
 } from './api';
@@ -31,6 +33,8 @@ import { fetchCurrentUser } from '../authentication/api';
 import { nonce as nonceApi } from '../authentication/api';
 import { throwError } from 'redux-saga-test-plan/providers';
 import { setActiveMessengerId } from '../chat';
+import { Connectors } from '../../lib/web3';
+import { getSignedToken } from '../web3/saga';
 
 const featureFlags = { allowWeb3Registration: false };
 jest.mock('../../lib/feature-flags', () => ({
@@ -485,6 +489,37 @@ describe('openInviteToastWhenRewardsPopupClosed', () => {
       .run();
 
     expect(registration.isInviteToastOpen).toEqual(true);
+  });
+});
+
+describe('authorizeAndCreateWeb3Account', () => {
+  it('creates a web3 account', async () => {
+    const inviteCode = 'INV123';
+    const signedToken = '0x9876';
+    const {
+      returnValue,
+      storeState: { registration },
+    } = await expectSaga(authorizeAndCreateWeb3Account, { payload: { connector: Connectors.Metamask } })
+      .provide([
+        [
+          call(getSignedToken, Connectors.Metamask),
+          signedToken,
+        ],
+        [
+          call(apiCreateWeb3Account, { inviteCode, web3Token: signedToken }),
+          { success: true, response: {} },
+        ],
+        [
+          call(fetchCurrentUser),
+          { id: '123' },
+        ],
+      ])
+      .withReducer(rootReducer, initialState({ stage: RegistrationStage.WalletAccountCreation, inviteCode }))
+      .run();
+
+    expect(registration.stage).toEqual(RegistrationStage.ProfileDetails);
+    expect(registration.userId).toEqual('123');
+    expect(returnValue).toEqual(true);
   });
 });
 

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -104,15 +104,8 @@ export function* authorizeAndCreateWeb3Account(action) {
       yield put(setErrors([result.error]));
       return false;
     }
-    const token = result.token;
-    // XXX: temporary to show success
-    // yield put(
-    //   setErrors([
-    //     `Got a signed token: ${token.substring(0, 6)}`,
-    //   ])
-    // );
     const inviteCode = yield select((state) => state.registration.inviteCode);
-    result = yield call(apiCreateWeb3Account, { inviteCode, web3Token: token });
+    result = yield call(apiCreateWeb3Account, { inviteCode, web3Token: result.token });
     if (result.success) {
       const userFetch = yield call(fetchCurrentUser);
       if (userFetch) {

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -94,10 +94,26 @@ export function* createAccount(action) {
   return false;
 }
 
-export function* createWeb3Account(action) {
-  const { token } = action.payload;
+// XXX
+// translateError(error: any) {
+//   if (error.code && error.code === -32603) {
+//     // Metamask: User rejected the signature request by closing the window or clicking Reject
+//     return '';
+//   }
+
+//   return 'Error signing token';
+// }
+export function* authorizeAndCreateWeb3Account(action) {
+  const { connector } = action.payload;
+
   yield put(setLoading(true));
   try {
+    const token = yield call(getSignedToken, connector);
+    if (!token) {
+      // XXX: real errors here
+      yield put(setErrors(['XXX: Sign token error']));
+      return false;
+    }
     // XXX: temporary to show success
     yield put(
       setErrors([
@@ -105,10 +121,7 @@ export function* createWeb3Account(action) {
       ])
     );
     // const inviteCode = yield select((state) => state.registration.inviteCode);
-    // const result = yield call(apiCreateWeb3Account, {
-    //   inviteCode,
-    //   web3Token: token,
-    // });
+    // const result = yield call(apiCreateWeb3Account, { inviteCode, web3Token: token });
     // if (result.success) {
     //   const userFetch = yield call(fetchCurrentUser);
     //   if (userFetch) {
@@ -129,36 +142,6 @@ export function* createWeb3Account(action) {
   }
   return false;
 }
-
-// XXX: test this...use yields and calls, etc.
-export function* authorizeAndCreateWeb3Account(action) {
-  console.log('authing via connector', action.payload);
-  const { connector } = action.payload;
-
-  yield put(setLoading(true));
-  try {
-    const token = yield getSignedToken(connector);
-    if (!token) {
-      yield put(setErrors(['XXX: Sign token error']));
-      return false;
-    }
-    // XXX: test when this endpoint just errors
-    return yield call(createWeb3Account, { payload: { token } });
-  } catch (e) {
-    yield put(setErrors([AccountCreationErrors.UNKNOWN_ERROR]));
-  } finally {
-    yield put(setLoading(false));
-  }
-}
-
-// translateError(error: any) {
-//   if (error.code && error.code === -32603) {
-//     // Metamask: User rejected the signature request by closing the window or clicking Reject
-//     return '';
-//   }
-
-//   return 'Error signing token';
-// }
 
 export function validateAccountInfo({ email, password }) {
   const validationErrors = [];

--- a/src/store/web3/channels.ts
+++ b/src/store/web3/channels.ts
@@ -1,0 +1,10 @@
+import { multicastChannel } from 'redux-saga';
+import { call } from 'redux-saga/effects';
+
+let theWeb3Channel;
+export function* web3Channel() {
+  if (!theWeb3Channel) {
+    theWeb3Channel = yield call(multicastChannel);
+  }
+  return theWeb3Channel;
+}

--- a/src/store/web3/index.test.ts
+++ b/src/store/web3/index.test.ts
@@ -1,4 +1,12 @@
-import { reducer, setConnectionStatus, setConnector, setAddress, setChain, Web3State, setWalletModalOpen } from '.';
+import {
+  reducer,
+  setConnectionStatus,
+  setConnector,
+  setWalletAddress,
+  setChain,
+  Web3State,
+  setWalletModalOpen,
+} from '.';
 import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 
 describe('web3 reducer', () => {
@@ -29,7 +37,7 @@ describe('web3 reducer', () => {
   });
 
   it('should replace existing state with new address', () => {
-    const actual = reducer(initialExistingState, setAddress('0x0000000000000000000000000000000000000007'));
+    const actual = reducer(initialExistingState, setWalletAddress('0x0000000000000000000000000000000000000007'));
 
     expect(actual.value.address).toEqual('0x0000000000000000000000000000000000000007');
   });

--- a/src/store/web3/index.ts
+++ b/src/store/web3/index.ts
@@ -5,10 +5,12 @@ import { WalletType } from '@zer0-os/zos-component-library';
 export enum SagaActionTypes {
   UpdateConnector = 'web3/saga/updateConnector',
   SetAddress = 'web3/saga/setAddress',
+  SetConnectionError = 'web3/saga/setConnectionError',
 }
 
 export const updateConnector = createAction<Connectors | WalletType>(SagaActionTypes.UpdateConnector);
 export const setAddress = createAction<string>(SagaActionTypes.SetAddress);
+export const setConnectionError = createAction<string>(SagaActionTypes.SetConnectionError);
 
 export interface Web3State {
   status: ConnectionStatus;
@@ -46,12 +48,18 @@ const slice = createSlice({
     setWalletModalOpen: (state, action: PayloadAction<boolean>) => {
       state.isWalletModalOpen = action.payload;
     },
-    setConnectionError: (state, action: PayloadAction<string>) => {
+    setWalletConnectionError: (state, action: PayloadAction<string>) => {
       state.value.error = action.payload;
     },
   },
 });
 
-export const { setConnector, setWalletAddress, setChain, setConnectionStatus, setWalletModalOpen, setConnectionError } =
-  slice.actions;
+export const {
+  setConnector,
+  setWalletAddress,
+  setChain,
+  setConnectionStatus,
+  setWalletModalOpen,
+  setWalletConnectionError,
+} = slice.actions;
 export const { reducer } = slice;

--- a/src/store/web3/index.ts
+++ b/src/store/web3/index.ts
@@ -4,9 +4,11 @@ import { WalletType } from '@zer0-os/zos-component-library';
 
 export enum SagaActionTypes {
   UpdateConnector = 'web3/saga/updateConnector',
+  SetAddress = 'web3/saga/setAddress',
 }
 
-const updateConnector = createAction<Connectors | WalletType>(SagaActionTypes.UpdateConnector);
+export const updateConnector = createAction<Connectors | WalletType>(SagaActionTypes.UpdateConnector);
+export const setAddress = createAction<string>(SagaActionTypes.SetAddress);
 
 export interface Web3State {
   status: ConnectionStatus;
@@ -35,7 +37,7 @@ const slice = createSlice({
     setConnector: (state, action: PayloadAction<Connectors>) => {
       state.value.connector = action.payload;
     },
-    setAddress: (state, action: PayloadAction<string>) => {
+    setWalletAddress: (state, action: PayloadAction<string>) => {
       state.value.address = action.payload;
     },
     setChain: (state, action: PayloadAction<Chains>) => {
@@ -50,7 +52,6 @@ const slice = createSlice({
   },
 });
 
-export const { setConnector, setAddress, setChain, setConnectionStatus, setWalletModalOpen, setConnectionError } =
+export const { setConnector, setWalletAddress, setChain, setConnectionStatus, setWalletModalOpen, setConnectionError } =
   slice.actions;
 export const { reducer } = slice;
-export { updateConnector };

--- a/src/store/web3/saga.test.ts
+++ b/src/store/web3/saga.test.ts
@@ -1,8 +1,10 @@
 import { expectSaga } from 'redux-saga-test-plan';
 
-import { updateConnector } from './saga';
-import { Connectors, ConnectionStatus } from '../../lib/web3';
+import { getSignedToken, updateConnector, waitForAddressChange } from './saga';
+import { Connectors, ConnectionStatus, personalSignToken } from '../../lib/web3';
 import { reducer } from '.';
+import { call } from 'redux-saga/effects';
+import { getService } from '../../lib/web3/provider-service';
 
 describe('web3 saga', () => {
   it('sets new connector and status to Connecting', async () => {
@@ -18,5 +20,29 @@ describe('web3 saga', () => {
         connector: Connectors.Metamask,
       },
     });
+  });
+});
+
+describe('getSignedToken', () => {
+  it('connects and waits for an address change when connection is not already set up', async () => {
+    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+      .provide([
+        [
+          call(waitForAddressChange),
+          '0x1234',
+        ],
+        [
+          call(getService),
+          { get: () => ({ provider: 'stub' }) },
+        ],
+        [
+          call(personalSignToken, { provider: 'stub' }, '0x1234'),
+          '0x9876',
+        ],
+      ])
+      .withReducer(reducer)
+      .run();
+
+    expect(returnValue).toEqual('0x9876');
   });
 });

--- a/src/store/web3/saga.test.ts
+++ b/src/store/web3/saga.test.ts
@@ -1,11 +1,12 @@
 import { expectSaga } from 'redux-saga-test-plan';
 
-import { getSignedToken, updateConnector, waitForAddressChange } from './saga';
+import { getSignedToken, updateConnector, waitForAddressChange, waitForError } from './saga';
 import { Connectors, ConnectionStatus, personalSignToken } from '../../lib/web3';
 import { reducer } from '.';
 import { call } from 'redux-saga/effects';
 import { getService } from '../../lib/web3/provider-service';
 import { RootState, rootReducer } from '../reducer';
+import { throwError } from 'redux-saga-test-plan/providers';
 
 describe('web3 saga', () => {
   it('sets new connector and status to Connecting', async () => {
@@ -44,7 +45,8 @@ describe('getSignedToken', () => {
       .withReducer(rootReducer, { web3: { value: { connector: Connectors.Infura, address: '' } } } as RootState)
       .run();
 
-    expect(returnValue).toEqual('0x9876');
+    expect(returnValue.success).toEqual(true);
+    expect(returnValue.token).toEqual('0x9876');
   });
 
   it('connects when the connector has changed', async () => {
@@ -67,7 +69,8 @@ describe('getSignedToken', () => {
       .call(waitForAddressChange)
       .run();
 
-    expect(returnValue).toEqual('0x9876');
+    expect(returnValue.success).toEqual(true);
+    expect(returnValue.token).toEqual('0x9876');
   });
 
   it('does not try to connect again if an address/connector is already selected', async () => {
@@ -85,6 +88,45 @@ describe('getSignedToken', () => {
       .withReducer(rootReducer, { web3: { value: { connector: Connectors.Metamask, address: '0x1234' } } } as RootState)
       .run();
 
-    expect(returnValue).toEqual('0x9876');
+    expect(returnValue.success).toEqual(true);
+    expect(returnValue.token).toEqual('0x9876');
+  });
+
+  it('returns an error when connection error occurs', async () => {
+    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+      .provide([
+        [
+          call(waitForError),
+          'an-error-occurred',
+        ],
+      ])
+      .withReducer(rootReducer, { web3: { value: { connector: Connectors.Infura, address: '' } } } as RootState)
+      .run();
+
+    expect(returnValue.success).toEqual(false);
+    expect(returnValue.error).toEqual('an-error-occurred');
+  });
+
+  it('returns an error when signing error occurs', async () => {
+    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+      .provide([
+        [
+          call(waitForAddressChange),
+          '0x1234',
+        ],
+        [
+          call(getService),
+          { get: () => ({ provider: 'stub' }) },
+        ],
+        [
+          call(personalSignToken, { provider: 'stub' }, '0x1234'),
+          throwError(new Error()),
+        ],
+      ])
+      .withReducer(rootReducer, { web3: { value: { connector: Connectors.Infura, address: '' } } } as RootState)
+      .run();
+
+    expect(returnValue.success).toEqual(false);
+    expect(returnValue.error).toEqual('Error signing token');
   });
 });

--- a/src/store/web3/saga.test.ts
+++ b/src/store/web3/saga.test.ts
@@ -2,9 +2,10 @@ import { expectSaga } from 'redux-saga-test-plan';
 
 import { getSignedToken, updateConnector, waitForAddressChange } from './saga';
 import { Connectors, ConnectionStatus, personalSignToken } from '../../lib/web3';
-import { reducer } from '.';
+import { Web3State, reducer } from '.';
 import { call } from 'redux-saga/effects';
 import { getService } from '../../lib/web3/provider-service';
+import { RootState, rootReducer } from '../reducer';
 
 describe('web3 saga', () => {
   it('sets new connector and status to Connecting', async () => {
@@ -40,7 +41,25 @@ describe('getSignedToken', () => {
           '0x9876',
         ],
       ])
-      .withReducer(reducer)
+      .withReducer(rootReducer)
+      .run();
+
+    expect(returnValue).toEqual('0x9876');
+  });
+
+  it('does not try to connect again if an address is already selected', async () => {
+    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+      .provide([
+        [
+          call(getService),
+          { get: () => ({ provider: 'stub' }) },
+        ],
+        [
+          call(personalSignToken, { provider: 'stub' }, '0x1234'),
+          '0x9876',
+        ],
+      ])
+      .withReducer(rootReducer, { web3: { value: { address: '0x1234' } } } as RootState)
       .run();
 
     expect(returnValue).toEqual('0x9876');

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -1,8 +1,9 @@
-import { takeLatest, put, takeEvery, call } from 'redux-saga/effects';
+import { takeLatest, put, takeEvery, call, take } from 'redux-saga/effects';
 import { SagaActionTypes, setConnectionStatus, setConnector, setWalletAddress } from '.';
 
-import { ConnectionStatus } from '../../lib/web3';
+import { ConnectionStatus, Connectors, personalSignToken } from '../../lib/web3';
 import { web3Channel } from './channels';
+import { getService } from '../../lib/web3/provider-service';
 
 export function* updateConnector(action) {
   console.log('updating connector', action.payload);
@@ -17,6 +18,34 @@ export function* setAddress(action) {
   const channel = yield call(web3Channel);
   console.log('publishing!!', action.payload);
   yield put(channel, { type: 'ADDRESS_CHANGED', payload: action.payload });
+}
+
+export function* getSignedToken(connector) {
+  yield updateConnector({ payload: connector });
+
+  // XXX: If you've already signed then the address won't change. Web3 needs to
+  // be able to handle this case and just provide the address.
+  const channel = yield call(web3Channel);
+  let addressChangedAction;
+  while (!addressChangedAction) {
+    const web3Action = yield take(channel, '*');
+    console.log('got a multicast', web3Action);
+    if (web3Action.type === 'ADDRESS_CHANGED') {
+      addressChangedAction = web3Action;
+    }
+  }
+  console.log('address changed in saga!');
+
+  // XXX: if address is null....
+  const address = addressChangedAction.payload;
+
+  const provider = yield getService().get();
+  try {
+    return yield personalSignToken(provider, address);
+  } catch (error) {
+    yield updateConnector(Connectors.None);
+  }
+  return null;
 }
 
 export function* saga() {

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -26,15 +26,8 @@ export function* getSignedToken(connector) {
   // XXX: If you've already signed then the address won't change. Web3 needs to
   // be able to handle this case and just provide the address.
   const channel = yield call(web3Channel);
-  let addressChangedAction;
-  while (!addressChangedAction) {
-    const web3Action = yield take(channel, '*');
-    console.log('got a multicast', web3Action);
-    if (web3Action.type === 'ADDRESS_CHANGED') {
-      addressChangedAction = web3Action;
-    }
-  }
-  console.log('address changed in saga!');
+  const addressChangedAction = yield take(channel, 'ADDRESS_CHANGED');
+  console.log('got a multicast', addressChangedAction);
 
   // XXX: if address is null....
   const address = addressChangedAction.payload;

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -19,9 +19,10 @@ export function* setAddress(action) {
 }
 
 export function* getSignedToken(connector) {
-  let address = yield select((state) => state.web3.value.address);
+  let current = yield select((state) => state.web3.value);
 
-  if (!address) {
+  let address = current.address;
+  if (current.connector !== connector || !current.address) {
     yield updateConnector({ payload: connector });
     address = yield call(waitForAddressChange);
   }

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -1,13 +1,26 @@
-import { takeLatest, put } from 'redux-saga/effects';
-import { SagaActionTypes, setConnectionStatus, setConnector } from '.';
+import { takeLatest, put, takeEvery, call } from 'redux-saga/effects';
+import { SagaActionTypes, setConnectionStatus, setConnector, setWalletAddress } from '.';
 
 import { ConnectionStatus } from '../../lib/web3';
+import { web3Channel } from './channels';
 
 export function* updateConnector(action) {
+  console.log('updating connector', action.payload);
   yield put(setConnector(action.payload));
   yield put(setConnectionStatus(ConnectionStatus.Connecting));
 }
 
+export function* setAddress(action) {
+  console.log('setting address?', action);
+  yield put(setWalletAddress(action.payload));
+  // Publish a system message across the channel
+  const channel = yield call(web3Channel);
+  console.log('publishing!!', action.payload);
+  yield put(channel, { type: 'ADDRESS_CHANGED', payload: action.payload });
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.UpdateConnector, updateConnector);
+  // XXX: Temporary? Does this happen more organically based on other events?
+  yield takeEvery(SagaActionTypes.SetAddress, setAddress);
 }

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -1,4 +1,4 @@
-import { takeLatest, put, takeEvery, call, take } from 'redux-saga/effects';
+import { takeLatest, put, takeEvery, call, take, select } from 'redux-saga/effects';
 import { SagaActionTypes, setConnectionStatus, setConnector, setWalletAddress } from '.';
 
 import { ConnectionStatus, Connectors, personalSignToken } from '../../lib/web3';
@@ -19,11 +19,12 @@ export function* setAddress(action) {
 }
 
 export function* getSignedToken(connector) {
-  yield updateConnector({ payload: connector });
+  let address = yield select((state) => state.web3.value.address);
 
-  // XXX: If you've already signed then the address won't change. Web3 needs to
-  // be able to handle this case and just provide the address.
-  const address = yield call(waitForAddressChange);
+  if (!address) {
+    yield updateConnector({ payload: connector });
+    address = yield call(waitForAddressChange);
+  }
 
   const providerService = yield call(getProviderService);
   try {

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -42,6 +42,5 @@ export function* waitForAddressChange() {
 
 export function* saga() {
   yield takeLatest(SagaActionTypes.UpdateConnector, updateConnector);
-  // XXX: Temporary? Does this happen more organically based on other events?
   yield takeEvery(SagaActionTypes.SetAddress, setAddress);
 }

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -4,7 +4,6 @@ import { SagaActionTypes, setConnectionStatus, setConnector, setWalletAddress } 
 import { ConnectionStatus, Connectors, personalSignToken } from '../../lib/web3';
 import { web3Channel } from './channels';
 import { getService as getProviderService } from '../../lib/web3/provider-service';
-import { getProvider } from '../../lib/cloudinary/provider';
 
 export function* updateConnector(action) {
   yield put(setConnector(action.payload));


### PR DESCRIPTION
### What does this do?

This refactors the web3 registration logic into a saga. This includes pushing some web3 connection activities into sagas as well to allow for reacting to changes without having to listen to component property updates.

### Why are we making this change?

We use web3-react to connect to the web3 external pieces. This means we're reliant upon component property changes to tell us when something in that library has changed. By making that layer as thin as possible (aka, just publishing the changes up to redux) we can then build our event system outside of components. This should make it much easier for us to build and test our user flows and provide a more consistent experience from a development perspective.

### How do I test this?

Register a new account via web3 through the new invite flow.
