### PR TITLE
Implement ability to search groups via group name in the conversation list sidebar

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel.test.tsx
@@ -62,6 +62,55 @@ describe('ConversationListPanel', () => {
     ]);
   });
 
+  it('renders conversation group names as well in the filtered conversation list', function () {
+    const conversations = [
+      { id: 'convo-id-1', name: '', otherMembers: [{ firstName: 'test' }] },
+      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }] },
+      {
+        id: 'convo-id-3',
+        name: 'Test Group',
+        otherMembers: [
+          { firstName: 'name-1' },
+          { firstName: 'name-2' },
+        ],
+      },
+      {
+        id: 'convo-id-4',
+        name: 'My Awesome group',
+        otherMembers: [
+          { firstName: 'name-1' },
+          { firstName: 'name-2' },
+        ],
+      },
+    ];
+
+    const wrapper = subject({ conversations: conversations as any });
+
+    let displayChatNames = renderedConversations(wrapper).map((c) => c.id);
+    expect(displayChatNames).toStrictEqual([
+      'convo-id-1',
+      'convo-id-2',
+      'convo-id-3',
+      'convo-id-4',
+    ]);
+
+    // change to -> 'test'
+    wrapper.find('Input').simulate('change', 'test');
+    displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual([
+      '', // convo-id-1 chat (one-2-one)
+      'Test Group',
+    ]);
+
+    // change to -> 'Group'
+    wrapper.find('Input').simulate('change', 'Group');
+    displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual([
+      'Test Group',
+      'My Awesome group',
+    ]);
+  });
+
   it('renders user search results', async function () {
     const search = jest.fn();
     search.mockResolvedValue([

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -57,8 +57,11 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     }
 
     const searchRegEx = new RegExp(escapeRegExp(this.state.filter), 'i');
-    return this.props.conversations.filter((conversation) =>
-      searchRegEx.test(otherMembersToString(conversation.otherMembers))
+    return this.props.conversations.filter(
+      (conversation) =>
+        conversation.otherMembers.length === 1
+          ? searchRegEx.test(otherMembersToString(conversation.otherMembers)) // for one-to-one
+          : searchRegEx.test(conversation.name ?? '') // for group
     );
   }
 


### PR DESCRIPTION
Before (search results does not show groups)

<img width="315" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/490380b6-e5be-4592-b6cf-4e987fcb2d72">

<img width="330" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/d98dc995-9994-4e1b-81e1-ba471d2f285b">

After

<img width="373" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/e8c6ff75-bdfc-465f-a846-78fac168daf7">

<img width="319" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/a8ec21ad-60fe-4a61-a409-cbe51b6e01ff">