### PR TITLE
feat: implement scrollbar containers and styles

### DIFF
--- a/src/_scrollbar.scss
+++ b/src/_scrollbar.scss
@@ -1,4 +1,4 @@
-@mixin scrollbar($width: 4px, $color: rgba(225, 225, 254, 0.15), $radius: 5px, $opacity: 0.19) {
+@mixin scrollbar($width: 4px, $height: 292px, $color: rgba(225, 225, 254, 0.15), $radius: 5px, $opacity: 0.19) {
   &::-webkit-scrollbar {
     width: $width;
   }
@@ -6,5 +6,6 @@
   &::-webkit-scrollbar-thumb {
     background: $color;
     border-radius: $radius;
+    height: $height;
   }
 }

--- a/src/_scrollbar.scss
+++ b/src/_scrollbar.scss
@@ -1,4 +1,4 @@
-@mixin scrollbar($width: 4px, $height: 292px, $color: rgba(225, 225, 254, 0.15), $radius: 5px, $opacity: 0.19) {
+@mixin scrollbar($width: 4px, $color: rgba(225, 225, 254, 0.15), $radius: 5px, $opacity: 0.19) {
   &::-webkit-scrollbar {
     width: $width;
   }
@@ -6,6 +6,5 @@
   &::-webkit-scrollbar-thumb {
     background: $color;
     border-radius: $radius;
-    height: $height;
   }
 }

--- a/src/_scrollbar.scss
+++ b/src/_scrollbar.scss
@@ -1,0 +1,10 @@
+@mixin scrollbar($width: 4px, $color: rgba(225, 225, 254, 0.15), $radius: 5px, $opacity: 0.19) {
+  &::-webkit-scrollbar {
+    width: $width;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: $color;
+    border-radius: $radius;
+  }
+}

--- a/src/app-sandbox/styles.scss
+++ b/src/app-sandbox/styles.scss
@@ -66,8 +66,6 @@ $speed: animation.$animation-duration;
       opacity: 1;
       transition: opacity animation.$animation-duration-quadruple ease-in;
 
-      overflow-y: auto;
-      overflow-x: hidden;
       height: inherit;
     }
 

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -12,6 +12,7 @@ import { Button, Modal } from '@zero-tech/zui/components';
 import { Item, Option } from '../lib/types';
 import { UserSearchResults } from './user-search-results';
 import { conversationToOption, itemToOption } from '../lib/utils';
+import { ScrollbarContainer } from '../../scrollbar-container';
 
 export interface Properties {
   conversations: Channel[];
@@ -133,30 +134,33 @@ export class ConversationListPanel extends React.Component<Properties, State> {
               onChange={this.searchChanged}
             />
           </div>
-          <div className='messages-list__item-list'>
-            {this.filteredConversations.map((c) => (
-              <ConversationItem
-                key={c.id}
-                conversation={c}
-                filter={this.state.filter}
-                onClick={this.props.onConversationClick}
-                myUserId={this.props.myUserId}
-                activeConversationId={this.props.activeConversationId}
-              />
-            ))}
 
-            {this.filteredConversations?.length === 0 && this.state.filter !== '' && (
-              <div className='messages-list__empty'>{`You do not have any active conversations with '${this.state.filter}' `}</div>
-            )}
+          <ScrollbarContainer variant='on-hover'>
+            <div className='messages-list__item-list'>
+              {this.filteredConversations.map((c) => (
+                <ConversationItem
+                  key={c.id}
+                  conversation={c}
+                  filter={this.state.filter}
+                  onClick={this.props.onConversationClick}
+                  myUserId={this.props.myUserId}
+                  activeConversationId={this.props.activeConversationId}
+                />
+              ))}
 
-            {this.state.userSearchResults?.length > 0 && this.state.filter !== '' && (
-              <UserSearchResults
-                results={this.state.userSearchResults}
-                filter={this.state.filter}
-                onCreate={this.props.onCreateConversation}
-              />
-            )}
-          </div>
+              {this.filteredConversations?.length === 0 && this.state.filter !== '' && (
+                <div className='messages-list__empty'>{`You do not have any active conversations with '${this.state.filter}' `}</div>
+              )}
+
+              {this.state.userSearchResults?.length > 0 && this.state.filter !== '' && (
+                <UserSearchResults
+                  results={this.state.userSearchResults}
+                  filter={this.state.filter}
+                  onCreate={this.props.onCreateConversation}
+                />
+              )}
+            </div>
+          </ScrollbarContainer>
         </div>
         {/* Note: this does not work. directMessages is never null */}
         {/* This should change to this.filteredConversations?.length === 0 */}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -65,8 +65,6 @@ $side-padding: 16px;
       flex-grow: 1;
       // Forcing a height here allows the flex-grow to fill the size without growing too big
       height: 1px;
-
-      overflow: auto;
       padding: 0px $side-padding;
     }
 

--- a/src/components/scrollbar-container/index.test.tsx
+++ b/src/components/scrollbar-container/index.test.tsx
@@ -1,0 +1,47 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ScrollbarContainer, Properties } from '.';
+
+describe('ScrollbarContainer', () => {
+  const defaultProps: Properties = {
+    children: <div>Test Content</div>,
+    variant: 'fixed',
+  };
+
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps = { ...defaultProps, ...props };
+    return shallow(<ScrollbarContainer {...allProps} />);
+  };
+
+  it('renders children correctly', () => {
+    const wrapper = subject();
+    expect(wrapper.find('.scrollbar-container__content').contains(<div>Test Content</div>)).toBe(true);
+  });
+
+  it('applies "fixed" variant by default', () => {
+    const wrapper = subject();
+    expect(wrapper.find('.scrollbar-container__content').prop('data-variant')).toEqual('fixed');
+  });
+
+  it('applies "on-hover" variant when specified', () => {
+    const wrapper = subject({ variant: 'on-hover' });
+    expect(wrapper.find('.scrollbar-container__content').prop('data-variant')).toEqual('on-hover');
+  });
+
+  it('displays panel when variant is "on-hover"', () => {
+    const wrapper = subject({ variant: 'on-hover' });
+    expect(wrapper.find('.scrollbar-container__panel')).toHaveLength(1);
+  });
+
+  it('does not display panel when variant is "fixed"', () => {
+    const wrapper = subject();
+    expect(wrapper.find('.scrollbar-container__panel')).toHaveLength(0);
+  });
+
+  it('hides panel when content is at the bottom', () => {
+    const wrapper = subject({ variant: 'on-hover' });
+    wrapper.setState({ showPanel: false });
+    expect(wrapper.find('.scrollbar-container__panel')).toHaveLength(0);
+  });
+});

