### PR TITLE
Clear the interval when disconnecting sendbird

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -16,6 +16,7 @@ interface RealtimeChatEvents {
 
 export class Chat {
   sendbird: SendbirdGroupChat = null;
+  interval = null;
 
   accessToken: string;
 
@@ -48,8 +49,8 @@ export class Chat {
 
     // every 10s check if the connection state is CLOSED, if it is, set the app to foreground,
     // to prevent sendbird sdk from disconnecting (when the app is in the background)
-    setInterval(() => {
-      if (this.sendbird.connectionState === ConnectionState.CLOSED) {
+    this.interval = setInterval(() => {
+      if (this.sendbird && this.sendbird.connectionState === ConnectionState.CLOSED) {
         this.sendbird.setForegroundState();
       }
     }, 10 * 1000);
@@ -113,6 +114,10 @@ export class Chat {
   }
 
   disconnect(): void {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
     if (this.sendbird !== null) {
       this.sendbird.disconnect().then(() => {
         this.sendbird = null;


### PR DESCRIPTION
### What does this do?

Clears our 'keep-alive' interval in the sendbird class and adds a little null safety.

### Why are we making this change?

So things don't explode when you logout

### How do I test this?

Login...then logout and confirm the page doesn't explode with an error.

