### PR TITLE
Zos 353: Realtime messages arent consistent

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -28,6 +28,7 @@ export class Chat {
     }) as SendbirdGroupChat;
 
     this.sendbird.options.sessionTokenRefreshTimeout = 1800; // 30min Max
+    this.sendbird.options.websocketResponseTimeout = 1800; // 30min Max
   }
 
   async connect(userId: string, accessToken) {
@@ -45,6 +46,13 @@ export class Chat {
     this.initSessionHandler(events);
     this.initConnectionHandlers(events);
     this.initChannelHandlers(events);
+
+    // every 10s set the app to foreground, to prevent sendbird sdk from disconnecting
+    // when the app is in the background.
+    // note: this is a temporary fix, we should find a better way to handle this
+    setInterval(() => {
+      this.sendbird.setForegroundState();
+    }, 10 * 1000);
   }
 
   initSessionHandler(events: RealtimeChatEvents) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -27,8 +27,7 @@ export class Chat {
       modules: [new GroupChannelModule()],
     }) as SendbirdGroupChat;
 
-    this.sendbird.options.sessionTokenRefreshTimeout = 1800; // 30min Max
-    this.sendbird.options.websocketResponseTimeout = 1800; // 30min Max
+    this.sendbird.options.sessionTokenRefreshTimeout = 2 * 60 * 60; // 2 hour
   }
 
   async connect(userId: string, accessToken) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -27,7 +27,7 @@ export class Chat {
       modules: [new GroupChannelModule()],
     }) as SendbirdGroupChat;
 
-    this.sendbird.options.sessionTokenRefreshTimeout = 1800; // Max
+    this.sendbird.options.sessionTokenRefreshTimeout = 1800; // 30min Max
   }
 
   async connect(userId: string, accessToken) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -1,4 +1,4 @@
-import SendbirdChat, { ConnectionHandler, ConnectionState, LogLevel, SessionHandler } from '@sendbird/chat';
+import SendbirdChat, { ConnectionHandler, ConnectionState, SessionHandler } from '@sendbird/chat';
 import { GroupChannelHandler, GroupChannelModule, SendbirdGroupChat } from '@sendbird/chat/groupChannel';
 import { config } from '../../config';
 
@@ -29,7 +29,6 @@ export class Chat {
 
     this.sendbird.options.sessionTokenRefreshTimeout = 1800; // 30min Max
     this.sendbird.options.websocketResponseTimeout = 1800; // 30min Max
-    //this.sendbird.logLevel = LogLevel.DEBUG;
   }
 
   async connect(userId: string, accessToken) {
@@ -48,7 +47,7 @@ export class Chat {
     this.initConnectionHandlers(events);
     this.initChannelHandlers(events);
 
-    // every 10s check if the connection state is CLOSED, if it is, set the app to foreground,
+    // every 5s check if the connection state is CLOSED, if it is, set the app to foreground,
     // to prevent sendbird sdk from disconnecting (when the app is in the background)
     setInterval(() => {
       if (this.sendbird.connectionState === ConnectionState.CLOSED) {
@@ -81,9 +80,6 @@ export class Chat {
       onReconnectStarted: () => events.reconnectStart(),
       onReconnectSucceeded: () => events.reconnectStop(),
       onReconnectFailed: () => this.sendbird.reconnect(),
-      onDisconnected: () => {
-        console.log('disconnected at: ', new Date().valueOf());
-      },
     });
 
     this.sendbird.addConnectionHandler('connectionHandler', connectionHandler);

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -46,13 +46,13 @@ export class Chat {
     this.initConnectionHandlers(events);
     this.initChannelHandlers(events);
 
-    // every 5s check if the connection state is CLOSED, if it is, set the app to foreground,
+    // every 10s check if the connection state is CLOSED, if it is, set the app to foreground,
     // to prevent sendbird sdk from disconnecting (when the app is in the background)
     setInterval(() => {
       if (this.sendbird.connectionState === ConnectionState.CLOSED) {
         this.sendbird.setForegroundState();
       }
-    }, 5 * 1000);
+    }, 10 * 1000);
   }
 
   initSessionHandler(events: RealtimeChatEvents) {

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -17,6 +17,7 @@ const fetchChannels = createAction<string>(SagaActionTypes.FetchChannels);
 const fetchConversations = createAction<string>(SagaActionTypes.FetchConversations);
 const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
 const channelsReceived = createAction<ChannelsReceivedPayload>(SagaActionTypes.ChannelsReceived);
+const startChannelsAndConversationsAutoRefresh = createAction(SagaActionTypes.StartChannelsAndConversationsAutoRefresh);
 
 const slice = createNormalizedListSlice({
   name: 'channelsList',
@@ -25,7 +26,13 @@ const slice = createNormalizedListSlice({
 
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
-export { fetchChannels, fetchConversations, createConversation, channelsReceived };
+export {
+  fetchChannels,
+  fetchConversations,
+  createConversation,
+  channelsReceived,
+  startChannelsAndConversationsAutoRefresh,
+};
 
 export function denormalizeChannels(state) {
   return denormalizeChannelsAndConversations(state).filter((c) => c.isChannel);


### PR DESCRIPTION
### What does this do?

Forces a channels + conversations refresh after reconnection with the sendbird client. 

### Why are we making this change?

Realtime message doesn't seem as realtime as they should be.