### PR TITLE
Push logout functionality from components to sagas

### DIFF
--- a/src/components/authentication/index.test.tsx
+++ b/src/components/authentication/index.test.tsx
@@ -149,24 +149,6 @@ describe('Authentication', () => {
     expect(nonceOrAuthorize).not.toHaveBeenCalled();
   });
 
-  it('should call terminateAuthorization when disconnect event triggered', () => {
-    const terminateAuthorization = jest.fn();
-
-    const wrapper = subject({
-      connectionStatus: ConnectionStatus.Disconnected,
-      user: {
-        isLoading: false,
-        data: USER_DATA,
-      },
-
-      terminateAuthorization,
-    });
-
-    wrapper.setProps({ connectionStatus: ConnectionStatus.Connected });
-
-    expect(terminateAuthorization).toHaveBeenCalled();
-  });
-
   it('should set logged in state to false, if user is loaded but user data is still null, and redirects to login', () => {
     const wrapper = subject({
       user: {

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -73,16 +73,6 @@ export class Container extends React.Component<Properties, State> {
       this.authorize();
     }
 
-    if (
-      prevProps.connectionStatus !== ConnectionStatus.Connected &&
-      this.props.connectionStatus === ConnectionStatus.Connected &&
-      this.props.user.isLoading === false &&
-      !this.props.currentAddress &&
-      this.props.user.data !== null
-    ) {
-      this.props.terminateAuthorization();
-    }
-
     // loading is done, but user data is still null (that means fetchCurrentUser saga failed),
     // then "force login"
     if (prevProps.user.isLoading === true && this.props.user.isLoading === false && this.props.user.data === null) {

--- a/src/components/wallet-manager/index.test.tsx
+++ b/src/components/wallet-manager/index.test.tsx
@@ -13,7 +13,7 @@ describe('WalletManager', () => {
   const subject = (props: any = {}) => {
     const allProps = {
       loginByWeb3: () => undefined,
-      updateConnector: () => undefined,
+      logout: () => undefined,
       setWalletModalOpen: () => undefined,
       ...props,
     };
@@ -72,15 +72,15 @@ describe('WalletManager', () => {
     );
   });
 
-  it('calls update connector when disconnect event occurs', () => {
-    const updateConnector = jest.fn();
+  it('calls logout when disconnect occurs', () => {
+    const logout = jest.fn();
     const currentAddress = '0x0000000000000000000000000000000000000001';
 
-    const wrapper = subject({ updateConnector, currentAddress });
+    const wrapper = subject({ logout, currentAddress });
 
     wrapper.find(UserActionsContainer).simulate('disconnect');
 
-    expect(updateConnector).toHaveBeenCalledWith('none');
+    expect(logout).toHaveBeenCalled();
     expect(wrapper.find(ConnectButton).exists()).toBe(true);
   });
 

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -16,6 +16,7 @@ import { UserActionsContainer } from '../user-actions/container';
 import { WalletSelectModal } from '../wallet-select/modal';
 import { WalletType } from '../wallet-select/wallets';
 import { loginByWeb3 } from '../../store/login';
+import { logout } from '../../store/authentication';
 
 interface PublicProperties {
   className?: string;
@@ -24,7 +25,7 @@ interface PublicProperties {
 export interface Properties extends PublicProperties {
   currentAddress: string;
   connectionStatus: ConnectionStatus;
-  updateConnector: (connector: WalletType | Connectors.None) => void;
+  logout: () => void;
   loginByWeb3: (connector: Connectors) => void;
   setWalletModalOpen: (isWalletModalOpen: boolean) => void;
   isWalletModalOpen: Web3State['isWalletModalOpen'];
@@ -59,7 +60,7 @@ export class Container extends React.Component<Properties> {
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
-      updateConnector,
+      logout,
       loginByWeb3,
       setWalletModalOpen,
       updateConversationState: (isOpen: boolean) => updateSidekick({ isOpen }),
@@ -67,7 +68,7 @@ export class Container extends React.Component<Properties> {
   }
 
   handleDisconnect = () => {
-    this.props.updateConnector(Connectors.None);
+    this.props.logout();
   };
 
   get showModal(): boolean {

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -5,7 +5,7 @@ import { ConnectionStatus, Connectors } from '../../lib/web3';
 import { getChainNameFromId } from '../../lib/web3/chains';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
-import { Web3State, setWalletModalOpen, updateConnector } from '../../store/web3';
+import { Web3State, setWalletModalOpen } from '../../store/web3';
 import { isElectron } from '../../utils';
 import { Button as ConnectButton } from '../../components/authentication/button';
 import './styles.scss';

--- a/src/store/authentication/index.ts
+++ b/src/store/authentication/index.ts
@@ -5,11 +5,13 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 export enum SagaActionTypes {
   NonceOrAuthorize = 'authentication/saga/nonceOrAuthorize',
   Terminate = 'authentication/saga/terminate',
+  Logout = 'authentication/saga/logout',
   FetchCurrentUserWithChatAccessToken = 'authentication/saga/fetchCurrentUserWithChatAccessToken',
 }
 
 const nonceOrAuthorize = createAction<Payload>(SagaActionTypes.NonceOrAuthorize);
 const terminate = createAction<Payload>(SagaActionTypes.Terminate);
+export const logout = createAction(SagaActionTypes.Logout);
 const fetchCurrentUserWithChatAccessToken = createAction<Payload>(SagaActionTypes.FetchCurrentUserWithChatAccessToken);
 
 const initialState: AuthenticationState = {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -17,6 +17,8 @@ import { clearNotifications } from '../notifications/saga';
 import { clearUsers } from '../users/saga';
 import { clearMessages } from '../messages/saga';
 import { multicastChannel } from 'redux-saga';
+import { updateConnector } from '../web3/saga';
+import { Connectors } from '../../lib/web3';
 
 export interface Payload {
   signedWeb3Token: string;
@@ -134,7 +136,13 @@ export function* clearUserState() {
 export function* saga() {
   yield takeLatest(SagaActionTypes.NonceOrAuthorize, nonceOrAuthorize);
   yield takeLatest(SagaActionTypes.Terminate, terminate);
+  yield takeLatest(SagaActionTypes.Logout, logout);
   yield takeLatest(SagaActionTypes.FetchCurrentUserWithChatAccessToken, getCurrentUserWithChatAccessToken);
+}
+
+export function* logout() {
+  yield call(updateConnector, { payload: Connectors.None });
+  yield call(terminate);
 }
 
 let theChannel;

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -49,7 +49,7 @@ export function* getSignedToken(connector) {
     const token = yield call(personalSignToken, providerService.get(), address);
     return { success: true, token };
   } catch (error) {
-    yield updateConnector(Connectors.None);
+    yield updateConnector({ payload: Connectors.None });
     return { success: false, error: 'Error signing token' };
   }
 }


### PR DESCRIPTION
### What does this do?

Moves the logout handling to a saga rather than within the components reacting to property updates.

