### PR TITLE
Move file message sending into the send saga

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { Container } from './chat-view-container';
 import { ChatView } from './chat-view';
 import { Message } from '../../store/messages';
+import { Media } from '../message-input/utils';
 
 describe('ChannelViewContainer', () => {
   const subject = (props: any = {}) => {
@@ -179,25 +180,17 @@ describe('ChannelViewContainer', () => {
     expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ channelId, parentMessage: { id: 'parent' } }));
   });
 
-  it('should call uploadFileMessage when media is uploaded', () => {
-    const uploadFileMessage = jest.fn();
-    const media = [
-      {
-        id: 'id image 1',
-        url: 'url media',
-        name: 'image 1',
-      },
-    ];
+  it('calls sendMessage with files', () => {
+    const sendMessage = jest.fn();
+    const channelId = 'the-channel-id';
 
-    const wrapper = subject({
-      uploadFileMessage,
-      channelId: 'the-channel-id',
-      channel: { hasMore: true, name: 'first channel' },
-    });
+    const wrapper = subject({ sendMessage, channelId, channel: {} });
 
-    wrapper.find(ChatView).first().prop('sendMessage')('', [], media);
+    wrapper.find(ChatView).first().prop('sendMessage')('', [], [{ id: 'file-id', name: 'file-name' } as Media]);
 
-    expect(uploadFileMessage).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId, files: [{ id: 'file-id', name: 'file-name' }] })
+    );
   });
 
   it('should call joinChannel when join button is clicked', () => {

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -143,7 +143,18 @@ describe('ChannelViewContainer', () => {
     });
   });
 
