### PR TITLE
feat: add settings menu

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -35,6 +35,8 @@ describe('messenger-list', () => {
       allowExpand: true,
       includeRewardsAvatar: false,
       isMessengerFullScreen: false,
+      userName: '',
+      userHandle: '',
       userAvatarUrl: '',
       zero: '',
       zeroPreviousDay: '',
@@ -52,6 +54,7 @@ describe('messenger-list', () => {
       enterFullScreenMessenger: () => null,
       fetchRewards: () => null,
       rewardsPopupClosed: () => null,
+      logout: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,8 +15,8 @@ import {
   membersSelected,
   startCreateConversation,
 } from '../../../store/create-conversation';
+import { logout } from '../../../store/authentication';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
-
 import { IconExpand1, IconXClose } from '@zero-tech/zui/icons';
 
 import './styles.scss';
@@ -68,6 +68,7 @@ export interface Properties extends PublicProperties {
   enterFullScreenMessenger: () => void;
   fetchRewards: (_obj: any) => void;
   rewardsPopupClosed: () => void;
+  logout: () => void;
 }
 
 interface State {
@@ -129,6 +130,7 @@ export class Container extends React.Component<Properties, State> {
       fetchRewards,
       enterFullScreenMessenger: () => enterFullScreenMessenger(),
       rewardsPopupClosed,
+      logout,
     };
   }
 
@@ -224,6 +226,7 @@ export class Container extends React.Component<Properties, State> {
           includeRewardsAvatar={this.props.includeRewardsAvatar}
           userAvatarUrl={this.props.userAvatarUrl}
           onRewardsPopupClose={this.props.rewardsPopupClosed}
+          onLogout={this.props.logout}
         />
 
         <div className='direct-message-members'>

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -49,6 +49,8 @@ export interface Properties extends PublicProperties {
   allowClose: boolean;
   allowExpand: boolean;
   includeRewardsAvatar: boolean;
+  userName: string;
+  userHandle: string;
   userAvatarUrl: string;
   zero: string;
   zeroPreviousDay: string;
@@ -110,6 +112,8 @@ export class Container extends React.Component<Properties, State> {
       allowExpand: !layout?.value?.isMessengerFullScreen,
       includeRewardsAvatar: layout?.value?.isMessengerFullScreen,
       isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
+      userName: user?.data?.profileSummary?.firstName || '',
+      userHandle: user?.data?.handle || '',
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
       myUserId: user?.data?.id,
       zero: rewards.zero,
@@ -224,6 +228,8 @@ export class Container extends React.Component<Properties, State> {
           isMessengerFullScreen={this.props.isMessengerFullScreen}
           isFirstTimeLogin={this.props.isFirstTimeLogin}
           includeRewardsAvatar={this.props.includeRewardsAvatar}
+          userName={this.props.userName}
+          userHandle={this.props.userHandle}
           userAvatarUrl={this.props.userAvatarUrl}
           onRewardsPopupClose={this.props.rewardsPopupClosed}
           onLogout={this.props.logout}

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -10,11 +10,14 @@ describe('rewards-bar', () => {
       isFirstTimeLogin: false,
       includeRewardsAvatar: false,
       isMessengerFullScreen: false,
+      userName: '',
+      userHandle: '',
       userAvatarUrl: '',
       zero: '',
       zeroPreviousDay: '',
       isRewardsLoading: false,
       onRewardsPopupClose: () => {},
+      onLogout: () => {},
       ...props,
     };
 
@@ -94,11 +97,11 @@ describe('rewards-bar', () => {
     expect(wrapper.find(TooltipPopup).prop('open')).toBeFalse();
   });
 
-  it('renders the rewards avatar as necessary', function () {
+  it('renders the SettingsMenu as necessary', function () {
     let wrapper = subject({ includeRewardsAvatar: true });
-    expect(wrapper).toHaveElement('Avatar');
+    expect(wrapper).toHaveElement('SettingsMenu');
 
     wrapper.setProps({ includeRewardsAvatar: false });
-    expect(wrapper).not.toHaveElement('Avatar');
+    expect(wrapper).not.toHaveElement('SettingsMenu');
   });
 });

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -1,13 +1,15 @@
-import { Avatar, DropdownMenu, Status } from '@zero-tech/zui/components';
-import { IconCurrencyDollar, IconLogOut3 } from '@zero-tech/zui/icons';
+import { Status } from '@zero-tech/zui/components';
+import { IconCurrencyDollar } from '@zero-tech/zui/icons';
 import classnames from 'classnames';
 import * as React from 'react';
 import { RewardsFAQModal } from '../rewards-faq-modal';
 import { RewardsPopupContainer } from '../rewards-popup/container';
 import { TooltipPopup } from '../tooltip-popup/tooltip-popup';
+import { SettingsMenu } from '../settings-menu';
 import { bem } from '../../lib/bem';
 
 import './styles.scss';
+
 const c = bem('rewards-bar');
 
 export interface Properties {
@@ -79,30 +81,6 @@ export class RewardsBar extends React.Component<Properties, State> {
   closeRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: false });
   closeRewardsTooltip = () => this.setState({ isRewardsTooltipOpen: false });
 
-  handleLogout = () => {
-    this.props.onLogout();
-  };
-
-  renderSettingsHeader() {
-    return (
-      <div className={c('settings-user')}>
-        <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
-        <div className={c('settings-user-details')}>
-          <div className={c('settings-user-name')}>User Name</div>
-          <div className={c('settings-user-address')}>User Address</div>
-        </div>
-      </div>
-    );
-  }
-
-  renderSettingsOption(icon, label) {
-    return (
-      <div className={c('settings-option')}>
-        {icon} {label}
-      </div>
-    );
-  }
-
   renderRewardsBar() {
     return (
       <div
@@ -111,24 +89,7 @@ export class RewardsBar extends React.Component<Properties, State> {
         })}
       >
         {this.props.includeRewardsAvatar && (
-          <DropdownMenu
-            menuClassName={c('settings')}
-            items={[
-              {
-                id: 'header',
-                label: this.renderSettingsHeader(),
-                onSelect: () => {},
-              },
-              {
-                id: 'log-out',
-                label: this.renderSettingsOption(<IconLogOut3 />, 'Log Out'),
-                onSelect: () => this.handleLogout(),
-              },
-            ]}
-            side='right'
-            alignMenu='start'
-            trigger={<Avatar size={'medium'} type={'circle'} imageURL={this.props.userAvatarUrl} />}
-          />
+          <SettingsMenu onLogout={this.props.onLogout} userAvatarUrl={this.props.userAvatarUrl} />
         )}
         <button
           onClick={this.openRewards}

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -1,5 +1,5 @@
-import { Avatar, Status } from '@zero-tech/zui/components';
-import { IconCurrencyDollar } from '@zero-tech/zui/icons';
+import { Avatar, DropdownMenu, Status } from '@zero-tech/zui/components';
+import { IconCurrencyDollar, IconLogOut3 } from '@zero-tech/zui/icons';
 import classnames from 'classnames';
 import * as React from 'react';
 import { RewardsFAQModal } from '../rewards-faq-modal';
@@ -20,6 +20,7 @@ export interface Properties {
   isMessengerFullScreen: boolean;
   isRewardsLoading: boolean;
 
+  onLogout: () => void;
   onRewardsPopupClose: () => void;
 }
 
@@ -78,6 +79,30 @@ export class RewardsBar extends React.Component<Properties, State> {
   closeRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: false });
   closeRewardsTooltip = () => this.setState({ isRewardsTooltipOpen: false });
 
+  handleLogout = () => {
+    this.props.onLogout();
+  };
+
+  renderSettingsHeader() {
+    return (
+      <div className={c('settings-user')}>
+        <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
+        <div className={c('settings-user-details')}>
+          <div className={c('settings-user-name')}>User Name</div>
+          <div className={c('settings-user-address')}>User Address</div>
+        </div>
+      </div>
+    );
+  }
+
+  renderSettingsOption(icon, label) {
+    return (
+      <div className={c('settings-option')}>
+        {icon} {label}
+      </div>
+    );
+  }
+
   renderRewardsBar() {
     return (
       <div
@@ -86,7 +111,24 @@ export class RewardsBar extends React.Component<Properties, State> {
         })}
       >
         {this.props.includeRewardsAvatar && (
-          <Avatar size={'medium'} type={'circle'} imageURL={this.props.userAvatarUrl} />
+          <DropdownMenu
+            menuClassName={c('settings')}
+            items={[
+              {
+                id: 'header',
+                label: this.renderSettingsHeader(),
+                onSelect: () => {},
+              },
+              {
+                id: 'log-out',
+                label: this.renderSettingsOption(<IconLogOut3 />, 'Log Out'),
+                onSelect: () => this.handleLogout(),
+              },
+            ]}
+            side='right'
+            alignMenu='start'
+            trigger={<Avatar size={'medium'} type={'circle'} imageURL={this.props.userAvatarUrl} />}
+          />
         )}
         <button
           onClick={this.openRewards}

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -86,7 +86,7 @@ export class RewardsBar extends React.Component<Properties, State> {
         })}
       >
         {this.props.includeRewardsAvatar && (
-          <Avatar size={'small'} type={'circle'} imageURL={this.props.userAvatarUrl} />
+          <Avatar size={'medium'} type={'circle'} imageURL={this.props.userAvatarUrl} />
         )}
         <button
           onClick={this.openRewards}

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -15,6 +15,9 @@ const c = bem('rewards-bar');
 export interface Properties {
   isFirstTimeLogin: boolean;
   includeRewardsAvatar: boolean;
+
+  userName: string;
+  userHandle: string;
   userAvatarUrl: string;
 
   zero: string;
@@ -98,7 +101,12 @@ export class RewardsBar extends React.Component<Properties, State> {
         })}
       >
         {this.props.includeRewardsAvatar && (
-          <SettingsMenu onLogout={this.props.onLogout} userAvatarUrl={this.props.userAvatarUrl} />
+          <SettingsMenu
+            onLogout={this.props.onLogout}
+            userName={this.props.userName}
+            userHandle={this.props.userHandle}
+            userAvatarUrl={this.props.userAvatarUrl}
+          />
         )}
         <button
           onClick={this.openRewards}

--- a/src/components/rewards-bar/styles.scss
+++ b/src/components/rewards-bar/styles.scss
@@ -17,50 +17,6 @@
     }
   }
 
-  &__settings {
-    width: 256px;
-    padding: 8px;
-  }
-
-  // &__settings-header {
-  //   &:hover {
-  //     cursor: default;
-  //   }
-  // }
-
-  &__settings-user {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-  }
-
-  &__settings-user-details {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  &__settings-user-name {
-    font-size: 14px;
-    font-weight: 700;
-    line-height: 17px;
-    color: theme.$color-greyscale-12;
-  }
-
-  &__settings-user-address {
-    font-size: 10px;
-    line-height: 1712pxpx;
-    color: theme.$color-greyscale-11;
-  }
-
-  &__settings-option {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    font-size: 16px;
-    line-height: 24px;
-  }
-
   &__rewards-button {
     all: unset;
     cursor: pointer;

--- a/src/components/rewards-bar/styles.scss
+++ b/src/components/rewards-bar/styles.scss
@@ -17,6 +17,50 @@
     }
   }
 
+  &__settings {
+    width: 256px;
+    padding: 8px;
+  }
+
+  // &__settings-header {
+  //   &:hover {
+  //     cursor: default;
+  //   }
+  // }
+
+  &__settings-user {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__settings-user-details {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__settings-user-name {
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 17px;
+    color: theme.$color-greyscale-12;
+  }
+
+  &__settings-user-address {
+    font-size: 10px;
+    line-height: 1712pxpx;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__settings-option {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    line-height: 24px;
+  }
+
   &__rewards-button {
     all: unset;
     cursor: pointer;

--- a/src/components/settings-menu/index.test.tsx
+++ b/src/components/settings-menu/index.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Properties, SettingsMenu } from '.';
+import { DropdownMenu } from '@zero-tech/zui/components';
+
+describe('settings-menu', () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      userName: '',
+      userHandle: '',
+      userAvatarUrl: '',
+      onLogout: () => {},
+      ...props,
+    };
+
+    return shallow(<SettingsMenu {...allProps} />);
+  };
+
+  it('renders DropdownMenu component', function () {
+    const wrapper = subject({});
+
+    expect(wrapper).toHaveElement(DropdownMenu);
+  });
+
+  it('calls onLogout prop when logout item is selected', function () {
+    const mockOnLogout = jest.fn();
+    const wrapper = subject({ onLogout: mockOnLogout });
+    const dropdownMenu = wrapper.find(DropdownMenu);
+
+    dropdownMenu.prop('items')[2].onSelect();
+
+    expect(mockOnLogout).toHaveBeenCalled();
+  });
+});

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -1,19 +1,23 @@
 import * as React from 'react';
 
 import { IconLogOut3 } from '@zero-tech/zui/icons';
-import { Avatar, DropdownMenu } from '@zero-tech/zui/components';
+import { Address, Avatar, DropdownMenu } from '@zero-tech/zui/components';
 
 import { bem } from '../../lib/bem';
 
 import './styles.scss';
 
 export interface Properties {
+  userName: string;
+  userHandle: string;
   userAvatarUrl: string;
 
   onLogout: () => void;
 }
 
 export class SettingsMenu extends React.Component<Properties> {
+  containsAtSymbol = this.props.userHandle.includes('@');
+
   handleLogout = () => {
     this.props.onLogout();
   };
@@ -25,8 +29,10 @@ export class SettingsMenu extends React.Component<Properties> {
       <div className={c('')}>
         <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
         <div className={c('user-details')}>
-          <div className={c('name')}>User Name</div>
-          <div className={c('address')}>User Address</div>
+          <div className={c('name')}>{this.props.userName}</div>
+          <div className={c('address')}>
+            {this.containsAtSymbol ? this.props.userHandle : <Address address={this.props.userHandle} />}
+          </div>
         </div>
       </div>
     );

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -17,6 +17,7 @@ export interface Properties {
 
 export class SettingsMenu extends React.Component<Properties> {
   containsAtSymbol = this.props.userHandle.includes('@');
+  userHandle = this.containsAtSymbol ? this.props.userHandle : <Address address={this.props.userHandle} />;
 
   handleLogout = () => {
     this.props.onLogout();
@@ -30,9 +31,7 @@ export class SettingsMenu extends React.Component<Properties> {
         <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
         <div className={c('user-details')}>
           <div className={c('name')}>{this.props.userName}</div>
-          <div className={c('address')}>
-            {this.containsAtSymbol ? this.props.userHandle : <Address address={this.props.userHandle} />}
-          </div>
+          <div className={c('address')}>{this.userHandle}</div>
         </div>
       </div>
     );

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -7,8 +7,6 @@ import { bem } from '../../lib/bem';
 
 import './styles.scss';
 
-const c = bem('settings-menu');
-
 export interface Properties {
   userAvatarUrl: string;
 
@@ -21,12 +19,14 @@ export class SettingsMenu extends React.Component<Properties> {
   };
 
   renderSettingsHeader() {
+    const c = bem('header');
+
     return (
-      <div className={c('user')}>
+      <div className={c('')}>
         <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
         <div className={c('user-details')}>
-          <div className={c('user-name')}>User Name</div>
-          <div className={c('user-address')}>User Address</div>
+          <div className={c('name')}>User Name</div>
+          <div className={c('address')}>User Address</div>
         </div>
       </div>
     );
@@ -34,7 +34,7 @@ export class SettingsMenu extends React.Component<Properties> {
 
   renderSettingsOption(icon, label) {
     return (
-      <div className={c('option')}>
+      <div className={'option'}>
         {icon} {label}
       </div>
     );
@@ -43,7 +43,7 @@ export class SettingsMenu extends React.Component<Properties> {
   render() {
     return (
       <DropdownMenu
-        menuClassName={c('')}
+        menuClassName={'settings-menu'}
         items={[
           {
             id: 'header',
@@ -51,7 +51,14 @@ export class SettingsMenu extends React.Component<Properties> {
             onSelect: () => {},
           },
           {
-            id: 'log-out',
+            className: 'divider',
+            id: 'divider',
+            label: <div />,
+            onSelect: () => {},
+          },
+          {
+            className: 'logout',
+            id: 'logout',
             label: this.renderSettingsOption(<IconLogOut3 />, 'Log Out'),
             onSelect: () => this.handleLogout(),
           },

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { IconLogOut3 } from '@zero-tech/zui/icons';
+import { Avatar, DropdownMenu } from '@zero-tech/zui/components';
+
+import { bem } from '../../lib/bem';
+
+import './styles.scss';
+
+const c = bem('settings-menu');
+
+export interface Properties {
+  userAvatarUrl: string;
+
+  onLogout: () => void;
+}
+
+export class SettingsMenu extends React.Component<Properties> {
+  handleLogout = () => {
+    this.props.onLogout();
+  };
+
+  renderSettingsHeader() {
+    return (
+      <div className={c('user')}>
+        <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
+        <div className={c('user-details')}>
+          <div className={c('user-name')}>User Name</div>
+          <div className={c('user-address')}>User Address</div>
+        </div>
+      </div>
+    );
+  }
+
+  renderSettingsOption(icon, label) {
+    return (
+      <div className={c('option')}>
+        {icon} {label}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <DropdownMenu
+        menuClassName={c('')}
+        items={[
+          {
+            id: 'header',
+            label: this.renderSettingsHeader(),
+            onSelect: () => {},
+          },
+          {
+            id: 'log-out',
+            label: this.renderSettingsOption(<IconLogOut3 />, 'Log Out'),
+            onSelect: () => this.handleLogout(),
+          },
+        ]}
+        side='right'
+        alignMenu='start'
+        trigger={<Avatar size={'medium'} type={'circle'} imageURL={this.props.userAvatarUrl} />}
+      />
+    );
+  }
+}

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -54,17 +54,4 @@
   .zui-dropdown-item.logout {
     color: theme.$color-failure-11;
   }
-
-  //   .zui-dropdown-trigger {
-  //     &:first-child:focus {
-  //       outline: none;
-  //     }
-  //     &:first-child:active {
-  //       outline: none;
-  //     }
-  //   }
-  .zui-dropdown-trigger:focus,
-  .zui-dropdown-menu.open .zui-dropdown-trigger {
-    outline: none;
-  }
 }

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -4,36 +4,67 @@
   width: 256px;
   padding: 8px;
 
-  &__user {
+  > *:first-child {
+    &:hover {
+      background: none;
+      cursor: default;
+    }
+  }
+
+  .header {
     display: flex;
     align-items: center;
     gap: 16px;
+    pointer-events: none;
+
+    &__user-details {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    &__name {
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 17px;
+      color: theme.$color-greyscale-12;
+    }
+
+    &__address {
+      font-size: 10px;
+      line-height: 12px;
+      color: theme.$color-greyscale-11;
+    }
   }
 
-  &__user-details {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  &__user-name {
-    font-size: 14px;
-    font-weight: 700;
-    line-height: 17px;
-    color: theme.$color-greyscale-12;
-  }
-
-  &__user-address {
-    font-size: 10px;
-    line-height: 1712pxpx;
-    color: theme.$color-greyscale-11;
-  }
-
-  &__option {
+  .option {
     display: flex;
     align-items: center;
     gap: 10px;
     font-size: 16px;
     line-height: 24px;
+  }
+
+  .zui-dropdown-item.divider {
+    border-bottom: 1px solid theme.$color-primary-5;
+    margin: 8px 0px;
+    padding: 0;
+  }
+
+  .zui-dropdown-item.logout {
+    color: theme.$color-failure-11;
+  }
+
+  //   .zui-dropdown-trigger {
+  //     &:first-child:focus {
+  //       outline: none;
+  //     }
+  //     &:first-child:active {
+  //       outline: none;
+  //     }
+  //   }
+  .zui-dropdown-trigger:focus,
+  .zui-dropdown-menu.open .zui-dropdown-trigger {
+    outline: none;
   }
 }

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -1,0 +1,39 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.settings-menu {
+  width: 256px;
+  padding: 8px;
+
+  &__user {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  &__user-details {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__user-name {
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 17px;
+    color: theme.$color-greyscale-12;
+  }
+
+  &__user-address {
+    font-size: 10px;
+    line-height: 1712pxpx;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    line-height: 24px;
+  }
+}

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -34,6 +34,10 @@
       font-size: 10px;
       line-height: 12px;
       color: theme.$color-greyscale-11;
+
+      span {
+        color: theme.$color-greyscale-11;
+      }
     }
   }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -12,6 +12,7 @@ html {
 }
 
 body {
+  height: 100vh;
   overscroll-behavior-y: none;
   margin: 0;
   font-family: fonts.$font-family, 'Helvetica Neue Ultra Light', Helvetica, Arial, 'Lucida Grande', 'sans-serif';


### PR DESCRIPTION
### What does this do?
Triggers a drop down menu per the below-provided specs when a user clicks on their pfp in the upper left corner of the conversation list sidebar.

Populate a drop down menu with two items:
- a header with the user’s pfp, display name, and wallet / zID (as applicable, see design)
- logout option

* when clicking to logout the user should be redirected to login page.

### Why are we making this change?
Visibility for user to see which account they are logged into and ability to logout/disconnect.

### How do I test this?
Open messenger. Click profile icon (avatar in top left corner in the sidekick. Dropdown menu should appear with the two items detailed above. Check logout functionality by clicking logout. Should redirect you to the login page.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/b5cd84f2-a4ce-408d-909c-36af46f51997



