### PR TITLE
Fix date separator in chat views

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -233,6 +233,7 @@ $scrollbar-width: 5px;
       font-weight: 400;
       font-size: 12px;
       line-height: 15px;
+      clear: both;
 
       &-date {
         color: theme.$color-greyscale-transparency-11;


### PR DESCRIPTION
### What does this do?

Fixes the date separator in chat views to not float beside messages.

Before:
![image](https://github.com/zer0-os/zOS/assets/43770/f5238ca6-f3b5-4464-a317-6ac3154f1c2c)


After:
![image](https://github.com/zer0-os/zOS/assets/43770/10a12f74-0764-4f08-9ee3-47f689e0df9e)

