### PR TITLE
Move Web3Connect component render up the tree

### DIFF
--- a/src/authentication/create-wallet-account/container.tsx
+++ b/src/authentication/create-wallet-account/container.tsx
@@ -6,7 +6,6 @@ import { AccountCreationErrors, createWeb3Account } from '../../store/registrati
 
 import { CreateWalletAccount } from '.';
 import { RootState } from '../../store/reducer';
-import { Web3Connect } from '../../components/web3-connect';
 
 export interface Properties {
   error: string;
@@ -46,15 +45,11 @@ export class Container extends React.Component<Properties> {
 
   render() {
     return (
-      <>
-        <Web3Connect>
-          <CreateWalletAccount
-            onSelect={this.connectorSelected}
-            error={this.props.error}
-            isConnecting={this.props.isConnecting}
-          />
-        </Web3Connect>
-      </>
+      <CreateWalletAccount
+        onSelect={this.connectorSelected}
+        error={this.props.error}
+        isConnecting={this.props.isConnecting}
+      />
     );
   }
 }

--- a/src/authentication/web3-login/container.tsx
+++ b/src/authentication/web3-login/container.tsx
@@ -6,7 +6,6 @@ import { loginByWeb3 } from '../../store/login';
 import { connectContainer } from '../../store/redux-container';
 
 import { Web3Login } from '.';
-import { Web3Connect } from '../../components/web3-connect';
 
 export interface Web3LoginContainerProperties {
   error: string;
@@ -33,9 +32,7 @@ export class Container extends React.Component<Web3LoginContainerProperties> {
 
   render() {
     return (
-      <Web3Connect>
-        <Web3Login error={this.props.error} isConnecting={this.props.isConnecting} onSelect={this.props.loginByWeb3} />
-      </Web3Connect>
+      <Web3Login error={this.props.error} isConnecting={this.props.isConnecting} onSelect={this.props.loginByWeb3} />
     );
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import '../node_modules/@zer0-os/zos-component-library/dist/index.css';
 import './index.scss';
 import { Invite } from './invite';
 import { LoginPage } from './pages';
+import { Web3Connect } from './components/web3-connect';
 
 runSagas();
 
@@ -43,10 +44,12 @@ ReactDOM.render(
         <EscapeManagerProvider>
           <Router history={history}>
             <Web3ReactContextProvider>
-              <Route path='/get-access' exact component={Invite} />
-              <Route path='/login' exact component={LoginPage} />
-              <Route path='/:znsRoute?/' exact render={redirectToDefaults} />
-              <Route path='/:znsRoute/:app' component={ZnsRouteConnect} />
+              <Web3Connect>
+                <Route path='/get-access' exact component={Invite} />
+                <Route path='/login' exact component={LoginPage} />
+                <Route path='/:znsRoute?/' exact render={redirectToDefaults} />
+                <Route path='/:znsRoute/:app' component={ZnsRouteConnect} />
+              </Web3Connect>
             </Web3ReactContextProvider>
           </Router>
         </EscapeManagerProvider>

--- a/src/zns-route-connect.test.tsx
+++ b/src/zns-route-connect.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Container } from './zns-route-connect';
-import { Main } from './Main';
-import { Web3Connect } from './components/web3-connect';
 import { Authentication } from './components/authentication';
 
 describe('ZnsRouteConnect', () => {
@@ -47,14 +45,6 @@ describe('ZnsRouteConnect', () => {
 
     return shallow(<Container {...allProps} />);
   };
-
-  it('renders Main component as child of Web3Connect', () => {
-    const container = subject();
-
-    const web3Connect = container.find(Main).closest(Web3Connect);
-
-    expect(web3Connect.exists()).toBe(true);
-  });
 
   it('redirects on mount if znsRoute has no leading zero', () => {
     const replace = jest.fn();

--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -5,7 +5,6 @@ import { History } from 'history';
 
 import { setRoute } from './store/zns';
 import { setSelectedApp } from './store/apps';
-import { Web3Connect } from './components/web3-connect';
 import { Main } from './Main';
 import { Apps } from './lib/apps';
 import { Authentication } from './components/authentication';
@@ -99,12 +98,10 @@ export class Container extends React.Component<Properties> {
       <>
         <Authentication />
         <CreateAccount />
-        <Web3Connect>
-          <AuthenticationContextProvider value={this.authenticationContext}>
-            <ChatConnect />
-            <Main />
-          </AuthenticationContextProvider>
-        </Web3Connect>
+        <AuthenticationContextProvider value={this.authenticationContext}>
+          <ChatConnect />
+          <Main />
+        </AuthenticationContextProvider>
       </>
     );
   }


### PR DESCRIPTION
### What does this do?

This moves the Web3Connect component render up the tree so that we only render it once when the app loads up.

### Why are we making this change?

Moving between parts of the app and having that component wire up from scratch multiple times causes extra, invalid, system level events. This resolves that by making sure it only renders once.

### How do I test this?

* Login via web3. It should log you in.

Note: There is still an issue where your conversations may not load properly. This is a separate issue that will be resolved independently.

