### PR TITLE
Use optimisticId to manage rendering of optimistic text based messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "prettier-plugin-multiline-arrays": "^1.0.0",
         "pretty-quick": "^3.1.3",
         "redux-saga-test-plan": "^4.0.4",
+        "uuid": "^9.0.0",
         "wait-on": "^6.0.1"
       },
       "engines": {
@@ -3362,6 +3363,14 @@
         "@giphy/js-types": "^4.4.0",
         "dompurify": "^2.2.2",
         "uuid": "^8.3.0"
+      }
+    },
+    "node_modules/@giphy/js-util/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@giphy/react-components": {
@@ -25747,6 +25756,15 @@
         "which": "^2.0.2"
       }
     },
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/node-notifier/node_modules/which": {
       "version": "2.0.2",
       "license": "ISC",
@@ -33642,8 +33660,10 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -37812,6 +37832,13 @@
         "@giphy/js-types": "^4.4.0",
         "dompurify": "^2.2.2",
         "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@giphy/react-components": {
@@ -52610,6 +52637,12 @@
         "which": "^2.0.2"
       },
       "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        },
         "which": {
           "version": "2.0.2",
           "optional": true,
@@ -57815,7 +57848,10 @@
       "version": "1.0.1"
     },
     "uuid": {
-      "version": "8.3.2"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true
     },
     "uvu": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "prettier-plugin-multiline-arrays": "^1.0.0",
     "pretty-quick": "^3.1.3",
     "redux-saga-test-plan": "^4.0.4",
