### PR TITLE
fix: prevent horizontal scroll in empty state search results

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -73,6 +73,7 @@ $side-padding: 16px;
       color: theme.$color-greyscale-11;
       font-size: $font-size-medium;
       line-height: 17px;
+      word-break: break-word;
     }
   }
 }


### PR DESCRIPTION
### What does this do?
- prevents horizontal scroll when empty state search results message is longer than the sidekick/conversation panel container.

### Why are we making this change?
- improve the ux when empty state is displayed.

### How do I test this?
- type a long string into the search input and check whether the word breaks when filling the sidekick/conversation panel container.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


BEFORE:

<img width="362" alt="Screenshot 2023-06-19 at 13 32 51" src="https://github.com/zer0-os/zOS/assets/39112648/47bf21f0-5687-4df1-be38-617e6e03332c">


AFTER:

<img width="362" alt="Screenshot 2023-06-19 at 13 32 31" src="https://github.com/zer0-os/zOS/assets/39112648/cdd431ab-a315-4740-a34b-ce7aeb5467c8">



