### PR TITLE
Remove unused code that was pretending to render an empty state

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -4,7 +4,7 @@ import Tooltip from '../../tooltip';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { SearchConversations } from '../search-conversations';
 import { Channel } from '../../../store/channels';
-import { IconMessagePlusSquare, IconMessageQuestionSquare, IconUserPlus1 } from '@zero-tech/zui/icons';
+import { IconMessagePlusSquare, IconUserPlus1 } from '@zero-tech/zui/icons';
 import { IconButton } from '../../icon-button';
 import { ConversationItem } from './conversation-item';
 import { InviteDialogContainer } from '../../invite-dialog/container';
@@ -90,22 +90,6 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     );
   };
 
-  renderNoMessages = (): JSX.Element => {
-    return (
-      <div className='messages-list__start'>
-        <div className='messages-list__start-title'>
-          <span className='messages-list__start-icon'>
-            <IconMessageQuestionSquare size={34} label='You have no messages yet' />
-          </span>
-          You have no messages yet
-        </div>
-        <span className='messages-list__start-conversation' onClick={this.props.startConversation}>
-          Start a Conversation
-        </span>
-      </div>
-    );
-  };
-
   openInviteDialog = (): void => {
     this.setState({ inviteDialogOpen: true });
   };
@@ -163,9 +147,6 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             </div>
           </ScrollbarContainer>
         </div>
-        {/* Note: this does not work. directMessages is never null */}
-        {/* This should change to this.filteredConversations?.length === 0 */}
-        {!this.props.conversations && <div className='messages-list__new-messages'>{this.renderNoMessages()}</div>}
         <Button
           className={'messages-list__invite-button'}
           variant={'text'}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -25,31 +25,6 @@ $side-padding: 16px;
   pointer-events: auto; /* Enable pointer events for click event */
 
   .messages-list {
-    &__start {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      font-size: 14px;
-      font-weight: 400;
-      color: themeDeprecated.$font-color-primary;
-
-      &-icon {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin-bottom: 12px;
-        path {
-          color: theme.$color-primary-11;
-        }
-      }
-      &-conversation {
-        margin-top: 18px;
-        font-weight: 700;
-        color: theme.$color-secondary-11;
-        cursor: pointer;
-      }
-    }
-
     &__items {
       flex-grow: 1;
       display: flex;


### PR DESCRIPTION
### What does this do?

This removes buggy code that was never being hit. It was intended to show an empty state if you didn't have any conversations.

### Why are we making this change?

1. It didn't even work. It would never render because the conditional was bad.
2. In the new Messenger you should always have at least one conversation anyway as we create one when you sign up.
3. Even if you do have an empty conversation list, it looks fine just leaving it empty.

