### PR TITLE
Group conversation messages shouldn't fill the max width

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -203,7 +203,6 @@ export class Message extends React.Component<Properties, State> {
         className={classNames('message', this.props.className, {
           'message--owner': isOwner,
           'message--media': Boolean(media),
-          'message--sender-avatar': this.props.showSenderAvatar,
         })}
       >
         {this.props.showSenderAvatar && (

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -52,13 +52,6 @@
     }
   }
 
-  &--sender-avatar {
-    .message__block {
-      flex: 1;
-      z-index: 1;
-    }
-  }
-
   &__block {
     background-color: theme.$color-primary-3;
     border-radius: 8px 8px 8px 0px;


### PR DESCRIPTION
### What does this do?

Fixes the issue where group conversation messages were filling the max width available rather than being limited to the size of the content.

Before:
![image](https://github.com/zer0-os/zOS/assets/43770/bc9414a1-55e6-41ac-9de3-692644734614)

After:
![image](https://github.com/zer0-os/zOS/assets/43770/061c80f7-ae0d-44f0-bbe9-d38b855c9f92)
