### PR TITLE
Render child messages if the parent is not found

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -73,6 +73,22 @@ describe('ChannelViewContainer', () => {
     ]);
   });
 
+  it('messages with rootMessageId but no parent found are still included', () => {
+    const messages = [
+      { id: 'message-one', message: 'what', rootMessageId: '' },
+      { id: 'message-two', message: 'hello', rootMessageId: '' },
+      { id: 'message-child', message: 'what', rootMessageId: 'message-root', media: { some: 'media' } },
+    ];
+
+    const wrapper = subject({ channel: { messages } });
+
+    expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([
+      { id: 'message-one', message: 'what', rootMessageId: '' },
+      { id: 'message-two', message: 'hello', rootMessageId: '' },
+      { id: 'message-child', message: 'what', rootMessageId: 'message-root', media: { some: 'media' } },
+    ]);
+  });
+
   it('passes channel name to child', () => {
     const wrapper = subject({ channel: { name: 'first channel' } });
 

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -247,11 +247,8 @@ export class Container extends React.Component<Properties, State> {
     // Assumption is that messages are already ordered by date and that
     // the "child" message will always come after the "parent" message.
     (this.channel?.messages || []).forEach((m) => {
-      if (m.rootMessageId) {
-        // Add the media piece of the "child" message to the "parent" message.
-        if (messagesById[m.rootMessageId]) {
-          messagesById[m.rootMessageId].media = m.media;
-        }
+      if (m.rootMessageId && messagesById[m.rootMessageId]) {
+        messagesById[m.rootMessageId].media = m.media;
       } else {
         // Hmm... not sure how we ended up with integers as our message ids. For now, just cast to a string.
         messagesById[m.id.toString()] = m;


### PR DESCRIPTION
### What does this do?

Previously we were hiding child messages if the parent didn't exist because it probably happened due to a deletion. But now we properly delete the messages as a group so this should work as expected for the user on the web interface. However, since mobile does not yet treat these as a single message it is possible to delete the parent and not the child. In this case, we'd want to still see the child in the web to be consistent with the view the user sees in mobile.

