### PR TITLE
Refactor: Extract uploadable file class

### DIFF
--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -42,7 +42,7 @@ export async function sendMessagesByChannelId(
 
   const response = await post<any>(`/chatChannels/${channelId}/message`).send(data);
 
-  return response;
+  return response.body;
 }
 
 export async function deleteMessageApi(channelId: string, messageId: number): Promise<number> {

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -136,7 +136,7 @@ describe(performSend, () => {
   it('returns the new message information', async () => {
     const { returnValue } = await expectSaga(performSend, 'channel-id', '', null, null, '')
       .provide([
-        stubResponse(matchers.call.fn(sendMessagesByChannelId), { body: { id: 'new-id' } }),
+        stubResponse(matchers.call.fn(sendMessagesByChannelId), { id: 'new-id' }),
       ])
       .run();
 
@@ -160,7 +160,8 @@ describe(performSend, () => {
     const { storeState } = await expectSaga(performSend, channelId, message, [], null, 'optimistic-id')
       .provide([
         stubResponse(matchers.call.fn(sendMessagesByChannelId), {
-          body: { id: 'new-id', optimisticId: 'optimistic-id' },
+          id: 'new-id',
+          optimisticId: 'optimistic-id',
         }),
         ...successResponses(),
       ])
@@ -296,6 +297,6 @@ function existingChannelState(channel) {
 
 function successResponses() {
   return [
-    stubResponse(matchers.call.fn(sendMessagesByChannelId), { status: 200, body: { id: 'message 1', message: {} } }),
+    stubResponse(matchers.call.fn(sendMessagesByChannelId), { id: 'message 1', message: {} }),
   ];
 }

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -9,7 +9,7 @@ import {
   messageSendFailed,
   performSend,
   send,
-  uploadFileMessage,
+  uploadFileMessages,
 } from './saga';
 import { RootState, rootReducer } from '../reducer';
 import { stubResponse } from '../../test/saga';
@@ -51,7 +51,7 @@ describe(send, () => {
 
     testSaga(send, { payload: { channelId, files } })
       .next()
-      .call(uploadFileMessage, { payload: { channelId, media: files, rootMessageId: '' } })
+      .call(uploadFileMessages, channelId, files, '')
       .next()
       .isDone();
   });
@@ -66,7 +66,7 @@ describe(send, () => {
       .next({ optimisticMessage: { id: 'optimistic-message-id' } })
       .next()
       .next({ id: 'root-id' })
-      .call(uploadFileMessage, { payload: { channelId, media: files, rootMessageId: 'root-id' } })
+      .call(uploadFileMessages, channelId, files, 'root-id')
       .next()
       .isDone();
   });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -308,20 +308,20 @@ export function* uploadFileMessages(
 ) {
   let messages = [];
   for (const file of media) {
+    let newMessage;
     if (file.nativeFile && getFileType(file.nativeFile) === FileType.Media) {
-      const messagesResponse = yield call(uploadFileMessageApi, channelId, file.nativeFile, rootMessageId);
-      rootMessageId = ''; // only the first media file should connect to the root message for now.
-      messages.push(messagesResponse);
+      newMessage = yield call(uploadFileMessageApi, channelId, file.nativeFile, rootMessageId);
     } else if (file.giphy) {
       const original = file.giphy.images.original;
       const giphyFile = { url: original.url, name: file.name, type: file.giphy.type };
-      const messageResponse = yield call(sendFileMessage, channelId, giphyFile);
-      messages.push(messageResponse);
+      newMessage = yield call(sendFileMessage, channelId, giphyFile);
     } else {
       const uploadResponse = yield call(uploadAttachment, file.nativeFile);
-      const messagesResponse = yield call(sendFileMessage, channelId, uploadResponse);
-      messages.push(messagesResponse);
+      newMessage = yield call(sendFileMessage, channelId, uploadResponse);
     }
+
+    rootMessageId = ''; // only the first file should connect to the root message for now.
+    messages.push(newMessage);
   }
 
   if (!messages.length) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -179,7 +179,7 @@ export function* createOptimisticPreview(channelId: string, optimisticMessage) {
 
 export function* performSend(channelId, message, mentionedUserIds, parentMessage, optimisticId) {
   try {
-    const result = yield call(
+    const createdMessage = yield call(
       sendMessagesByChannelId,
       channelId,
       message,
@@ -189,7 +189,6 @@ export function* performSend(channelId, message, mentionedUserIds, parentMessage
       optimisticId
     );
     const existingMessageIds = yield select(rawMessagesSelector(channelId));
-    const createdMessage = result.body;
     const messages = yield call(replaceOptimisticMessage, existingMessageIds, createdMessage);
     if (messages) {
       yield put(receive({ id: channelId, messages: messages }));
@@ -317,11 +316,11 @@ export function* uploadFileMessages(
       const original = file.giphy.images.original;
       const giphyFile = { url: original.url, name: file.name, type: file.giphy.type };
       const messageResponse = yield call(sendFileMessage, channelId, giphyFile);
-      messages.push(messageResponse.body);
+      messages.push(messageResponse);
     } else {
       const uploadResponse = yield call(uploadAttachment, file.nativeFile);
       const messagesResponse = yield call(sendFileMessage, channelId, uploadResponse);
-      messages.push(messagesResponse.body);
+      messages.push(messagesResponse);
     }
   }
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -311,7 +311,7 @@ export function* uploadFileMessages(
 
   let messages = [];
   for (const uploadableFile of uploadableFiles) {
-    messages.push(yield uploadableFile.upload(channelId, null, rootMessageId));
+    messages.push(yield uploadableFile.upload(channelId, rootMessageId));
     rootMessageId = ''; // only the first file should connect to the root message for now.
   }
 
@@ -346,14 +346,14 @@ const createUploadableFile = (file) => {
 
 class UploadableMedia {
   constructor(private file) {}
-  *upload(channelId, _file, rootMessageId) {
+  *upload(channelId, rootMessageId) {
     return yield call(uploadFileMessageApi, channelId, this.file.nativeFile, rootMessageId);
   }
 }
 
 class UploadableGiphy {
   constructor(private file) {}
-  *upload(channelId, _file, _rootMessageId) {
+  *upload(channelId, _rootMessageId) {
     const original = this.file.giphy.images.original;
     const giphyFile = { url: original.url, name: this.file.name, type: this.file.giphy.type };
     return yield call(sendFileMessage, channelId, giphyFile);
@@ -362,7 +362,7 @@ class UploadableGiphy {
 
 class UploadableAttachment {
   constructor(private file) {}
-  *upload(channelId, _file, _rootMessageId) {
+  *upload(channelId, _rootMessageId) {
     const uploadResponse = yield call(uploadAttachment, this.file.nativeFile);
     return yield call(sendFileMessage, channelId, uploadResponse);
   }

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -22,7 +22,6 @@ import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { ChannelEvents, conversationsChannel } from '../channels-list/channels';
-import { create } from 'lodash';
 
 export interface Payload {
   channelId: string;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -144,7 +144,7 @@ export function* send(action) {
   }
 
   if (files?.length) {
-    yield call(uploadFileMessage, { payload: { channelId, media: files, rootMessageId } });
+    yield call(uploadFileMessages, channelId, files, rootMessageId);
   }
 }
 
@@ -302,10 +302,11 @@ export function* editMessage(action) {
   }
 }
 
-export function* uploadFileMessage(action) {
-  const { channelId, media: payloadMedia, rootMessageId = '' } = action.payload;
-  const media: { nativeFile: any; giphy: any; name: any }[] = payloadMedia;
-
+export function* uploadFileMessages(
+  channelId = null,
+  media: { nativeFile?: any; giphy: any; name: any }[] = null,
+  rootMessageId = ''
+) {
   let root = rootMessageId;
   let messages = [];
   for (const file of media.filter((i) => i.nativeFile)) {

--- a/src/store/messages/saga.uploadFileMessage.test.ts
+++ b/src/store/messages/saga.uploadFileMessage.test.ts
@@ -63,7 +63,7 @@ describe(uploadFileMessages, () => {
       url: 'file-url',
       type: 'file',
     } as FileUploadResult;
-    const messageSendResponse = { body: { id: 'new-id' } };
+    const messageSendResponse = { id: 'new-id' };
 
     const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
 
@@ -87,7 +87,7 @@ describe(uploadFileMessages, () => {
       giphy: { images: { original: { url: 'url_giphy' } }, type: 'gif' },
     };
     const expectedFileToSend = { url: 'url_giphy', name: 'giphy-file', type: 'gif' };
-    const messageSendResponse = { body: { id: 'new-id' } };
+    const messageSendResponse = { id: 'new-id' };
 
     const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
 

--- a/src/store/messages/saga.uploadFileMessage.test.ts
+++ b/src/store/messages/saga.uploadFileMessage.test.ts
@@ -2,16 +2,16 @@ import { expectSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { FileUploadResult, uploadFileMessage } from './saga';
+import { FileUploadResult, uploadFileMessages } from './saga';
 
 import { sendFileMessage, uploadAttachment, uploadFileMessage as uploadFileMessageApi } from './api';
 import { RootState, rootReducer } from '../reducer';
 import { stubResponse } from '../../test/saga';
 import { denormalize as denormalizeChannel, normalize as normalizeChannel } from '../channels';
 
-describe(uploadFileMessage, () => {
+describe(uploadFileMessages, () => {
   it('does nothing if there are no files', async () => {
-    await expectSaga(uploadFileMessage, { payload: { channelId: 'id', media: [] } })
+    await expectSaga(uploadFileMessages, 'id', [])
       .not.call.fn(uploadFileMessageApi)
       .not.call.fn(uploadAttachment)
       .not.call.fn(sendFileMessage)
@@ -25,7 +25,7 @@ describe(uploadFileMessage, () => {
 
     const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
 
-    const { storeState } = await expectSaga(uploadFileMessage, { payload: { channelId, media: [imageFile] } })
+    const { storeState } = await expectSaga(uploadFileMessages, channelId, [imageFile])
       .provide([stubResponse(call(uploadFileMessageApi, channelId, imageFile.nativeFile, ''), imageCreationResponse)])
       .withReducer(rootReducer, initialState as any)
       .run();
@@ -45,7 +45,7 @@ describe(uploadFileMessage, () => {
       imageFile1,
       imageFile2,
     ];
-    await expectSaga(uploadFileMessage, { payload: { channelId, media, rootMessageId } })
+    await expectSaga(uploadFileMessages, channelId, media, rootMessageId)
       .provide([
         stubResponse(matchers.call.fn(uploadFileMessageApi), {}),
       ])
@@ -67,7 +67,7 @@ describe(uploadFileMessage, () => {
 
     const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
 
-    const { storeState } = await expectSaga(uploadFileMessage, { payload: { channelId, media: [pdfFile] } })
+    const { storeState } = await expectSaga(uploadFileMessages, channelId, [pdfFile])
       .provide([
         stubResponse(call(uploadAttachment, pdfFile.nativeFile), fileUploadResult),
         stubResponse(call(sendFileMessage, channelId, fileUploadResult), messageSendResponse),
@@ -91,7 +91,7 @@ describe(uploadFileMessage, () => {
 
     const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
 
-    const { storeState } = await expectSaga(uploadFileMessage, { payload: { channelId, media: [giphy] } })
+    const { storeState } = await expectSaga(uploadFileMessages, channelId, [giphy])
       .provide([
         stubResponse(call(sendFileMessage, channelId, expectedFileToSend as any), messageSendResponse),
       ])


### PR DESCRIPTION
### What does this do?

Refactors the `uploadFileMessage` saga into specific handler classes.

### Why are we making this change?

Tidying up in preparation for optimistic rendering of file uploads. This condences the outer controlling logic and allows the differences to be more easily viewed/adjusted.

### How do I test this?

Upload various combinations of things

