### PR TITLE
feat(rewards-popup): number formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@zero-tech/zui": "^0.25.1",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
+        "decimal.js": "^10.4.3",
         "emoji-mart": "^3.0.1",
         "es6-promise-debounce": "^1.0.1",
         "ethers": "^5.5.2",
@@ -15041,8 +15042,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.3.1",
-      "license": "MIT"
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -45772,7 +45774,9 @@
       "version": "1.2.0"
     },
     "decimal.js": {
-      "version": "10.3.1"
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "decode-named-character-reference": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@zero-tech/zui": "^0.25.1",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
-        "decimal.js": "^10.4.3",
         "emoji-mart": "^3.0.1",
         "es6-promise-debounce": "^1.0.1",
         "ethers": "^5.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "lodash.get": "^4.4.2",
         "lodash.kebabcase": "^4.1.1",
         "lodash.uniqby": "^4.7.0",
+        "millify": "^6.1.0",
         "moment": "^2.29.4",
         "normalizr": "^3.6.2",
         "pusher-js": "^8.0.2",
@@ -9324,12 +9325,66 @@
         "node": ">=12"
       }
     },
+    "node_modules/@zero-tech/zapp-daos/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/@zero-tech/zapp-daos/node_modules/dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
       "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/millify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/millify/-/millify-4.0.1.tgz",
+      "integrity": "sha512-PQg2KMwIJF29it8/iC+w9kj/Xai3Jp914Ft5VPpr8XgVUGDuXT/jlOqXJswmG97RM78O6cBBKaO7GVp0DhhKmA==",
+      "dependencies": {
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "millify": "bin/millify"
       }
     },
     "node_modules/@zero-tech/zapp-daos/node_modules/node-fetch": {
@@ -9368,6 +9423,55 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@zero-tech/zapp-daos/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@zero-tech/zapp-nfts": {
@@ -25061,8 +25165,9 @@
       "license": "MIT"
     },
     "node_modules/millify": {
-      "version": "4.0.1",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/millify/-/millify-6.1.0.tgz",
+      "integrity": "sha512-H/E3J6t+DQs/F2YgfDhxUVZz/dF8JXPPKTLHL/yHCcLZLtCXJDUaqvhJXQwqOVBvbyNn4T0WjLpIHd7PAw7fBA==",
       "dependencies": {
         "yargs": "^17.0.1"
       },
@@ -41992,10 +42097,49 @@
             }
           }
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "dotenv": {
           "version": "16.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
           "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
+        },
+        "millify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/millify/-/millify-4.0.1.tgz",
+          "integrity": "sha512-PQg2KMwIJF29it8/iC+w9kj/Xai3Jp914Ft5VPpr8XgVUGDuXT/jlOqXJswmG97RM78O6cBBKaO7GVp0DhhKmA==",
+          "requires": {
+            "yargs": "^17.0.1"
+          }
         },
         "node-fetch": {
           "version": "2.6.7",
@@ -42023,6 +42167,40 @@
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
           }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
