### PR TITLE
feat: add empty current conversation search results state and adjust positioning

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -143,7 +143,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
               />
             ))}
 
-            {this.filteredConversations?.length === 0 && (
+            {this.filteredConversations?.length === 0 && this.state.filter !== '' && (
               <div className='messages-list__empty'>{`You do not have any active conversations with '${this.state.filter}' `}</div>
             )}
 

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -143,6 +143,10 @@ export class ConversationListPanel extends React.Component<Properties, State> {
               />
             ))}
 
+            {this.filteredConversations?.length === 0 && (
+              <div className='messages-list__empty'>{`You do not have any active conversations with '${this.state.filter}' `}</div>
+            )}
+
             {this.state.userSearchResults?.length > 0 && this.state.filter !== '' && (
               <UserSearchResults
                 results={this.state.userSearchResults}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -69,6 +69,13 @@ $side-padding: 16px;
       overflow: auto;
       padding: 0px $side-padding;
     }
+
+    &__empty {
+      padding: 8px;
+      color: theme.$color-greyscale-11;
+      font-size: $font-size-medium;
+      line-height: 17px;
+    }
   }
 }
 
@@ -479,7 +486,7 @@ $side-padding: 16px;
   margin-top: 24px;
 
   &__title {
-    padding: 10px 0;
+    padding: 8px;
     color: theme.$color-greyscale-11;
     font-size: $font-size-medium;
     line-height: 17px;


### PR DESCRIPTION
### What does this do?
When searching and there are no results for current conversations that match what the user has entered,  an empty state will be displayed to inform the user and this will also ensure the vertical padding looks correct. 

### Why are we making this change?
As per design to ensure the gap between search bar and conversation list looks correct.

### How do I test this?
Enter into the search input a name you don't have a current conversation with but there are user results.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  

Before 
<img width="440" alt="Screenshot 2023-06-09 at 13 13 14" src="https://github.com/zer0-os/zOS/assets/39112648/e5609864-6c55-4aae-a0ed-086ebff64bc7">


After
<img width="453" alt="Screenshot 2023-06-09 at 12 52 07" src="https://github.com/zer0-os/zOS/assets/39112648/3ff9d791-a6f0-4313-8cb7-f76851c72caa">
