### PR TITLE
fix: unread message content to bold if link present in message

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -420,17 +420,20 @@ $side-padding: 16px;
     text-overflow: ellipsis;
     padding-right: 1px;
 
-    div {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-
     &[data-variant='unread'] {
+      font-weight: 700;
+      color: theme.$color-greyscale-12;
+
       div {
         font-weight: 700;
         color: theme.$color-greyscale-12;
       }
+    }
+
+    div {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
   }
 
@@ -447,6 +450,7 @@ $side-padding: 16px;
     height: 16px;
     text-align: center;
     font-size: 8px;
+    font-weight: 700;
     line-height: 11px;
     margin-left: 3px;
   }


### PR DESCRIPTION
### What does this do?
If there is a link present in the unread message content, the text is not displaying as bold, like the name of the user. This is because there is an additional child div tag when a link is added to the message, so the style is not applied. This PR gives the unread message the correct style when a link is present.

One other small change added - font-weight on unread message number/count.

### Why are we making this change?
As per design.

### How do I test this?
Create an unread message to your user from another test user, and ensure to include a link in the message. When opening the messenger the user with the unread message should have their name in bold and the message in bold.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before
<img width="274" alt="Screenshot 2023-06-12 at 16 23 36" src="https://github.com/zer0-os/zOS/assets/39112648/1eb49033-887f-4781-8ba3-3a5c280fcf95">

After
<img width="274" alt="Screenshot 2023-06-12 at 16 23 24" src="https://github.com/zer0-os/zOS/assets/39112648/9ee0736e-8939-4351-b274-6806dc55e564">

