### PR TITLE
Listen to real time message edit events

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -10,6 +10,7 @@ interface RealtimeChatEvents {
   reconnectStop: () => void;
   receiveNewMessage: (channelId: string, message: Message) => void;
   receiveDeleteMessage: (channelId: string, messageId: number) => void;
+  onMessageUpdated: (channelId: string, message: Message) => void;
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
   invalidChatAccessToken: () => void;
 }
@@ -93,6 +94,10 @@ export class Chat {
         if (channel.isGroupChannel()) {
           events.receiveNewMessage(channelId, this.mapMessage(message));
         }
+      },
+      onMessageUpdated: (channel, message) => {
+        const channelId = this.getChannelId(channel);
+        events.onMessageUpdated(channelId, this.mapMessage(message));
       },
       onMessageDeleted: (channel, messageId) => {
         const channelId = this.getChannelId(channel);

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -4,6 +4,7 @@ import { chat } from '../../lib/chat';
 
 export enum Events {
   MessageReceived = 'chat/message/received',
+  MessageUpdated = 'chat/message/updated',
   MessageDeleted = 'chat/message/deleted',
   UnreadCountChanged = 'chat/message/unreadCountChanged',
   ReconnectStart = 'chat/recconectStart',
@@ -23,6 +24,8 @@ export function createChatConnection(userId, chatAccessToken) {
   return eventChannel((emit) => {
     const receiveNewMessage = (channelId, message) =>
       emit({ type: Events.MessageReceived, payload: { channelId, message } });
+    const onMessageUpdated = (channelId, message) =>
+      emit({ type: Events.MessageUpdated, payload: { channelId, message } });
     const receiveDeleteMessage = (channelId, messageId) =>
       emit({ type: Events.MessageDeleted, payload: { channelId, messageId } });
     const receiveUnreadCount = (channelId, unreadCount) =>
@@ -35,6 +38,7 @@ export function createChatConnection(userId, chatAccessToken) {
       reconnectStart,
       reconnectStop,
       receiveNewMessage,
+      onMessageUpdated,
       receiveDeleteMessage,
       receiveUnreadCount,
       invalidChatAccessToken,

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -22,9 +22,10 @@ import {
   getPreview,
   clearMessages,
   sendBrowserNotification,
+  receiveUpdateMessage,
 } from './saga';
 
-import { rootReducer } from '../reducer';
+import { RootState, rootReducer } from '../reducer';
 import { mapMessage, send as sendBrowserMessage } from '../../lib/browser';
 
 describe('messages saga', () => {
@@ -962,5 +963,34 @@ describe('messages saga', () => {
       messages: {},
       channels,
     });
+  });
+});
+
+describe(receiveUpdateMessage, () => {
+  it('updates the messages', async () => {
+    const message = {
+      id: 8667728016,
+      message: 'original message',
+      parentMessageText: null,
+      createdAt: 1678861267433,
+      updatedAt: 0,
+    };
+    const editedMessage = {
+      id: 8667728016,
+      message: 'edited message',
+      parentMessageText: null,
+      createdAt: 1678861267433,
+      updatedAt: 1678861290000,
+    };
+
+    const messages = { 8667728016: message };
+
+    const { storeState } = await expectSaga(receiveUpdateMessage, {
+      payload: { channelId: 'channel-1', message: editedMessage },
+    })
+      .withReducer(rootReducer, { normalized: { messages } as any } as RootState)
+      .run();
+
+    expect(storeState.normalized.messages).toEqual({ 8667728016: editedMessage });
   });
 });


### PR DESCRIPTION
### What does this do?

Updates chat messages in real time when they've been edited from another session. Not yet implemented: link previews, attachments.

### Why are we making this change?

For a smooth experience

### How do I test this?

1. Open a conversation with another account
2. Edit a message from the other account
3. Verify that the original screen updates in "real time"

