### PR TITLE
fix: message input hidden text when multiline

### DIFF
--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -39,7 +39,7 @@
     display: flex;
     align-items: flex-end;
     gap: 16px;
-    align-self: stretch;
+    width: 100%;
   }
 
   &__icon-outer {
@@ -81,12 +81,12 @@
 
   &__chat-container {
     display: flex;
-    padding: 8px 1px 8px 16px;
+    padding: 7px 0px 7px 16px;
     flex-direction: column;
     justify-content: center;
     align-items: flex-end;
     gap: 8px;
-    flex: 1 0 0;
+    width: 100%;
 
     background-color: theme.$color-primary-1;
     border: 1px solid theme.$color-greyscale-6;
@@ -110,16 +110,12 @@
     justify-content: flex-end;
     align-items: center;
     gap: 8px;
-    flex-shrink: 0;
-    align-self: stretch;
   }
 
   &__mentions-text-area {
     display: flex;
     flex-direction: column;
     flex: 1 0 0;
-    font-size: 14px;
-    line-height: 17px;
 
     &__wrap {
       &__suggestions {
@@ -133,6 +129,11 @@
     position: relative;
     overflow-y: visible;
 
+    &__control {
+      font-size: 14px;
+      line-height: 17px;
+    }
+
     &__highlighter {
       position: relative;
       box-sizing: border-box;
@@ -142,7 +143,7 @@
       white-space: pre-wrap;
       background: transparent;
       overflow-wrap: break-word;
-      border: 1px solid transparent;
+      border: none !important;
       text-align: start;
 
       &__substring {
@@ -155,11 +156,8 @@
     textarea {
       color: theme.$color-greyscale-12;
       word-break: break-word;
-      font-size: 14px !important;
-      line-height: 17px;
-      font-weight: 400;
       outline: none;
-      border: 1px solid transparent;
+      border: none;
     }
 
     &__input {
@@ -178,6 +176,8 @@
       bottom: 0px;
       overflow: hidden;
       resize: none;
+      border: none;
+      padding: 0px;
     }
 
     &__suggestions {


### PR DESCRIPTION
### What does this do?
- fixes bug raised by product where some multiline text can be hidden when typing into the message input. 
- removes some hidden borders
- correctly sets font size and line height of text in input

### Why are we making this change?
- ui and ux enhancement
- bug fix

### How do I test this?
- type a range of long and short strings into the message input and check the correct behaviour is occurring. No text should ever be hidden unless scroll is triggered at max height of 200px.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before: 


https://github.com/zer0-os/zOS/assets/39112648/dd9df5d4-5fd6-4acc-8b4d-625e5b360016


After:

https://github.com/zer0-os/zOS/assets/39112648/d9477d6c-0a5e-4866-b3ae-c73f2cfab370

