### PR TITLE
Clean up the send message saga tests a bit

### DIFF
--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -3,7 +3,7 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { getLinkPreviews, sendMessagesByChannelId } from './api';
 import { send } from './saga';
-import { rootReducer } from '../reducer';
+import { RootState, rootReducer } from '../reducer';
 import { stubResponse } from '../../test/saga';
 
 describe(send, () => {
@@ -13,11 +13,9 @@ describe(send, () => {
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;
 
-    const initialState = defaultState();
-
     await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .provide(successResponses())
-      .withReducer(rootReducer, initialState as any)
+      .withReducer(rootReducer, defaultState())
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
   });
@@ -27,8 +25,6 @@ describe(send, () => {
     const message = 'www.google.com';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;
-
-    const initialState = defaultState();
 
     const {
       storeState: {
@@ -51,7 +47,7 @@ describe(send, () => {
         ],
         ...successResponses(),
       ])
-      .withReducer(rootReducer, initialState as any)
+      .withReducer(rootReducer, defaultState() as any)
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
 
@@ -65,15 +61,13 @@ describe(send, () => {
     const mentionedUserIds = [];
     const parentMessage = { message: 'hello', messageId: '98765650', userId: '12YT67565J' };
 
-    const initialState = defaultState();
-
     const {
       storeState: {
         normalized: { channels },
       },
     } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .provide(successResponses())
-      .withReducer(rootReducer, initialState as any)
+      .withReducer(rootReducer, defaultState() as any)
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
     expect(channels[channelId].messageIdsCache).not.toStrictEqual([]);
@@ -107,7 +101,7 @@ describe(send, () => {
         normalized: { channels },
       },
     } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
-      .withReducer(rootReducer, initialState as any)
+      .withReducer(rootReducer, initialState)
       .provide([stubResponse(matchers.call.fn(sendMessagesByChannelId), { status: 400, body: {} })])
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
@@ -122,7 +116,7 @@ function defaultState() {
     authentication: {
       user: {
         data: {
-          id: 1,
+          id: '1',
           profileId: '2',
           profileSummary: {
             firstName: 'Johnn',
@@ -132,7 +126,7 @@ function defaultState() {
         },
       },
     },
-  };
+  } as RootState;
 }
 
 function successResponses() {

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -13,27 +13,9 @@ describe(send, () => {
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;
 
-    const initialState = {
-      authentication: {
-        user: {
-          data: {
-            id: 1,
-            profileId: '2',
-            profileSummary: {
-              firstName: 'Johnn',
-              lastName: 'Doe',
-              profileImage: '/image.jpg',
-            },
-          },
-        },
-      },
-    };
+    const initialState = defaultState();
 
-    const {
-      storeState: {
-        normalized: { channels },
-      },
-    } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+    await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .provide([
         [
           matchers.call.fn(sendMessagesByChannelId),
@@ -43,7 +25,6 @@ describe(send, () => {
       .withReducer(rootReducer, initialState as any)
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
-    expect(channels[channelId].messageIdsCache).not.toStrictEqual([]);
   });
 
   it('send message with link preview', async () => {
@@ -52,21 +33,7 @@ describe(send, () => {
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;
 
-    const initialState = {
-      authentication: {
-        user: {
-          data: {
-            id: 1,
-            profileId: '2',
-            profileSummary: {
-              firstName: 'Johnn',
-              lastName: 'Doe',
-              profileImage: '/image.jpg',
-            },
-          },
-        },
-      },
-    };
+    const initialState = defaultState();
 
     const {
       storeState: {
@@ -110,21 +77,7 @@ describe(send, () => {
     const mentionedUserIds = [];
     const parentMessage = { message: 'hello', messageId: '98765650', userId: '12YT67565J' };
 
-    const initialState = {
-      authentication: {
-        user: {
-          data: {
-            id: 1,
-            profileId: '2',
-            profileSummary: {
-              firstName: 'Johnn',
-              lastName: 'Doe',
-              profileImage: '/image.jpg',
-            },
-          },
-        },
-      },
-    };
+    const initialState = defaultState();
 
     const {
       storeState: {
@@ -163,19 +116,7 @@ describe(send, () => {
           },
         },
       },
-      authentication: {
-        user: {
-          data: {
-            id: 1,
-            profileId: '2',
-            profileSummary: {
-              firstName: 'Johnn',
-              lastName: 'Doe',
-              profileImage: '/image.jpg',
-            },
-          },
-        },
-      },
+      ...defaultState(),
     };
 
     const {
@@ -197,3 +138,21 @@ describe(send, () => {
     expect(channels[channelId].messageIdsCache.length).toEqual(1);
   });
 });
+
+function defaultState() {
+  return {
+    authentication: {
+      user: {
+        data: {
+          id: 1,
+          profileId: '2',
+          profileSummary: {
+            firstName: 'Johnn',
+            lastName: 'Doe',
+            profileImage: '/image.jpg',
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -43,20 +43,13 @@ describe(send, () => {
 
   it('reply message', async () => {
     const channelId = 'channel-id';
-    const message = 'reply';
-    const mentionedUserIds = [];
     const parentMessage = { message: 'hello', messageId: '98765650', userId: '12YT67565J' };
 
-    const {
-      storeState: {
-        normalized: { channels },
-      },
-    } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+    await expectSaga(send, { payload: { channelId, message: '', mentionedUserIds: [], parentMessage } })
       .provide(successResponses())
       .withReducer(rootReducer, defaultState() as any)
-      .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
+      .call(sendMessagesByChannelId, channelId, '', [], parentMessage)
       .run();
-    expect(channels[channelId].messageIdsCache).not.toStrictEqual([]);
   });
 
   it('send message return a 400 status', async () => {

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -8,7 +8,7 @@ import { stubResponse } from '../../test/saga';
 
 describe(send, () => {
   it('send message', async () => {
-    const channelId = '0x000000000000000000000000000000000000000A';
+    const channelId = 'channel-id';
     const message = 'hello';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;
@@ -21,7 +21,7 @@ describe(send, () => {
   });
 
   it('send message with link preview', async () => {
-    const channelId = '0x000000000000000000000000000000000000000A';
+    const channelId = 'channel-id';
     const message = 'www.google.com';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;
@@ -56,7 +56,7 @@ describe(send, () => {
   });
 
   it('reply message', async () => {
-    const channelId = '0x000000000000000000000000000000000000000A';
+    const channelId = 'channel-id';
     const message = 'reply';
     const mentionedUserIds = [];
     const parentMessage = { message: 'hello', messageId: '98765650', userId: '12YT67565J' };
@@ -74,7 +74,7 @@ describe(send, () => {
   });
 
   it('send message return a 400 status', async () => {
-    const channelId = '0x000000000000000000000000000000000000000A';
+    const channelId = 'channel-id';
     const message = 'hello';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
     const parentMessage = null;

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -12,24 +12,21 @@ describe(send, () => {
     const channelId = 'channel-id';
     const message = 'hello';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
-    const parentMessage = null;
 
-    await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+    await expectSaga(send, { payload: { channelId, message, mentionedUserIds } })
       .provide(successResponses())
       .withReducer(rootReducer, defaultState())
-      .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
+      .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, undefined)
       .run();
   });
 
   it('send message with link preview', async () => {
     const channelId = 'channel-id';
     const message = 'www.google.com';
-    const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
-    const parentMessage = null;
 
     const linkPreview = { id: 'fdf2ce2b-062e-4a83-9c27-03f36c81c0c0' };
 
-    const { storeState } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+    const { storeState } = await expectSaga(send, { payload: { channelId, message } })
       .provide([
         stubResponse(matchers.call.fn(getLinkPreviews), linkPreview),
         ...successResponses(),

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -4,6 +4,7 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { getLinkPreviews, sendMessagesByChannelId } from './api';
 import { send } from './saga';
 import { rootReducer } from '../reducer';
+import { stubResponse } from '../../test/saga';
 
 describe(send, () => {
   it('send message', async () => {
@@ -15,12 +16,7 @@ describe(send, () => {
     const initialState = defaultState();
 
     await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
-      .provide([
-        [
-          matchers.call.fn(sendMessagesByChannelId),
-          { status: 200, body: { id: 'message 1', message } },
-        ],
-      ])
+      .provide(successResponses())
       .withReducer(rootReducer, initialState as any)
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
@@ -41,10 +37,6 @@ describe(send, () => {
     } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .provide([
         [
-          matchers.call.fn(sendMessagesByChannelId),
-          { status: 200, body: { id: 'message 1', message } },
-        ],
-        [
           matchers.call.fn(getLinkPreviews),
           {
             status: 200,
@@ -57,6 +49,7 @@ describe(send, () => {
             },
           },
         ],
+        ...successResponses(),
       ])
       .withReducer(rootReducer, initialState as any)
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
@@ -79,12 +72,7 @@ describe(send, () => {
         normalized: { channels },
       },
     } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
-      .provide([
-        [
-          matchers.call.fn(sendMessagesByChannelId),
-          { status: 200, body: { id: 'message 1', message } },
-        ],
-      ])
+      .provide(successResponses())
       .withReducer(rootReducer, initialState as any)
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
@@ -120,12 +108,7 @@ describe(send, () => {
       },
     } = await expectSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .withReducer(rootReducer, initialState as any)
-      .provide([
-        [
-          matchers.call.fn(sendMessagesByChannelId),
-          { status: 400, body: {} },
-        ],
-      ])
+      .provide([stubResponse(matchers.call.fn(sendMessagesByChannelId), { status: 400, body: {} })])
       .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
       .run();
 
@@ -150,4 +133,10 @@ function defaultState() {
       },
     },
   };
+}
+
+function successResponses() {
+  return [
+    stubResponse(matchers.call.fn(sendMessagesByChannelId), { status: 200, body: { id: 'message 1', message: {} } }),
+  ];
 }

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -4,7 +4,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { getLinkPreviews, sendMessagesByChannelId } from './api';
 import { send } from './saga';
 import { rootReducer } from '../reducer';
-import { send as sendBrowserMessage } from '../../lib/browser';
 
 describe(send, () => {
   it('send message', async () => {
@@ -57,10 +56,6 @@ describe(send, () => {
               description: 'Search the world information, including webpages.',
             },
           },
-        ],
-        [
-          matchers.call.fn(sendBrowserMessage),
-          undefined,
         ],
       ])
       .withReducer(rootReducer, initialState as any)

--- a/src/test/saga.ts
+++ b/src/test/saga.ts
@@ -1,0 +1,6 @@
+export function stubResponse(matcher, response) {
+  return [
+    matcher,
+    response,
+  ] as any;
+}


### PR DESCRIPTION
### What does this do?

Tried to clean up the send message saga tests a bit.

Note: this is just cleaning what's there whether it's correct or not. Next step will be making these tests more thorough and refactoring the send message a bit to allow us modify it more easily.

### Why are we making this change?

They were unnecessarily long and included data unrelated to the thing being tested, etc.

