### PR TITLE
fix: handle word break and ellipsis when there is a link in a messaage

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -413,7 +413,6 @@ $side-padding: 16px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    flex-grow: 1;
     padding-right: 1px;
 
     div {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -401,8 +401,6 @@ $side-padding: 16px;
     font-size: 10px;
     line-height: 12px;
     white-space: nowrap;
-    flex-grow: 0;
-    flex-shrink: 0;
   }
 
   &__message {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -401,6 +401,8 @@ $side-padding: 16px;
     font-size: 10px;
     line-height: 12px;
     white-space: nowrap;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 
   &__message {
@@ -409,6 +411,9 @@ $side-padding: 16px;
     font-size: $font-size-small;
     line-height: 15px;
     overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    flex-grow: 1;
     padding-right: 1px;
 
     div {


### PR DESCRIPTION
### What does this do?
Fixes message height issue when there is a link in a message.

### Why are we making this change?
Bug in production causing chats to overlap/overflow.

### How do I test this?
Check conversation panel and conversation items are not overlapping.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="260" alt="Screenshot 2023-06-09 at 14 36 58" src="https://github.com/zer0-os/zOS/assets/39112648/cd128d23-d497-47c8-89a7-4e4c9715415c">

After: 
<img width="260" alt="Screenshot 2023-06-09 at 14 37 04" src="https://github.com/zer0-os/zOS/assets/39112648/df6fc954-5bf7-400a-8180-8a3d9315cb54">
