### PR TITLE
Dont show rewards tooltip if rewards are '0'

### DIFF
--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -82,7 +82,12 @@ describe('rewards-bar', () => {
   });
 
   it('closes rewards tooltip popup if clicked on close icon', async function () {
-    const wrapper = subject({ zero: '9000000000000000000', isRewardsLoading: false, isMessengerFullScreen: true });
+    const wrapper = subject({
+      zero: '9000000000000000000',
+      zeroPreviousDay: '1000000000000000000',
+      isRewardsLoading: false,
+      isMessengerFullScreen: true,
+    });
     expect(wrapper.find(TooltipPopup).prop('open')).toBeTrue();
 
     wrapper.find(TooltipPopup).simulate('close');

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -78,6 +78,15 @@ export class RewardsBar extends React.Component<Properties, State> {
   closeRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: false });
   closeRewardsTooltip = () => this.setState({ isRewardsTooltipOpen: false });
 
+  showNewRewardsToUser = () => {
+    return (
+      this.props.isMessengerFullScreen &&
+      !this.props.isFirstTimeLogin &&
+      this.isNewRewardsLoaded() &&
+      this.stringifyZero(this.props.zeroPreviousDay) !== '0'
+    );
+  };
+
   renderRewardsBar() {
     return (
       <div
@@ -97,9 +106,7 @@ export class RewardsBar extends React.Component<Properties, State> {
           <div>Rewards</div>
           <div className={c('rewards-icon')}>
             <IconCurrencyDollar size={16} />
-            {this.props.isMessengerFullScreen && !this.props.isFirstTimeLogin && this.isNewRewardsLoaded() && (
-              <Status type='idle' className={c('rewards-icon__status')} />
-            )}
+            {this.showNewRewardsToUser() && <Status type='idle' className={c('rewards-icon__status')} />}
           </div>
         </button>
       </div>
@@ -109,7 +116,7 @@ export class RewardsBar extends React.Component<Properties, State> {
   render() {
     return (
       <div>
-        {this.props.isMessengerFullScreen && !this.props.isFirstTimeLogin && this.isNewRewardsLoaded() ? ( // only show the rewards tooltip popup if in full screen mode
+        {this.showNewRewardsToUser() ? ( // only show the rewards tooltip popup if in full screen mode
           <TooltipPopup
             open={!this.props.isRewardsLoading && this.state.isRewardsTooltipOpen}
             align='center'


### PR DESCRIPTION
Prevents this state

![image](https://github.com/zer0-os/zOS/assets/33264364/5b9be44f-fcf1-4484-9e2f-f96115feba0f)