-  it('should call sendMessage when textearea is clicked', () => {
+  it('should not send message if there is no channel id', () => {
+    const sendMessage = jest.fn();
+    const message = 'test message';
+
+    const wrapper = subject({ sendMessage, channel: {} });
+
+    wrapper.find(ChatView).first().prop('sendMessage')(message, [], []);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('should call sendMessage when chat view publishes message', () => {
     const sendMessage = jest.fn();
     const message = 'test message';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -154,20 +154,29 @@ describe('ChannelViewContainer', () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it('should call sendMessage when chat view publishes message', () => {
+  it('calls sendMessage when chat view publishes message', () => {
     const sendMessage = jest.fn();
     const message = 'test message';
     const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
+    const channelId = 'the-channel-id';
 
-    const wrapper = subject({
-      sendMessage,
-      channelId: 'the-channel-id',
-      channel: { hasMore: true, name: 'first channel' },
-    });
+    const wrapper = subject({ sendMessage, channelId, channel: {} });
 
     wrapper.find(ChatView).first().prop('sendMessage')(message, mentionedUserIds, []);
 
-    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ channelId, message, mentionedUserIds }));
+  });
+
+  it('calls sendMessage with parent message a reply is included', () => {
+    const sendMessage = jest.fn();
+    const channelId = 'the-channel-id';
+
+    const wrapper = subject({ sendMessage, channelId, channel: {} });
+
+    wrapper.find(ChatView).simulate('reply', { id: 'parent' });
+    wrapper.find(ChatView).first().prop('sendMessage')('message', [], []);
+
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ channelId, parentMessage: { id: 'parent' } }));
   });
 
   it('should call uploadFileMessage when media is uploaded', () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -185,10 +185,12 @@ export class Container extends React.Component<Properties, State> {
     }
 
     if (this.isNotEmpty(message)) {
-      let payloadSendMessage: PayloadSendMessage = { channelId, message, mentionedUserIds };
-      if (this.state.reply) {
-        payloadSendMessage.parentMessage = this.state.reply;
-      }
+      let payloadSendMessage = {
+        channelId,
+        message,
+        mentionedUserIds,
+        parentMessage: this.state.reply,
+      };
 
       this.props.sendMessage(payloadSendMessage);
       this.removeReply();

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -180,7 +180,11 @@ export class Container extends React.Component<Properties, State> {
 
   handleSendMessage = (message: string, mentionedUserIds: string[] = [], media: Media[] = []): void => {
     const { channelId } = this.props;
-    if (channelId && this.isNotEmpty(message)) {
+    if (!channelId) {
+      return;
+    }
+
+    if (this.isNotEmpty(message)) {
       let payloadSendMessage: PayloadSendMessage = { channelId, message, mentionedUserIds };
       if (this.state.reply) {
         payloadSendMessage.parentMessage = this.state.reply;
@@ -190,7 +194,7 @@ export class Container extends React.Component<Properties, State> {
       this.removeReply();
     }
 
-    if (channelId && media.length) {
+    if (media.length) {
       this.props.uploadFileMessage({ channelId, media });
     }
   };

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -7,7 +7,6 @@ import { setActiveChannelId } from '../../store/chat';
 import {
   fetch as fetchMessages,
   send as sendMessage,
-  uploadFileMessage,
   deleteMessage,
   editMessage,
   Message,
@@ -22,7 +21,6 @@ import {
   EditPayload,
   Payload as PayloadFetchMessages,
   SendPayload as PayloadSendMessage,
-  MediaPayload,
 } from '../../store/messages/saga';
 import { Payload as PayloadJoinChannel } from '../../store/channels/types';
 import { withContext as withAuthenticationContext } from '../authentication/context';
@@ -35,7 +33,6 @@ export interface Properties extends PublicProperties {
   fetchMessages: (payload: PayloadFetchMessages) => void;
   user: AuthenticationState['user'];
   sendMessage: (payload: PayloadSendMessage) => void;
-  uploadFileMessage: (payload: MediaPayload) => void;
   deleteMessage: (payload: PayloadFetchMessages) => void;
   editMessage: (payload: EditPayload) => void;
   joinChannel: (payload: PayloadJoinChannel) => void;
@@ -82,7 +79,6 @@ export class Container extends React.Component<Properties, State> {
     return {
       fetchMessages,
       sendMessage,
-      uploadFileMessage,
       startMessageSync,
       stopSyncChannels,
       deleteMessage,
@@ -184,20 +180,18 @@ export class Container extends React.Component<Properties, State> {
       return;
     }
 
+    let payloadSendMessage = {
+      channelId,
+      message,
+      mentionedUserIds,
+      parentMessage: this.state.reply,
+      files: media,
+    };
+
+    this.props.sendMessage(payloadSendMessage);
+
     if (this.isNotEmpty(message)) {
-      let payloadSendMessage = {
-        channelId,
-        message,
-        mentionedUserIds,
-        parentMessage: this.state.reply,
-      };
-
-      this.props.sendMessage(payloadSendMessage);
       this.removeReply();
-    }
-
-    if (media.length) {
-      this.props.uploadFileMessage({ channelId, media });
     }
   };
 

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -81,7 +81,6 @@ export enum SagaActionTypes {
   EditMessage = 'messages/saga/editMessage',
   startMessageSync = 'messages/saga/startMessageSync',
   stopSyncChannels = 'messages/saga/stopSyncChannels',
-  uploadFileMessage = 'messages/saga/uploadFileMessage',
 }
 
 const fetch = createAction<Payload>(SagaActionTypes.Fetch);
@@ -90,7 +89,6 @@ const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
 const startMessageSync = createAction<Payload>(SagaActionTypes.startMessageSync);
 const stopSyncChannels = createAction<Payload>(SagaActionTypes.stopSyncChannels);
-const uploadFileMessage = createAction<MediaPayload>(SagaActionTypes.uploadFileMessage);
 
 const slice = createNormalizedSlice({
   name: 'messages',
@@ -98,4 +96,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { fetch, send, startMessageSync, stopSyncChannels, deleteMessage, editMessage, uploadFileMessage, removeAll };
+export { fetch, send, startMessageSync, stopSyncChannels, deleteMessage, editMessage, removeAll };

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -1,4 +1,4 @@
-import { Payload, SendPayload, QueryUploadPayload, MediaPayload, EditPayload } from './saga';
+import { Payload, SendPayload, QueryUploadPayload, EditPayload } from './saga';
 import { createAction } from '@reduxjs/toolkit';
 
 import { createNormalizedSlice, removeAll } from '../normalized';

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -29,6 +29,13 @@ describe(send, () => {
       .next()
       .isDone();
   });
+
+  it('ignores empty messages', async () => {
+    const channelId = 'channel-id';
+    const message = '   ';
+
+    testSaga(send, { payload: { channelId, message } }).next().isDone();
+  });
 });
 
 describe(createOptimisticMessage, () => {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -130,6 +130,9 @@ export function* fetch(action) {
 
 export function* send(action) {
   const { channelId, message, mentionedUserIds, parentMessage } = action.payload;
+  if (message.trim() === '') {
+    return;
+  }
 
   const { optimisticMessage } = yield call(createOptimisticMessage, channelId, message, parentMessage);
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -17,7 +17,6 @@ import {
   sendFileMessage,
 } from './api';
 import { FileType, extractLink, getFileType, linkifyType, createOptimisticMessageObject } from './utils';
-import { Media as MediaUtils } from '../../components/message-input/utils';
 import { ParentMessage } from '../../lib/chat/types';
 import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
 import { takeEveryFromBus } from '../../lib/saga';
@@ -62,9 +61,15 @@ export interface SendPayload {
   optimisticId?: string;
 }
 
+interface MediaInfo {
+  nativeFile?: File;
+  giphy?: any;
+  name: string;
+}
+
 export interface MediaPayload {
   channelId?: string;
-  media: MediaUtils[];
+  media: MediaInfo[];
 }
 
 const rawMessagesSelector = (channelId) => (state) => {
@@ -273,7 +278,8 @@ export function* editMessage(action) {
 }
 
 export function* uploadFileMessage(action) {
-  const { channelId, media } = action.payload;
+  const { channelId, media: payloadMedia } = action.payload;
+  const media: { nativeFile: any; giphy: any; name: any }[] = payloadMedia;
 
   let messages = [];
   for (const file of media.filter((i) => i.nativeFile)) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -68,11 +68,6 @@ interface MediaInfo {
   name: string;
 }
 
-export interface MediaPayload {
-  channelId?: string;
-  media: MediaInfo[];
-}
-
 const rawMessagesSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels[${channelId}].messages`, []);
 };


### PR DESCRIPTION
### What does this do?

Moves the sending of file based messages into the general message send saga

### Why are we making this change?

Move towards rendering image based messages with text as a single bubble. This pushes the sending logic into the same place so we can control what gets tied together.

### How do I test this?

Send an image (or other file) message with some messgae text. Ensure all the messages send as usual.

