### PR TITLE
Refactor: message send saga split to main chunks

### DIFF
--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -1,56 +1,54 @@
-import { expectSaga } from 'redux-saga-test-plan';
+import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { getLinkPreviews, sendMessagesByChannelId } from './api';
-import { send } from './saga';
+import { createOptimisticMessage, messageSendFailed, send } from './saga';
 import { RootState, rootReducer } from '../reducer';
 import { stubResponse } from '../../test/saga';
 import { denormalize as denormalizeChannel, normalize as normalizeChannel } from '../channels';
-import { throwError } from 'redux-saga-test-plan/providers';
 
 describe(send, () => {
-  it('sends a basic text message', async () => {
+  it('creates optimistic message and then sends the request', async () => {
     const channelId = 'channel-id';
     const message = 'hello';
+    const mentionedUserIds = [
+      'user-id1',
+      'user-id2',
+    ];
+    const parentMessage = { id: 'parent-id' };
 
-    await expectSaga(send, { payload: { channelId, message } })
-      .provide(successResponses())
-      .withReducer(rootReducer, defaultState())
-      .call(sendMessagesByChannelId, channelId, message, undefined, undefined)
-      .run();
+    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+      .next()
+      .call(createOptimisticMessage, channelId, message, parentMessage)
+      .next([])
+      .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage)
+      .next()
+      .isDone();
   });
 
-  it('sends a basic text message with mentioned users', async () => {
+  it('handles message send failure', async () => {
     const channelId = 'channel-id';
-    const message = 'hello';
-    const mentionedUserIds = ['user-id'];
+    const existingMessages = ['message1'];
 
-    await expectSaga(send, { payload: { channelId, message, mentionedUserIds } })
-      .provide(successResponses())
-      .withReducer(rootReducer, defaultState())
-      .call(sendMessagesByChannelId, channelId, message, mentionedUserIds, undefined)
-      .run();
+    testSaga(send, { payload: { channelId } })
+      .next()
+      // .call(createOptimisticMessage)
+      .next({ existingMessages })
+      // .call(sendMessagesByChannelId)
+      .throw(new Error('simulated api call failed'))
+      .call(messageSendFailed, channelId, existingMessages)
+      .next()
+      .isDone();
   });
+});
 
-  it('sends a message that is a reply', async () => {
-    const channelId = 'channel-id';
-    const parentMessage = { message: 'hello', messageId: '98765650', userId: '12YT67565J' };
-
-    await expectSaga(send, { payload: { channelId, parentMessage } })
-      .provide(successResponses())
-      .withReducer(rootReducer, defaultState() as any)
-      .call(sendMessagesByChannelId, channelId, undefined, undefined, parentMessage)
-      .run();
-  });
-
+describe(createOptimisticMessage, () => {
   it('creates an optimistic message', async () => {
     const channelId = 'channel-id';
     const message = 'test message';
 
-    const { storeState } = await expectSaga(send, { payload: { channelId, message } })
-      .provide([
-        ...successResponses(),
-      ])
+    const { storeState } = await expectSaga(createOptimisticMessage, channelId, message, undefined)
+      .provide([...successResponses()])
       .withReducer(rootReducer, defaultState())
       .run();
 
@@ -63,14 +61,10 @@ describe(send, () => {
   it('adds a link preview to the optimistic message', async () => {
     const channelId = 'channel-id';
     const message = 'www.google.com';
-
     const linkPreview = { id: 'fdf2ce2b-062e-4a83-9c27-03f36c81c0c0' };
 
-    const { storeState } = await expectSaga(send, { payload: { channelId, message } })
-      .provide([
-        stubResponse(matchers.call.fn(getLinkPreviews), linkPreview),
-        ...successResponses(),
-      ])
+    const { storeState } = await expectSaga(createOptimisticMessage, channelId, message, undefined)
+      .provide([stubResponse(matchers.call.fn(getLinkPreviews), linkPreview)])
       .withReducer(rootReducer, defaultState())
       .run();
 
@@ -78,7 +72,7 @@ describe(send, () => {
     expect(channel.messages[0].preview).toEqual(linkPreview);
   });
 
-  it('resets the existing messages if the send call fails', async () => {
+  it('returns the initial set of messages', async () => {
     const channelId = 'channel-id';
     const existingMessages = [
       { id: 'message 1', message: 'message_0001', createdAt: 10000000007 },
@@ -89,11 +83,33 @@ describe(send, () => {
       ...defaultState(),
     };
 
-    const { storeState } = await expectSaga(send, { payload: { channelId, message: 'failed message' } })
+    const { returnValue } = await expectSaga(createOptimisticMessage, channelId, 'failed message', undefined)
+      .provide([...successResponses()])
       .withReducer(rootReducer, initialState)
-      .provide([
-        stubResponse(matchers.call.fn(sendMessagesByChannelId), throwError(new Error('api call failed'))),
-      ])
+      .run();
+
+    expect(returnValue.existingMessages).toEqual(existingMessages.map((m) => m.id));
+  });
+});
+
+describe(messageSendFailed, () => {
+  it('resets the existing messages if the send call fails', async () => {
+    const channelId = 'channel-id';
+    const existingMessages = [
+      { id: 'message 1', message: 'message_0001', createdAt: 10000000007 },
+    ];
+    const optimisticMessageList = [
+      ...existingMessages,
+      { id: 'optimistic' },
+    ];
+
+    const initialState = {
+      ...existingChannelState({ id: channelId, messages: optimisticMessageList }),
+      ...defaultState(),
+    };
+
+    const { storeState } = await expectSaga(messageSendFailed, channelId, existingMessages)
+      .withReducer(rootReducer, initialState)
       .run();
 
     const channel = denormalizeChannel(channelId, storeState);
@@ -105,17 +121,19 @@ describe(send, () => {
     const existingMessages = [
       { id: 'message 1', message: 'message_0001', createdAt: 10000000007 },
     ];
+    const optimisticChannel = {
+      id: channelId,
+      lastMessage: { id: 'optimistic' },
+      lastMessageCreatedAt: 10000000010,
+    };
 
     const initialState = {
-      ...existingChannelState({ id: channelId, messages: existingMessages }),
+      ...existingChannelState(optimisticChannel),
       ...defaultState(),
     };
 
-    const { storeState } = await expectSaga(send, { payload: { channelId, message: 'failed message' } })
+    const { storeState } = await expectSaga(messageSendFailed, channelId, existingMessages)
       .withReducer(rootReducer, initialState)
-      .provide([
-        stubResponse(matchers.call.fn(sendMessagesByChannelId), throwError(new Error('api call failed'))),
-      ])
       .run();
 
     const channel = denormalizeChannel(channelId, storeState);


### PR DESCRIPTION
### What does this do?

Refactors the message send saga into a "flow management" style.

### Why are we making this change?

This allows us to test the "phases" of sending a message independently so we can test the intermediate state changes more easily.

### How do I test this?

Verify that sending messages still works.

