### PR TITLE
Remove tooltip from hover on '+' New Conversation button 

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -91,11 +91,9 @@ export class ConversationListPanel extends React.Component<Properties, State> {
               placeholder='Search'
               value={this.state.filter}
             />
-            <Tooltip placement='left' overlay='Create Zero Message'>
-              <div className='messages-list__items-conversations-new'>
-                <IconButton Icon={IconPlus} onClick={this.props.startConversation} size={24} />
-              </div>
-            </Tooltip>
+            <div className='messages-list__items-conversations-new'>
+              <IconButton Icon={IconPlus} onClick={this.props.startConversation} size={24} />
+            </div>
           </div>
 
           <ScrollbarContainer variant='on-hover'>

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import Tooltip from '../../tooltip';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { Channel } from '../../../store/channels';
 import { IconPlus, IconUserPlus1 } from '@zero-tech/zui/icons';


### PR DESCRIPTION
This tooltip has been removed

<img width="578" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6b7f6ddc-b111-4185-a649-2f33cad819b5">
