### PR TITLE
fix: prevent clicking on a link in the message preview of the conversation item component

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -434,6 +434,10 @@ $side-padding: 16px;
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+
+    a {
+      pointer-events: none;
+    }
   }
 
   &__unread-count {


### PR DESCRIPTION
### What does this do?
- when a url/link is present in the message preview in the conversation item and the user clicks this with the intention of opening the chat, this will also trigger a new tab to open to the url.

### Why are we making this change?
- this is not desired behaviour. If there is a url/link visible in the message preview and it is clicked, only the chat should open, not the link itself.

### How do I test this?
- click a conversation item in the conversation list panel that shows a url in the message preview (aim to click this specific part of the conversation item) and a new tab to that page should not open.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Before:

https://github.com/zer0-os/zOS/assets/39112648/dedc5b34-0163-4ed1-b6ab-d42e075b1f0c



After:

https://github.com/zer0-os/zOS/assets/39112648/7790cf13-8d93-439d-ada0-354db41b76be

