### PR TITLE
fix: rewards tooltip ui styling

### DIFF
--- a/src/components/tooltip-popup/styles.scss
+++ b/src/components/tooltip-popup/styles.scss
@@ -15,7 +15,8 @@
     animation: fadein 700ms ease-out forwards;
 
     display: flex;
-    padding: 14px;
+    align-items: center;
+    padding: 16px;
     max-width: 32rem;
     height: 24px;
     background-color: theme.$color-primary-3;
@@ -47,6 +48,9 @@
   }
 
   &__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-left: 8px;
   }
 }

--- a/src/components/tooltip-popup/tooltip-popup.tsx
+++ b/src/components/tooltip-popup/tooltip-popup.tsx
@@ -31,7 +31,7 @@ export class TooltipPopup extends React.Component<Properties> {
             <TooltipPrimitive.Content side={this.props.side} align={this.props.align} className={c('content')}>
               {this.props.content}
               <TooltipPrimitive.Arrow className={c('arrow')} width={32} height={16} />
-              <IconButton className={c('close')} Icon={IconXClose} onClick={this.props.onClose} />
+              <IconButton className={c('close')} Icon={IconXClose} size={16} onClick={this.props.onClose} />
             </TooltipPrimitive.Content>
           </TooltipPrimitive.Root>
         </TooltipPrimitive.Provider>


### PR DESCRIPTION
Before:

<img width="646" alt="Screenshot 2023-06-26 at 16 24 22" src="https://github.com/zer0-os/zOS/assets/39112648/ff3688d6-3134-4a7f-b1f7-a34f306b0b28">

After:
<img width="810" alt="Screenshot 2023-06-26 at 16 47 00" src="https://github.com/zer0-os/zOS/assets/39112648/d4e31ab3-e1e9-4426-b637-f77676886010">
 - hover x icon
<img width="810" alt="Screenshot 2023-06-26 at 16 47 32" src="https://github.com/zer0-os/zOS/assets/39112648/e0b3417f-ac56-4198-b77d-97b93c0ff90c">


As per Figma design:
https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=9680-494052&mode=design&t=bry2DJnD3v3oNeLq-0