### PR TITLE
Move web3 login logic to saga

### DIFF
--- a/src/components/authentication/index.test.tsx
+++ b/src/components/authentication/index.test.tsx
@@ -97,7 +97,7 @@ describe('Authentication', () => {
     expect(personalSignToken).toHaveBeenCalledWith(expect.any(Object), changedAddress);
   });
 
-  it('should terminateAuthorization before authorize', async () => {
+  it('should terminateAuthorization before reauthorize', async () => {
     const nonceOrAuthorize = jest.fn();
     const terminateAuthorization = jest.fn();
 
@@ -110,7 +110,11 @@ describe('Authentication', () => {
       nonceOrAuthorize,
     });
 
-    await wrapper.setProps({ connectionStatus: ConnectionStatus.Connected, currentAddress });
+    await wrapper.setProps({
+      connectionStatus: ConnectionStatus.Connected,
+      currentAddress,
+      user: { isLoading: false, data: USER_DATA },
+    });
 
     await new Promise(setImmediate);
 
@@ -133,7 +137,11 @@ describe('Authentication', () => {
       nonceOrAuthorize,
     });
 
-    await wrapper.setProps({ connectionStatus: ConnectionStatus.Connected, currentAddress });
+    await wrapper.setProps({
+      connectionStatus: ConnectionStatus.Connected,
+      currentAddress,
+      user: { isLoading: false, data: USER_DATA },
+    });
 
     await new Promise(setImmediate);
 

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -67,7 +67,8 @@ export class Container extends React.Component<Properties, State> {
       this.props.connectionStatus === ConnectionStatus.Connected &&
       this.props.currentAddress &&
       this.props.currentAddress !== prevProps.currentAddress &&
-      this.props.user.isLoading === false
+      this.props.user.isLoading === false &&
+      this.props.user.data !== null
     ) {
       this.authorize();
     }

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -40,6 +40,8 @@ export function* nonceOrAuthorize(action) {
 
     yield processUserAccount({ user, chatAccessToken, isLoading: false });
   }
+
+  return { nonce };
 }
 
 export function* terminate() {

--- a/src/store/login/index.ts
+++ b/src/store/login/index.ts
@@ -1,7 +1,9 @@
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Connectors } from '../../lib/web3';
 
 export enum SagaActionTypes {
   EmailLogin = 'login/emailLogin',
+  Web3Login = 'login/web3Login',
 }
 
 export type LoginState = {
@@ -23,6 +25,10 @@ export enum EmailLoginErrors {
   INVALID_EMAIL_PASSWORD = 'INVALID_EMAIL_PASSWORD',
 }
 
+export enum Web3LoginErrors {
+  PROFILE_NOT_FOUND = 'PROFILE_NOT_FOUND',
+}
+
 export const initialState: LoginState = {
   stage: LoginStage.EmailLogin,
   loading: false,
@@ -30,6 +36,7 @@ export const initialState: LoginState = {
 };
 
 export const loginByEmail = createAction<{ email: string; password: string }>(SagaActionTypes.EmailLogin);
+export const loginByWeb3 = createAction<Connectors>(SagaActionTypes.Web3Login);
 
 const slice = createSlice({
   name: 'login',


### PR DESCRIPTION
### What does this do?

Refactor to move the web3 login control flow to a saga.

### Why are we making this change?

Similar to #618, we're trying to localize the flow control in sagas so components can just deal with rendering rather than performing logic based on property changes.

### How do I test this?

Enable public zOS and test creating new accounts by wallet in various ways.

