### PR TITLE
Assume all messages are loaded after creating a conversation

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -87,6 +87,7 @@ export function* createConversation(action) {
       Array.isArray(existingConversationsList) && existingConversationsList.includes(conversation.id);
 
     if (!hasExistingConversation) {
+      conversation.hasLoadedMessages = true; // Brand new conversation doesn't have messages to load
       // add new chat to the list
       yield put(
         receive([


### PR DESCRIPTION
### What does this do?

Sets the hasLoadedMessages flag when creating a new conversation. Since it's new, we have the messages already :)

### Why are we making this change?

When we create a new conversation we don't want to show the skeleton loader.

NOTE: Simpler to review with whitespace ignored. I nested some tests.