### PR TITLE
Render skeleton when loading chat messages

### DIFF
--- a/src/components/chat-view-container/chat-skeleton.test.tsx
+++ b/src/components/chat-view-container/chat-skeleton.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ChatSkeleton, Properties } from './chat-skeleton';
+
+describe(ChatSkeleton, () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps = {
+      conversationId: '',
+      ...props,
+    };
+
+    return shallow(<ChatSkeleton {...allProps} />);
+  };
+
+  it('renders the next skeleton when the channel id changes', () => {
+    const wrapper = subject({ conversationId: 'aaa' });
+
+    expect(wrapper).toHaveElement('ChatSkeleton1');
+
+    wrapper.setProps({ conversationId: 'bbb' });
+    expect(wrapper).toHaveElement('ChatSkeleton2');
+  });
+
+  it('loops around to the first skeleton again', () => {
+    const wrapper = subject({ conversationId: 'aaa' });
+
+    // To ensure we don't depend on test order, we figure out which one is currently rendered
+    // and then re-render until we know we've rendered the last one. Then we can test that
+    // it loops around to the first one again.
+    let id = 1;
+    if (wrapper.find('ChatSkeleton1').length !== 0) {
+      id = 1;
+    } else if (wrapper.find('ChatSkeleton2').length !== 0) {
+      id = 2;
+    } else {
+      id = 3;
+    }
+    while (id < 3) {
+      id++;
+      wrapper.setProps({ conversationId: `convo${id}` });
+    }
+
+    wrapper.setProps({ conversationId: 'should restart' });
+    expect(wrapper).toHaveElement('ChatSkeleton1');
+  });
+});

--- a/src/components/chat-view-container/chat-skeleton.tsx
+++ b/src/components/chat-view-container/chat-skeleton.tsx
@@ -6,16 +6,42 @@ import { bem } from '../../lib/bem';
 const c = bem('chat-skeleton');
 
 export interface Properties {
-  templateNumber: 1 | 2 | 3;
+  conversationId: string;
 }
 
