### PR TITLE
[Bug] Pasting an image in messenger chat will also paste it in "channels" chat

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -208,6 +208,10 @@ export class MessageInput extends React.Component<Properties, State> {
   };
 
   clipboardEvent = async (event) => {
+    if (document.activeElement !== this.textareaRef.current) {
+      return;
+    }
+
     const items = event.clipboardData.items;
 
     const newImages: any[] = Array.from(items)


### PR DESCRIPTION
Fixes this issue:

https://github.com/zer0-os/zOS/assets/33264364/e041acfc-c483-42e4-99ad-e379aef1abf1

