### PR TITLE
Show rewards tooltip on "top" of conversation

### DIFF
--- a/src/components/tooltip-popup/styles.scss
+++ b/src/components/tooltip-popup/styles.scss
@@ -3,6 +3,8 @@
 
 .tooltip-popup {
   display: block;
+  z-index: 1000;
+  position: relative;
 
   &__trigger {
     position: relative;


### PR DESCRIPTION
Before (tooltip is active but it was hidden)

![image](https://github.com/zer0-os/zOS/assets/33264364/803412ce-a517-47df-9fed-528762e6ea42)


After

![image](https://github.com/zer0-os/zOS/assets/33264364/827d8557-834c-4a5a-9010-135947e0c5f5)
