### PR TITLE
feat: basic changes to composing a message mention highlights

### DIFF
--- a/src/components/message-input/mentions-config.ts
+++ b/src/components/message-input/mentions-config.ts
@@ -15,7 +15,7 @@ export const userMentionsConfig: MentionsConfig = {
   //eslint-disable-next-line
   regexGlobal: /@\[(.+?)\]\(user:([A-Za-z0-9_\-]+)\)/gi,
   displayTransform: (_, display) => {
-    return `${display}`;
+    return `${display.trim()}`;
   },
 };
 

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -17,8 +17,9 @@
 @mixin tag-highlight() {
   mark,
   strong {
+    background-color: theme.$color-primary-9 !important;
     animation: fade-background-in 200ms ease-in forwards;
-    color: themeDeprecated.$text-on-accent;
+    border-radius: 4px;
   }
   mark {
     padding: 3px;

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -17,7 +17,7 @@
 @mixin tag-highlight() {
   mark,
   strong {
-    background-color: theme.$color-primary-9 !important;
+    background-color: theme.$color-primary-7 !important;
     animation: fade-background-in 200ms ease-in forwards;
     border-radius: 4px;
   }


### PR DESCRIPTION
### What does this do?
- after some investigating and trial and error, these changes are likely the best we can do at this time with highlighting mentions whilst composing a message due to the restrictions of react-mentions and the figma design.

Demo shows latest changes and what it looked like before:

https://github.com/zer0-os/zOS/assets/39112648/72373924-8e8a-40e1-941b-fd2e56a7bba5

