### PR TITLE
add video support

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -135,6 +135,7 @@ describe('MessageInput', () => {
     const mimeTypes = {
       'image/*': [],
       'text/*': [],
+      'video/*': [],
       'application/pdf': [],
       'application/msword': [],
     };

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -88,7 +88,7 @@ export class MessageInput extends React.Component<Properties, State> {
     return {
       'image/*': [],
       'text/*': [],
-      //'video/*': [],
+      'video/*': [],
       'application/pdf': [],
       'application/msword': [],
     };
@@ -309,7 +309,8 @@ export class MessageInput extends React.Component<Properties, State> {
               <div {...getRootProps({ className: 'mentions-text-area' })}>
                 <ImageCards images={this.images} onRemoveImage={this.removeMediaPreview} size='small' />
                 <AudioCards audios={this.audios} onRemove={this.removeMediaPreview} />
-                <AttachmentCards attachments={this.files} onRemove={this.removeMediaPreview} />
+                <AttachmentCards attachments={this.files} type='file' onRemove={this.removeMediaPreview} />
+                <AttachmentCards attachments={this.videos} type='video' onRemove={this.removeMediaPreview} />
                 {this.props.reply && <ReplyCard message={this.props.reply.message} onRemove={this.removeReply} />}
                 <div className='message-input__emoji-picker'>
                   <EmojiPicker

--- a/src/platform-apps/channels/attachment-cards/attachment-card.tsx
+++ b/src/platform-apps/channels/attachment-cards/attachment-card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import './styles.scss';
-import { IconXClose } from '@zero-tech/zui/icons';
+import { IconVideoRecorder, IconXClose } from '@zero-tech/zui/icons';
 import { IconButton } from '@zero-tech/zui/components';
 
 export interface Attachment {
@@ -15,6 +15,7 @@ export interface Properties {
   attachment: Attachment;
   onRemove?: () => void;
   onClick?: (attachment: Attachment) => void;
+  type?: 'video' | 'file';
 }
 
 export default class AttachmentCard extends React.Component<Properties, undefined> {
@@ -50,7 +51,9 @@ export default class AttachmentCard extends React.Component<Properties, undefine
   file() {
     const content = (
       <div className='attachment-card__file'>
-        <div className='attachment-card__icon'>{this.renderPaperClip()}</div>
+        <div className='attachment-card__icon'>
+          {this.props.type === 'video' ? <IconVideoRecorder size={18} /> : this.renderPaperClip()}
+        </div>
         <span className='attachment-card__name'>{this.props.attachment.name}</span>
       </div>
     );

--- a/src/platform-apps/channels/attachment-cards/index.tsx
+++ b/src/platform-apps/channels/attachment-cards/index.tsx
@@ -9,6 +9,7 @@ export interface Properties {
   border?: boolean;
   onRemove?: (attachment: any) => void;
   onAttachmentClicked?: (attachment: any) => void;
+  type?: 'video' | 'file';
 }
 
 export default class AttachmentCards extends React.Component<Properties, undefined> {
@@ -36,6 +37,7 @@ export default class AttachmentCards extends React.Component<Properties, undefin
         {attachments.map((attachment) => {
           return (
             <AttachmentCard
+              type={this.props.type}
               key={attachment.url}
               attachment={attachment}
               onRemove={this.props.onRemove ? this.itemRemoved.bind(this, attachment) : null}


### PR DESCRIPTION
Allows users to send video files as well. I have kept similar design to attachment card, since we're going to change it anyway. 

preview:
<img width="363" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/8004f03e-351e-4fa5-8233-0c15ae8ed77b">

sent:
<img width="575" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/608c3c3f-c091-476c-b80a-69c07510d2b1">
