### PR TITLE
Remove `ChatConnect` (Connection Lost message)

### DIFF
--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -9,7 +9,6 @@ import { Main } from './Main';
 import { Apps } from './lib/apps';
 import { Create as CreateAccount } from './components/account/create';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { ChatConnect } from './components/chat-connect/chat-connect';
 
 export interface Properties {
   setRoute: (routeApp: { route: string; hasAppChanged: boolean }) => void;
@@ -97,7 +96,6 @@ export class Container extends React.Component<Properties> {
       <>
         <CreateAccount />
         <AuthenticationContextProvider value={this.authenticationContext}>
-          <ChatConnect />
           <Main />
         </AuthenticationContextProvider>
       </>


### PR DESCRIPTION
### What does this do?

Removes this message

<img width="801" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2b010f6d-a7eb-485b-bd02-67a693143ace">

NOTE: I haven't removed the actual component, just it's usage (since we may need it later)
