### PR TITLE
fix: increase zindex of giphy container

### DIFF
--- a/src/components/message-input/giphy/styles.scss
+++ b/src/components/message-input/giphy/styles.scss
@@ -9,6 +9,7 @@
   padding: 5px;
   border-radius: 5px;
   border: 1px solid themeDeprecated.$input-arrow-color;
+  z-index: 12;
 
   &--fullscreen {
     right: 65px;


### PR DESCRIPTION
### What does this do?
- increase z-index of giphy container so when replying to a message the text is no longer layered above.

### Why are we making this change?
- UI error.

### How do I test this?
- open a chat and select a message to reply to. Open the giphy container next to the message input. Check that the text of the reply message is layered behind the giphy container.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
  Before:
  
<img width="790" alt="Screenshot 2023-07-10 at 21 16 34" src="https://github.com/zer0-os/zOS/assets/39112648/e1bb30d0-251c-48dc-8799-9b01ffc26c5e">

  
  After:

<img width="790" alt="Screenshot 2023-07-10 at 21 17 06" src="https://github.com/zer0-os/zOS/assets/39112648/a7a3f963-8797-4a82-8074-f8e88da0dd23">
