### PR TITLE
Reload the conversation list when we've been invited to a channel

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -12,6 +12,7 @@ interface RealtimeChatEvents {
   receiveDeleteMessage: (channelId: string, messageId: number) => void;
   onMessageUpdated: (channelId: string, message: Message) => void;
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
+  onUserReceivedInvitation: (channel) => void;
   invalidChatAccessToken: () => void;
 }
 
@@ -108,6 +109,9 @@ export class Chat {
         const channelId = this.getChannelId(channel);
 
         events.receiveUnreadCount(channelId, (channel as any).unreadMessageCount);
+      },
+      onUserReceivedInvitation: (channel) => {
+        events.onUserReceivedInvitation(this.getChannelId(channel));
       },
     });
 

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -10,6 +10,7 @@ export enum Events {
   ReconnectStart = 'chat/recconectStart',
   ReconnectStop = 'chat/recconectStop',
   InvalidToken = 'chat/invalidToken',
+  ChannelInvitationReceived = 'chat/channel/invitationReceived',
 }
 
 let theBus;
@@ -33,6 +34,8 @@ export function createChatConnection(userId, chatAccessToken) {
     const reconnectStart = () => emit({ type: Events.ReconnectStart, payload: {} });
     const reconnectStop = () => emit({ type: Events.ReconnectStop, payload: {} });
     const invalidChatAccessToken = () => emit({ type: Events.InvalidToken, payload: {} });
+    const onUserReceivedInvitation = (channelId) =>
+      emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
 
     chat.initChat({
       reconnectStart,
@@ -42,6 +45,7 @@ export function createChatConnection(userId, chatAccessToken) {
       receiveDeleteMessage,
       receiveUnreadCount,
       invalidChatAccessToken,
+      onUserReceivedInvitation,
     });
     chat.connect(userId, chatAccessToken);
 


### PR DESCRIPTION
### What does this do?

If we receive a user invite to a channel we reload the conversation list right away rather than wait for the intermittent poll. We do this because we don't yet have an endpoint to load a single converation's details.

### Why are we making this change?

For better real time behaviour.

### How do I test this?

Open two session. In one session start a new conversation including the person from the other session. Verify that the new conversation is visible to the other session fairly quickly.

