### PR TITLE
Move web3 account change handling into sagas

### DIFF
--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -2,18 +2,12 @@ import React from 'react';
 
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
-import { inject as injectWeb3 } from '../../lib/web3/web3-react';
-import { inject as injectProviderService } from '../../lib/web3/provider-service';
-import { ConnectionStatus } from '../../lib/web3';
 import { fetchCurrentUserWithChatAccessToken } from '../../store/authentication';
 import { AuthenticationState } from '../../store/authentication/types';
 import { Redirect } from 'react-router-dom';
 import { featureFlags } from '../../lib/feature-flags';
 
 export interface Properties {
-  connectionStatus: ConnectionStatus;
-  providerService: { get: () => any };
-  currentAddress: string;
   fetchCurrentUserWithChatAccessToken: () => void;
   user: AuthenticationState['user'];
 }
@@ -30,12 +24,8 @@ export class Container extends React.Component<Properties, State> {
   static mapState(state: RootState): Partial<Properties> {
     const {
       authentication: { user },
-      web3: { status, value },
     } = state;
-
     return {
-      currentAddress: value.address,
-      connectionStatus: status,
       user,
     };
   }
@@ -69,4 +59,4 @@ export class Container extends React.Component<Properties, State> {
   }
 }
 
-export const Authentication = injectProviderService(injectWeb3(connectContainer<{}>(Container)));
+export const Authentication = connectContainer<{}>(Container);

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -10,6 +10,7 @@ import { AuthenticationState } from '../../store/authentication/types';
 import { updateConnector } from '../../store/web3';
 import { Redirect } from 'react-router-dom';
 import { featureFlags } from '../../lib/feature-flags';
+import { web3ChangeAccount } from '../../store/login';
 
 export interface Properties {
   connectionStatus: ConnectionStatus;
@@ -19,6 +20,7 @@ export interface Properties {
   nonceOrAuthorize: (payload: { signedWeb3Token: string }) => void;
   terminateAuthorization: () => void;
   fetchCurrentUserWithChatAccessToken: () => void;
+  web3ChangeAccount: () => void;
   user: AuthenticationState['user'];
   personalSignToken: any;
 }
@@ -55,6 +57,7 @@ export class Container extends React.Component<Properties, State> {
       fetchCurrentUserWithChatAccessToken,
       terminateAuthorization: terminate,
       updateConnector,
+      web3ChangeAccount,
     };
   }
 
