### PR TITLE
feat: Implement image replacement functionality

### DIFF
--- a/src/authentication/create-account-details/index.tsx
+++ b/src/authentication/create-account-details/index.tsx
@@ -67,6 +67,7 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
               onChange={this.trackImage}
               icon={this.renderImageUploadIcon()}
               uploadText='Select or drag and drop'
+              onError={Boolean(this.props.errors.image)}
             />
           </div>
           {this.imageError && <Alert variant='error'>{this.imageError}</Alert>}

--- a/src/authentication/create-account-details/index.tsx
+++ b/src/authentication/create-account-details/index.tsx
@@ -67,7 +67,7 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
               onChange={this.trackImage}
               icon={this.renderImageUploadIcon()}
               uploadText='Select or drag and drop'
-              onError={Boolean(this.props.errors.image)}
+              isError={Boolean(this.props.errors.image)}
             />
           </div>
           {this.imageError && <Alert variant='error'>{this.imageError}</Alert>}

--- a/src/authentication/create-account-details/index.tsx
+++ b/src/authentication/create-account-details/index.tsx
@@ -68,6 +68,7 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
               icon={this.renderImageUploadIcon()}
               uploadText='Select or drag and drop'
               isError={Boolean(this.props.errors.image)}
+              errorMessage={this.props.errors.image}
             />
           </div>
           {this.imageError && <Alert variant='error'>{this.imageError}</Alert>}

