### PR TITLE
Fix bug where sending an image message would break messages received during upload

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -274,11 +274,7 @@ export function* editMessage(action) {
 export function* uploadFileMessage(action) {
   const { channelId, media } = action.payload;
 
-  const existingMessages = yield select(rawMessagesSelector(channelId));
-
-  if (!media.length) return;
-
-  let messages = [...existingMessages];
+  let messages = [];
   for (const file of media.filter((i) => i.nativeFile)) {
     if (!file.nativeFile) continue;
 
@@ -307,10 +303,18 @@ export function* uploadFileMessage(action) {
     messages.push(messageResponse.body);
   }
 
+  if (!messages.length) {
+    return;
+  }
+
+  const existingMessages = yield select(rawMessagesSelector(channelId));
   yield put(
     receive({
       id: channelId,
-      messages,
+      messages: [
+        ...existingMessages,
+        ...messages,
+      ],
     })
   );
 }


### PR DESCRIPTION
### What does this do?

Adds newly uploaded file based messages to the channel message list as of the time of completion.

### Why are we making this change?

There was a bug previously where if you uploaded a file based message and new messages came in while those files were uploading the converstion messages would get overwritten with the old state when the image uploads finally finished.

### How do I test this?

Send file based messages and verify that things still work

