### PR TITLE
chore: bump version (`0.25.0`) -> (`0.25.1`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@zero-tech/zapp-daos": "latest",
         "@zero-tech/zapp-nfts": "latest",
         "@zero-tech/zapp-staking": "latest",
-        "@zero-tech/zui": "^0.25.0",
+        "@zero-tech/zui": "^0.25.1",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -10706,9 +10706,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.25.0.tgz",
-      "integrity": "sha512-N41AaV45qLaWmWwsYZKFhOo/xwmp9rCoZMBqDHT5RfXuLRzXtPxaZXmNjzhvN/WbT/2yJOnb3q9FLSZU2aBGSw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.25.1.tgz",
+      "integrity": "sha512-JLGzFn4UWTU+uTotuHC42VlHJbzgUo4a/BppxnU81vNTP8ZiBL855eH2d+A/0VUNX6mQFC7TayeEuKPZ8R7f4Q==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -41726,7 +41726,7 @@
       "integrity": "sha512-vYYN02Jx+M2MVCjjQYsY/NJrGousc9+WY0Z/6UxCtsk19SKQ7RshuxJxIUDcQ0IyxwOFWI/ssMQ1u82UB7rkGQ==",
       "requires": {
         "@zero-tech/zns-sdk": "0.8.9",
-        "@zero-tech/zui": "^0.25.0",
+        "@zero-tech/zui": "^0.25.1",
         "classnames": "^2.3.1",
         "react-query": "^3.39.1"
       },
@@ -41782,7 +41782,7 @@
         "@zero-tech/zapp-utils": "0.6.5",
         "@zero-tech/zdao-sdk": "0.14.1",
         "@zero-tech/zns-sdk": "0.10.2",
-        "@zero-tech/zui": "^0.25.0",
+        "@zero-tech/zui": "^0.25.1",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "markdown-to-text": "^0.1.1",
@@ -41958,7 +41958,7 @@
         "@zero-tech/zns-sdk": "0.10.1",
         "@zero-tech/zsale-sdk": "0.1.6",
         "@zero-tech/ztoken-sdk": "^0.0.3",
-        "@zero-tech/zui": "^0.25.0",
+        "@zero-tech/zui": "^0.25.1",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "moment": "^2.29.4",
@@ -42040,7 +42040,7 @@
         "@zero-tech/zapp-utils": "^0.6.5",
         "@zero-tech/zfi-sdk": "0.2.1",
         "@zero-tech/zns-sdk": "0.6.1",
-        "@zero-tech/zui": "^0.25.0",
+        "@zero-tech/zui": "^0.25.1",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "millify": "^5.0.1",
@@ -42733,9 +42733,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.25.0.tgz",
-      "integrity": "sha512-N41AaV45qLaWmWwsYZKFhOo/xwmp9rCoZMBqDHT5RfXuLRzXtPxaZXmNjzhvN/WbT/2yJOnb3q9FLSZU2aBGSw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.25.1.tgz",
+      "integrity": "sha512-JLGzFn4UWTU+uTotuHC42VlHJbzgUo4a/BppxnU81vNTP8ZiBL855eH2d+A/0VUNX6mQFC7TayeEuKPZ8R7f4Q==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@zero-tech/zapp-daos": "latest",
     "@zero-tech/zapp-nfts": "latest",
     "@zero-tech/zapp-staking": "latest",
-    "@zero-tech/zui": "^0.25.0",
+    "@zero-tech/zui": "^0.25.1",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
- bump zui version (`0.25.0`) -> (`0.25.1`)