### PR TITLE
Render image message with text

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -58,6 +58,21 @@ describe('ChannelViewContainer', () => {
     expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([]);
   });
 
+  it('groups message media with rootId onto parent message', () => {
+    const messages = [
+      { id: 'message-root', message: 'what', rootMessageId: '' },
+      { id: 'message-two', message: 'hello', rootMessageId: '' },
+      { id: 'message-child', message: 'what', rootMessageId: 'message-root', media: { some: 'media' } },
+    ];
+
+    const wrapper = subject({ channel: { messages } });
+
+    expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([
+      { id: 'message-root', message: 'what', rootMessageId: '', media: { some: 'media' } },
+      { id: 'message-two', message: 'hello', rootMessageId: '' },
+    ]);
+  });
+
   it('passes channel name to child', () => {
     const wrapper = subject({ channel: { name: 'first channel' } });
 

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -244,6 +244,8 @@ export class Container extends React.Component<Properties, State> {
   get messages() {
     const messagesById = {};
     const messages = [];
+    // Assumption is that messages are already ordered by date and that
+    // the "child" message will always come after the "parent" message.
     (this.channel?.messages || []).forEach((m) => {
       if (m.rootMessageId) {
         // Add the media piece of the "child" message to the "parent" message.

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -241,6 +241,25 @@ export class Container extends React.Component<Properties, State> {
     }
   };
 
+  get messages() {
+    const messagesById = {};
+    const messages = [];
+    (this.channel?.messages || []).forEach((m) => {
+      if (m.rootMessageId) {
+        // Add the media piece of the "child" message to the "parent" message.
+        if (messagesById[m.rootMessageId]) {
+          messagesById[m.rootMessageId].media = m.media;
+        }
+      } else {
+        // Hmm... not sure how we ended up with integers as our message ids. For now, just cast to a string.
+        messagesById[m.id.toString()] = m;
+        messages.push(m);
+      }
+    });
+
+    return messages;
+  }
+
   render() {
     if (!this.props.channel) return null;
 
@@ -251,7 +270,7 @@ export class Container extends React.Component<Properties, State> {
           id={this.channel.id}
           name={this.channel.name}
           isMessengerFullScreen={this.props.isMessengerFullScreen}
-          messages={this.channel.messages || []}
+          messages={this.messages}
           hasLoadedMessages={this.channel.hasLoadedMessages ?? false}
           onFetchMore={this.fetchMore}
           user={this.props.user.data}

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -127,7 +127,9 @@
     width: 100%;
 
     img {
-      width: 100%;
+      display: block;
+      margin: auto;
+      max-width: 100%;
       border-radius: 8px;
     }
   }


### PR DESCRIPTION
### What does this do?

Renders a media message that has a root message as a single message bubble.

Side effects include:
1. Deleting the message only deletes the text message. This means that mobile would still show the image.
2. Until mobile makes changes, these would still show as separate messages on mobile.
3. Cannot edit the text (because we don't allow editing with media)
4. The "last message" preview still shows "You: sent an image"

### Why are we making this change?

Better experience

### How do I test this?

Attach an image (or movie) to a message and type some text. When rendered it should appear as a single message bubble.

![image](https://github.com/zer0-os/zOS/assets/43770/b32f5b54-f870-479b-971e-c70a89c8feb7)
