### PR TITLE
Fixes issue when the 'more' menu doesn't show up on messages prior to a date stamp

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -221,6 +221,7 @@ $scrollbar-width: 5px;
     overflow: inherit;
     transition: opacity 0.9s ease-out;
     opacity: 1;
+    clear: both;
 
     .message__header {
       display: flex;


### PR DESCRIPTION
### What does this do?

Fixes an issue where messages just prior to the date stamp in a conversation wouldn't react to mouse events thus preventing the 'more' menu from showing up.

Before:
![before](https://github.com/zer0-os/zOS/assets/43770/e41703db-3d9a-402c-9680-183402ddcaf5)

After:
![after](https://github.com/zer0-os/zOS/assets/43770/d3344114-11f5-40b7-aa0d-b614e8e29240)


