### PR TITLE
feat(rewards-popup): match close button to Figma

### DIFF
--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -60,7 +60,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
               Icon={IconXClose}
               className={c('close-button')}
               variant='tertiary'
-              color='greyscale'
+              size={32}
               onClick={this.abort}
             />
             <ZeroSymbol height={32} width={32} />

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -45,8 +45,14 @@
 
   &__close-button {
     position: absolute;
-    top: 16px;
-    right: 16px;
+    top: 18px;
+    right: 18px;
+
+    svg {
+      path {
+        color: theme.$color-greyscale-12;
+      }
+    }
   }
 
   &__heading {


### PR DESCRIPTION
### What does this do?

`Close` button
- Correct button size
- Correct button color

### Why are we making this change?

Match UI to Figma

### How do I test this?

- Open Rewards popup
- [Compare `Close` button to Figma](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=7019%3A313888&mode=design&t=iBCZXrRXxzczRa8n-1)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