--- a/src/components/scrollbar-container/index.tsx
+++ b/src/components/scrollbar-container/index.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+import './styles.scss';
+
+export interface Properties {
+  children: React.ReactNode;
+  variant?: 'on-hover' | 'fixed';
+}
+
+interface State {
+  showPanel: boolean;
+}
+
+export class ScrollbarContainer extends React.Component<Properties, State> {
+  scrollContainerRef;
+  constructor(props) {
+    super(props);
+    this.state = {
+      showPanel: true,
+    };
+    this.scrollContainerRef = React.createRef();
+    this.checkScrollBottom = this.checkScrollBottom.bind(this);
+  }
+
+  componentDidMount() {
+    const { variant } = this.props;
+    if (variant === 'on-hover') {
+      const currentRef = this.scrollContainerRef.current;
+      if (currentRef) {
+        currentRef.addEventListener('scroll', this.checkScrollBottom);
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.variant !== this.props.variant) {
+      const { variant } = this.props;
+      const currentRef = this.scrollContainerRef.current;
+      if (currentRef) {
+        if (variant === 'on-hover') {
+          currentRef.addEventListener('scroll', this.checkScrollBottom);
+        } else {
+          currentRef.removeEventListener('scroll', this.checkScrollBottom);
+        }
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    const { variant } = this.props;
+    if (variant === 'on-hover') {
+      const currentRef = this.scrollContainerRef.current;
+      if (currentRef) {
+        currentRef.removeEventListener('scroll', this.checkScrollBottom);
+      }
+    }
+  }
+
+  checkScrollBottom() {
+    const { variant } = this.props;
+    if (variant === 'on-hover') {
+      const { scrollTop, scrollHeight, clientHeight } = this.scrollContainerRef.current;
+      const atBottom = scrollHeight - scrollTop === clientHeight;
+      this.setState({ showPanel: !atBottom });
+    }
+  }
+
+  render() {
+    const { children, variant = 'fixed' } = this.props;
+    const { showPanel } = this.state;
+
+    return (
+      <div className='scrollbar-container'>
+        <div className='scrollbar-container__content' data-variant={variant} ref={this.scrollContainerRef}>
+          {children}
+        </div>
+        {variant === 'on-hover' && showPanel && <div className='scrollbar-container__panel'></div>}
+      </div>
+    );
+  }
+}

--- a/src/components/scrollbar-container/index.tsx
+++ b/src/components/scrollbar-container/index.tsx
@@ -12,8 +12,8 @@ interface State {
 }
 
 export class ScrollbarContainer extends React.Component<Properties, State> {
-  scrollContainerRef;
-  constructor(props) {
+  scrollContainerRef: React.RefObject<HTMLDivElement>;
+  constructor(props: Properties) {
     super(props);
     this.state = {
       showPanel: true,
@@ -32,7 +32,7 @@ export class ScrollbarContainer extends React.Component<Properties, State> {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Properties) {
     if (prevProps.variant !== this.props.variant) {
       const { variant } = this.props;
       const currentRef = this.scrollContainerRef.current;

--- a/src/components/scrollbar-container/styles.scss
+++ b/src/components/scrollbar-container/styles.scss
@@ -4,10 +4,6 @@
   position: relative;
   height: 100%;
 
-  &:hover {
-    padding-right: 0;
-  }
-
   &__content {
     overflow: auto;
     width: 100%;

--- a/src/components/scrollbar-container/styles.scss
+++ b/src/components/scrollbar-container/styles.scss
@@ -1,0 +1,36 @@
+@import '../../scrollbar.scss';
+
+.scrollbar-container {
+  position: relative;
+
+  &__content {
+    overflow: auto;
+    width: 100%;
+    height: 100%;
+
+    @include scrollbar();
+
+    &[data-variant='on-hover'] {
+      overflow: hidden;
+
+      &:hover {
+        overflow: auto;
+        @include scrollbar();
+
+        ~ .scrollbar-container__panel {
+          display: none;
+        }
+      }
+    }
+  }
+
+  &__panel {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 46px;
+    background: linear-gradient(180deg, rgba(31, 27, 34, 0) 0%, rgba(31, 27, 34, 1) 100%);
+    box-sizing: border-box;
+  }
+}

--- a/src/components/scrollbar-container/styles.scss
+++ b/src/components/scrollbar-container/styles.scss
@@ -4,8 +4,6 @@
   position: relative;
   height: 100%;
 
-  overflow: hidden;
-
   &:hover {
     padding-right: 0;
   }

--- a/src/components/scrollbar-container/styles.scss
+++ b/src/components/scrollbar-container/styles.scss
@@ -39,5 +39,9 @@
     height: 46px;
     background: linear-gradient(180deg, rgba(31, 27, 34, 0) 0%, rgba(31, 27, 34, 1) 100%);
     box-sizing: border-box;
+
+    &:hover {
+      display: none;
+    }
   }
 }

--- a/src/components/scrollbar-container/styles.scss
+++ b/src/components/scrollbar-container/styles.scss
@@ -3,7 +3,8 @@
 .scrollbar-container {
   position: relative;
   height: 100%;
-  padding-right: 4px;
+
+  overflow: hidden;
 
   &:hover {
     padding-right: 0;
@@ -17,10 +18,14 @@
     @include scrollbar();
 
     &[data-variant='on-hover'] {
-      overflow: hidden;
+      &::-webkit-scrollbar-thumb {
+        display: none;
+      }
 
       &:hover {
-        overflow: auto;
+        &::-webkit-scrollbar-thumb {
+          display: block;
+        }
 
         @include scrollbar();
 

--- a/src/components/scrollbar-container/styles.scss
+++ b/src/components/scrollbar-container/styles.scss
@@ -2,6 +2,12 @@
 
 .scrollbar-container {
   position: relative;
+  height: 100%;
+  padding-right: 4px;
+
+  &:hover {
+    padding-right: 0;
+  }
 
   &__content {
     overflow: auto;
@@ -15,6 +21,7 @@
 
       &:hover {
         overflow: auto;
+
         @include scrollbar();
 
         ~ .scrollbar-container__panel {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,7 @@
 @use 'modules/font' as fonts;
 @use 'modules/animation' as animation;
 @use 'shared-components/theme-engine/theme' as theme;
-@import '~@zer0-os/zos-component-library/dist/assets/scroll';
+@import './scrollbar';
 
 @import-normalize;
 
@@ -76,6 +76,10 @@ hr.glow:before {
 
 .glow-text {
   text-shadow: 0 0 10px var(--glow-text-color);
+}
+
+* {
+  @include scrollbar();
 }
 
 .button-reset {

--- a/src/index.scss
+++ b/src/index.scss
@@ -78,10 +78,6 @@ hr.glow:before {
   text-shadow: 0 0 10px var(--glow-text-color);
 }
 
-* {
-  @include scrollbar();
-}
-
 .button-reset {
   cursor: pointer;
   background: none;

--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -17,6 +17,7 @@ import { AppLayout, AppContextPanel, AppContent } from '@zer0-os/zos-component-l
 import './styles.scss';
 import { AuthenticationState } from '../../store/authentication/types';
 import { ChatViewContainer } from '../../components/chat-view-container/chat-view-container';
+import { ScrollbarContainer } from '../../components/scrollbar-container';
 
 interface PublicProperties {
   store: Store<RootState>;
@@ -91,7 +92,9 @@ export class Container extends React.Component<Properties> {
       <Provider store={this.props.store}>
         <AppLayout className='channels'>
           <AppContextPanel>
-            <ChannelList channels={this.props.channels} currentChannelId={this.props.channelId} />
+            <ScrollbarContainer variant='on-hover'>
+              <ChannelList channels={this.props.channels} currentChannelId={this.props.channelId} />
+            </ScrollbarContainer>
           </AppContextPanel>
           <AppContent className='channel-app'>{this.renderChannelView()}</AppContent>
         </AppLayout>


### PR DESCRIPTION
### What does this do?
- adds `scrollbar()` mixin (rather than use from zos-component-library)
- adds a new `ScrollbarContainer` that handles the style and behaviour of the scrollbar.
- adds a faded panel to to the `ScrollbarContainer` and its behaviour.
- adds the `ScrollbarContainer` to the conversation list panel message items.
- adds the `Scrollbar` container to the channel list content.
- adds `scrollbar()` mixin styles for the invert scroll on the main container.
- adds tests.

### Why are we making this change?
As per designs.

### How do I test this?
Open the app and start scrolling on the channel list, the main channel message container and the conversations panel 🙂 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/64fd399a-7862-4cc5-8215-38d792c5b6ac

