### PR TITLE
fix: unread icon position

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -445,6 +445,7 @@ $side-padding: 16px;
   &__content {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     width: 100%;
   }
 


### PR DESCRIPTION
### What does this do?
Fixes the placement of the unread icon.

### Why are we making this change?
Unread Icon wasn't being placed at the end of the container.
As per figma design.

### How do I test this?
Check the conversation list panel for a *short* unread message and check the placement of the unread icon. It should sit at the end of the container as per design.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Berfore
<img width="329" alt="Screenshot 2023-06-09 at 10 11 30" src="https://github.com/zer0-os/zOS/assets/39112648/295974ae-2558-4bf0-a7a5-d7ea888a2dff">

After
<img width="329" alt="Screenshot 2023-06-09 at 10 11 40" src="https://github.com/zer0-os/zOS/assets/39112648/8effd848-b57f-46f2-8654-ccf027e49c1c">

