### PR TITLE
feat(rewards-popup): add arrow

### DIFF
--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -56,6 +56,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
       >
         <div className={c('underlay')} onClick={this.abort}>
           <div className={c('content')} onClick={this.preventAbortOnChildClick}>
+            <div className={c('arrow')} data-position={this.props.isFullScreen ? 'left' : 'top'}></div>
             <IconButton
               Icon={IconXClose}
               className={c('close-button')}

--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -56,7 +56,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
       >
         <div className={c('underlay')} onClick={this.abort}>
           <div className={c('content')} onClick={this.preventAbortOnChildClick}>
-            <div className={c('arrow')} data-position={this.props.isFullScreen ? 'left' : 'top'}></div>
+            <div className={c('arrow')}></div>
             <IconButton
               Icon={IconXClose}
               className={c('close-button')}

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -4,8 +4,51 @@
 @import '../../layout';
 
 .rewards-popup {
+  $padding-x: 32px;
+  $padding-y: 40px;
+
   position: absolute;
   z-index: 10;
+
+  &__arrow {
+    $size: 16px;
+
+    position: relative;
+    height: 0;
+    width: 100%;
+
+    z-index: -1;
+
+    &[data-position='top'] {
+      &::after {
+        $height: $size / 2;
+        $width: $size;
+        top: -$padding-y - $height;
+        left: calc(100% - $width / 2);
+        height: 8px;
+        width: 16px;
+        clip-path: polygon(0 100%, 50% 0, 100% 100%); // make a triangle
+      }
+    }
+
+    &[data-position='left'] {
+      &::after {
+        $height: $size;
+        $width: $size / 2;
+        top: -$padding-y + 16px;
+        left: -$padding-x - $width;
+        height: 16px;
+        width: 8px;
+        clip-path: polygon(100% 0, 0 50%, 100% 100%); /* rotated triangle */
+      }
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      background: theme.$color-primary-2;
+    }
+  }
 
   &__content {
     box-sizing: border-box;
@@ -27,7 +70,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 40px 32px;
+    padding: $padding-y $padding-x;
   }
 
   &--full-screen {

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -6,41 +6,26 @@
 .rewards-popup {
   $padding-x: 32px;
   $padding-y: 40px;
+  $size: 16px;
 
   position: absolute;
   z-index: 10;
 
   &__arrow {
-    $size: 16px;
-
     position: relative;
     height: 0;
     width: 100%;
 
     z-index: -1;
 
-    &[data-position='top'] {
-      &::after {
-        $height: $size / 2;
-        $width: $size;
-        top: -$padding-y - $height;
-        left: calc(100% - $width / 2);
-        height: 8px;
-        width: 16px;
-        clip-path: polygon(0 100%, 50% 0, 100% 100%); // make a triangle
-      }
-    }
-
-    &[data-position='left'] {
-      &::after {
-        $height: $size;
-        $width: $size / 2;
-        top: -$padding-y + 16px;
-        left: -$padding-x - $width;
-        height: 16px;
-        width: 8px;
-        clip-path: polygon(100% 0, 0 50%, 100% 100%); /* rotated triangle */
-      }
+    &::after {
+      $height: $size / 2;
+      $width: $size;
+      top: -$padding-y - $height;
+      left: calc(100% - $width / 2);
+      height: 8px;
+      width: 16px;
+      clip-path: polygon(0 100%, 50% 0, 100% 100%); // make a triangle
     }
 
     &::after {
@@ -83,6 +68,18 @@
   &--full-screen.rewards-popup--with-title {
     .rewards-popup__content {
       top: 40px;
+    }
+
+    &__arrow {
+      &::after {
+        $height: $size;
+        $width: $size / 2;
+        top: -$padding-y + 16px;
+        left: -$padding-x - $width;
+        height: 16px;
+        width: 8px;
+        clip-path: polygon(100% 0, 0 50%, 100% 100%); /* rotated triangle */
+      }
     }
   }
 

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -3,37 +3,39 @@
 @import '../../animation';
 @import '../../layout';
 
-.rewards-popup {
-  $padding-x: 32px;
-  $padding-y: 40px;
-  $size: 16px;
+$content-padding-x: 32px;
+$content-padding-y: 40px;
 
-  position: absolute;
-  z-index: 10;
+@mixin arrow($position) {
+  $is-top: $position == 'top';
+  $arrow-size: 16px;
 
-  &__arrow {
+  .rewards-popup__arrow {
     position: relative;
     height: 0;
     width: 100%;
-
-    z-index: -1;
-
-    &::after {
-      $height: $size / 2;
-      $width: $size;
-      top: -$padding-y - $height;
-      left: calc(100% - $width / 2);
-      height: 8px;
-      width: 16px;
-      clip-path: polygon(0 100%, 50% 0, 100% 100%); // make a triangle
-    }
 
     &::after {
       content: '';
       position: absolute;
       background: theme.$color-primary-2;
+
+      $height: if($is-top, $arrow-size / 2, $arrow-size);
+      $width: if($is-top, $arrow-size, $arrow-size / 2);
+      height: $height;
+      width: $width;
+      top: if($is-top, -$content-padding-y - $height, -$content-padding-y + 16px);
+      left: if($is-top, calc(100% - $width / 2), -$content-padding-x - $width);
+      clip-path: if($is-top, polygon(0 100%, 50% 0, 100% 100%), polygon(100% 0, 0 50%, 100% 100%));
     }
   }
+}
+
+.rewards-popup {
+  position: absolute;
+  z-index: 10;
+
+  @include arrow('top');
 
   &__content {
     box-sizing: border-box;
@@ -55,7 +57,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: $padding-y $padding-x;
+    padding: $content-padding-y $content-padding-x;
   }
 
   &--full-screen {
@@ -63,23 +65,13 @@
       top: 2px;
       left: $width-sidekick + $width-world-navigation + 2px;
     }
+
+    @include arrow('left');
   }
 
   &--full-screen.rewards-popup--with-title {
     .rewards-popup__content {
       top: 40px;
-    }
-
-    &__arrow {
-      &::after {
-        $height: $size;
-        $width: $size / 2;
-        top: -$padding-y + 16px;
-        left: -$padding-x - $width;
-        height: 16px;
-        width: 8px;
-        clip-path: polygon(100% 0, 0 50%, 100% 100%); /* rotated triangle */
-      }
     }
   }
 


### PR DESCRIPTION
### What does this do?

Adds the arrow to the rewards popup [per Figma](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=9680%3A494052&mode=design&t=iBCZXrRXxzczRa8n-1).

### Why are we making this change?

Matching UI to Figma.

### How do I test this?

1. Open messenger
2. Hit "Rewards"
3. In full screen, check that the arrow is on the top left edge of the popup
4. In side panel, check that the arrow is on the top right edge of the popup

![Screenshot 2023-06-29 at 4 16 59 PM](https://github.com/zer0-os/zOS/assets/12437916/283fd0b5-0d44-4082-9b1a-1a6397f3c74b)

![Screenshot 2023-06-29 at 4 17 11 PM](https://github.com/zer0-os/zOS/assets/12437916/9b666e43-56f3-45f3-90cc-887f0bfc7766)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
