### PR TITLE
fix: rewards modal design and copy issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@zero-tech/zapp-daos": "latest",
     "@zero-tech/zapp-nfts": "latest",
     "@zero-tech/zapp-staking": "latest",
-    "@zero-tech/zui": "^0.23.0",
+    "@zero-tech/zui": "^0.24.1",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",

--- a/src/components/rewards-faq-modal/constants.tsx
+++ b/src/components/rewards-faq-modal/constants.tsx
@@ -10,7 +10,7 @@ export const rewardsFaq = [
   {
     content:
       'A product does not exist without the people who use it. You — the user — are inherently valuable, as is the content you create, private or public. Big Tech social media recognizes that and exploits you for it, leaving you with nothing. At ZERO, we recognize the wealth of your content by rewarding you with $ZERO tokens. Your social interactions are valuable; you deserve to share that value.',
-    title: 'This seems too good to be true, how can I earn for doing nothing?',
+    title: 'Earning $ZERO for just chatting? What’s the catch? This seems too good to be true.',
   },
   {
     content: (
@@ -36,21 +36,21 @@ export const rewardsFaq = [
         </div>
       </div>
     ),
-    title: 'How does Zero make money if it’s free AND I’m being paid?',
+    title: 'So what is $ZERO?',
   },
   {
     content:
       'We don’t — not for now, at least. As an early adopter of ZERO tech, you are being rewarded simply for being here. Your participation and feedback are crucial to our goal of continual improvement of our zApps and ecosystem. Eventually, as we scale, the your individual rewards will diminish. Congrats on being early! The party’s just starting.',
-    title: 'When can I redeem my tokens into cash?',
+    title: 'How does ZERO make money if the app is free AND I’m being paid?',
   },
   {
     content:
       'By chatting! In a DM, in a group, wherever, in-app. The more meaningful conversations you have with other users, the more rewards you’ll reap. Every 24 hours, or epoch, you will be awarded an appropriate amount of $ZERO derived from the previous day’s activities. The precise formula for determining how much you’ll make is ever-changing to combat botting and accommodate a growing user base.',
-    title: 'What do i need to do to earn tokens?',
+    title: 'How do I earn $ZERO tokens?',
   },
   {
     content:
       'The ability to withdraw your $ZERO to an external wallet will be introduced at a future date, to support the release of our ZNS (ZERO Naming System) domain functionality. Until then, sit tight and enjoy watching numba go up!',
-    title: 'Is Zero a DAO?',
+    title: 'How can I withdraw/redeem my $ZERO?',
   },
 ];

--- a/src/components/rewards-faq-modal/index.tsx
+++ b/src/components/rewards-faq-modal/index.tsx
@@ -25,7 +25,7 @@ export class RewardsFAQModal extends React.Component<Properties> {
         <Modal open={this.props.isRewardsFAQModalOpen} onOpenChange={this.closeRewardsFAQModal} className={c('')}>
           <div className={c('title-bar')}>
             <h3 className={c('title')}>Zero Rewards</h3>
-            <IconButton className={c('close')} Icon={IconXClose} onClick={this.closeRewardsFAQModal} />
+            <IconButton size={32} className={c('close')} Icon={IconXClose} onClick={this.closeRewardsFAQModal} />
           </div>
           <Accordion contrast='low' items={rewardsFaq} />
         </Modal>

--- a/src/components/rewards-faq-modal/styles.scss
+++ b/src/components/rewards-faq-modal/styles.scss
@@ -13,7 +13,7 @@
     display: flex;
     height: 53px;
     border-bottom: 1px solid theme.$color-primary-4;
-    margin-bottom: 20px;
+    margin-bottom: 40px;
     color: theme.$color-greyscale-12;
 
     > *:first-child {
@@ -29,7 +29,11 @@
   }
 
   &__close {
-    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    width: 32px;
 
     &:focus-visible {
       outline: none;

--- a/src/components/rewards-faq-modal/styles.scss
+++ b/src/components/rewards-faq-modal/styles.scss
@@ -32,8 +32,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 32px;
-    width: 32px;
+    height: 40px;
+    width: 40px;
 
     &:focus-visible {
       outline: none;


### PR DESCRIPTION
### What does this do?
Right now there are a number of stylistic issues with the Rewards modal, both in terms of elements and copy.

1. Alters the modal to utilize the “x” button icon specified in the designs.
2. Alter the accordion design component to match design specifications (done by updating in zUI and pulling in new version to zOS).
3. Update the position modal, one accordion open per time.
4. Updates the FAQ copy

### Why are we making this change?
As per design.

### How do I test this?
When viewing the rewards pop up, select `Learn more about zero rewards`. The reward faq modal will appear and compare this against the figma design [here](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=7563-326198&t=tFqXY6i77gQzc6G1-4)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

