### PR TITLE
Increase size of group conversation participant avatars next to message bubble in conversation window

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -422,7 +422,7 @@ $scrollbar-width: 5px;
 
       &__left {
         margin-right: 8px;
-        width: 16px;
+        width: 32px;
       }
 
       &__author-avatar {
@@ -430,8 +430,8 @@ $scrollbar-width: 5px;
         background-position: center;
         background-repeat: no-repeat;
         background-size: cover;
-        width: 16px;
-        height: 16px;
+        width: 32px;
+        height: 32px;
         overflow: hidden;
         border-radius: 50%;
       }


### PR DESCRIPTION
<img width="436" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/8dfb6a23-bd47-459f-b18d-c8bd656d0471">

<img width="122" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/4792be08-3ffe-49d0-adc0-885a6870ee5e">

<img width="1496" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/23fe71a8-de46-4d69-b5a7-df6e3a167121">
