### PR TITLE
Don't stop polling if error occured

### DIFF
--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -4,13 +4,23 @@ import { get, post } from '../../lib/api/rest';
 import { DirectMessage } from './types';
 
 export async function fetchChannels(id: string) {
-  const channels = await get<any>(`/api/networks/${id}/chatChannels`);
-  return await channels.body;
+  try {
+    const channels = await get<any>(`/api/networks/${id}/chatChannels`);
+    return await channels.body;
+  } catch (error: any) {
+    console.log('Error occured while fetching chatChannels ', error?.response?.body?.error); // eg. error.code = ENOTFOUND
+    return [];
+  }
 }
 
 export async function fetchConversations(): Promise<Channel[]> {
-  const directMessages = await get<Channel[]>('/directMessages/mine');
-  return directMessages.body;
+  try {
+    const directMessages = await get<Channel[]>('/directMessages/mine');
+    return directMessages.body;
+  } catch (error: any) {
+    console.log('Error occured while fetching conversations ', error?.response);
+    return [];
+  }
 }
 
 export async function createConversation(


### PR DESCRIPTION
For now, if an error occures during polling, i am just returning an empty state. This is how it'll look

<img width="1496" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6411224d-d800-48cb-af3a-171cdeea5899">

But now it'll continue to poll. 