### PR TITLE
Add padding to the "no results view"

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -7,6 +7,7 @@ import './styles.scss';
 import '../list/styles.scss';
 
 import { itemToOption } from '../lib/utils';
+import classNames from 'classnames';
 
 export interface Properties {
   search: (query: string) => Promise<Item[]>;
@@ -55,7 +56,9 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
         />
 
         {this.state.results?.length === 0 && this.state.results !== '' && (
-          <div className='messages-list__empty'>{`No results for '${this.state.searchString}' `}</div>
+          <div className={classNames('messages-list__empty', 'messages-list__empty-top-padding')}>
+            {`No results for '${this.state.searchString}' `}
+          </div>
         )}
 
         {this.props.children}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -73,6 +73,10 @@ $side-padding: 16px;
       line-height: 17px;
       word-break: break-word;
       text-align: center;
+
+      &-top-padding {
+        padding-top: 32px;
+      }
     }
   }
 }


### PR DESCRIPTION
### What does this do?

Based on Eth & Kelly's feedback, updated the top padding for the "no results" text to be consistent across both cases.

![image](https://github.com/zer0-os/zOS/assets/33264364/2cf51356-f2ed-4109-b5bf-68ba37b04451)
![image](https://github.com/zer0-os/zOS/assets/33264364/ebe56a18-89e9-4629-87a3-d127a4863783)
