### PR TITLE
Add an action type to the user login/logout events

### DIFF
--- a/src/store/authentication/channels.ts
+++ b/src/store/authentication/channels.ts
@@ -1,0 +1,15 @@
+import { multicastChannel } from 'redux-saga';
+import { call } from 'redux-saga/effects';
+
+export enum Events {
+  UserLogin = 'user/login',
+  UserLogout = 'user/logout',
+}
+
+let theChannel;
+export function* authChannel() {
+  if (!theChannel) {
+    theChannel = yield call(multicastChannel);
+  }
+  return theChannel;
+}

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -47,13 +47,13 @@ export function* nonceOrAuthorize(action) {
 }
 
 export function* terminate() {
+  yield processUserAccount({ user: null, nonce: null, chatAccessToken: null, isLoading: false });
+
   try {
     yield call(clearSessionApi);
   } catch {
     /* No operation, if user is unauthenticated deleting the cookie fails */
   }
-
-  yield processUserAccount({ user: null, nonce: null, chatAccessToken: null, isLoading: false });
 }
 
 export function* getCurrentUserWithChatAccessToken() {
@@ -102,9 +102,6 @@ export function* processUserAccount(params: {
       : ChannelsListSagaActionTypes.StopChannelsAndConversationsAutoRefresh,
   });
 
-  // XXX: I wonder if we have weird race conditions if we rely on these events
-  // and, for account change, we'd get a logout AND a login event...in succession...
-  // which happens first...who's process runs when...figure this out.
   let type = '';
   if (user) {
     yield spawn(initializeUserState, user);

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -16,7 +16,6 @@ import { clearChannelsAndConversations } from '../channels-list/saga';
 import { clearNotifications } from '../notifications/saga';
 import { clearUsers } from '../users/saga';
 import { clearMessages } from '../messages/saga';
-import { multicastChannel } from 'redux-saga';
 import { updateConnector } from '../web3/saga';
 import { Connectors } from '../../lib/web3';
 import { Events, authChannel } from './channels';

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -102,15 +102,23 @@ export function* processUserAccount(params: {
       : ChannelsListSagaActionTypes.StopChannelsAndConversationsAutoRefresh,
   });
 
+  // XXX: I wonder if we have weird race conditions if we rely on these events
+  // and, for account change, we'd get a logout AND a login event...in succession...
+  // which happens first...who's process runs when...figure this out.
+  let type = '';
   if (user) {
     yield spawn(initializeUserState, user);
+    // XXX: move to a constant
+    type = 'USER_LOGIN';
   } else {
     yield spawn(clearUserState);
+    type = 'USER_LOGOUT';
   }
 
+  // XXX: MOve the auth channel to a separate file and put the event types in there too.
   // Publish a message across the authChannel
   const channel = yield call(authChannel);
-  yield put(channel, { userId: user?.id });
+  yield put(channel, { type, userId: user?.id });
 }
 
 export function* initializeUserState(user: User) {

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,4 +1,4 @@
-import { put, call, select, race, take, fork, takeEvery } from 'redux-saga/effects';
+import { put, call, select, race, take, fork } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, setGroupUsers, setStage } from '.';
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
 import { fetchConversationsWithUsers } from '../channels-list/api';

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,9 +1,10 @@
-import { put, call, select, race, take, fork } from 'redux-saga/effects';
+import { put, call, select, race, take, fork, takeEvery } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, setGroupUsers, setStage } from '.';
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
 import { fetchConversationsWithUsers } from '../channels-list/api';
 import { setActiveMessengerId } from '../chat';
-import { authChannel, currentUserSelector } from '../authentication/saga';
+import { currentUserSelector } from '../authentication/saga';
+import { Events, authChannel } from '../authentication/channels';
 
 export function* reset() {
   yield put(setGroupUsers([]));
@@ -129,7 +130,7 @@ function* handleGroupDetails() {
 function* authWatcher() {
   const channel = yield call(authChannel);
   while (true) {
-    yield take(channel, 'USER_LOGOUT');
+    yield take(channel, Events.UserLogout);
     yield put({ type: SagaActionTypes.Cancel });
   }
 }

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -129,9 +129,7 @@ function* handleGroupDetails() {
 function* authWatcher() {
   const channel = yield call(authChannel);
   while (true) {
-    const payload = yield take(channel, '*');
-    if (!payload.userId) {
-      yield put({ type: SagaActionTypes.Cancel });
-    }
+    yield take(channel, 'USER_LOGOUT');
+    yield put({ type: SagaActionTypes.Cancel });
   }
 }

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -2,7 +2,7 @@ import { take, put, call, race, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, reset, setInvite } from '.';
 import { getInvite } from './api';
 import { config } from '../../config';
-import { authChannel } from '../authentication/saga';
+import { authChannel } from '../authentication/channels';
 
 export function* fetchInvite() {
   while (true) {

--- a/src/store/notifications/saga.test.ts
+++ b/src/store/notifications/saga.test.ts
@@ -17,7 +17,7 @@ import {
 import { setStatus, relevantNotificationTypes, SagaActionTypes, relevantNotificationEvents } from '.';
 import { fetchNotification, fetchNotifications } from './api';
 import { sample } from 'lodash';
-import { authChannel } from '../authentication/saga';
+import { authChannel } from '../authentication/channels';
 import { multicastChannel } from 'redux-saga';
 
 describe('notifications list saga', () => {

--- a/src/store/notifications/saga.ts
+++ b/src/store/notifications/saga.ts
@@ -13,7 +13,7 @@ import {
 } from '.';
 import { fetchNotification, fetchNotifications } from './api';
 import PusherClient from '../../lib/pusher';
-import { authChannel } from '../authentication/saga';
+import { authChannel } from '../authentication/channels';
 
 export interface Payload {
   userId: string;


### PR DESCRIPTION
### What does this do?

Adds a `type` attribute to the multicast user events.

### Why are we making this change?

Allows listeners to filter on the event type that they care about.

### How do I test this?

Login and logout in various configurations. Verify that the create conversation state is cleared, notifications are re-registered, inivites are fetched for the new user, etc.