+    "uuid": "^9.0.0",
     "wait-on": "^6.0.1"
   },
   "overrides": {

--- a/src/lib/chat/chat-message.test.tsx
+++ b/src/lib/chat/chat-message.test.tsx
@@ -121,27 +121,29 @@ describe('sendbird events', () => {
 
       const mappedMessage = mapMessage(rawSendbirdResponse);
 
-      expect(mappedMessage).toStrictEqual({
-        id: 8728123760,
-        message: 'test mention @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) with image',
-        parentMessageText: 'hi @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) ',
-        createdAt: 1680691559605,
-        updatedAt: 0,
-        sender: {
-          userId: '1bc08a9b-6f5b-497f-9d0b-3cf47abe426a',
-          firstName: '0x03D3...d161',
-          lastName: '',
-          profileImage:
-            'https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg',
-          profileId: 'b52d1815-97db-45a7-8477-5b976e9eedde',
-        },
-        mentionedUsers: [],
-        hidePreview: false,
-        image: undefined,
-        media: undefined,
-        isAdmin: false,
-        admin: {},
-      });
+      expect(mappedMessage).toEqual(
+        expect.objectContaining({
+          id: 8728123760,
+          message: 'test mention @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) with image',
+          parentMessageText: 'hi @[0xE883...5870 ](user:9bf99cf6-559e-46e8-ba73-07faed8747ac) ',
+          createdAt: 1680691559605,
+          updatedAt: 0,
+          sender: {
+            userId: '1bc08a9b-6f5b-497f-9d0b-3cf47abe426a',
+            firstName: '0x03D3...d161',
+            lastName: '',
+            profileImage:
+              'https://res.cloudinary.com/fact0ry-dev/image/upload/v1623021589/zero-assets/avatars/pfp-16.jpg',
+            profileId: 'b52d1815-97db-45a7-8477-5b976e9eedde',
+          },
+          mentionedUsers: [],
+          hidePreview: false,
+          image: undefined,
+          media: undefined,
+          isAdmin: false,
+          admin: {},
+        })
+      );
     });
 
     it('maps an admin message', () => {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -90,6 +90,7 @@ function extractMessageData(jsonData, isMediaMessage) {
   let hidePreview = false;
   let media;
   let admin;
+  let optimisticId = '';
 
   try {
     const data = jsonData ? JSON.parse(jsonData) : {};
@@ -101,9 +102,17 @@ function extractMessageData(jsonData, isMediaMessage) {
     mentionedUsers = data.mentionedUsers || [];
     hidePreview = data.hidePreview || false;
     admin = data.admin || {};
+    optimisticId = data.optimisticId || '';
   } catch (e) {}
 
-  return { mentionedUsers, hidePreview, media, image: media?.type === 'image' ? media : undefined, admin };
+  return {
+    mentionedUsers,
+    hidePreview,
+    media,
+    image: media?.type === 'image' ? media : undefined,
+    admin,
+    optimisticId,
+  };
 }
 
 export function map(sendbirdMessage) {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -36,7 +36,6 @@ export interface Channel {
   hasJoined?: boolean;
   groupChannelType: GroupChannelType;
   icon?: string;
-  messageIdsCache?: string[];
   isChannel: boolean;
   hasLoadedMessages: boolean;
 }

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -22,9 +22,10 @@ export async function sendMessagesByChannelId(
   message: string,
   mentionedUserIds: string[],
   parentMessage?: ParentMessage,
-  file?: FileUploadResult
+  file?: FileUploadResult,
+  optimisticId?: string
 ): Promise<any> {
-  const data: SendPayload = { message, mentionedUserIds };
+  const data: SendPayload = { message, mentionedUserIds, optimisticId };
 
   if (parentMessage) {
     data.parentMessageId = parentMessage.messageId;

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -66,6 +66,7 @@ export interface Message {
     inviterId?: string;
     inviteeId?: string;
   };
+  optimisticId?: string;
 }
 
 export interface EditMessageOptions {

--- a/src/store/messages/saga.receiveNewMessage.test.ts
+++ b/src/store/messages/saga.receiveNewMessage.test.ts
@@ -12,7 +12,7 @@ import { stubResponse } from '../../test/saga';
 describe(receiveNewMessage, () => {
   it('adds the message to the channel', async () => {
     const channelId = 'channel-id';
-    const message = { id: 'new-message', message: 'a new message' };
+    const message = { id: 'new-message', message: 'a new message', optimisticId: 'other-front-end-id' };
     const existingMessages = [{ id: 'message-1', message: 'message_0001' }];
 
     const { storeState } = await expectSaga(receiveNewMessage, { payload: { channelId, message } })
@@ -125,16 +125,19 @@ describe(receiveNewMessage, () => {
 
   it('replaces optimistically rendered message', async () => {
     const channelId = 'channel-id';
-    const message = { id: 'system-provided-id', message: 'true message for asserting. normally would not change.' };
+    const message = {
+      id: 'system-provided-id',
+      message: 'test message for asserting. normally would not change.',
+      optimisticId: 'optimistic-id',
+    };
     const existingMessages = [
-      { id: 'optimistic-id', message: 'optimistic' },
+      { id: 'optimistic-id', message: 'optimistic', optimisticId: 'optimistic-id' },
       { id: 'standard-id', message: 'message_0001' },
     ];
 
     const initialState = existingChannelState({
       id: channelId,
       messages: existingMessages,
-      messageIdsCache: ['optimistic-id'],
     });
 
     const { storeState } = await expectSaga(receiveNewMessage, { payload: { channelId, message } })
@@ -144,29 +147,22 @@ describe(receiveNewMessage, () => {
 
     const channel = denormalizeChannel(channelId, storeState);
     expect(channel.messages[0].id).toEqual('system-provided-id');
-    expect(channel.messages[0].message).toEqual('true message for asserting. normally would not change.');
+    expect(channel.messages[0].message).toEqual('test message for asserting. normally would not change.');
     expect(channel.messages[1].id).toEqual('standard-id');
-    expect(channel.messageIdsCache).toEqual([]);
   });
 
-  it('replaces first found optimistically rendered message even if more messages have been sent', async () => {
-    // Note: This is a bug. We should replace exactly the message we rendered optimistically.
-    // For now, this tests current behavior. Fixes to come.
+  it('replaces the correct optimistic message if multiple have been sent', async () => {
     const channelId = 'channel-id';
-    const message = { id: 'system-provided-id', message: 'true message for asserting. normally would not change.' };
+    const message = { id: 'system-provided-id', optimisticId: 'optimistic-id-2' };
     const existingMessages = [
-      { id: 'optimistic-id-1', message: 'optimistic1' },
-      { id: 'optimistic-id-2', message: 'optimistic2' },
+      { id: 'optimistic-id-1', message: 'optimistic1', optimisticId: 'optimistic-id-1' },
+      { id: 'optimistic-id-2', message: 'optimistic2', optimisticId: 'optimistic-id-2' },
       { id: 'standard-id', message: 'message_0001' },
     ];
 
     const initialState = existingChannelState({
       id: channelId,
       messages: existingMessages,
-      messageIdsCache: [
-        'optimistic-id-1',
-        'optimistic-id-2',
-      ],
     });
 
     const { storeState } = await expectSaga(receiveNewMessage, { payload: { channelId, message } })
@@ -175,8 +171,8 @@ describe(receiveNewMessage, () => {
       .run();
 
     const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.messages[0].id).toEqual('system-provided-id');
-    expect(channel.messageIdsCache).toEqual(['optimistic-id-2']);
+    expect(channel.messages[0].id).toEqual('optimistic-id-1');
+    expect(channel.messages[1].id).toEqual('system-provided-id');
   });
 });
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -15,7 +15,7 @@ import {
   getLinkPreviews,
   uploadAttachment,
 } from './api';
-import { FileType, extractLink, getFileType, linkifyType, messageFactory } from './utils';
+import { FileType, extractLink, getFileType, linkifyType, createOptimisticMessageObject } from './utils';
 import { Media as MediaUtils } from '../../components/message-input/utils';
 import { ParentMessage } from '../../lib/chat/types';
 import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
@@ -134,7 +134,7 @@ export function* createOptimisticMessage(channelId, message, parentMessage) {
   const existingMessages = yield select(rawMessagesSelector(channelId));
   const currentUser = yield select(currentUserSelector());
 
-  const temporaryMessage = messageFactory(message, currentUser, parentMessage);
+  const temporaryMessage = createOptimisticMessageObject(message, currentUser, parentMessage);
 
   // add cache message id to prevent having double messages when we receive the message from sendbird.
   // We should set a reference id and post that to the server to be able to match the message when it

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -57,6 +57,7 @@ export interface SendPayload {
   parentMessageId?: number;
   parentMessageUserId?: string;
   file?: FileUploadResult;
+  optimisticId?: string;
 }
 
 export interface MediaPayload {
@@ -124,7 +125,7 @@ export function* send(action) {
   );
 
   yield spawn(createOptimisticPreview, channelId, optimisticMessage);
-  yield spawn(performSend, channelId, message, mentionedUserIds, parentMessage, existingMessages);
+  yield spawn(performSend, channelId, message, mentionedUserIds, parentMessage, existingMessages, optimisticMessage.id);
 }
 
 export function* createOptimisticMessage(channelId, message, parentMessage) {
@@ -165,9 +166,9 @@ export function* createOptimisticPreview(channelId: string, optimisticMessage) {
   }
 }
 
-export function* performSend(channelId, message, mentionedUserIds, parentMessage, existingMessages) {
+export function* performSend(channelId, message, mentionedUserIds, parentMessage, existingMessages, optimisticId) {
   try {
-    yield call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage);
+    yield call(sendMessagesByChannelId, channelId, message, mentionedUserIds, parentMessage, null, optimisticId);
   } catch (e) {
     yield call(messageSendFailed, channelId, existingMessages);
   }

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -14,7 +14,11 @@ export interface linkifyType {
   end: number;
 }
 
-export function messageFactory(messageText: string, user: User, parentMessage: ParentMessage = null): Message {
+export function createOptimisticMessageObject(
+  messageText: string,
+  user: User,
+  parentMessage: ParentMessage = null
+): Message {
   return {
     createdAt: Date.now(),
     hidePreview: false,

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -19,10 +19,12 @@ export function createOptimisticMessageObject(
   user: User,
   parentMessage: ParentMessage = null
 ): Message {
+  const id = uuidv4();
   return {
     createdAt: Date.now(),
     hidePreview: false,
-    id: uuidv4(),
+    id,
+    optimisticId: id,
     mentionedUserIds: [],
     message: messageText,
     isAdmin: false,

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { Message } from './index';
 import { User } from './../authentication/types';
 import * as linkifyjs from 'linkifyjs';
@@ -16,7 +18,7 @@ export function messageFactory(messageText: string, user: User, parentMessage: P
   return {
     createdAt: Date.now(),
     hidePreview: false,
-    id: Date.now(),
+    id: uuidv4(),
     mentionedUserIds: [],
     message: messageText,
     isAdmin: false,


### PR DESCRIPTION
### What does this do?

Uses an optimisticId when sending text based messages to correlate received events for optimistically rendered data.

### Why are we making this change?

The existing cached array is fragile and buggy at the moment. This allows us to be more accurate.

### How do I test this?

Send messages and then try to edit them after a couple of seconds. If you can edit them successfully that means the data store was updated correctly.

