### PR TITLE
Add `setActiveChannelId` state

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -13,6 +13,7 @@ describe('ChannelViewContainer', () => {
       channelId: '',
       fetchMessages: () => undefined,
       joinChannel: () => undefined,
+      setActiveChannelId: () => undefined,
       user: {
         isLoading: false,
         data: null,

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { RootState } from '../../store/reducer';
 
 import { connectContainer } from '../../store/redux-container';
+import { setActiveChannelId } from '../../store/chat';
 import {
   fetch as fetchMessages,
   send as sendMessage,
@@ -30,6 +31,7 @@ import { ParentMessage } from '../../lib/chat/types';
 
 export interface Properties extends PublicProperties {
   channel: Channel;
+  setActiveChannelId: (channelId: string) => void;
   fetchMessages: (payload: PayloadFetchMessages) => void;
   user: AuthenticationState['user'];
   sendMessage: (payload: PayloadSendMessage) => void;
@@ -88,6 +90,7 @@ export class Container extends React.Component<Properties, State> {
       joinChannel,
       markAllMessagesAsReadInChannel,
       editMessage,
+      setActiveChannelId,
     };
   }
 
@@ -105,13 +108,14 @@ export class Container extends React.Component<Properties, State> {
 
     if (channelId && channelId !== prevProps.channelId) {
       this.props.stopSyncChannels(prevProps);
+
+      this.props.setActiveChannelId(channelId);
       this.props.fetchMessages({ channelId });
-      this.setState({
-        reply: null,
-      });
+      this.setState({ reply: null });
     }
 
     if (channelId && prevProps.user.data === null && this.props.user.data !== null) {
+      this.props.setActiveChannelId(channelId);
       this.props.fetchMessages({ channelId });
     }
 

--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import getDeepProperty from 'lodash.get';
+import { setActiveChannelId } from '../../store/chat';
 
 import { RootState } from '../../store/reducer';
 import { Store } from 'redux';
@@ -28,6 +29,8 @@ interface PublicProperties {
 }
 
 export interface Properties extends PublicProperties {
+  setActiveChannelId: (channelId: string) => void;
+
   domainId: string;
   channels: Channel[];
   fetchChannels: (domainId: string) => void;
@@ -52,7 +55,14 @@ export class Container extends React.Component<Properties> {
   static mapActions(_props: Properties): Partial<Properties> {
     return {
       fetchChannels,
+      setActiveChannelId,
     };
+  }
+
+  setActiveChannelId() {
+    if (this.props.channelId) {
+      this.props.setActiveChannelId(this.props.channelId);
+    }
   }
 
   componentDidMount() {
@@ -61,6 +71,12 @@ export class Container extends React.Component<Properties> {
     if (domainId) {
       this.props.fetchChannels(domainId);
     }
+
+    this.setActiveChannelId();
+  }
+
+  componentWillUnmount(): void {
+    this.props.setActiveChannelId(null);
   }
 
   componentDidUpdate(prevProps: Properties) {
@@ -72,6 +88,11 @@ export class Container extends React.Component<Properties> {
 
     if (prevProps.user.data !== user.data || prevProps.domainId !== domainId) {
       this.props.fetchChannels(domainId);
+    }
+
+    // to handle the case when you switch between apps (eg.Chat -> Trade -> Chat)
+    if (prevProps.channelId !== this.props.channelId) {
+      this.setActiveChannelId();
     }
   }
 

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -8,6 +8,7 @@ const initialState: ChatState = {
   },
   isReconnecting: false,
   activeConversationId: null,
+  activeChannelId: null,
 };
 
 const slice = createSlice({
@@ -23,8 +24,11 @@ const slice = createSlice({
     setactiveConversationId: (state, action: PayloadAction<ChatState['activeConversationId']>) => {
       state.activeConversationId = action.payload;
     },
+    setActiveChannelId: (state, action: PayloadAction<ChatState['activeChannelId']>) => {
+      state.activeChannelId = action.payload;
+    },
   },
 });
 
-export const { setChatAccessToken, setReconnecting, setactiveConversationId } = slice.actions;
+export const { setChatAccessToken, setReconnecting, setactiveConversationId, setActiveChannelId } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -5,4 +5,5 @@ export interface ChatState {
     isLoading: boolean;
   };
   activeConversationId: string;
+  activeChannelId: string;
 }


### PR DESCRIPTION
### What does this do?

Whenever you're on an active channel, it will update the global state and set it the channel. Having an `activeChannelId` & an `activeConversationId` as a global state is useful accross saga events. 
