### PR TITLE
Null check on the conversation search highlighting

### DIFF
--- a/src/components/messenger/lib/utils.test.ts
+++ b/src/components/messenger/lib/utils.test.ts
@@ -10,6 +10,15 @@ describe('highlightFilter', () => {
     expect(result).toEqual(text);
   });
 
+  it('returns unmodified text when text is not provided', () => {
+    const text = null;
+    const filter = 'world';
+
+    const result = highlightFilter(null, filter);
+
+    expect(result).toEqual(text);
+  });
+
   it('returns highlighted text when filter matches text', () => {
     const text = 'Hello World';
     const filter = 'World';

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -20,7 +20,7 @@ export const conversationToOption = (conversation: Channel): Option[] => {
 export const highlightFilter = (text, filter) => {
   const regex = new RegExp(`(${filter})`, 'i');
 
-  if (filter !== '') {
+  if (filter !== '' && text) {
     return text.split(regex).map((part, index) =>
       part.toLowerCase() === filter.toLowerCase() ? (
         <span key={index} className='highlighted-text'>


### PR DESCRIPTION
### What does this do?

Adds a null/undefined/empty check to the highlightFilter function.

### Why are we making this change?

Bug fix: if a profile doesn't have a name this would crash.