@@ -52157,7 +52335,9 @@
       }
     },
     "millify": {
-      "version": "4.0.1",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/millify/-/millify-6.1.0.tgz",
+      "integrity": "sha512-H/E3J6t+DQs/F2YgfDhxUVZz/dF8JXPPKTLHL/yHCcLZLtCXJDUaqvhJXQwqOVBvbyNn4T0WjLpIHd7PAw7fBA==",
       "requires": {
         "yargs": "^17.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@zero-tech/zui": "^0.25.1",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
-    "decimal.js": "^10.4.3",
     "emoji-mart": "^3.0.1",
     "es6-promise-debounce": "^1.0.1",
     "ethers": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
     "lodash.uniqby": "^4.7.0",
+    "millify": "^6.1.0",
     "moment": "^2.29.4",
     "normalizr": "^3.6.2",
     "pusher-js": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@zero-tech/zui": "^0.25.1",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
+    "decimal.js": "^10.4.3",
     "emoji-mart": "^3.0.1",
     "es6-promise-debounce": "^1.0.1",
     "ethers": "^5.5.2",

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -46,13 +46,13 @@ describe('rewards-bar', () => {
   it('parses token number to renderable string', function () {
     const wrapper = subject({ zero: '9123456789111315168' });
     wrapper.find('.rewards-bar__rewards-button').simulate('click');
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('9.1234');
+    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('9.12');
 
     wrapper.setProps({ zero: '9123000000000000000' });
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('9.123');
+    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('9.12');
 
     wrapper.setProps({ zero: '23456789111315168' });
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('0.0234');
+    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('0.02');
 
     wrapper.setProps({ zero: '0' });
     expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('0');

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -7,6 +7,7 @@ import { RewardsPopupContainer } from '../rewards-popup/container';
 import { TooltipPopup } from '../tooltip-popup/tooltip-popup';
 import { SettingsMenu } from '../settings-menu';
 import { bem } from '../../lib/bem';
+import { formatWeiAmount } from '../../lib/number';
 
 import './styles.scss';
 
@@ -47,14 +48,6 @@ export class RewardsBar extends React.Component<Properties, State> {
     super(props);
     this.state.isRewardsPopupOpen = props.isFirstTimeLogin;
     this.state.isRewardsTooltipOpen = !props.isFirstTimeLogin;
-  }
-
-  stringifyZero(zero: string) {
-    const stringValue = zero.padStart(19, '0');
-    const whole = stringValue.slice(0, -18);
-    const decimal = stringValue.slice(-18).slice(0, 4).replace(/0+$/, '');
-    const decimalString = decimal.length > 0 ? `.${decimal}` : '';
-    return `${whole}${decimalString}`;
   }
 
   openRewards = () => {
@@ -114,7 +107,7 @@ export class RewardsBar extends React.Component<Properties, State> {
             open={!this.props.isRewardsLoading && this.state.isRewardsTooltipOpen}
             align='center'
             side='left'
-            content={`You’ve earned ${this.stringifyZero(this.props.zeroPreviousDay)} ZERO today`}
+            content={`You’ve earned ${formatWeiAmount(this.props.zeroPreviousDay)} ZERO today`}
             onClose={this.closeRewardsTooltip}
           >
             {this.renderRewardsBar()}
@@ -127,7 +120,7 @@ export class RewardsBar extends React.Component<Properties, State> {
           <RewardsPopupContainer
             onClose={this.closeRewards}
             openRewardsFAQModal={this.openRewardsFAQModal} // modal is opened in the popup, after which the popup is closed
-            zero={this.stringifyZero(this.props.zero)}
+            zero={formatWeiAmount(this.props.zero)}
             isLoading={this.props.isRewardsLoading}
           />
         )}

--- a/src/components/rewards-popup/container.tsx
+++ b/src/components/rewards-popup/container.tsx
@@ -33,6 +33,7 @@ export class Container extends React.Component<Properties> {
       isFullScreen: layout.value.isMessengerFullScreen,
     };
   }
+
   static mapActions() {
     return {};
   }

--- a/src/components/rewards-popup/index.test.tsx
+++ b/src/components/rewards-popup/index.test.tsx
@@ -18,8 +18,9 @@ describe('RewardsPopup', () => {
     return shallow(<RewardsPopup {...allProps} />);
   };
 
-  // @note 29-06-2023
-  //
+  /* @note 29-06-2023
+   * Removed this test as component isn't rigged up to render USD price
+   */
   // it('renders your rewards count in USD', function () {
   //   const wrapper = subject({ usd: '$5.71' });
   //

--- a/src/components/rewards-popup/index.test.tsx
+++ b/src/components/rewards-popup/index.test.tsx
@@ -18,12 +18,14 @@ describe('RewardsPopup', () => {
     return shallow(<RewardsPopup {...allProps} />);
   };
 
-  it('renders your rewards count in USD', function () {
-    const wrapper = subject({ usd: '$5.71' });
-
-    const skeleton = wrapper.find('.rewards-popup__rewards-usd SkeletonText');
-    expect((skeleton.prop('asyncText') as any).text).toEqual('$5.71');
-  });
+  // @note 29-06-2023
+  //
+  // it('renders your rewards count in USD', function () {
+  //   const wrapper = subject({ usd: '$5.71' });
+  //
+  //   const skeleton = wrapper.find('.rewards-popup__rewards-usd SkeletonText');
+  //   expect((skeleton.prop('asyncText') as any).text).toEqual('$5.71');
+  // });
 
   it('renders your rewards count in ZERO', function () {
     const wrapper = subject({ zero: '838' });

--- a/src/components/rewards-popup/index.test.tsx
+++ b/src/components/rewards-popup/index.test.tsx
@@ -5,8 +5,8 @@ import { RewardsPopup, Properties } from '.';
 describe('RewardsPopup', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
-      usd: '',
-      zero: '',
+      usd: '1',
+      zero: '1',
       isLoading: false,
       isFullScreen: false,
       withTitleBar: true,

--- a/src/components/rewards-popup/index.test.tsx
+++ b/src/components/rewards-popup/index.test.tsx
@@ -18,16 +18,6 @@ describe('RewardsPopup', () => {
     return shallow(<RewardsPopup {...allProps} />);
   };
 
-  /* @note 29-06-2023
-   * Removed this test as component isn't rigged up to render USD price
-   */
-  // it('renders your rewards count in USD', function () {
-  //   const wrapper = subject({ usd: '$5.71' });
-  //
-  //   const skeleton = wrapper.find('.rewards-popup__rewards-usd SkeletonText');
-  //   expect((skeleton.prop('asyncText') as any).text).toEqual('$5.71');
-  // });
-
   it('renders your rewards count in ZERO', function () {
     const wrapper = subject({ zero: '838' });
 

--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { formatNumber } from '../../lib/number';
+import { formatCryptoAmount } from '../../lib/number';
 
 import { IconGift1, IconTrendUp1, IconXClose } from '@zero-tech/zui/icons';
 import { Button, IconButton, SkeletonText } from '@zero-tech/zui/components';
@@ -72,7 +72,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
               <SkeletonText
                 asyncText={{
                   isLoading: this.props.isLoading,
-                  text: formatNumber(this.props.usd),
+                  text: formatCryptoAmount(this.props.usd),
                 }}
                 skeletonOptions={{
                   width: 50,

--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { formatNumber } from '../../lib/number';
+
 import { IconGift1, IconTrendUp1, IconXClose } from '@zero-tech/zui/icons';
 import { Button, IconButton, SkeletonText } from '@zero-tech/zui/components';
 import { ReactComponent as ZeroSymbol } from '../../zero-symbol.svg';
@@ -70,7 +72,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
               <SkeletonText
                 asyncText={{
                   isLoading: this.props.isLoading,
-                  text: this.props.usd,
+                  text: formatNumber(this.props.usd),
                 }}
                 skeletonOptions={{
                   width: 50,

--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { formatCryptoAmount } from '../../lib/number';
-
 import { IconGift1, IconTrendUp1, IconXClose } from '@zero-tech/zui/icons';
 import { Button, IconButton, SkeletonText } from '@zero-tech/zui/components';
 import { ReactComponent as ZeroSymbol } from '../../zero-symbol.svg';
@@ -72,7 +70,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
               <SkeletonText
                 asyncText={{
                   isLoading: this.props.isLoading,
-                  text: formatCryptoAmount(this.props.usd),
+                  text: this.props.usd,
                 }}
                 skeletonOptions={{
                   width: 50,

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -1,29 +1,29 @@
-import { formatNumber } from './number'; // replace with your actual file name
+import { formatCryptoAmount } from './number'; // replace with your actual file name
 
-describe('formatNumber', () => {
+describe('formatCryptoAmount', () => {
   it('should commify numbers less than 1 million', () => {
-    expect(formatNumber('12345')).toEqual('12,345');
+    expect(formatCryptoAmount('12345')).toEqual('12,345');
   });
 
   it('should round numbers less than 1 million to 2 DP of precision', () => {
-    expect(formatNumber('12345.6942069420')).toEqual('12,345.69');
-    expect(formatNumber('12345.6')).toEqual('12,345.6');
+    expect(formatCryptoAmount('12345.6942069420')).toEqual('12,345.69');
+    expect(formatCryptoAmount('12345.6')).toEqual('12,345.6');
   });
 
   it('should format numbers greater than or equal to 1 million with suffix M', () => {
-    expect(formatNumber('12345678')).toEqual('12.35M');
+    expect(formatCryptoAmount('12345678')).toEqual('12.35M');
   });
 
   it('should format numbers greater than or equal to 1 billion with suffix B', () => {
-    expect(formatNumber('12345678000')).toEqual('12.35B');
+    expect(formatCryptoAmount('12345678000')).toEqual('12.35B');
   });
 
   it('should format numbers greater than or equal to 1 trillion with suffix T', () => {
-    expect(formatNumber('12345678000000')).toEqual('12.35T');
+    expect(formatCryptoAmount('12345678000000')).toEqual('12.35T');
   });
 
   it('should handle negative numbers', () => {
-    expect(formatNumber('-12345')).toEqual('-12,345');
-    expect(formatNumber('-12345678')).toEqual('-12.35M');
+    expect(formatCryptoAmount('-12345')).toEqual('-12,345');
+    expect(formatCryptoAmount('-12345678')).toEqual('-12.35M');
   });
 });

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -2,18 +2,28 @@ import { formatNumber } from './number'; // replace with your actual file name
 
 describe('formatNumber', () => {
   it('should commify numbers less than 1 million', () => {
-    expect(formatNumber(12345)).toEqual('12,345');
     expect(formatNumber('12345')).toEqual('12,345');
   });
 
-  it('should format numbers less than 1 million with at most two decimal places', () => {
-    expect(formatNumber(12345.694206942)).toEqual('12,345.69');
+  it('should round numbers less than 1 million to 2 DP of precision', () => {
     expect(formatNumber('12345.6942069420')).toEqual('12,345.69');
     expect(formatNumber('12345.6')).toEqual('12,345.6');
   });
 
-  it('should format numbers greater than or equal to 1 million with suffix', () => {
-    expect(formatNumber(12345678)).toEqual('12.35M');
+  it('should format numbers greater than or equal to 1 million with suffix M', () => {
     expect(formatNumber('12345678')).toEqual('12.35M');
+  });
+
+  it('should format numbers greater than or equal to 1 billion with suffix B', () => {
+    expect(formatNumber('12345678000')).toEqual('12.35B');
+  });
+
+  it('should format numbers greater than or equal to 1 trillion with suffix T', () => {
+    expect(formatNumber('12345678000000')).toEqual('12.35T');
+  });
+
+  it('should handle negative numbers', () => {
+    expect(formatNumber('-12345')).toEqual('-12,345');
+    expect(formatNumber('-12345678')).toEqual('-12.35M');
   });
 });

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -1,29 +1,32 @@
-import { formatCryptoAmount } from './number'; // replace with your actual file name
+import { formatWeiAmount } from './number';
+import { parseEther } from 'ethers/lib/utils'; // replace with your actual file name
 
-describe('formatCryptoAmount', () => {
+const get = (num: string) => parseEther(num).toString();
+
+describe('formatWeiAmount', () => {
   it('should commify numbers less than 1 million', () => {
-    expect(formatCryptoAmount('12345')).toEqual('12,345');
+    expect(formatWeiAmount(get('12345'))).toEqual('12,345');
   });
 
   it('should round numbers less than 1 million to 2 DP of precision', () => {
-    expect(formatCryptoAmount('12345.6942069420')).toEqual('12,345.69');
-    expect(formatCryptoAmount('12345.6')).toEqual('12,345.6');
+    expect(formatWeiAmount(get('12345.694206942'))).toEqual('12,345.69');
+    expect(formatWeiAmount(get('12345.6'))).toEqual('12,345.6');
   });
 
   it('should format numbers greater than or equal to 1 million with suffix M', () => {
-    expect(formatCryptoAmount('12345678')).toEqual('12.35M');
+    expect(formatWeiAmount(get('12345678'))).toEqual('12.35M');
   });
 
   it('should format numbers greater than or equal to 1 billion with suffix B', () => {
-    expect(formatCryptoAmount('12345678000')).toEqual('12.35B');
+    expect(formatWeiAmount(get('12345678000'))).toEqual('12.35B');
   });
 
   it('should format numbers greater than or equal to 1 trillion with suffix T', () => {
-    expect(formatCryptoAmount('12345678000000')).toEqual('12.35T');
+    expect(formatWeiAmount(get('12345678000000'))).toEqual('12.35T');
   });
 
   it('should handle negative numbers', () => {
-    expect(formatCryptoAmount('-12345')).toEqual('-12,345');
-    expect(formatCryptoAmount('-12345678')).toEqual('-12.35M');
+    expect(formatWeiAmount(get('-12345'))).toEqual('-12,345');
+    expect(formatWeiAmount(get('-12345678'))).toEqual('-12.35M');
   });
 });

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -1,0 +1,19 @@
+import { formatNumber } from './number'; // replace with your actual file name
+
+describe('formatNumber', () => {
+  it('should commify numbers less than 1 million', () => {
+    expect(formatNumber(12345)).toEqual('12,345');
+    expect(formatNumber('12345')).toEqual('12,345');
+  });
+
+  it('should format numbers less than 1 million with at most two decimal places', () => {
+    expect(formatNumber(12345.694206942)).toEqual('12,345.69');
+    expect(formatNumber('12345.6942069420')).toEqual('12,345.69');
+    expect(formatNumber('12345.6')).toEqual('12,345.6');
+  });
+
+  it('should format numbers greater than or equal to 1 million with suffix', () => {
+    expect(formatNumber(12345678)).toEqual('12.35M');
+    expect(formatNumber('12345678')).toEqual('12.35M');
+  });
+});

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -13,6 +13,10 @@ describe('formatWeiAmount', () => {
     expect(formatWeiAmount(get('12345.6'))).toEqual('12,345.6');
   });
 
+  it('should format numbers greater than or equal to 100,000 with suffix M', () => {
+    expect(formatWeiAmount(get('123456'))).toEqual('123.46K');
+  });
+
   it('should format numbers greater than or equal to 1 million with suffix M', () => {
     expect(formatWeiAmount(get('12345678'))).toEqual('12.35M');
   });

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -13,7 +13,7 @@ describe('formatWeiAmount', () => {
     expect(formatWeiAmount(get('12345.6'))).toEqual('12,345.6');
   });
 
-  it('should format numbers greater than or equal to 100,000 with suffix M', () => {
+  it('should format numbers greater than or equal to 100,000 with suffix K', () => {
     expect(formatWeiAmount(get('123456'))).toEqual('123.46K');
   });
 

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,19 +1,21 @@
-import Decimal from 'decimal.js';
 import millify from 'millify';
 
 /**
  * Format a number to a string with commas and max 2 decimal places
  * @param num number to format
  */
-export function formatCryptoAmount(num: string): string {
-  const numAsDecimal = new Decimal(num).toDecimalPlaces(2);
+export function formatWeiAmount(num: string): string {
+  const stringValue = num.padStart(19, '0');
+  const whole = stringValue.slice(0, -18);
+  const decimal = stringValue.slice(-18).slice(0, 4).replace(/0+$/, '');
+  const decimalString = decimal.length > 0 ? `.${decimal}` : '';
 
-  if (numAsDecimal.abs().greaterThanOrEqualTo(1000000)) {
-    return millify(numAsDecimal.toNumber(), { precision: 2 });
+  const asString = whole + decimalString;
+  const asNum = Number(asString);
+
+  if (asNum > 100000 || asNum <= -100000) {
+    return millify(asNum, { precision: 2 });
   }
 
-  return numAsDecimal
-    .toString()
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-    .replace(/\.0+$/, ''); // remove trailing zeros
+  return asNum.toLocaleString('en-US', { maximumFractionDigits: 2 });
 }

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,0 +1,14 @@
+import { millify } from 'millify';
+
+export function formatNumber(num: number | string): string {
+  let asNum;
+  if (typeof num === 'string') {
+    asNum = parseFloat(num);
+  } else {
+    asNum = num;
+  }
+
+  if (asNum >= 1000000) return millify(asNum, { precision: 2 });
+
+  return asNum.toLocaleString('en-US', { maximumFractionDigits: 2 });
+}

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,14 +1,15 @@
-import { millify } from 'millify';
+import Decimal from 'decimal.js';
+import millify from 'millify';
 
-export function formatNumber(num: number | string): string {
-  let asNum;
-  if (typeof num === 'string') {
-    asNum = parseFloat(num);
-  } else {
-    asNum = num;
+export function formatNumber(num: string): string {
+  const numAsDecimal = new Decimal(num).toDecimalPlaces(2);
+
+  if (numAsDecimal.abs().greaterThanOrEqualTo(1000000)) {
+    return millify(numAsDecimal.toNumber(), { precision: 2 });
   }
 
-  if (asNum >= 1000000) return millify(asNum, { precision: 2 });
-
-  return asNum.toLocaleString('en-US', { maximumFractionDigits: 2 });
+  return numAsDecimal
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    .replace(/\.0+$/, ''); // remove trailing zeros
 }

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,6 +1,10 @@
 import Decimal from 'decimal.js';
 import millify from 'millify';
 
+/**
+ * Format a number to a string with commas and max 2 decimal places
+ * @param num number to format
+ */
 export function formatCryptoAmount(num: string): string {
   const numAsDecimal = new Decimal(num).toDecimalPlaces(2);
 

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js';
 import millify from 'millify';
 
-export function formatNumber(num: string): string {
+export function formatCryptoAmount(num: string): string {
   const numAsDecimal = new Decimal(num).toDecimalPlaces(2);
 
   if (numAsDecimal.abs().greaterThanOrEqualTo(1000000)) {


### PR DESCRIPTION
### What does this do?

Formats the reward amount in the rewards modal as described in [Jira](https://wilderworld.atlassian.net/browse/ZOS-430?atlOrigin=eyJpIjoiMTlkZTM0OTMxNWM5NDA3YzkwZmE1MTNkODY3Yzc3ZTkiLCJwIjoiaiJ9).

### Why are we making this change?

The rewards amount did not match Figma.

### How do I test this?

- Open the rewards modal
- Check that the number is formatting as per the description in Jira.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
