### PR TITLE
feat: add show arrow dropdown menu prop on messages menu

### DIFF
--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -115,6 +115,7 @@ export class MessageMenu extends React.Component<Properties, State> {
           side='bottom'
           alignMenu='center'
           onOpenChange={this.props.onOpenChange}
+          showArrow
           trigger={
             <div
               className={classNames('dropdown-menu-trigger', {


### PR DESCRIPTION
### What does this do?
- adds `showArrow` prop to dropdown menu on messages menu

### Why are we making this change?
- to display the arrow that points to the dropdown menu trigger

### How do I test this?
Open chat and click three dots menu. Should see arrow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
