### PR TITLE
Render conversation contents as soon as the chat view is opened

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -54,7 +54,6 @@ interface PublicProperties {
 }
 export interface State {
   countNewMessages: number;
-  isFirstMessagesFetchDone: boolean;
   reply: null | ParentMessage;
 }
 
@@ -89,7 +88,7 @@ export class Container extends React.Component<Properties, State> {
     };
   }
 
-  state = { countNewMessages: 0, isFirstMessagesFetchDone: false, reply: null };
+  state = { countNewMessages: 0, reply: null };
 
   componentDidMount() {
     const { channelId } = this.props;
@@ -105,16 +104,12 @@ export class Container extends React.Component<Properties, State> {
       this.props.stopSyncChannels(prevProps);
       this.props.fetchMessages({ channelId });
       this.setState({
-        isFirstMessagesFetchDone: false,
         reply: null,
       });
     }
 
     if (channelId && prevProps.user.data === null && this.props.user.data !== null) {
       this.props.fetchMessages({ channelId });
-      this.setState({
-        isFirstMessagesFetchDone: false,
-      });
     }
 
     if (
@@ -135,17 +130,11 @@ export class Container extends React.Component<Properties, State> {
       this.setState({ countNewMessages: channel.countNewMessages });
     }
 
-    if (!this.state.isFirstMessagesFetchDone && channel && Boolean(channel.messages)) {
-      this.setState({
-        isFirstMessagesFetchDone: true,
-      });
-    }
-
-    if (this.state.isFirstMessagesFetchDone && channel && channel.unreadCount > 0 && user.data) {
+    if (channel && channel.unreadCount > 0 && user.data) {
       this.props.markAllMessagesAsReadInChannel({ channelId, userId: user.data.id });
     }
 
-    if (this.state.isFirstMessagesFetchDone && this.textareaRef && channel && Boolean(channel.messages)) {
+    if (this.textareaRef && channel && Boolean(channel.messages)) {
       this.onMessageInputRendered(this.textareaRef);
       this.textareaRef = null;
     }
@@ -253,10 +242,7 @@ export class Container extends React.Component<Properties, State> {
     return (
       <>
         <ChatView
-          className={classNames(
-            { 'channel-view--messages-fetched': this.state.isFirstMessagesFetchDone },
-            this.props.className
-          )}
+          className={classNames(this.props.className)}
           id={this.channel.id}
           name={this.channel.name}
           messages={this.channel.messages || []}

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -125,11 +125,9 @@ $scrollbar-width: 5px;
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    visibility: hidden;
 
     &--messages-fetched {
       animation: fadein animation.$animation-duration-double ease-out forwards;
-      visibility: visible;
     }
 
     &__main {

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -126,10 +126,6 @@ $scrollbar-width: 5px;
     height: 100%;
     box-sizing: border-box;
 
-    &--messages-fetched {
-      animation: fadein animation.$animation-duration-double ease-out forwards;
-    }
-
     &__main {
       padding-right: var(--layout-app-content-right-padding);
     }


### PR DESCRIPTION
### What does this do?

This removes the chat view load animations when we're fetching the messages. This allows the user to receive an interactive view immediately.

### Why are we making this change?

To provide a snappier feel to the conversation window. Still to come are loading skeletons so that it's clear that message data may still be loading when you open a conversation for the first time.

Before:

https://github.com/zer0-os/zOS/assets/43770/ab5f84d3-47e7-4121-a995-1fd18fb73f87


After:

https://github.com/zer0-os/zOS/assets/43770/a896a233-054c-417c-8ce2-b0951ab26385

