### PR TITLE
fix: display correct address for user handle

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -87,6 +87,8 @@ export class Container extends React.Component<Properties, State> {
       layout,
       rewards,
     } = state;
+    const hasWallet = user?.data?.wallets.length > 0;
+
     const conversations = denormalizeConversations(state)
       .sort((a, b) =>
         compareDatesDesc(a.lastMessage?.createdAt || a.createdAt, b.lastMessage?.createdAt || b.createdAt)
@@ -113,7 +115,7 @@ export class Container extends React.Component<Properties, State> {
       includeRewardsAvatar: layout?.value?.isMessengerFullScreen,
       isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
       userName: user?.data?.profileSummary?.firstName || '',
-      userHandle: user?.data?.handle || '',
+      userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
       myUserId: user?.data?.id,
       zero: rewards.zero,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -87,7 +87,7 @@ export class Container extends React.Component<Properties, State> {
       layout,
       rewards,
     } = state;
-    const hasWallet = user?.data?.wallets.length > 0;
+    const hasWallet = user?.data?.wallets?.length > 0;
 
     const conversations = denormalizeConversations(state)
       .sort((a, b) =>

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -45,7 +45,6 @@ export class SettingsMenu extends React.Component<Properties, State> {
 
   renderSettingsHeader() {
     const c = bem('header');
-
     return (
       <div className={c('')}>
         <Avatar size={'regular'} type={'circle'} imageURL={this.props.userAvatarUrl} />

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -5,6 +5,7 @@ export interface AuthorizationResponse {
 
 interface Wallet {
   id: string;
+  publicAddress: string;
 }
 
 interface ProfileSummary {
@@ -14,6 +15,7 @@ interface ProfileSummary {
   lastName: string;
   profileImage: string;
   ssbPublicKey: string;
+  primaryEmail: string;
 }
 
 export interface UserPayload {


### PR DESCRIPTION
### What does this do?
- fixes the secondary user information in profile settings menu

### Why are we making this change?
- currently displaying incorrect data (using wrong type).

### How do I test this?
- sign in and click profile avatar. Check out secondary user information. This should be wallet address if available, or email address if no wallet address.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="321" alt="mmanu1mys4zmrrxafe88" src="https://github.com/zer0-os/zOS/assets/39112648/afd0d2fb-f9c2-44de-bf0d-23e10ee571e5">

After:
<img width="368" alt="Screenshot 2023-07-05 at 14 50 46" src="https://github.com/zer0-os/zOS/assets/39112648/89557568-8ed8-4674-a2a7-02976d18b0dd">

<img width="368" alt="Screenshot 2023-07-05 at 14 45 32" src="https://github.com/zer0-os/zOS/assets/39112648/5394e984-bd3b-4fee-869d-a4105bc7039f">
