### PR TITLE
Fade in the messages once fetched

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -216,6 +216,8 @@ $scrollbar-width: 5px;
 }
 
 .messages__container {
+  animation: fadein 200ms ease-out forwards;
+
   .messages {
     position: relative;
     overflow: inherit;


### PR DESCRIPTION
### What does this do?

Fades in the messages once they're fetched to ease the feel a bit.

### Why are we making this change?

Based on feedback from the design team we decided this smooths out the transition between chats and between the loading state to completed state.

