### PR TITLE
feat: highlight conversation item if unread message

### DIFF
--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -34,4 +34,3 @@ export const highlightFilter = (text, filter) => {
 
   return text;
 };
-

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -97,6 +97,9 @@ export class ConversationItem extends React.Component<Properties> {
 
   render() {
     const { conversation } = this.props;
+    const hasUnreadMessages = conversation.unreadCount !== 0;
+    const dataVariant = hasUnreadMessages && 'unread';
+
     return (
       <Tooltip
         placement='left'
@@ -112,14 +115,16 @@ export class ConversationItem extends React.Component<Properties> {
           {this.renderAvatar()}
           <div className={c('summary')}>
             <div className={c('header')}>
-              <div className={c('name')}>{this.highlightedName()}</div>
+              <div className={c('name')} data-variant={dataVariant}>
+                {this.highlightedName()}
+              </div>
               <div className={c('timestamp')}>{this.displayDate}</div>
             </div>
             <div className={c('content')}>
-              <div className={c('message')}>
+              <div className={c('message')} data-variant={dataVariant}>
                 <ContentHighlighter message={this.message} />
               </div>
-              {conversation.unreadCount !== 0 && <div className={c('unread-count')}>{conversation.unreadCount}</div>}
+              {hasUnreadMessages && <div className={c('unread-count')}>{conversation.unreadCount}</div>}
             </div>
           </div>
         </div>

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -355,8 +355,6 @@ $side-padding: 16px;
   margin-bottom: 8px;
   padding: 0 8px;
 
-  font-style: normal;
-  font-weight: 700;
   font-size: $font-size-small;
   line-height: 17px;
 
@@ -391,6 +389,10 @@ $side-padding: 16px;
     text-overflow: ellipsis;
     flex-grow: 1;
     font-size: $font-size-medium;
+
+    &[data-variant='unread'] {
+      font-weight: 700;
+    }
   }
 
   &__timestamp {
@@ -407,8 +409,20 @@ $side-padding: 16px;
     font-size: $font-size-small;
     line-height: 15px;
     overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    padding-right: 1px;
+
+    div {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    &[data-variant='unread'] {
+      div {
+        font-weight: 700;
+        color: theme.$color-greyscale-12;
+      }
+    }
   }
 
   &__unread-count {
@@ -432,11 +446,6 @@ $side-padding: 16px;
     display: flex;
     align-items: center;
     width: 100%;
-  }
-
-  &__message {
-    flex-grow: 1;
-    padding-right: 1px;
   }
 
   &__group-icon {


### PR DESCRIPTION
### What does this do?
Adds bold font-weight to name and message in conversation item when there is an unread message for that current conversation.  Also changed the colour as per design.

Also some refactoring.

### Why are we making this change?
As per design.

### How do I test this?
Receive a message and check in the conversation list panel whether the name and message is now bold in font weight.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="243" alt="Screenshot 2023-06-08 at 15 27 05" src="https://github.com/zer0-os/zOS/assets/39112648/0b557e6f-a6c2-459f-bd1f-8d87bda9ab6f">