### PR TITLE
Don't create scrollbars on the HTML node

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -7,6 +7,10 @@
 
 @import 'variables';
 
+html {
+  overflow: hidden;
+}
+
 body {
   overscroll-behavior-y: none;
   margin: 0;


### PR DESCRIPTION
### What does this do?

Sets overflow to hidden on the HTML node

### Why are we making this change?

To prevent scrollbars from showing up on the overall page when things are rendering.

### How do I test this?

Open the sidekick with lots of conversations. Scroll rapidly. You should _not_ see a second scrollbar appear.

