### PR TITLE
Update `IconExpand1` to latest zUI `IconCollapse1`

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconXClose, IconMinus, IconExpand1 } from '@zero-tech/zui/icons';
+import { IconXClose, IconMinus, IconExpand1, IconCollapse1 } from '@zero-tech/zui/icons';
 import { shallow } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import { Channel, User } from '../../../store/channels';
@@ -13,6 +13,7 @@ describe('messenger-chat', () => {
       setactiveConversationId: jest.fn(),
       directMessage: null,
       isFullScreen: false,
+      allowCollapse: false,
       enterFullScreenMessenger: () => null,
       exitFullScreenMessenger: () => null,
       ...props,
@@ -68,9 +69,9 @@ describe('messenger-chat', () => {
 
   it('publishes exit full screen event', function () {
     const exitFullScreenMessenger = jest.fn();
-    const wrapper = subject({ exitFullScreenMessenger, isFullScreen: true });
+    const wrapper = subject({ exitFullScreenMessenger, isFullScreen: true, allowCollapse: true });
 
-    icon(wrapper, IconExpand1).simulate('click');
+    icon(wrapper, IconCollapse1).simulate('click');
 
     expect(exitFullScreenMessenger).toHaveBeenCalledOnce();
   });

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconExpand1, IconMinus, IconUsers1, IconXClose } from '@zero-tech/zui/icons';
+import { IconExpand1, IconMinus, IconUsers1, IconXClose, IconCollapse1 } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import { setactiveConversationId } from '../../../store/chat';
 import { RootState } from '../../../store/reducer';
@@ -21,6 +21,7 @@ export interface Properties extends PublicProperties {
   setactiveConversationId: (activeDirectMessageId: string) => void;
   directMessage: Channel;
   isFullScreen: boolean;
+  allowCollapse: boolean;
   enterFullScreenMessenger: () => void;
   exitFullScreenMessenger: () => void;
 }
@@ -36,6 +37,7 @@ export class Container extends React.Component<Properties, State> {
     const {
       chat: { activeConversationId },
       layout,
+      authentication: { user },
     } = state;
 
     const directMessage = denormalize(activeConversationId, state);
@@ -44,6 +46,7 @@ export class Container extends React.Component<Properties, State> {
       activeConversationId,
       directMessage,
       isFullScreen: layout.value?.isMessengerFullScreen,
+      allowCollapse: layout.value?.isMessengerFullScreen && user?.data?.isAMemberOfWorlds,
     };
   }
 
@@ -174,9 +177,9 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__subtitle'>{this.renderSubTitle()}</div>
             </span>
 
-            {this.props.isFullScreen && (
+            {this.props.allowCollapse && (
               <div>
-                <IconButton onClick={this.handleDockRight} Icon={IconExpand1} size={28} />
+                <IconButton onClick={this.handleDockRight} Icon={IconCollapse1} size={24} />
               </div>
             )}
           </div>


### PR DESCRIPTION
Uses

<img width="75" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/8af5b923-ba59-4a28-8d36-40e55b42af68">

instead of the expand icon