### PR TITLE
Send file based messages even with no text

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -87,6 +87,20 @@ describe('MessageInput', () => {
     expect(onSubmit).toHaveBeenCalledWith('Hello', [], []);
   });
 
+  it('submits message when Enter is pressed and files have been added', () => {
+    const onSubmit = jest.fn();
+    const dropzoneToMedia = (files) => files;
+    const wrapper = subject({ onSubmit, dropzoneToMedia });
+    const dropzone = wrapper.find(Dropzone).shallow();
+
+    const input = dropzone.find(MentionsInput);
+    wrapper.find(Dropzone).simulate('drop', [{ name: 'file1' }]);
+    input.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith('', [], [{ name: 'file1' }]);
+  });
+
   it('submits message when send icon is clicked', () => {
     const onSubmit = jest.fn();
     const wrapper = subject({ onSubmit, placeholder: 'Speak' });

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -34,6 +34,7 @@ export interface Properties extends PublicPropertiesContainer {
     addPasteListener: (listener: EventListenerOrEventListenerObject) => void;
     removePasteListener: (listener: EventListenerOrEventListenerObject) => void;
   };
+  dropzoneToMedia?: (files: any[]) => Media[];
 }
 
 interface State {
@@ -121,7 +122,7 @@ export class MessageInput extends React.Component<Properties, State> {
 
   onSend = (): void => {
     const { mentionedUserIds, value, media } = this.state;
-    if (value) {
+    if (value || media.length) {
       this.props.onSubmit(value, mentionedUserIds, media);
       this.setState({ value: '', mentionedUserIds: [], media: [] });
     }
@@ -226,7 +227,9 @@ export class MessageInput extends React.Component<Properties, State> {
   };
 
   imagesSelected = (acceptedFiles): void => {
-    const newImages: Media[] = dropzoneToMedia(acceptedFiles);
+    const newImages: Media[] = this.props.dropzoneToMedia
+      ? this.props.dropzoneToMedia(acceptedFiles)
+      : dropzoneToMedia(acceptedFiles);
     if (newImages.length) {
       this.mediaSelected(newImages);
     }


### PR DESCRIPTION
### What does this do?

Fixes a bug where we couldn't submit the message when there were only files and no message text.

