### PR TITLE
Mentions don't render properly in the conversation list

### DIFF
--- a/src/components/messenger/list/conversation-item.test.tsx
+++ b/src/components/messenger/list/conversation-item.test.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 
 import { ConversationItem, Properties } from './conversation-item';
 import moment from 'moment';
+import { ContentHighlighter } from '../../content-highlighter';
 
 describe('ConversationItem', () => {
   const subject = (props: Partial<Properties>) => {
@@ -134,7 +135,7 @@ describe('ConversationItem', () => {
       } as any,
     });
 
-    expect(wrapper.find('.conversation-item__message').text()).toEqual('I said something here');
+    expect(wrapper.find(ContentHighlighter).prop('message')).toEqual('I said something here');
   });
 
   describe('status', () => {

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -10,6 +10,7 @@ import { IconUsers1 } from '@zero-tech/zui/icons';
 
 import { bem } from '../../../lib/bem';
 import moment from 'moment';
+import { ContentHighlighter } from '../../content-highlighter';
 const c = bem('conversation-item');
 
 export interface Properties {
@@ -106,7 +107,9 @@ export class ConversationItem extends React.Component<Properties> {
               <div className={c('timestamp')}>{this.displayDate}</div>
             </div>
             <div className={c('content')}>
-              <div className={c('message')}>{this.message}</div>
+              <div className={c('message')}>
+                <ContentHighlighter message={this.message} />
+              </div>
               {conversation.unreadCount !== 0 && <div className={c('unread-count')}>{conversation.unreadCount}</div>}
             </div>
           </div>


### PR DESCRIPTION
Before

<img width="355" alt="Conversations" src="https://github.com/zer0-os/zOS/assets/33264364/0ee927d8-05eb-4cc6-8019-eff33def5f0d">

After

<img width="330" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/34f032b4-e0c1-4163-bf9e-ba2037b37a99">
