### PR TITLE
Delete multi-part messages fully

### DIFF
--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -1,11 +1,10 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { fetchMessagesByChannelId, deleteMessageApi, editMessageApi } from './api';
+import { fetchMessagesByChannelId, editMessageApi } from './api';
 import {
   fetchNewMessages,
   stopSyncChannels,
-  deleteMessage,
   receiveDelete,
   editMessage,
   getPreview,
@@ -147,46 +146,6 @@ describe('messages saga', () => {
       .withReducer(rootReducer)
       .call(editMessageApi, channelId, messageIdToEdit, message, mentionedUserIds, undefined)
       .run();
-  });
-
-  it('delete message', async () => {
-    const channelId = '280251425_833da2e2748a78a747786a9de295dd0c339a2d95';
-    const messages = [
-      { id: 1, message: 'This is my first message' },
-      { id: 2, message: 'I will delete this message' },
-      { id: 3, message: 'This is my third message' },
-    ];
-
-    const messageIdToDelete = messages[1].id;
-
-    const initialState = {
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            messages: messages.map((m) => m.id),
-          },
-        },
-        messages,
-      },
-    };
-
-    const {
-      storeState: { normalized },
-    } = await expectSaga(deleteMessage, { payload: { channelId, messageId: messageIdToDelete } })
-      .withReducer(rootReducer, initialState as any)
-      .provide([
-        [
-          matchers.call.fn(deleteMessageApi),
-          200,
-        ],
-      ])
-      .run();
-
-    expect(normalized.channels[channelId].messages).toEqual([
-      messages[0].id,
-      messages[2].id,
-    ]);
   });
 
   it('receive delete message', async () => {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -259,6 +259,10 @@ export function* deleteMessage(action) {
     })
   );
 
+  // In the future we'd prefer that the api did this so that the front-ends
+  // could treat these as independent messages. However, given that we have
+  // multiple front ends and they don't all support treating these messages
+  // as a single entity yet, this is how we'll do it for now.
   for (let id of messageIdsToDelete) {
     yield call(deleteMessageApi, channelId, id);
   }

--- a/src/store/messages/test/helpers.ts
+++ b/src/store/messages/test/helpers.ts
@@ -1,0 +1,11 @@
+import { normalize as normalizeChannel } from '../../channels';
+import { RootState } from '../../reducer';
+
+export function existingChannelState(channel) {
+  const normalized = normalizeChannel(channel);
+  return {
+    normalized: {
+      ...normalized.entities,
+    },
+  } as RootState;
+}


### PR DESCRIPTION
### What does this do?

When you delete a message this will find all the associated child messages and delete them too.

### Why are we making this change?

So the user doesn't know that there are multiple messages behind the scenes and can clean up appropriately.

### How do I test this?

Create a media message with text and then delete it. Verify that 2 network calls are made to delete both the text message and the media message.

