### PR TITLE
feat: conversation item preview mentions as plaintext

### DIFF
--- a/src/components/content-highlighter/content-highlight.test.tsx
+++ b/src/components/content-highlighter/content-highlight.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ContentHighlighter, Properties } from './';
+import { textToPlainEmojis } from './text-to-emojis';
+
+jest.mock('./text-to-emojis', () => ({
+  textToPlainEmojis: jest.fn((text) => text),
+}));
+
+describe('ContentHighlighter', () => {
+  const render = (props: Partial<Properties>) => {
+    const defaultProps: Properties = {
+      message: '',
+      mentionedUserIds: [],
+      variant: 'primary',
+      ...props,
+    };
+    return shallow(<ContentHighlighter {...defaultProps} />);
+  };
+
+  it('renders without crashing', () => {
+    render({});
+  });
+
+  it('renders content with plain emojis', () => {
+    const message = 'Hello, world! :)';
+    (textToPlainEmojis as jest.Mock).mockReturnValueOnce('Hello, world! 🙂');
+
+    const wrapper = render({
+      message,
+    });
+
+    expect(wrapper.text()).toContain('Hello, world! 🙂');
+  });
+
+  it('renders content with a user mention', () => {
+    const wrapper = render({
+      message: 'Hello, @[John Doe](user:123)!',
+      mentionedUserIds: [{ id: '123', profileId: 'john_doe' }],
+    });
+    expect(wrapper.find('.content-highlighter__user-mention').text()).toEqual('@John Doe');
+  });
+
+  it('renders content with a user mention without a profileId', () => {
+    const wrapper = render({
+      message: 'Hello, @[John Doe](user:123)!',
+      mentionedUserIds: [{ id: '123' }],
+    });
+    expect(wrapper.find('.content-highlighter__user-mention').text()).toEqual('@John Doe');
+    expect(wrapper.find('.content-highlighter__user-mention').prop('id')).toBeUndefined();
+  });
+
+  it('renders content with a different variant', () => {
+    const wrapper = render({
+      message: 'Hello, @[John Doe](user:123)!',
+      mentionedUserIds: [{ id: '123', profileId: 'john_doe' }],
+      variant: 'negative',
+    });
+    expect(wrapper.find('.content-highlighter__user-mention').prop('data-variant')).toEqual('negative');
+  });
+});

--- a/src/components/content-highlighter/content-highlight.test.tsx
+++ b/src/components/content-highlighter/content-highlight.test.tsx
@@ -13,7 +13,6 @@ describe('ContentHighlighter', () => {
     const defaultProps: Properties = {
       message: '',
       mentionedUserIds: [],
-      variant: 'primary',
       ...props,
     };
     return shallow(<ContentHighlighter {...defaultProps} />);

--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -8,6 +8,7 @@ import * as linkifyjs from 'linkifyjs';
 export interface Properties {
   message: string;
   mentionedUserIds?: any[];
+  variant?: 'primary' | 'negative';
 }
 
 export class ContentHighlighter extends React.Component<Properties> {
@@ -40,7 +41,11 @@ export class ContentHighlighter extends React.Component<Properties> {
           props.id = profileId;
         }
 
-        return <span {...props}>{mention}</span>;
+        return (
+          <span data-variant={this.props.variant} {...props}>
+            {mention}
+          </span>
+        );
       }
 
       return part;

--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -8,7 +8,7 @@ import * as linkifyjs from 'linkifyjs';
 export interface Properties {
   message: string;
   mentionedUserIds?: any[];
-  variant?: 'primary' | 'negative';
+  variant?: 'negative';
 }
 
 export class ContentHighlighter extends React.Component<Properties> {

--- a/src/components/content-highlighter/styles.scss
+++ b/src/components/content-highlighter/styles.scss
@@ -1,3 +1,4 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
 @use '../../shared-components/theme-engine/theme' as themeDeprecated;
 
 .content-highlighter {
@@ -9,5 +10,13 @@
     margin-bottom: 0.8px;
     margin-top: 0.8px;
     display: inline-block;
+
+    &[data-variant='negative'] {
+      background-color: unset;
+      color: theme.$color-greyscale-11;
+      padding: 0;
+      border-radius: unset;
+      margin: 0;
+    }
   }
 }

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -153,7 +153,7 @@ export class ConversationItem extends React.Component<Properties> {
             </div>
             <div className={c('content')}>
               <div className={c('message')} is-unread={isUnread}>
-                <ContentHighlighter message={this.message} />
+                <ContentHighlighter message={this.message} variant='negative' />
               </div>
               {hasUnreadMessages && <div className={c('unread-count')}>{conversation.unreadCount}</div>}
             </div>


### PR DESCRIPTION
### What does this do?
- adds a `negative` variant to the content highlighter so mentions are displayed in plain text if variant is set to `negative`.
- adds tests for content-highlighter

### Why are we making this change?
- as per figma desings.

### How do I test this?
- open app, navigate to a conversation and tag a user when composing a message. Send message and check UI in conversation item in sidekick.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

<img width="236" alt="Screenshot 2023-07-10 at 12 24 43" src="https://github.com/zer0-os/zOS/assets/39112648/e14b81d1-e970-4a41-8fc3-67c0094ba81a">

After:

<img width="236" alt="Screenshot 2023-07-10 at 12 24 38" src="https://github.com/zer0-os/zOS/assets/39112648/8c9b3a6a-e2be-4d2d-92d5-dc98ca1f463f">
