### PR TITLE
fix: improve ux of sidekick tab content container width (fullscreen-messenger)

### DIFF
--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -23,7 +23,7 @@
   }
 
   &__tab-content {
-    width: 100%;
+    width: inherit;
 
     &--messages {
       height: 100%;


### PR DESCRIPTION
### What does this do?
- adds inherited width to sidekick tab content container to fix jolting width when searching users.

The width of the sidekick container should remain at `270px`.

### Why are we making this change?
- to improve the UX of the sidekick container re the width jolting.

### How do I test this?
- in the sidekick panel, start typing 'to' for example, and determine whether or not the width of the sidekick panels remains the same throughout.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
Before:

https://github.com/zer0-os/zOS/assets/39112648/be2e165c-b1d6-413b-bfff-2530dd443da7

<img width="321" alt="Screenshot 2023-06-19 at 12 50 37" src="https://github.com/zer0-os/zOS/assets/39112648/d41e3318-47a2-492a-88df-cef448415ca4">

After:

https://github.com/zer0-os/zOS/assets/39112648/19350588-73d6-4baf-b5bb-db52ffe7f090

<img width="321" alt="Screenshot 2023-06-19 at 12 51 05" src="https://github.com/zer0-os/zOS/assets/39112648/6d69a0a2-46b1-4b9b-9a4b-8f15f2e9e94a">
