### PR TITLE
Refactor: use the newly renamed getAuthChannel

### DIFF
--- a/src/store/authentication/channels.ts
+++ b/src/store/authentication/channels.ts
@@ -13,6 +13,3 @@ export function* getAuthChannel() {
   }
   return theChannel;
 }
-
-// Temporary until all consumers update
-export const authChannel = getAuthChannel;

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -18,7 +18,7 @@ import { clearUsers } from '../users/saga';
 import { clearMessages } from '../messages/saga';
 import { updateConnector } from '../web3/saga';
 import { Connectors } from '../../lib/web3';
-import { Events, authChannel } from './channels';
+import { Events, getAuthChannel } from './channels';
 import { getHistory } from '../../lib/browser';
 import { featureFlags } from '../../lib/feature-flags';
 
@@ -130,12 +130,12 @@ export function* logout() {
 }
 
 export function* publishUserLogin(user) {
-  const channel = yield call(authChannel);
+  const channel = yield call(getAuthChannel);
   yield put(channel, { type: Events.UserLogin, userId: user.id });
 }
 
 export function* publishUserLogout() {
-  const channel = yield call(authChannel);
+  const channel = yield call(getAuthChannel);
   yield put(channel, { type: Events.UserLogout });
 }
 

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -4,7 +4,7 @@ import { channelsReceived, createConversation as performCreateConversation } fro
 import { fetchConversationsWithUsers } from '../channels-list/api';
 import { setactiveConversationId } from '../chat';
 import { currentUserSelector } from '../authentication/saga';
-import { Events, authChannel } from '../authentication/channels';
+import { Events, getAuthChannel } from '../authentication/channels';
 
 export function* reset() {
   yield put(setGroupUsers([]));
@@ -144,7 +144,7 @@ function* handleGroupDetails() {
 }
 
 function* authWatcher() {
-  const channel = yield call(authChannel);
+  const channel = yield call(getAuthChannel);
   while (true) {
     yield take(channel, Events.UserLogout);
     yield put({ type: SagaActionTypes.Cancel });

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -2,7 +2,7 @@ import { take, put, call, race, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, reset, setInvite } from '.';
 import { getInvite } from './api';
 import { config } from '../../config';
-import { authChannel } from '../authentication/channels';
+import { getAuthChannel } from '../authentication/channels';
 
 export function* fetchInvite() {
   while (true) {
@@ -34,7 +34,7 @@ export function* fetchInvite() {
 }
 
 export function* saga() {
-  const channel = yield call(authChannel);
+  const channel = yield call(getAuthChannel);
 
   while (true) {
     const { userId = undefined } = yield take(channel, '*');

--- a/src/store/notifications/saga.test.ts
+++ b/src/store/notifications/saga.test.ts
@@ -17,7 +17,7 @@ import {
 import { setStatus, relevantNotificationTypes, SagaActionTypes, relevantNotificationEvents } from '.';
 import { fetchNotification, fetchNotifications } from './api';
 import { sample } from 'lodash';
-import { authChannel } from '../authentication/channels';
+import { getAuthChannel } from '../authentication/channels';
 import { multicastChannel } from 'redux-saga';
 
 describe('notifications list saga', () => {
@@ -227,7 +227,7 @@ describe('notifications list saga', () => {
 
     testSaga(authWatcher)
       .next()
-      .call(authChannel)
+      .call(getAuthChannel)
 
       .next(channel)
       .inspect((action) => {

--- a/src/store/notifications/saga.ts
+++ b/src/store/notifications/saga.ts
@@ -13,7 +13,7 @@ import {
 } from '.';
 import { fetchNotification, fetchNotifications } from './api';
 import PusherClient from '../../lib/pusher';
-import { authChannel } from '../authentication/channels';
+import { getAuthChannel } from '../authentication/channels';
 
 export interface Payload {
   userId: string;
@@ -97,7 +97,7 @@ export function* clearNotifications() {
 }
 
 export function* authWatcher() {
-  const channel = yield call(authChannel);
+  const channel = yield call(getAuthChannel);
 
   while (true) {
     const { userId = undefined } = yield take(channel, '*');


### PR DESCRIPTION
### What does this do?

Previously added a new accessor (rename basically) for the auth channel. This follows through on changing all the existing usages to the new name.

