### PR TITLE
fix: update class name to fix message input margin

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -67,7 +67,7 @@ $scrollbar-width: 5px;
   flex-direction: column;
   height: 100vh;
 
-  .chat-message__input-wrapper {
+  .message-input {
     margin-right: calc(var(--layout-app-content-right-padding) + $scrollbar-width);
   }
 }


### PR DESCRIPTION
### What does this do?
- fixes the margin for the compose a message input.

### Why are we making this change?
- this change is to fix the margin to what is currently in production. This was not an intended design change, therefore the fix is required.

### How do I test this?
- open the app (not in full screen) and check the message input has equal margins as per screenshots below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="1013" alt="Screenshot 2023-07-10 at 10 28 36" src="https://github.com/zer0-os/zOS/assets/39112648/5e77a4a6-1ded-40cc-a4d6-f788e3d6e469">

<img width="1013" alt="Screenshot 2023-07-10 at 10 28 26" src="https://github.com/zer0-os/zOS/assets/39112648/a8c6526f-5566-4877-a65c-16adc03e4607">

After:
<img width="1013" alt="Screenshot 2023-07-10 at 10 28 18" src="https://github.com/zer0-os/zOS/assets/39112648/a55fa3d9-04c9-4a1f-953a-943d0748baf0">
