### PR TITLE
Translate the correct lastMessageAt field

### DIFF
--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -26,7 +26,7 @@ export const channelMapper = (currentChannel): Partial<Channel> => {
     hasJoined: currentChannel.hasJoined,
     otherMembers: currentChannel.otherMembers || [],
     lastMessage: currentChannel.lastMessage || null,
-    lastMessageCreatedAt: currentChannel.lastMessageCreatedAt || null,
+    lastMessageCreatedAt: currentChannel.lastMessage?.createdAt || null,
     isChannel: currentChannel.isChannel === undefined ? true : currentChannel.isChannel,
     groupChannelType: currentChannel.groupChannelType || '',
   };


### PR DESCRIPTION
### What does this do?

Fixes the channel mapping to use a field that is actually returned from the api.

### Why are we making this change?

Because this currently doesn't work.

