### PR TITLE
Fix issue where multiple image uploads would render an image twice

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -298,12 +298,15 @@ export function* uploadFileMessage(action) {
     return;
   }
 
-  const existingMessages = yield select(rawMessagesSelector(channelId));
+  const existingMessageIds = yield select(rawMessagesSelector(channelId));
+  // Remove messages already received from the real time events
+  // This should simplify when we implement optimistic rendering
+  messages = messages.filter((m) => !existingMessageIds.includes(m.id));
   yield put(
     receive({
       id: channelId,
       messages: [
-        ...existingMessages,
+        ...existingMessageIds,
         ...messages,
       ],
     })


### PR DESCRIPTION
### What does this do?

This ensures we don't add image messages to the channel if they've already been added (usually because of a real time event happening in between).

### Why are we making this change?

Bug fix

