### PR TITLE
feat: reposition sender avatar

### DIFF
--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -120,8 +120,8 @@ describe('ChatView', () => {
     const classNames = wrapper.find(Message).map((m) => m.prop('className'));
 
     expect(classNames).toIncludeAllMembers([
-      'messages__message messages__message--first-in-group',
-      'messages__message messages__message--first-in-group',
+      'messages__message messages__message--last-in-group',
+      'messages__message messages__message--last-in-group',
       'messages__message',
       'messages__message',
     ]);

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -138,10 +138,11 @@ export class ChatView extends React.Component<Properties, State> {
           if (message.isAdmin) {
             return <AdminMessageContainer key={message.id} message={message} />;
           } else {
-            const isFirstFromUser =
-              index === 0 ||
-              allMessages[index - 1].isAdmin ||
-              message.sender.userId !== allMessages[index - 1].sender.userId;
+            const isLastFromUser =
+              index === allMessages.length - 1 ||
+              allMessages[index + 1].isAdmin ||
+              message.sender.userId !== allMessages[index + 1].sender.userId;
+
             const isUserOwnerOfTheMessage =
               // eslint-disable-next-line eqeqeq
               this.props.user && message.sender && this.props.user.id == message.sender.userId;
@@ -150,7 +151,7 @@ export class ChatView extends React.Component<Properties, State> {
               <div key={message.id} className='messages__message-row'>
                 <Message
                   className={classNames('messages__message', {
-                    'messages__message--first-in-group': isFirstFromUser && this.props.showSenderAvatar,
+                    'messages__message--last-in-group': isLastFromUser && this.props.showSenderAvatar,
                   })}
                   onImageClick={this.openLightbox}
                   messageId={message.id}

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -290,6 +290,7 @@ $scrollbar-width: 5px;
 
       &--sender-avatar {
         display: flex;
+        gap: 8px;
 
         .message__block {
           flex: 1;
@@ -429,6 +430,7 @@ $scrollbar-width: 5px;
       &__left {
         margin-right: 8px;
         width: 32px;
+        align-self: flex-end;
       }
 
       &__author-avatar {
@@ -449,7 +451,7 @@ $scrollbar-width: 5px;
         color: theme.$color-greyscale-12;
       }
 
-      &.messages__message--first-in-group {
+      &.messages__message--last-in-group {
         .message__author-avatar {
           display: block;
         }
@@ -496,6 +498,7 @@ $scrollbar-width: 5px;
   }
 
   .messages__message.message--owner {
+    flex-direction: row-reverse;
     float: right;
   }
 

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -249,6 +249,8 @@ $scrollbar-width: 5px;
       overflow: hidden;
 
       &--owner {
+        flex-direction: row-reverse;
+
         .message__block-body {
           transition: background-color 0.3s ease-out;
           position: relative;
@@ -497,7 +499,6 @@ $scrollbar-width: 5px;
   }
 
   .messages__message.message--owner {
-    flex-direction: row-reverse;
     float: right;
   }
 

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -428,7 +428,6 @@ $scrollbar-width: 5px;
       }
 
       &__left {
-        margin-right: 8px;
         width: 32px;
         align-self: flex-end;
       }


### PR DESCRIPTION
### What does this do?
- repositions sender avatar. This was required for the three dot menu positional changes. The three dot menu will now appear on the inside of the senders message, i.e. if sender is owner then the three dots appear to the left of the message, if the sender is not the owner, the three dots will appear to the right of the message.

### Why are we making this change?
- as per design.

### How do I test this?
- you can run the branch and open up a group chat to see the position of the avatars. They should be as per the `after` screenshot below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

<img width="1175" alt="Screenshot 2023-06-28 at 15 07 04" src="https://github.com/zer0-os/zOS/assets/39112648/d2b3257f-f89f-476e-8540-ea3105099f32">

After:

<img width="847" alt="Screenshot 2023-06-28 at 15 11 19" src="https://github.com/zer0-os/zOS/assets/39112648/0155bd98-f81d-4b6d-a7cb-8050e9908d8f">



