### PR TITLE
Fetch the link preview after rendering the optimisitic message

### DIFF
--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -10,7 +10,7 @@ import { denormalize as denormalizeChannel, normalize as normalizeChannel } from
 import { throwError } from 'redux-saga-test-plan/providers';
 
 describe(send, () => {
-  it('creates optimistic message, fetches preview, then sends the message', async () => {
+  it('creates optimistic message then fetches preview and sends the message in parallel', async () => {
     const channelId = 'channel-id';
     const message = 'hello';
     const mentionedUserIds = [
@@ -23,9 +23,9 @@ describe(send, () => {
       .next()
       .call(createOptimisticMessage, channelId, message, parentMessage)
       .next({ existingMessages: [{ id: 'existing-id' }], optimisticMessage: { id: 'optimistic-message-id' } })
-      .call(createOptimisticPreview, channelId, { id: 'optimistic-message-id' })
+      .spawn(createOptimisticPreview, channelId, { id: 'optimistic-message-id' })
       .next()
-      .call(performSend, channelId, message, mentionedUserIds, parentMessage, [{ id: 'existing-id' }])
+      .spawn(performSend, channelId, message, mentionedUserIds, parentMessage, [{ id: 'existing-id' }])
       .next()
       .isDone();
   });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -1,6 +1,6 @@
 import { currentUserSelector } from './../authentication/saga';
 import getDeepProperty from 'lodash.get';
-import { takeLatest, put, call, select, delay, all } from 'redux-saga/effects';
+import { takeLatest, put, call, select, delay, all, spawn } from 'redux-saga/effects';
 import { EditMessageOptions, Message, SagaActionTypes, schema, removeAll, denormalize } from '.';
 import { receive as receiveMessage } from './';
 import { receive } from '../channels';
@@ -123,8 +123,8 @@ export function* send(action) {
     parentMessage
   );
 
-  yield call(createOptimisticPreview, channelId, optimisticMessage);
-  yield call(performSend, channelId, message, mentionedUserIds, parentMessage, existingMessages);
+  yield spawn(createOptimisticPreview, channelId, optimisticMessage);
+  yield spawn(performSend, channelId, message, mentionedUserIds, parentMessage, existingMessages);
 }
 
 export function* createOptimisticMessage(channelId, message, parentMessage) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -124,12 +124,7 @@ export function* send(action) {
   );
 
   yield call(createOptimisticPreview, channelId, optimisticMessage);
-
-  try {
-    yield call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage);
-  } catch (e) {
-    yield call(messageSendFailed, channelId, existingMessages);
-  }
+  yield call(performSend, channelId, message, mentionedUserIds, parentMessage, existingMessages);
 }
 
 export function* createOptimisticMessage(channelId, message, parentMessage) {
@@ -167,6 +162,14 @@ export function* createOptimisticPreview(channelId: string, optimisticMessage) {
 
   if (preview) {
     yield put(receiveMessage({ id: optimisticMessage.id, preview }));
+  }
+}
+
+export function* performSend(channelId, message, mentionedUserIds, parentMessage, existingMessages) {
+  try {
+    yield call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage);
+  } catch (e) {
+    yield call(messageSendFailed, channelId, existingMessages);
   }
 }
 


### PR DESCRIPTION
### What does this do?

When sending a message we now render optimistically and then fetch any link previews in the background while sending the message.

### Why are we making this change?

More responsive feeling for the user

Before with 5s delay added to the link preview fetch:

https://github.com/zer0-os/zOS/assets/43770/22d65dc6-6493-4f54-94f2-352017da9173


After with 5s delay added:

https://github.com/zer0-os/zOS/assets/43770/fb245caa-5431-4b1d-b279-0166c4a8d92e

After with normal operation (only standard network delays, etc)

https://github.com/zer0-os/zOS/assets/43770/c67f7578-1c3a-4094-bb2d-db4713853261