@@ -81,23 +84,8 @@ export class Container extends React.Component<Properties, State> {
   }
 
   async authorize() {
-    const {
-      personalSignToken,
-      currentAddress,
-      nonceOrAuthorize,
-      updateConnector,
-      terminateAuthorization,
-      providerService,
-    } = this.props;
-
-    await personalSignToken(providerService.get(), currentAddress)
-      .then((signedWeb3Token) => {
-        terminateAuthorization();
-        nonceOrAuthorize({ signedWeb3Token });
-      })
-      .catch((_error) => {
-        updateConnector(Connectors.None);
-      });
+    // XXX: This shouldn't happen in the component. Move up to event based sagas.
+    this.props.web3ChangeAccount();
   }
 
   redirectIfNotLoggedIn = () => {

--- a/src/components/authentication/index.tsx
+++ b/src/components/authentication/index.tsx
@@ -4,25 +4,18 @@ import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { inject as injectWeb3 } from '../../lib/web3/web3-react';
 import { inject as injectProviderService } from '../../lib/web3/provider-service';
-import { ConnectionStatus, Connectors, personalSignToken } from '../../lib/web3';
-import { nonceOrAuthorize, terminate, fetchCurrentUserWithChatAccessToken } from '../../store/authentication';
+import { ConnectionStatus } from '../../lib/web3';
+import { fetchCurrentUserWithChatAccessToken } from '../../store/authentication';
 import { AuthenticationState } from '../../store/authentication/types';
-import { updateConnector } from '../../store/web3';
 import { Redirect } from 'react-router-dom';
 import { featureFlags } from '../../lib/feature-flags';
-import { web3ChangeAccount } from '../../store/login';
 
 export interface Properties {
   connectionStatus: ConnectionStatus;
   providerService: { get: () => any };
   currentAddress: string;
-  updateConnector: (Connectors) => void;
-  nonceOrAuthorize: (payload: { signedWeb3Token: string }) => void;
-  terminateAuthorization: () => void;
   fetchCurrentUserWithChatAccessToken: () => void;
-  web3ChangeAccount: () => void;
   user: AuthenticationState['user'];
-  personalSignToken: any;
 }
 
 interface State {
@@ -32,10 +25,6 @@ interface State {
 export class Container extends React.Component<Properties, State> {
   state: State = {
     isLoggedIn: true,
-  };
-
-  static defaultProps = {
-    personalSignToken,
   };
 
   static mapState(state: RootState): Partial<Properties> {
@@ -53,11 +42,7 @@ export class Container extends React.Component<Properties, State> {
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
-      nonceOrAuthorize,
       fetchCurrentUserWithChatAccessToken,
-      terminateAuthorization: terminate,
-      updateConnector,
-      web3ChangeAccount,
     };
   }
 
@@ -66,26 +51,11 @@ export class Container extends React.Component<Properties, State> {
   }
 
   componentDidUpdate(prevProps: Properties) {
-    if (
-      this.props.connectionStatus === ConnectionStatus.Connected &&
-      this.props.currentAddress &&
-      this.props.currentAddress !== prevProps.currentAddress &&
-      this.props.user.isLoading === false &&
-      this.props.user.data !== null
-    ) {
-      this.authorize();
-    }
-
     // loading is done, but user data is still null (that means fetchCurrentUser saga failed),
     // then "force login"
     if (prevProps.user.isLoading === true && this.props.user.isLoading === false && this.props.user.data === null) {
       this.setState({ isLoggedIn: false });
     }
-  }
-
-  async authorize() {
-    // XXX: This shouldn't happen in the component. Move up to event based sagas.
-    this.props.web3ChangeAccount();
   }
 
   redirectIfNotLoggedIn = () => {

--- a/src/store/authentication/channels.ts
+++ b/src/store/authentication/channels.ts
@@ -7,9 +7,12 @@ export enum Events {
 }
 
 let theChannel;
-export function* authChannel() {
+export function* getAuthChannel() {
   if (!theChannel) {
     theChannel = yield call(multicastChannel);
   }
   return theChannel;
 }
+
+// Temporary until all consumers update
+export const authChannel = getAuthChannel;

--- a/src/store/login/index.ts
+++ b/src/store/login/index.ts
@@ -4,6 +4,7 @@ import { Connectors } from '../../lib/web3';
 export enum SagaActionTypes {
   EmailLogin = 'login/emailLogin',
   Web3Login = 'login/web3Login',
+  Web3ChangeAccount = 'login/web3ChangeAccount',
 }
 
 export type LoginState = {
@@ -37,6 +38,7 @@ export const initialState: LoginState = {
 
 export const loginByEmail = createAction<{ email: string; password: string }>(SagaActionTypes.EmailLogin);
 export const loginByWeb3 = createAction<Connectors>(SagaActionTypes.Web3Login);
+export const web3ChangeAccount = createAction<Connectors>(SagaActionTypes.Web3ChangeAccount);
 
 const slice = createSlice({
   name: 'login',

--- a/src/store/login/index.ts
+++ b/src/store/login/index.ts
@@ -4,7 +4,6 @@ import { Connectors } from '../../lib/web3';
 export enum SagaActionTypes {
   EmailLogin = 'login/emailLogin',
   Web3Login = 'login/web3Login',
-  Web3ChangeAccount = 'login/web3ChangeAccount',
 }
 
 export type LoginState = {

--- a/src/store/login/index.ts
+++ b/src/store/login/index.ts
@@ -38,7 +38,6 @@ export const initialState: LoginState = {
 
 export const loginByEmail = createAction<{ email: string; password: string }>(SagaActionTypes.EmailLogin);
 export const loginByWeb3 = createAction<Connectors>(SagaActionTypes.Web3Login);
-export const web3ChangeAccount = createAction<Connectors>(SagaActionTypes.Web3ChangeAccount);
 
 const slice = createSlice({
   name: 'login',

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -2,7 +2,7 @@ import { call, put, take, takeLatest } from 'redux-saga/effects';
 
 import { emailLogin as apiEmailLogin } from './api';
 import { EmailLoginErrors, LoginStage, SagaActionTypes, Web3LoginErrors, setErrors, setLoading, setStage } from '.';
-import { getSignedToken } from '../web3/saga';
+import { getSignedTokenForConnector } from '../web3/saga';
 import { nonceOrAuthorize } from '../authentication/saga';
 import { setWalletModalOpen } from '../web3';
 
@@ -53,7 +53,7 @@ export function* web3Login(action) {
   yield put(setLoading(true));
   yield put(setErrors([]));
   try {
-    let result = yield call(getSignedToken, connector);
+    let result = yield call(getSignedTokenForConnector, connector);
     if (!result.success) {
       yield put(setErrors([result.error]));
       return;

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -2,9 +2,10 @@ import { call, put, take, takeLatest } from 'redux-saga/effects';
 
 import { emailLogin as apiEmailLogin } from './api';
 import { EmailLoginErrors, LoginStage, SagaActionTypes, Web3LoginErrors, setErrors, setLoading, setStage } from '.';
-import { getSignedTokenForConnector } from '../web3/saga';
-import { nonceOrAuthorize } from '../authentication/saga';
+import { getSignedToken, getSignedTokenForConnector, updateConnector } from '../web3/saga';
+import { logout, nonceOrAuthorize, terminate } from '../authentication/saga';
 import { setWalletModalOpen } from '../web3';
+import { Connectors } from '../../lib/web3';
 
 export function* emailLogin(action) {
   const { email, password } = action.payload;
@@ -75,8 +76,33 @@ export function* web3Login(action) {
   }
 }
 
+export function* web3ChangeAccount() {
+  let result = yield call(getSignedToken);
+  if (!result.success) {
+    // I'm not sure if this is the right thing to do.
+    // If you don't sign the token and we reset this to None
+    // then the connector is in a weird state where we have your
+    // newly selected address but you're logged into a different account
+    yield call(updateConnector, { payload: Connectors.None });
+  }
+
+  yield call(terminate);
+
+  result = yield call(nonceOrAuthorize, { payload: { signedWeb3Token: result.token } });
+  if (result.nonce) {
+    // For now, receiving a nonce means we are not logged in as it wants you
+    // to create a new account. This is to support the existing zOS flow where you can
+    // create a new account from the public zOS UI.
+    yield put(setErrors([Web3LoginErrors.PROFILE_NOT_FOUND]));
+  } else {
+    yield put(setStage(LoginStage.Done));
+  }
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.Web3Login, web3Login);
+  // XXX: this should only be happening if we logged in via web3
+  yield takeLatest(SagaActionTypes.Web3ChangeAccount, web3ChangeAccount);
 
   let success;
   do {

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -34,7 +34,7 @@ import { nonce as nonceApi } from '../authentication/api';
 import { throwError } from 'redux-saga-test-plan/providers';
 import { setActiveMessengerId } from '../chat';
 import { Connectors } from '../../lib/web3';
-import { getSignedToken } from '../web3/saga';
+import { getSignedTokenForConnector } from '../web3/saga';
 
 const featureFlags = { allowWeb3Registration: false };
 jest.mock('../../lib/feature-flags', () => ({
@@ -502,7 +502,7 @@ describe('authorizeAndCreateWeb3Account', () => {
     } = await expectSaga(authorizeAndCreateWeb3Account, { payload: { connector: Connectors.Metamask } })
       .provide([
         [
-          call(getSignedToken, Connectors.Metamask),
+          call(getSignedTokenForConnector, Connectors.Metamask),
           { success: true, token: signedToken },
         ],
         [

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -28,7 +28,7 @@ import { conversationsChannel } from '../channels-list/channels';
 import { rawConversationsList } from '../channels-list/saga';
 import { setActiveMessengerId } from '../chat';
 import { featureFlags } from '../../lib/feature-flags';
-import { getSignedToken } from '../web3/saga';
+import { getSignedTokenForConnector } from '../web3/saga';
 
 export function* validateInvite(action) {
   const { code } = action.payload;
@@ -99,7 +99,7 @@ export function* authorizeAndCreateWeb3Account(action) {
 
   yield put(setLoading(true));
   try {
-    let result = yield call(getSignedToken, connector);
+    let result = yield call(getSignedTokenForConnector, connector);
     if (!result.success) {
       yield put(setErrors([result.error]));
       return false;

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -29,6 +29,7 @@ import { rawConversationsList } from '../channels-list/saga';
 import { setActiveMessengerId } from '../chat';
 import { featureFlags } from '../../lib/feature-flags';
 import { getSignedTokenForConnector } from '../web3/saga';
+import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
 
 export function* validateInvite(action) {
   const { code } = action.payload;
@@ -168,6 +169,7 @@ export function* updateProfile(action) {
     if (response.success) {
       yield put(setFirstTimeLogin(true));
       yield put(setStage(RegistrationStage.Done));
+      yield spawn(clearRegistrationStateOnLogout);
       return true;
     } else {
       yield put(setErrors([ProfileDetailsErrors.UNKNOWN_ERROR]));
@@ -210,6 +212,13 @@ function* updateProfilePage() {
     const action = yield take(SagaActionTypes.UpdateProfile);
     success = yield call(updateProfile, action);
   } while (!success);
+}
+
+function* clearRegistrationStateOnLogout() {
+  const authChannel = yield call(getAuthChannel);
+  yield take(authChannel, AuthEvents.UserLogout);
+  yield put(setFirstTimeLogin(false));
+  yield put(setInviteToastOpen(false));
 }
 
 export function* saga() {

--- a/src/store/web3/channels.ts
+++ b/src/store/web3/channels.ts
@@ -1,6 +1,10 @@
 import { multicastChannel } from 'redux-saga';
 import { call } from 'redux-saga/effects';
 
+export enum Web3Events {
+  AddressChanged = 'web3/address-changed',
+}
+
 let theWeb3Channel;
 export function* web3Channel() {
   if (!theWeb3Channel) {

--- a/src/store/web3/channels.ts
+++ b/src/store/web3/channels.ts
@@ -6,9 +6,12 @@ export enum Web3Events {
 }
 
 let theWeb3Channel;
-export function* web3Channel() {
+export function* getWeb3Channel() {
   if (!theWeb3Channel) {
     theWeb3Channel = yield call(multicastChannel);
   }
   return theWeb3Channel;
 }
+
+// Temporary until all consumers update
+export const web3Channel = getWeb3Channel;

--- a/src/store/web3/saga.test.ts
+++ b/src/store/web3/saga.test.ts
@@ -1,6 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan';
 
-import { getSignedToken, updateConnector, waitForAddressChange, waitForError } from './saga';
+import { getSignedTokenForConnector, updateConnector, waitForAddressChange, waitForError } from './saga';
 import { Connectors, ConnectionStatus, personalSignToken } from '../../lib/web3';
 import { reducer } from '.';
 import { call } from 'redux-saga/effects';
@@ -25,9 +25,9 @@ describe('web3 saga', () => {
   });
 });
 
-describe('getSignedToken', () => {
+describe(getSignedTokenForConnector, () => {
   it('connects and waits for an address change when connection is not already set up', async () => {
-    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+    const { returnValue } = await expectSaga(getSignedTokenForConnector, Connectors.Metamask)
       .provide([
         [
           call(waitForAddressChange),
@@ -50,7 +50,7 @@ describe('getSignedToken', () => {
   });
 
   it('connects when the connector has changed', async () => {
-    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+    const { returnValue } = await expectSaga(getSignedTokenForConnector, Connectors.Metamask)
       .provide([
         [
           call(waitForAddressChange),
@@ -74,7 +74,7 @@ describe('getSignedToken', () => {
   });
 
   it('does not try to connect again if an address/connector is already selected', async () => {
-    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+    const { returnValue } = await expectSaga(getSignedTokenForConnector, Connectors.Metamask)
       .provide([
         [
           call(getService),
@@ -93,7 +93,7 @@ describe('getSignedToken', () => {
   });
 
   it('returns an error when connection error occurs', async () => {
-    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+    const { returnValue } = await expectSaga(getSignedTokenForConnector, Connectors.Metamask)
       .provide([
         [
           call(waitForError),
@@ -108,7 +108,7 @@ describe('getSignedToken', () => {
   });
 
   it('returns an error when signing error occurs', async () => {
-    const { returnValue } = await expectSaga(getSignedToken, Connectors.Metamask)
+    const { returnValue } = await expectSaga(getSignedTokenForConnector, Connectors.Metamask)
       .provide([
         [
           call(waitForAddressChange),

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -2,7 +2,7 @@ import { takeLatest, put, takeEvery, call, take, select, race } from 'redux-saga
 import { SagaActionTypes, setConnectionStatus, setConnector, setWalletAddress, setWalletConnectionError } from '.';
 
 import { ConnectionStatus, Connectors, personalSignToken } from '../../lib/web3';
-import { web3Channel } from './channels';
+import { Web3Events, web3Channel } from './channels';
 import { getService as getProviderService } from '../../lib/web3/provider-service';
 
 export function* updateConnector(action) {
@@ -13,9 +13,8 @@ export function* updateConnector(action) {
 export function* setAddress(action) {
   yield put(setWalletAddress(action.payload));
 
-  // Publish a system message across the channel
   const channel = yield call(web3Channel);
-  yield put(channel, { type: 'ADDRESS_CHANGED', payload: action.payload });
+  yield put(channel, { type: Web3Events.AddressChanged, payload: action.payload });
 }
 
 export function* setConnectionError(action) {
@@ -63,7 +62,7 @@ export function* getSignedToken(address = null) {
 
 export function* waitForAddressChange() {
   const channel = yield call(web3Channel);
-  const action = yield take(channel, 'ADDRESS_CHANGED');
+  const action = yield take(channel, Web3Events.AddressChanged);
   return action.payload;
 }
 

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -5,6 +5,11 @@ import { ConnectionStatus, Connectors, personalSignToken } from '../../lib/web3'
 import { Web3Events, web3Channel } from './channels';
 import { getService as getProviderService } from '../../lib/web3/provider-service';
 
+export function* isWeb3AccountConnected() {
+  const state = yield select((state) => state.web3);
+  return state.status === ConnectionStatus.Connected && state.value.address !== null;
+}
+
 export function* updateConnector(action) {
   yield put(setConnector(action.payload));
   yield put(setConnectionStatus(ConnectionStatus.Connecting));

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -44,6 +44,13 @@ export function* getSignedTokenForConnector(connector) {
     address = result.address;
   }
 
+  return yield call(getSignedToken, address);
+}
+
+export function* getSignedToken(address = null) {
+  if (!address) {
+    address = yield select((state) => state.web3.value.address);
+  }
   const providerService = yield call(getProviderService);
   try {
     const token = yield call(personalSignToken, providerService.get(), address);

--- a/src/store/web3/saga.ts
+++ b/src/store/web3/saga.ts
@@ -28,7 +28,7 @@ export function* setConnectionError(action) {
   }
 }
 
-export function* getSignedToken(connector) {
+export function* getSignedTokenForConnector(connector) {
   let current = yield select((state) => state.web3.value);
 
   let address = current.address;


### PR DESCRIPTION
### What does this do?

Moves the web3 account change handling logic from component prop updates to sagas

### Why are we making this change?

A continuation of the previous refactorings. Relying on a component to keep up with your application state to transition to new states is hard to manage. Having them in the sagas makes this simpler.

### How do I test this?

Log into the app via web3 in various states. Try changing the web3 account and verify that you are re-logged in as the new account or prompted to finish registering a new account.

