### PR TITLE
Remove the extra block-body css class usage

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -245,7 +245,6 @@ export class Message extends React.Component<Properties, State> {
               {!!this.props.updatedAt && !this.state.isEditing && <span {...cn('block-edited')}>(edited)</span>}
               {this.state.isEditing && this.props.message && (
                 <MessageInput
-                  {...cn('block-body')}
                   initialValue={this.props.message}
                   onSubmit={this.editMessage}
                   getUsersForMentions={this.props.getUsersForMentions}


### PR DESCRIPTION
### What does this do?

Removes the usage of a css class `block-body` as it was also used above and this caused confusion (and risk).

Tested rendering of the message and editing a message and it seems to have no impact.