--- a/src/components/account/create.tsx
+++ b/src/components/account/create.tsx
@@ -229,6 +229,8 @@ export class Container extends React.Component<Properties, State> {
                 onChange={this.onImageChange}
                 icon={this.renderImageUploadIcon()}
                 uploadText='Select or drag and drop'
+                onError={Boolean(this.state.error)}
+                errorMessage={this.state.error}
               />
             </div>
           </div>
@@ -247,8 +249,6 @@ export class Container extends React.Component<Properties, State> {
             />
             {Boolean(this.state.displayNameError) && this.renderError(this.state.displayNameError)}
           </div>
-
-          {Boolean(this.state.error) && this.renderError(this.state.error)}
 
           <div className='profile-prompt__submit'>
             <Button tabIndex={0} onClick={this.onSubmit} onEnterKeyPress={this.onSubmit}>

--- a/src/components/account/create.tsx
+++ b/src/components/account/create.tsx
@@ -229,7 +229,7 @@ export class Container extends React.Component<Properties, State> {
                 onChange={this.onImageChange}
                 icon={this.renderImageUploadIcon()}
                 uploadText='Select or drag and drop'
-                onError={Boolean(this.state.error)}
+                isError={Boolean(this.state.error)}
                 errorMessage={this.state.error}
               />
             </div>

--- a/src/components/account/create.tsx
+++ b/src/components/account/create.tsx
@@ -229,8 +229,6 @@ export class Container extends React.Component<Properties, State> {
                 onChange={this.onImageChange}
                 icon={this.renderImageUploadIcon()}
                 uploadText='Select or drag and drop'
-                isError={Boolean(this.state.error)}
-                errorMessage={this.state.error}
               />
             </div>
           </div>
@@ -249,6 +247,8 @@ export class Container extends React.Component<Properties, State> {
             />
             {Boolean(this.state.displayNameError) && this.renderError(this.state.displayNameError)}
           </div>
+
+          {Boolean(this.state.error) && this.renderError(this.state.error)}
 
           <div className='profile-prompt__submit'>
             <Button tabIndex={0} onClick={this.onSubmit} onEnterKeyPress={this.onSubmit}>

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -94,7 +94,7 @@ export class ImageUpload extends Component<Properties, State> {
                 ? this.renderPlaceholder(getRootProps(), getInputProps())
                 : this.renderImage(getRootProps(), getInputProps())}
             </section>
-            {!this.props.onError && <div className='image-upload__error-message'>{this.props.errorMessage}</div>}
+            {this.props.onError && <div className='image-upload__error-message'>{this.props.errorMessage}</div>}
           </div>
         )}
       </Dropzone>

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -27,6 +27,7 @@ export class ImageUpload extends Component<Properties, State> {
   dataVariant = this.props.onError ? 'error' : '';
   icon = this.props.onError ? <IconAlertCircle isFilled /> : this.props.icon;
   textContent = this.props.onError ? this.state?.files[0]?.name : this.props.uploadText;
+  errorMessage = this.props.errorMessage || 'Image upload failed. Please try again.';
 
   onDrop = (files: File[]) => {
     this.setState({ files });
@@ -94,7 +95,7 @@ export class ImageUpload extends Component<Properties, State> {
                 ? this.renderPlaceholder(getRootProps(), getInputProps())
                 : this.renderImage(getRootProps(), getInputProps())}
             </section>
-            {this.props.onError && <div className='image-upload__error-message'>{this.props.errorMessage}</div>}
+            {this.props.onError && <div className='image-upload__error-message'>{this.errorMessage}</div>}
           </div>
         )}
       </Dropzone>

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -1,5 +1,9 @@
 import React, { Component, ReactElement } from 'react';
 import Dropzone from 'react-dropzone';
+
+import { IconEdit5 } from '@zero-tech/zui/icons';
+import { IconButton } from '@zero-tech/zui/components';
+
 import './styles.scss';
 import classNames from 'classnames';
 
@@ -11,13 +15,33 @@ export interface Properties {
 }
 
 interface State {
-  files: any;
+  files: File[];
 }
 
 export class ImageUpload extends Component<Properties, State> {
   state = { files: [] };
 
-  onDrop = (files) => {
+  fileInputRef = React.createRef<HTMLInputElement>();
+
+  openFileDialog = () => {
+    if (this.fileInputRef.current) {
+      this.fileInputRef.current.click();
+    }
+  };
+
+  onEditClick = () => {
+    if (this.fileInputRef.current) {
+      this.fileInputRef.current.click();
+    }
+  };
+
+  handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      this.onDrop(Array.from(e.target.files));
+    }
+  };
+
+  onDrop = (files: File[]) => {
     this.setState({ files });
 
     if (typeof this.props.onChange === 'function') {
@@ -29,14 +53,25 @@ export class ImageUpload extends Component<Properties, State> {
     const file = this.state.files[0];
 
     return (
-      <img
-        className='image-upload__image'
-        src={URL.createObjectURL(file)}
-        onLoad={() => {
-          URL.revokeObjectURL(file.preview);
-        }}
-        alt='Profile'
-      />
+      <div className='image-upload__image-container'>
+        <img
+          className='image-upload__image'
+          src={URL.createObjectURL(file)}
+          onLoad={() => {
+            URL.revokeObjectURL(file.preview);
+          }}
+          alt='Profile'
+        />
+        <IconButton
+          className={'image-upload__edit-button'}
+          type='button'
+          color='primary'
+          variant='primary'
+          Icon={IconEdit5}
+          onClick={this.onEditClick}
+        />
+        <input type='file' className='image-upload__input' ref={this.fileInputRef} onChange={this.handleFileChange} />
+      </div>
     );
   };
 

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -12,7 +12,7 @@ export interface Properties {
   icon: ReactElement;
   uploadText: string;
   onChange: (file: File) => void;
-  onError?: boolean;
+  isError?: boolean;
   errorMessage?: string;
 }
 
@@ -24,9 +24,9 @@ export class ImageUpload extends Component<Properties, State> {
   state = { files: [] };
   fileInputRef = React.createRef<HTMLInputElement>();
 
-  dataVariant = this.props.onError ? 'error' : '';
-  icon = this.props.onError ? <IconAlertCircle isFilled /> : this.props.icon;
-  textContent = this.props.onError ? this.state?.files[0]?.name : this.props.uploadText;
+  dataVariant = this.props.isError ? 'error' : '';
+  icon = this.props.isError ? <IconAlertCircle isFilled /> : this.props.icon;
+  textContent = this.props.isError ? this.state?.files[0]?.name : this.props.uploadText;
   errorMessage = this.props.errorMessage || 'Image upload failed. Please try again.';
 
   onDrop = (files: File[]) => {
@@ -95,7 +95,7 @@ export class ImageUpload extends Component<Properties, State> {
                 ? this.renderPlaceholder(getRootProps(), getInputProps())
                 : this.renderImage(getRootProps(), getInputProps())}
             </section>
-            {this.props.onError && <div className='image-upload__error-message'>{this.errorMessage}</div>}
+            {this.props.isError && <div className='image-upload__error-message'>{this.errorMessage}</div>}
           </div>
         )}
       </Dropzone>

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -30,6 +30,12 @@ export class ImageUpload extends Component<Properties, State> {
     }
   };
 
+  onSimulateClick = () => {
+    if (this.fileInputRef.current) {
+      this.fileInputRef.current.click(); // simulating a click on the file input when the button is clicked
+    }
+  };
+
   renderImage = (rootProps: DropzoneRootProps, inputProps: DropzoneInputProps) => {
     const file = this.state.files[0];
 
@@ -50,12 +56,18 @@ export class ImageUpload extends Component<Properties, State> {
           color='primary'
           variant='primary'
           Icon={IconEdit5}
-          onClick={() => {
-            if (this.fileInputRef.current) {
-              this.fileInputRef.current.click(); // simulating a click on the file input when the button is clicked
-            }
-          }}
+          onClick={this.onSimulateClick}
         />
+      </div>
+    );
+  };
+
+  renderPlaceholder = (rootProps: DropzoneRootProps, inputProps: DropzoneInputProps) => {
+    return (
+      <div {...rootProps} className='image-upload__dropzone'>
+        <input {...inputProps} />
+        {this.props.icon}
+        <p>{this.props.uploadText}</p>
       </div>
     );
   };
@@ -71,15 +83,9 @@ export class ImageUpload extends Component<Properties, State> {
       >
         {({ getRootProps, getInputProps }) => (
           <section className={classNames('image-upload', this.props.className)}>
-            {this.state.files.length === 0 ? (
-              <div {...getRootProps({ className: 'image-upload__dropzone' })}>
-                <input {...getInputProps()} />
-                {this.props.icon}
-                <p>{this.props.uploadText}</p>
-              </div>
-            ) : (
-              this.renderImage(getRootProps(), getInputProps())
-            )}
+            {this.state.files.length === 0
+              ? this.renderPlaceholder(getRootProps(), getInputProps())
+              : this.renderImage(getRootProps(), getInputProps())}
           </section>
         )}
       </Dropzone>

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactElement } from 'react';
-import Dropzone from 'react-dropzone';
+import Dropzone, { DropzoneRootProps, DropzoneInputProps } from 'react-dropzone';
 
 import { IconEdit5 } from '@zero-tech/zui/icons';
 import { IconButton } from '@zero-tech/zui/components';
@@ -20,26 +20,7 @@ interface State {
 
 export class ImageUpload extends Component<Properties, State> {
   state = { files: [] };
-
   fileInputRef = React.createRef<HTMLInputElement>();
-
-  openFileDialog = () => {
-    if (this.fileInputRef.current) {
-      this.fileInputRef.current.click();
-    }
-  };
-
-  onEditClick = () => {
-    if (this.fileInputRef.current) {
-      this.fileInputRef.current.click();
-    }
-  };
-
-  handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      this.onDrop(Array.from(e.target.files));
-    }
-  };
 
   onDrop = (files: File[]) => {
     this.setState({ files });
@@ -49,11 +30,12 @@ export class ImageUpload extends Component<Properties, State> {
     }
   };
 
-  renderImage = () => {
+  renderImage = (rootProps: DropzoneRootProps, inputProps: DropzoneInputProps) => {
     const file = this.state.files[0];
 
     return (
-      <div className='image-upload__image-container'>
+      <div {...rootProps} className='image-upload__image-container'>
+        <input {...inputProps} ref={this.fileInputRef} />
         <img
           className='image-upload__image'
           src={URL.createObjectURL(file)}
@@ -68,9 +50,12 @@ export class ImageUpload extends Component<Properties, State> {
           color='primary'
           variant='primary'
           Icon={IconEdit5}
-          onClick={this.onEditClick}
+          onClick={() => {
+            if (this.fileInputRef.current) {
+              this.fileInputRef.current.click(); // simulating a click on the file input when the button is clicked
+            }
+          }}
         />
-        <input type='file' className='image-upload__input' ref={this.fileInputRef} onChange={this.handleFileChange} />
       </div>
     );
   };
@@ -93,7 +78,7 @@ export class ImageUpload extends Component<Properties, State> {
                 <p>{this.props.uploadText}</p>
               </div>
             ) : (
-              this.renderImage()
+              this.renderImage(getRootProps(), getInputProps())
             )}
           </section>
         )}

--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ReactElement } from 'react';
 import Dropzone, { DropzoneRootProps, DropzoneInputProps } from 'react-dropzone';
 
-import { IconEdit5 } from '@zero-tech/zui/icons';
+import { IconAlertCircle, IconEdit5 } from '@zero-tech/zui/icons';
 import { IconButton } from '@zero-tech/zui/components';
 
 import './styles.scss';
@@ -12,6 +12,8 @@ export interface Properties {
   icon: ReactElement;
   uploadText: string;
   onChange: (file: File) => void;
+  onError?: boolean;
+  errorMessage?: string;
 }
 
 interface State {
@@ -21,6 +23,10 @@ interface State {
 export class ImageUpload extends Component<Properties, State> {
   state = { files: [] };
   fileInputRef = React.createRef<HTMLInputElement>();
+
+  dataVariant = this.props.onError ? 'error' : '';
+  icon = this.props.onError ? <IconAlertCircle isFilled /> : this.props.icon;
+  textContent = this.props.onError ? this.state?.files[0]?.name : this.props.uploadText;
 
   onDrop = (files: File[]) => {
     this.setState({ files });
@@ -66,8 +72,8 @@ export class ImageUpload extends Component<Properties, State> {
     return (
       <div {...rootProps} className='image-upload__dropzone'>
         <input {...inputProps} />
-        {this.props.icon}
-        <p>{this.props.uploadText}</p>
+        {this.icon}
+        <p className='image-upload__text-content'>{this.textContent}</p>
       </div>
     );
   };
@@ -82,11 +88,14 @@ export class ImageUpload extends Component<Properties, State> {
         maxFiles={1}
       >
         {({ getRootProps, getInputProps }) => (
-          <section className={classNames('image-upload', this.props.className)}>
-            {this.state.files.length === 0
-              ? this.renderPlaceholder(getRootProps(), getInputProps())
-              : this.renderImage(getRootProps(), getInputProps())}
-          </section>
+          <div className='image-upload-container'>
+            <section className={classNames('image-upload', this.props.className)} data-variant={this.dataVariant}>
+              {this.state.files.length === 0
+                ? this.renderPlaceholder(getRootProps(), getInputProps())
+                : this.renderImage(getRootProps(), getInputProps())}
+            </section>
+            {!this.props.onError && <div className='image-upload__error-message'>{this.props.errorMessage}</div>}
+          </div>
         )}
       </Dropzone>
     );

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -19,13 +19,37 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-
+    color: theme.$color-greyscale-12;
     cursor: pointer;
+  }
+
+  &__image-container {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: flex-end;
+
+    height: 100%;
+    width: 100%;
   }
 
   &__image {
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  &__edit-button {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+
+    width: 32px;
+    height: 32px;
+  }
+
+  &__input {
+    display: none;
   }
 }

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -1,51 +1,78 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../variables';
 
-.image-upload {
-  width: 120px;
-  height: 120px;
-  border: 1px dashed theme.$color-greyscale-8;
-  background: theme.$color-primary-3;
-  border-radius: 9999px;
-  color: theme.$color-greyscale-8;
-  font-size: $font-size-small;
-  text-align: center;
-  overflow: hidden;
+.image-upload-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0px;
+  gap: 8px;
+  max-width: 181px;
 
-  &__dropzone {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: theme.$color-greyscale-12;
-    cursor: pointer;
-  }
+  .image-upload {
+    width: 120px;
+    height: 120px;
+    border: 1px dashed theme.$color-greyscale-8;
+    background: theme.$color-primary-3;
+    border-radius: 9999px;
+    color: theme.$color-greyscale-8;
+    font-size: $font-size-small;
+    text-align: center;
+    overflow: hidden;
 
-  &__image-container {
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: flex-end;
+    &[data-variant='error'] {
+      border: 1px dashed theme.$color-failure-8;
+      background: theme.$color-failure-4;
+    }
 
-    height: 100%;
-    width: 100%;
-  }
+    &__dropzone {
+      height: 100%;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: theme.$color-greyscale-12;
+      cursor: pointer;
+    }
 
-  &__image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
+    &__text-content {
+      word-break: break-all;
+    }
 
-  &__edit-button {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    position: absolute;
+    &__image-container {
+      display: flex;
+      flex-direction: row-reverse;
+      align-items: flex-end;
 
-    width: 32px;
-    height: 32px;
+      height: 100%;
+      width: 100%;
+    }
+
+    &__image {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    &__edit-button {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      position: absolute;
+
+      width: 32px;
+      height: 32px;
+    }
+
+    &__error-message {
+      color: theme.$color-failure-11;
+      line-height: 18px;
+      text-align: center;
+      white-space: break-spaces;
+      font-size: $font-size-small;
+    }
   }
 }

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -26,5 +26,6 @@
   &__image {
     width: 100%;
     height: 100%;
+    object-fit: cover;
   }
 }

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -48,8 +48,4 @@
     width: 32px;
     height: 32px;
   }
-
-  &__input {
-    display: none;
-  }
 }

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -38,7 +38,8 @@
     }
 
     &__text-content {
-      word-break: break-all;
+      word-break: break-word;
+      line-height: 18px;
     }
 
     &__image-container {

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -56,7 +56,7 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
             <Input value={this.state.name} onChange={this.nameChanged} />
           </div>
 
-          <div>
+          <div className={c('field-info-container')}>
             <div className={c('field-info')}>
               <span className={c('label')}>Group image</span>
               <span className={c('optional')}>Optional</span>

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -273,9 +273,17 @@ $side-padding: 16px;
     }
   }
 
+  &__field-info-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   &__field-info {
     display: flex;
-    align-content: stretch;
+    align-items: baseline;
+    justify-content: space-between;
+    width: 100%;
     line-height: 24px;
     margin-bottom: 12px;
     margin-top: 12px;
@@ -286,17 +294,12 @@ $side-padding: 16px;
   }
 
   &__label {
-    flex-grow: 1;
-
     color: theme.$color-greyscale-12;
     font-weight: 400;
     font-size: 16px;
   }
 
   &__optional {
-    flex-grow: 0;
-    flex-shrink: 0;
-
     color: theme.$color-greyscale-11;
     font-family: 'SF Pro Text';
     font-size: $font-size-small;

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -304,7 +304,6 @@ $side-padding: 16px;
 
   .group-details-panel__image-upload {
     font-size: $font-size-medium;
-    color: theme.$color-greyscale-12;
   }
 }
 


### PR DESCRIPTION
### What does this do?
After an image has been uploaded, there is now an option to choose another. This functionality is triggered by an edit icon. The drag and drop functionality also works for replacing an image.

Adds error state to `ImageUpload`.

This PR also fixes the aspect ratio issue on uploaded images.

### Why are we making this change?
So a user is able to change the image they have selected. This may be for a number of reasons, i.e. selected the wrong image in the media picker.

### How do I test this?
Navigate to one of the flows that contains the ImageUpload component. Upload an image and select the IconButton to open the media picker and replace the image, or drag and drop an image file over the ImageUpload component.

https://github.com/zer0-os/zOS/assets/39112648/9399e660-7e09-4443-9585-5e06a2cc200d

Error State:
<img width="452" alt="Screenshot 2023-06-01 at 13 45 33" src="https://github.com/zer0-os/zOS/assets/39112648/5ad75fcd-6a4e-4040-816c-ea397a0f3d2d">

<img width="452" alt="Screenshot 2023-06-01 at 14 32 01" src="https://github.com/zer0-os/zOS/assets/39112648/51f84004-e60d-4356-b7e5-af9a11b6c3d0">
