### PR TITLE
Fix rendering of messages in "Group Chat"

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -174,7 +174,7 @@
   }
 
   &__author-avatar {
-    display: none;
+    visibility: hidden;
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -193,7 +193,7 @@
 
   &.messages__message--last-in-group {
     .message__author-avatar {
-      display: block;
+      visibility: visible;
     }
   }
 


### PR DESCRIPTION
Position of some message bubbles isn't correct when rendering messages in group chat

Before
<img width="306" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/63682218-bddc-469a-bab4-ad92c413b819">
<img width="122" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2ae97e1e-ffb4-418b-8109-db8292613639">

After
<img width="140" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/0c2929c1-5162-455b-b8fc-7188f5eddcd1">
<img width="238" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6d69665c-901f-47ce-aba0-fa461cf4e95b">
