### PR TITLE
refactor: refactor userHandle check to a function (settings-menu)

### DIFF
--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -19,7 +19,14 @@ interface State {
   isDropdownOpen: boolean;
 }
 
-export class SettingsMenu extends React.Component<Properties> {
+export class SettingsMenu extends React.Component<Properties, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isDropdownOpen: false,
+    };
+  }
+
   containsAtSymbol() {
     return this.props.userHandle.includes('@');
   }

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -20,7 +20,7 @@ export class SettingsMenu extends React.Component<Properties> {
     return this.props.userHandle.includes('@');
   }
 
-  userHandle() {
+  getUserHandle() {
     return this.containsAtSymbol() ? this.props.userHandle : <Address address={this.props.userHandle} />;
   }
 
@@ -36,7 +36,7 @@ export class SettingsMenu extends React.Component<Properties> {
         <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
         <div className={c('user-details')}>
           <div className={c('name')}>{this.props.userName}</div>
-          <div className={c('address')}>{this.userHandle()}</div>
+          <div className={c('address')}>{this.getUserHandle()}</div>
         </div>
       </div>
     );

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -16,8 +16,13 @@ export interface Properties {
 }
 
 export class SettingsMenu extends React.Component<Properties> {
-  containsAtSymbol = this.props.userHandle.includes('@');
-  userHandle = this.containsAtSymbol ? this.props.userHandle : <Address address={this.props.userHandle} />;
+  containsAtSymbol() {
+    return this.props.userHandle.includes('@');
+  }
+
+  userHandle() {
+    return this.containsAtSymbol() ? this.props.userHandle : <Address address={this.props.userHandle} />;
+  }
 
   handleLogout = () => {
     this.props.onLogout();
@@ -31,7 +36,7 @@ export class SettingsMenu extends React.Component<Properties> {
         <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />
         <div className={c('user-details')}>
           <div className={c('name')}>{this.props.userName}</div>
-          <div className={c('address')}>{this.userHandle}</div>
+          <div className={c('address')}>{this.userHandle()}</div>
         </div>
       </div>
     );


### PR DESCRIPTION
### What does this do?
- Transform `containsAtSymbol` and `userHandle` into methods that get evaluated each time they are called, which would reflect changes in props. 

### Why are we making this change?
- When we initialize class fields like in `settings-menu` they get their values once at the time of class instantiation and won't get updated when props change. As a result, it would be better to transform `containsAtSymbol` and `userHandle` into methods.

