### PR TITLE
refactor: add `hasPanel` prop to hide or display scrollbar faded panel

### DIFF
--- a/src/components/scrollbar-container/index.test.tsx
+++ b/src/components/scrollbar-container/index.test.tsx
@@ -7,6 +7,7 @@ describe('ScrollbarContainer', () => {
   const defaultProps: Properties = {
     children: <div>Test Content</div>,
     variant: 'fixed',
+    hasPanel: false,
   };
 
   const subject = (props: Partial<Properties> = {}) => {
@@ -29,9 +30,14 @@ describe('ScrollbarContainer', () => {
     expect(wrapper.find('.scrollbar-container__content').prop('data-variant')).toEqual('on-hover');
   });
 
-  it('displays panel when variant is "on-hover"', () => {
-    const wrapper = subject({ variant: 'on-hover' });
+  it('displays panel when variant is "on-hover" and hasPanel prop is true', () => {
+    const wrapper = subject({ variant: 'on-hover', hasPanel: true });
     expect(wrapper.find('.scrollbar-container__panel')).toHaveLength(1);
+  });
+
+  it('does not display panel when variant is "on-hover" and hasPanel prop is false', () => {
+    const wrapper = subject({ variant: 'on-hover', hasPanel: false });
+    expect(wrapper.find('.scrollbar-container__panel')).toHaveLength(0);
   });
 
   it('does not display panel when variant is "fixed"', () => {

--- a/src/components/scrollbar-container/index.tsx
+++ b/src/components/scrollbar-container/index.tsx
@@ -17,7 +17,7 @@ export class ScrollbarContainer extends React.Component<Properties, State> {
   constructor(props: Properties) {
     super(props);
     this.state = {
-      showPanel: this.props.hasPanel,
+      showPanel: true,
     };
     this.scrollContainerRef = React.createRef();
     this.checkScrollBottom = this.checkScrollBottom.bind(this);
@@ -67,7 +67,7 @@ export class ScrollbarContainer extends React.Component<Properties, State> {
   }
 
   render() {
-    const { children, variant = 'fixed' } = this.props;
+    const { children, variant = 'fixed', hasPanel } = this.props;
     const { showPanel } = this.state;
 
     return (
@@ -75,7 +75,7 @@ export class ScrollbarContainer extends React.Component<Properties, State> {
         <div className='scrollbar-container__content' data-variant={variant} ref={this.scrollContainerRef}>
           {children}
         </div>
-        {variant === 'on-hover' && showPanel && <div className='scrollbar-container__panel'></div>}
+        {variant === 'on-hover' && showPanel && hasPanel && <div className='scrollbar-container__panel'></div>}
       </div>
     );
   }

--- a/src/components/scrollbar-container/index.tsx
+++ b/src/components/scrollbar-container/index.tsx
@@ -5,6 +5,7 @@ import './styles.scss';
 export interface Properties {
   children: React.ReactNode;
   variant?: 'on-hover' | 'fixed';
+  hasPanel?: boolean;
 }
 
 interface State {
@@ -16,7 +17,7 @@ export class ScrollbarContainer extends React.Component<Properties, State> {
   constructor(props: Properties) {
     super(props);
     this.state = {
-      showPanel: true,
+      showPanel: this.props.hasPanel,
     };
     this.scrollContainerRef = React.createRef();
     this.checkScrollBottom = this.checkScrollBottom.bind(this);


### PR DESCRIPTION
### What does this do?
- adds a prop to display or hide the scrollbar panel when the variant is `on-hover`

### Why are we making this change?
- design requested to remove this for now. By making this feature optional, we can use at a later date.

### How do I test this?
- search `<ScrollbarContainer />` in the code and add or remove `hasProp` to the attributes (explicitly). When running locally, if `hasProp` has been added to the attributes and the variant is `on-hover`, you will see the faded panel is rendered.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
