### PR TITLE
fix: all text to be entirely non-interactive in conversation list panel

### DIFF
--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -44,9 +44,6 @@
       }
     }
   }
-
-  user-select: none; /* Prevent text highlighting */
-  pointer-events: auto; /* Enable pointer events for click event */
 }
 
 .force-extra-specificity.autocomplete-members__search-wrapper {

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -44,6 +44,9 @@
       }
     }
   }
+
+  user-select: none; /* Prevent text highlighting */
+  pointer-events: auto; /* Enable pointer events for click event */
 }
 
 .force-extra-specificity.autocomplete-members__search-wrapper {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -21,6 +21,9 @@ $side-padding: 16px;
   flex-direction: column;
   padding-bottom: 16px;
 
+  user-select: none; /* Prevent text highlighting */
+  pointer-events: auto; /* Enable pointer events for click event */
+
   .messages-list {
     &__start {
       display: flex;
@@ -488,9 +491,6 @@ $side-padding: 16px;
     right: -0.125rem;
     border: 0.125rem solid var(--color-primary-1);
   }
-
-  user-select: none; /* Prevent text highlighting */
-  pointer-events: auto; /* Enable pointer events for click event */
 }
 
 .user-search-results {
@@ -527,9 +527,6 @@ $side-padding: 16px;
     white-space: nowrap;
     text-overflow: ellipsis;
   }
-
-  user-select: none; /* Prevent text highlighting */
-  pointer-events: auto; /* Enable pointer events for click event */
 }
 
 .messages-list__invite-button {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -437,7 +437,7 @@ $side-padding: 16px;
     }
 
     a {
-      pointer-events: none;
+      pointer-events: none; /* Disable pointer events for clicking urls */
     }
   }
 
@@ -488,6 +488,9 @@ $side-padding: 16px;
     right: -0.125rem;
     border: 0.125rem solid var(--color-primary-1);
   }
+
+  user-select: none; /* Prevent text highlighting */
+  pointer-events: auto; /* Enable pointer events for click event */
 }
 
 .user-search-results {
@@ -524,6 +527,9 @@ $side-padding: 16px;
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+
+  user-select: none; /* Prevent text highlighting */
+  pointer-events: auto; /* Enable pointer events for click event */
 }
 
 .messages-list__invite-button {


### PR DESCRIPTION
### What does this do?
Adjust preview text in Conversation List sidebar to be entirely non-interactive (e.g., cannot even select or highlight it)

### Why are we making this change?
Even if you can’t interact with links in the sidebar in the testing environment, you can still interact with text, including selecting / highlighting. All text in the sidebar should be un-interactable-with. 

### How do I test this?
Login and navigate to conversation list panel. Attempt to highlight text. Click conversation item to open conversation.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