-export class ChatSkeleton extends React.Component<Properties> {
+interface State {
+  skeletonId: number;
+}
+
+// Cheezy way to store the last rendered id. This works for now
+// because we only ever render one chat skeleton at a given time.
+let lastSkeletonId = -1;
+
+export class ChatSkeleton extends React.Component<Properties, State> {
+  state = { skeletonId: -1 };
+
+  constructor(props) {
+    super(props);
+    this.state = { skeletonId: this.setNextSkeleton() };
+  }
+
+  componentDidUpdate(prevProps: Readonly<Properties>): void {
+    if (prevProps.conversationId !== this.props.conversationId) {
+      this.setState({ skeletonId: this.setNextSkeleton() });
+    }
+  }
+
+  setNextSkeleton() {
+    lastSkeletonId = (lastSkeletonId + 1) % 3;
+    return lastSkeletonId;
+  }
+
   render() {
     return (
       <div className={c('')}>
-        {this.props.templateNumber === 1 && <ChatSkeleton1 />}
-        {this.props.templateNumber === 2 && <ChatSkeleton2 />}
-        {this.props.templateNumber === 3 && <ChatSkeleton3 />}
+        {this.state.skeletonId === 0 && <ChatSkeleton1 />}
+        {this.state.skeletonId === 1 && <ChatSkeleton2 />}
+        {this.state.skeletonId >= 2 && <ChatSkeleton3 />}
       </div>
     );
   }

--- a/src/components/chat-view-container/chat-skeleton.tsx
+++ b/src/components/chat-view-container/chat-skeleton.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+
+import { Skeleton } from '@zero-tech/zui/components';
+import { bem } from '../../lib/bem';
+
+const c = bem('chat-skeleton');
+
+export interface Properties {
+  templateNumber: 1 | 2 | 3;
+}
+
+export class ChatSkeleton extends React.Component<Properties> {
+  render() {
+    return (
+      <div className={c('')}>
+        {this.props.templateNumber === 1 && <ChatSkeleton1 />}
+        {this.props.templateNumber === 2 && <ChatSkeleton2 />}
+        {this.props.templateNumber === 3 && <ChatSkeleton3 />}
+      </div>
+    );
+  }
+}
+
+class ChatSkeleton1 extends React.PureComponent {
+  render() {
+    return (
+      <>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='65px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='520px' height='99px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='202px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='520px' height='69px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='310px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='181px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='520px' height='71px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='217px' height='33px' />
+        </div>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+class ChatSkeleton2 extends React.PureComponent {
+  render() {
+    return (
+      <>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='65px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='520px' height='75px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='336px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='202px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='310px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='249px' height='33px' />
+        </div>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='206px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='520px' height='71px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='142px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='520px' height='33px' />
+        </div>
+      </>
+    );
+  }
+}
+
+class ChatSkeleton3 extends React.PureComponent {
+  render() {
+    return (
+      <>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='65px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='520px' height='99px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='202px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='310px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='249px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='206px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='520px' height='135px' />
+        </div>
+        <div className={c('date')}>
+          <div>
+            <Skeleton width='100%' height='100%' />
+          </div>
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+        <div className={c('message')}>
+          <Skeleton width='520px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='206px' height='33px' />
+        </div>
+        <div className={c('message', 'owner')}>
+          <Skeleton width='270px' height='33px' />
+        </div>
+      </>
+    );
+  }
+}

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -250,6 +250,7 @@ export class Container extends React.Component<Properties, State> {
           name={this.channel.name}
           isMessengerFullScreen={this.props.isMessengerFullScreen}
           messages={this.channel.messages || []}
+          hasLoadedMessages={this.channel.hasLoadedMessages ?? false}
           onFetchMore={this.fetchMore}
           user={this.props.user.data}
           deleteMessage={this.handleDeleteMessage}

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -49,6 +49,7 @@ describe('ChatView', () => {
       onMessageInputRendered: () => null,
       isDirectMessage: true,
       isMessengerFullScreen: false,
+      hasLoadedMessages: true,
       ...props,
     };
 
@@ -217,6 +218,15 @@ describe('ChatView', () => {
     const wrapper = subject({ className });
 
     expect(wrapper.find(`.${className}`).exists()).toBe(true);
+  });
+
+  it('renders skeleton if messages have not been loaded yet', () => {
+    const wrapper = subject({ messages: MESSAGES_TEST, hasLoadedMessages: false });
+
+    expect(wrapper).toHaveElement('Skeleton');
+
+    wrapper.setProps({ hasLoadedMessages: true });
+    expect(wrapper).not.toHaveElement('Skeleton');
   });
 
   describe('Lightbox', () => {

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -223,10 +223,10 @@ describe('ChatView', () => {
   it('renders skeleton if messages have not been loaded yet', () => {
     const wrapper = subject({ messages: MESSAGES_TEST, hasLoadedMessages: false });
 
-    expect(wrapper).toHaveElement('Skeleton');
+    expect(wrapper).toHaveElement('ChatSkeleton');
 
     wrapper.setProps({ hasLoadedMessages: true });
-    expect(wrapper).not.toHaveElement('Skeleton');
+    expect(wrapper).not.toHaveElement('ChatSkeleton');
   });
 
   describe('Lightbox', () => {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -224,7 +224,7 @@ export class ChatView extends React.Component<Properties, State> {
             )}
             {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
             {this.props.messages.length > 0 && this.renderMessages()}
-            {!this.props.hasLoadedMessages && <ChatSkeleton templateNumber={1} />}
+            {!this.props.hasLoadedMessages && <ChatSkeleton conversationId={this.props.id} />}
             <div ref={this.bottomRef} />
           </div>
         </InvertedScroll>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -29,6 +29,7 @@ export interface Properties {
   id: string;
   name: string;
   messages: MessageModel[];
+  hasLoadedMessages: boolean;
   onFetchMore: () => void;
   user: User;
   hasJoined: boolean;
@@ -245,7 +246,7 @@ export class ChatView extends React.Component<Properties, State> {
             )}
             {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
             {this.props.messages.length > 0 && this.renderMessages()}
-            {this.renderLoadingState()}
+            {!this.props.hasLoadedMessages && this.renderLoadingState()}
             <div ref={this.bottomRef} />
           </div>
         </InvertedScroll>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -17,9 +17,9 @@ import { ParentMessage } from '../../lib/chat/types';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
 import { Message } from '../message';
 import { AdminMessageContainer } from '../admin-message/container';
-import { Skeleton } from '@zero-tech/zui/components';
 
 import './styles.scss';
+import { ChatSkeleton } from './chat-skeleton';
 
 interface ChatMessageGroups {
   [date: string]: MessageModel[];
@@ -193,28 +193,6 @@ export class ChatView extends React.Component<Properties, State> {
     return await searchMentionableUsersForChannel(this.props.id, search);
   };
 
-  renderLoadingState() {
-    return (
-      <>
-        <div className='chat-view__skeleton chat-view__skeleton--owner'>
-          <Skeleton width={'100%'} height={'52px'} />
-        </div>
-        <div className='chat-view__skeleton chat-view__skeleton--owner'>
-          <Skeleton width={'100%'} height={'327px'} />
-        </div>
-        <div className='chat-view__skeleton'>
-          <Skeleton width={'100%'} height={'327px'} />
-        </div>
-        <div className='chat-view__skeleton'>
-          <Skeleton width={'100%'} height={'52px'} />
-        </div>
-        <div className='chat-view__skeleton chat-view__skeleton--owner'>
-          <Skeleton width={'100%'} height={'100px'} />
-        </div>
-      </>
-    );
-  }
-
   render() {
     const { isLightboxOpen, lightboxMedia, lightboxStartIndex } = this.state;
     const { hasJoined: isMemberOfChannel } = this.props;
@@ -246,7 +224,7 @@ export class ChatView extends React.Component<Properties, State> {
             )}
             {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
             {this.props.messages.length > 0 && this.renderMessages()}
-            {!this.props.hasLoadedMessages && this.renderLoadingState()}
+            {!this.props.hasLoadedMessages && <ChatSkeleton templateNumber={1} />}
             <div ref={this.bottomRef} />
           </div>
         </InvertedScroll>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -17,6 +17,9 @@ import { ParentMessage } from '../../lib/chat/types';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
 import { Message } from '../message';
 import { AdminMessageContainer } from '../admin-message/container';
+import { Skeleton } from '@zero-tech/zui/components';
+
+import './styles.scss';
 
 interface ChatMessageGroups {
   [date: string]: MessageModel[];
@@ -189,6 +192,28 @@ export class ChatView extends React.Component<Properties, State> {
     return await searchMentionableUsersForChannel(this.props.id, search);
   };
 
+  renderLoadingState() {
+    return (
+      <>
+        <div className='chat-view__skeleton chat-view__skeleton--owner'>
+          <Skeleton width={'100%'} height={'52px'} />
+        </div>
+        <div className='chat-view__skeleton chat-view__skeleton--owner'>
+          <Skeleton width={'100%'} height={'327px'} />
+        </div>
+        <div className='chat-view__skeleton'>
+          <Skeleton width={'100%'} height={'327px'} />
+        </div>
+        <div className='chat-view__skeleton'>
+          <Skeleton width={'100%'} height={'52px'} />
+        </div>
+        <div className='chat-view__skeleton chat-view__skeleton--owner'>
+          <Skeleton width={'100%'} height={'100px'} />
+        </div>
+      </>
+    );
+  }
+
   render() {
     const { isLightboxOpen, lightboxMedia, lightboxStartIndex } = this.state;
     const { hasJoined: isMemberOfChannel } = this.props;
@@ -220,6 +245,7 @@ export class ChatView extends React.Component<Properties, State> {
             )}
             {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
             {this.props.messages.length > 0 && this.renderMessages()}
+            {this.renderLoadingState()}
             <div ref={this.bottomRef} />
           </div>
         </InvertedScroll>

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -1,0 +1,18 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+// Note: there are some classes in various other places (src/platform-apps/channels/styles.scss)
+
+.chat-view {
+  &__skeleton {
+    box-sizing: border-box;
+    padding: 8px 16px;
+    width: 100%;
+    max-width: 560px;
+    clear: both;
+    float: left;
+
+    &--owner {
+      float: right;
+    }
+  }
+}

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -1,12 +1,27 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../animation';
 
 // Note: there are some classes in various other places (src/platform-apps/channels/styles.scss)
 
-.chat-view {
-  &__skeleton {
+.chat-skeleton {
+  animation: fadein 1s ease-out forwards;
+  width: 100%;
+
+  &__date {
+    clear: both;
+    padding: 8px 0px;
+
+    > div {
+      box-sizing: border-box;
+      width: 111px;
+      height: 15px;
+      margin: auto;
+    }
+  }
+
+  &__message {
     box-sizing: border-box;
-    padding: 8px 16px;
-    width: 100%;
+    padding: 2px 16px;
     max-width: 560px;
     clear: both;
     float: left;

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -4,7 +4,7 @@
 // Note: there are some classes in various other places (src/platform-apps/channels/styles.scss)
 
 .chat-skeleton {
-  animation: fadein 1s ease-out forwards;
+  animation: fadein 1s ease-in forwards;
   width: 100%;
 
   &__date {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -38,6 +38,7 @@ export interface Channel {
   icon?: string;
   messageIdsCache?: string[];
   isChannel: boolean;
+  hasLoadedMessages: boolean;
 }
 
 export enum SagaActionTypes {

--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -40,6 +40,18 @@ describe(fetch, () => {
     expect(denormalize(channel.id, storeState).hasMore).toBe(false);
   });
 
+  it('sets hasLoadedMessages on channel', async () => {
+    const channel = { id: 'channel-id', hasLoadedMessages: false };
+    const messageResponse = {};
+
+    const { storeState } = await expectSaga(fetch, { payload: { channelId: channel.id } })
+      .provide([stubResponse(matchers.call.fn(fetchMessagesByChannelId), messageResponse)])
+      .withReducer(rootReducer, initialChannelState(channel))
+      .run();
+
+    expect(denormalize(channel.id, storeState).hasLoadedMessages).toBe(true);
+  });
+
   it('forces shouldSyncChannels to be true', async () => {
     const channel = { id: 'channel-id', shouldSyncChannels: false };
     const messageResponse = { shouldSyncChannels: false };

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -107,6 +107,7 @@ export function* fetch(action) {
       messages,
       hasMore: messagesResponse.hasMore,
       shouldSyncChannels: true,
+      hasLoadedMessages: true,
     })
   );
 }


### PR DESCRIPTION
### What does this do?

Adds skeleton loading templates to display while messages are being loaded for a conversation for the first time.

### Why are we making this change?

To reduce the feel of the loading time.


https://github.com/zer0-os/zOS/assets/43770/d08717ff-1e15-49af-9371-f181788063b0



