### PR TITLE
chore: bump zui version (`0.24.2`) -> (`0.24.3`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@zero-tech/zapp-daos": "latest",
         "@zero-tech/zapp-nfts": "latest",
         "@zero-tech/zapp-staking": "latest",
-        "@zero-tech/zui": "^0.24.2",
+        "@zero-tech/zui": "^0.24.3",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -10706,9 +10706,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.24.2.tgz",
-      "integrity": "sha512-YOdpal+uUPaq6p8lQzJ2POR0P04Yoob1iTX9u66kqm2EyJS2Dm+Laf/ydbQrCIpqeJ7biLUgJb2mykGQ/XxRKw==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.24.3.tgz",
+      "integrity": "sha512-fJNMku8WXLjkoKAL8PdXG86jTxf1Y1XBuIwOWFny3ePJerD/MUQmZEcS/qEhAom2qN5jWLqok73G6jxttaDXPA==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -41726,7 +41726,7 @@
       "integrity": "sha512-vYYN02Jx+M2MVCjjQYsY/NJrGousc9+WY0Z/6UxCtsk19SKQ7RshuxJxIUDcQ0IyxwOFWI/ssMQ1u82UB7rkGQ==",
       "requires": {
         "@zero-tech/zns-sdk": "0.8.9",
-        "@zero-tech/zui": "^0.24.2",
+        "@zero-tech/zui": "^0.24.3",
         "classnames": "^2.3.1",
         "react-query": "^3.39.1"
       },
@@ -41782,7 +41782,7 @@
         "@zero-tech/zapp-utils": "0.6.5",
         "@zero-tech/zdao-sdk": "0.14.1",
         "@zero-tech/zns-sdk": "0.10.2",
-        "@zero-tech/zui": "^0.24.2",
+        "@zero-tech/zui": "^0.24.3",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "markdown-to-text": "^0.1.1",
@@ -41958,7 +41958,7 @@
         "@zero-tech/zns-sdk": "0.10.1",
         "@zero-tech/zsale-sdk": "0.1.6",
         "@zero-tech/ztoken-sdk": "^0.0.3",
-        "@zero-tech/zui": "^0.24.2",
+        "@zero-tech/zui": "^0.24.3",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "moment": "^2.29.4",
@@ -42040,7 +42040,7 @@
         "@zero-tech/zapp-utils": "^0.6.5",
         "@zero-tech/zfi-sdk": "0.2.1",
         "@zero-tech/zns-sdk": "0.6.1",
-        "@zero-tech/zui": "^0.24.2",
+        "@zero-tech/zui": "^0.24.3",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "millify": "^5.0.1",
@@ -42733,9 +42733,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.24.2.tgz",
-      "integrity": "sha512-YOdpal+uUPaq6p8lQzJ2POR0P04Yoob1iTX9u66kqm2EyJS2Dm+Laf/ydbQrCIpqeJ7biLUgJb2mykGQ/XxRKw==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.24.3.tgz",
+      "integrity": "sha512-fJNMku8WXLjkoKAL8PdXG86jTxf1Y1XBuIwOWFny3ePJerD/MUQmZEcS/qEhAom2qN5jWLqok73G6jxttaDXPA==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@zero-tech/zapp-daos": "latest",
     "@zero-tech/zapp-nfts": "latest",
     "@zero-tech/zapp-staking": "latest",
-    "@zero-tech/zui": "^0.24.2",
+    "@zero-tech/zui": "^0.24.3",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
### What does this do?
- bumps zui version (`0.24.2`) -> (`0.24.3`)

### Why are we making this change?
- to pull in latest changes/additions from zui, including avatar component updates.

