### PR TITLE
fix: message input break long string

### DIFF
--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -147,6 +147,8 @@
 
       &__substring {
         visibility: hidden;
+        overflow-wrap: break-word;
+        word-break: break-word;
       }
 
       @include tag-highlight;


### PR DESCRIPTION
### What does this do?
Fixes this problem that's existed for some time:

BEFORE FIX:

https://github.com/zer0-os/zOS/assets/39112648/328e5f45-edcb-4ac7-8ef2-08ef9ad52e21

### Why are we making this change?
- this is a bug that breaks the UI.

### How do I test this?
- Type a long unbroken string into a message input and check the width of the input does not expand.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


AFTER FIX:

https://github.com/zer0-os/zOS/assets/39112648/37522653-477a-4887-82d5-b8cb28b8a2a4

