### PR TITLE
Revamp view control header display

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -41,6 +41,7 @@ export interface Properties extends PublicProperties {
   startMessageSync: (payload: PayloadFetchMessages) => void;
   stopSyncChannels: (payload: PayloadFetchMessages) => void;
   activeConversationId?: string;
+  isMessengerFullScreen: boolean;
   context: {
     isAuthenticated: boolean;
   };
@@ -65,12 +66,14 @@ export class Container extends React.Component<Properties, State> {
     const {
       authentication: { user },
       chat: { activeConversationId },
+      layout,
     } = state;
 
     return {
       channel,
       user,
       activeConversationId,
+      isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
     };
   }
 
@@ -245,6 +248,7 @@ export class Container extends React.Component<Properties, State> {
           className={classNames(this.props.className)}
           id={this.channel.id}
           name={this.channel.name}
+          isMessengerFullScreen={this.props.isMessengerFullScreen}
           messages={this.channel.messages || []}
           onFetchMore={this.fetchMore}
           user={this.props.user.data}

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -48,7 +48,7 @@ describe('ChatView', () => {
       resetCountNewMessage: () => null,
       onMessageInputRendered: () => null,
       isDirectMessage: true,
-
+      isMessengerFullScreen: false,
       ...props,
     };
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -47,6 +47,7 @@ export interface Properties {
   onMessageInputRendered: (ref: RefObject<HTMLTextAreaElement>) => void;
   isDirectMessage: boolean;
   showSenderAvatar?: boolean;
+  isMessengerFullScreen: boolean;
 }
 
 export interface State {
@@ -193,7 +194,11 @@ export class ChatView extends React.Component<Properties, State> {
     const { hasJoined: isMemberOfChannel } = this.props;
 
     return (
-      <div className={classNames('channel-view', this.props.className)}>
+      <div
+        className={classNames('channel-view', this.props.className, {
+          'channel-view__fullscreen': this.props.isMessengerFullScreen,
+        })}
+      >
         {this.isShowIndicator() && (
           <IndicatorMessage countNewMessages={this.props.countNewMessages} closeIndicator={this.closeIndicator} />
         )}

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconXClose, IconMinus, IconExpand1, IconLayoutRight } from '@zero-tech/zui/icons';
+import { IconXClose, IconMinus, IconExpand1 } from '@zero-tech/zui/icons';
 import { shallow } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import { Channel, User } from '../../../store/channels';
@@ -13,7 +13,6 @@ describe('messenger-chat', () => {
       setactiveConversationId: jest.fn(),
       directMessage: null,
       isFullScreen: false,
-      includeTitleBar: true,
       enterFullScreenMessenger: () => null,
       exitFullScreenMessenger: () => null,
       ...props,
@@ -71,7 +70,7 @@ describe('messenger-chat', () => {
     const exitFullScreenMessenger = jest.fn();
     const wrapper = subject({ exitFullScreenMessenger, isFullScreen: true });
 
-    icon(wrapper, IconLayoutRight).simulate('click');
+    icon(wrapper, IconExpand1).simulate('click');
 
     expect(exitFullScreenMessenger).toHaveBeenCalledOnce();
   });

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconExpand1, IconLayoutRight, IconMinus, IconUsers1, IconXClose } from '@zero-tech/zui/icons';
+import { IconExpand1, IconMinus, IconUsers1, IconXClose } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import { setactiveConversationId } from '../../../store/chat';
 import { RootState } from '../../../store/reducer';
@@ -21,7 +21,6 @@ export interface Properties extends PublicProperties {
   setactiveConversationId: (activeDirectMessageId: string) => void;
   directMessage: Channel;
   isFullScreen: boolean;
-  includeTitleBar: boolean;
   enterFullScreenMessenger: () => void;
   exitFullScreenMessenger: () => void;
 }
@@ -35,7 +34,6 @@ export class Container extends React.Component<Properties, State> {
 
   static mapState(state: RootState): Partial<Properties> {
     const {
-      authentication: { user },
       chat: { activeConversationId },
       layout,
     } = state;
@@ -46,7 +44,6 @@ export class Container extends React.Component<Properties, State> {
       activeConversationId,
       directMessage,
       isFullScreen: layout.value?.isMessengerFullScreen,
-      includeTitleBar: user?.data?.isAMemberOfWorlds,
     };
   }
 
@@ -145,20 +142,16 @@ export class Container extends React.Component<Properties, State> {
         className={classNames('direct-message-chat', {
           'direct-message-chat--transition': this.props.isFullScreen !== null || this.state.isMinimized,
           'direct-message-chat--full-screen': this.props.isFullScreen,
-          'direct-message-chat--no-title': !this.props.includeTitleBar,
           'direct-message-chat--minimized': this.state.isMinimized,
           'direct-message-chat--one-on-one': this.isOneOnOne(),
         })}
       >
         <div className='direct-message-chat__content'>
-          {this.props.includeTitleBar && (
+          {!this.props.isFullScreen && (
             <div className='direct-message-chat__title-bar'>
-              {this.props.isFullScreen && (
-                <IconButton onClick={this.handleDockRight} Icon={IconLayoutRight} size={12} />
-              )}
-              {!this.props.isFullScreen && <IconButton onClick={this.handleMaximize} Icon={IconExpand1} size={12} />}
-              {!this.props.isFullScreen && <IconButton onClick={this.handleMinimizeClick} Icon={IconMinus} size={12} />}
-              {!this.props.isFullScreen && <IconButton onClick={this.handleClose} Icon={IconXClose} size={12} />}
+              <IconButton onClick={this.handleMaximize} Icon={IconExpand1} size={12} />
+              <IconButton onClick={this.handleMinimizeClick} Icon={IconMinus} size={12} />
+              <IconButton onClick={this.handleClose} Icon={IconXClose} size={12} />
             </div>
           )}
 
@@ -180,6 +173,12 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__title'>{this.renderTitle()}</div>
               <div className='direct-message-chat__subtitle'>{this.renderSubTitle()}</div>
             </span>
+
+            {this.props.isFullScreen && (
+              <div>
+                <IconButton onClick={this.handleDockRight} Icon={IconExpand1} size={28} />
+              </div>
+            )}
           </div>
 
           <ChatViewContainer

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -33,6 +33,10 @@ $recent-indicator-size: 8px;
       height: calc(100% - $title-bar-height - $header-height);
       display: flex;
       flex-direction: column;
+
+      &__fullscreen {
+        height: calc(100% - $header-height);
+      }
     }
   }
 
@@ -76,6 +80,12 @@ $recent-indicator-size: 8px;
     border-bottom: 1px solid theme.$color-greyscale-transparency-2;
     display: flex;
     gap: 8px;
+
+    > div:last-child {
+      flex-grow: 1;
+      display: flex;
+      justify-content: flex-end;
+    }
 
     &-avatar {
       background-position: center;

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -419,7 +419,7 @@ describe('messenger-list', () => {
       expect(state.stage).toEqual(Stage.GroupDetails);
     });
 
-    test('stage', () => {
+    test('groupUsers', () => {
       const state = subject([], { groupUsers: [{ value: 'a-thing' }] });
 
       expect(state.groupUsers).toEqual([{ value: 'a-thing' }]);
@@ -445,10 +445,16 @@ describe('messenger-list', () => {
     });
 
     test('includeTitleBar', async () => {
-      let state = subject([], {}, [user({ isAMemberOfWorlds: false })]);
+      let state = DirectMessageChat.mapState({
+        ...getState([]),
+        layout: { value: { isMessengerFullScreen: true } } as LayoutState,
+      });
       expect(state.includeTitleBar).toEqual(false);
 
-      state = subject([], {}, [user({ isAMemberOfWorlds: true })]);
+      state = DirectMessageChat.mapState({
+        ...getState([]),
+        layout: { value: { isMessengerFullScreen: false } } as LayoutState,
+      });
       expect(state.includeTitleBar).toEqual(true);
     });
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -107,7 +107,7 @@ export class Container extends React.Component<Properties, State> {
       isFetchingExistingConversations: createConversation.startGroupChat.isLoading,
       isFirstTimeLogin: registration.isFirstTimeLogin,
       isInviteNotificationOpen: registration.isInviteToastOpen,
-      includeTitleBar: user?.data?.isAMemberOfWorlds,
+      includeTitleBar: !layout?.value?.isMessengerFullScreen,
       allowClose: !layout?.value?.isMessengerFullScreen,
       allowExpand: !layout?.value?.isMessengerFullScreen,
       includeRewardsAvatar: layout?.value?.isMessengerFullScreen,


### PR DESCRIPTION
+ removes top title for network users in full screen mode as well
+ add collapse icon in view control header

<img width="1496" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/147f3454-e379-469f-b2ac-6d8d194cd849">


Note: `IconExpand1` will be replaced by `IconCollapse1` after adding it in zUI.
![image](https://github.com/zer0-os/zOS/assets/33264364/4248eadf-8f37-41dc-9b0c-fc859e84cc42)
