### PR TITLE
Don't mangle tall images

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -56,18 +56,9 @@
     z-index: 1;
 
     &--fill {
-      width: 100%;
-
       .message__block-image {
-        // 5:4 aspect ratio
-        overflow: hidden;
-        height: 0;
-        padding-bottom: 125%;
-
         img {
-          position: absolute;
-          height: 100%;
-          object-fit: cover;
+          max-height: 640px;
         }
       }
     }


### PR DESCRIPTION
### What does this do?

Changes the "tall" image rendering to just show it with a max height of 640px

