### PR TITLE
Set the rootMessageId on the first media file in message list

### DIFF
--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -91,6 +91,7 @@ function extractMessageData(jsonData, isMediaMessage) {
   let media;
   let admin;
   let optimisticId = '';
+  let rootMessageId = '';
 
   try {
     const data = jsonData ? JSON.parse(jsonData) : {};
@@ -103,6 +104,7 @@ function extractMessageData(jsonData, isMediaMessage) {
     hidePreview = data.hidePreview || false;
     admin = data.admin || {};
     optimisticId = data.optimisticId || '';
+    rootMessageId = data.rootMessageId || '';
   } catch (e) {}
 
   return {
@@ -112,6 +114,7 @@ function extractMessageData(jsonData, isMediaMessage) {
     image: media?.type === 'image' ? media : undefined,
     admin,
     optimisticId,
+    rootMessageId,
   };
 }
 

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -65,8 +65,10 @@ export async function editMessageApi(
   return response.status;
 }
 
-export async function uploadFileMessage(channelId: string, media: File): Promise<Media> {
-  const response = await post<any>(`/upload/chatChannels/${channelId}/message`).attach('file', media);
+export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = ''): Promise<Media> {
+  const response = await post<any>(`/upload/chatChannels/${channelId}/message`)
+    .field('rootMessageId', rootMessageId)
+    .attach('file', media);
 
   return response.body;
 }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -67,6 +67,7 @@ export interface Message {
     inviteeId?: string;
   };
   optimisticId?: string;
+  rootMessageId?: string;
 }
 
 export interface EditMessageOptions {


### PR DESCRIPTION
### What does this do?

Sets the rootMessageId on the first media file when a message with both text and media files is sent.

Note: This does not yet render the messages as a single bubble.

### Why are we making this change?

This will allow us to later render the two messages as a single bubble.

### How do I test this?

Send a message with both text and an image. Verify the network request sends the rootMessageId on the first image message sent.
