### PR TITLE
Move some upload logic around

### DIFF
--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -2,7 +2,7 @@ import { AttachmentResponse } from '../../lib/api/attachment';
 import { del, get, post, put } from '../../lib/api/rest';
 import { ParentMessage } from '../../lib/chat/types';
 import { LinkPreview } from '../../lib/link-preview';
-import { AttachmentUploadResult, EditMessageOptions, Media, MessagesResponse } from './index';
+import { AttachmentUploadResult, EditMessageOptions, MessagesResponse } from './index';
 import { FileUploadResult, SendPayload } from './saga';
 import axios from 'axios';
 
@@ -65,7 +65,7 @@ export async function editMessageApi(
   return response.status;
 }
 
-export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = ''): Promise<Media> {
+export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = '') {
   const response = await post<any>(`/upload/chatChannels/${channelId}/message`)
     .field('rootMessageId', rootMessageId)
     .attach('file', media);

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -11,17 +11,15 @@ import {
   fetchMessagesByChannelId,
   sendMessagesByChannelId,
   editMessageApi,
-  uploadFileMessage as uploadFileMessageApi,
   getLinkPreviews,
-  uploadAttachment,
-  sendFileMessage,
 } from './api';
-import { FileType, extractLink, getFileType, linkifyType, createOptimisticMessageObject } from './utils';
+import { extractLink, linkifyType, createOptimisticMessageObject } from './utils';
 import { ParentMessage } from '../../lib/chat/types';
 import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { ChannelEvents, conversationsChannel } from '../channels-list/channels';
+import { createUploadableFile } from './uploadable';
 
 export interface Payload {
   channelId: string;
@@ -331,40 +329,6 @@ export function* uploadFileMessages(
       ],
     })
   );
-}
-
-const createUploadableFile = (file) => {
-  if (file.nativeFile && getFileType(file.nativeFile) === FileType.Media) {
-    return new UploadableMedia(file);
-  } else if (file.giphy) {
-    return new UploadableGiphy(file);
-  } else {
-    return new UploadableAttachment(file);
-  }
-};
-
-class UploadableMedia {
-  constructor(private file) {}
-  *upload(channelId, rootMessageId) {
-    return yield call(uploadFileMessageApi, channelId, this.file.nativeFile, rootMessageId);
-  }
-}
-
-class UploadableGiphy {
-  constructor(private file) {}
-  *upload(channelId, _rootMessageId) {
-    const original = this.file.giphy.images.original;
-    const giphyFile = { url: original.url, name: this.file.name, type: this.file.giphy.type };
-    return yield call(sendFileMessage, channelId, giphyFile);
-  }
-}
-
-class UploadableAttachment {
-  constructor(private file) {}
-  *upload(channelId, _rootMessageId) {
-    const uploadResponse = yield call(uploadAttachment, this.file.nativeFile);
-    return yield call(sendFileMessage, channelId, uploadResponse);
-  }
 }
 
 export function* receiveDelete(action) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -19,7 +19,7 @@ import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { ChannelEvents, conversationsChannel } from '../channels-list/channels';
-import { createUploadableFile } from './uploadable';
+import { Uploadable, createUploadableFile } from './uploadable';
 
 export interface Payload {
   channelId: string;
@@ -142,7 +142,8 @@ export function* send(action) {
   }
 
   if (files?.length) {
-    yield call(uploadFileMessages, channelId, files, rootMessageId);
+    const uploadableFiles = files.map(createUploadableFile);
+    yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
   }
 }
 
@@ -299,13 +300,7 @@ export function* editMessage(action) {
   }
 }
 
-export function* uploadFileMessages(
-  channelId = null,
-  media: { nativeFile?: any; giphy: any; name: any }[] = null,
-  rootMessageId = ''
-) {
-  const uploadableFiles = media.map(createUploadableFile);
-
+export function* uploadFileMessages(channelId = null, rootMessageId = '', uploadableFiles: Uploadable[]) {
   let messages = [];
   for (const uploadableFile of uploadableFiles) {
     messages.push(yield uploadableFile.upload(channelId, rootMessageId));

--- a/src/store/messages/saga.uploadFileMessage.test.ts
+++ b/src/store/messages/saga.uploadFileMessage.test.ts
@@ -1,24 +1,20 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import { call } from 'redux-saga/effects';
-import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { FileUploadResult, uploadFileMessages } from './saga';
+import { uploadFileMessages } from './saga';
 
-import { sendFileMessage, uploadAttachment, uploadFileMessage as uploadFileMessageApi } from './api';
 import { RootState, rootReducer } from '../reducer';
-import { stubResponse } from '../../test/saga';
 import { denormalize as denormalizeChannel, normalize as normalizeChannel } from '../channels';
 
 describe(uploadFileMessages, () => {
   it('uploads an uploadable file', async () => {
+    const imageCreationResponse = { id: 'image-message-id' };
+    const upload = jest.fn().mockReturnValue(imageCreationResponse);
+    const uploadable = { upload };
     const channelId = 'channel-id';
-    const imageFile = { nativeFile: { type: 'image/png' } } as any;
-    const imageCreationResponse = { id: 'image-message-id', image: {} };
 
     const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
 
-    const { storeState } = await expectSaga(uploadFileMessages, channelId, [imageFile])
-      .provide([stubResponse(call(uploadFileMessageApi, channelId, imageFile.nativeFile, ''), imageCreationResponse)])
+    const { storeState } = await expectSaga(uploadFileMessages, channelId, '', [uploadable])
       .withReducer(rootReducer, initialState as any)
       .run();
 
@@ -28,22 +24,21 @@ describe(uploadFileMessages, () => {
   });
 
   it('first media file sets its rootMessageId', async () => {
+    const imageCreationResponse = { id: 'image-message-id' };
+    const upload1 = jest.fn().mockReturnValue(imageCreationResponse);
+    const upload2 = jest.fn().mockReturnValue(imageCreationResponse);
+    const uploadable1 = { upload: upload1 };
+    const uploadable2 = { upload: upload2 };
     const channelId = 'channel-id';
     const rootMessageId = 'root-message-id';
-    const imageFile1 = { nativeFile: { type: 'image/png', name: 'file1' } } as any;
-    const imageFile2 = { nativeFile: { type: 'image/png', name: 'file2' } } as any;
 
-    const media = [
-      imageFile1,
-      imageFile2,
-    ];
-    await expectSaga(uploadFileMessages, channelId, media, rootMessageId)
-      .provide([
-        stubResponse(matchers.call.fn(uploadFileMessageApi), {}),
-      ])
-      .call(uploadFileMessageApi, channelId, imageFile1.nativeFile, rootMessageId)
-      .call(uploadFileMessageApi, channelId, imageFile2.nativeFile, '')
-      .run();
+    await expectSaga(uploadFileMessages, channelId, rootMessageId, [
+      uploadable1,
+      uploadable2,
+    ]).run();
+
+    expect(upload1).toHaveBeenCalledWith(channelId, rootMessageId);
+    expect(upload2).toHaveBeenCalledWith(channelId, '');
   });
 });
 

--- a/src/store/messages/saga.uploadFileMessage.test.ts
+++ b/src/store/messages/saga.uploadFileMessage.test.ts
@@ -10,15 +10,7 @@ import { stubResponse } from '../../test/saga';
 import { denormalize as denormalizeChannel, normalize as normalizeChannel } from '../channels';
 
 describe(uploadFileMessages, () => {
-  it('does nothing if there are no files', async () => {
-    await expectSaga(uploadFileMessages, 'id', [])
-      .not.call.fn(uploadFileMessageApi)
-      .not.call.fn(uploadAttachment)
-      .not.call.fn(sendFileMessage)
-      .run();
-  });
-
-  it('uploads media file', async () => {
+  it('uploads an uploadable file', async () => {
     const channelId = 'channel-id';
     const imageFile = { nativeFile: { type: 'image/png' } } as any;
     const imageCreationResponse = { id: 'image-message-id', image: {} };
@@ -52,55 +44,6 @@ describe(uploadFileMessages, () => {
       .call(uploadFileMessageApi, channelId, imageFile1.nativeFile, rootMessageId)
       .call(uploadFileMessageApi, channelId, imageFile2.nativeFile, '')
       .run();
-  });
-
-  it('uploads non-media (attachment)', async () => {
-    const channelId = 'channel-id';
-    const pdfFile = { nativeFile: { type: 'application/pdf' } } as any;
-    const fileUploadResult = {
-      name: 'filename',
-      key: 'file-key',
-      url: 'file-url',
-      type: 'file',
-    } as FileUploadResult;
-    const messageSendResponse = { id: 'new-id' };
-
-    const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
-
-    const { storeState } = await expectSaga(uploadFileMessages, channelId, [pdfFile])
-      .provide([
-        stubResponse(call(uploadAttachment, pdfFile.nativeFile), fileUploadResult),
-        stubResponse(call(sendFileMessage, channelId, fileUploadResult), messageSendResponse),
-      ])
-      .withReducer(rootReducer, initialState as any)
-      .run();
-
-    const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.messages[0].id).toEqual('existing-message');
-    expect(channel.messages[1]).toEqual({ id: 'new-id' });
-  });
-
-  it('send Giphy message', async () => {
-    const channelId = 'channel-id';
-    const giphy = {
-      name: 'giphy-file',
-      giphy: { images: { original: { url: 'url_giphy' } }, type: 'gif' },
-    };
-    const expectedFileToSend = { url: 'url_giphy', name: 'giphy-file', type: 'gif' };
-    const messageSendResponse = { id: 'new-id' };
-
-    const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
-
-    const { storeState } = await expectSaga(uploadFileMessages, channelId, [giphy])
-      .provide([
-        stubResponse(call(sendFileMessage, channelId, expectedFileToSend as any), messageSendResponse),
-      ])
-      .withReducer(rootReducer, initialState as any)
-      .run();
-
-    const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.messages[0].id).toEqual('existing-message');
-    expect(channel.messages[1]).toEqual({ id: 'new-id' });
   });
 });
 

--- a/src/store/messages/uploadable.test.ts
+++ b/src/store/messages/uploadable.test.ts
@@ -1,0 +1,65 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { call } from 'redux-saga/effects';
+import { FileUploadResult } from './saga';
+
+import { sendFileMessage, uploadAttachment, uploadFileMessage as uploadFileMessageApi } from './api';
+import { stubResponse } from '../../test/saga';
+import { UploadableAttachment, UploadableGiphy, UploadableMedia } from './uploadable';
+
+describe(UploadableMedia, () => {
+  it('uploads the media file', async () => {
+    const channelId = 'channel-id';
+    const imageFile = { nativeFile: { type: 'image/png' } } as any;
+    const uploadable = new UploadableMedia(imageFile);
+
+    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, 'root-id'))
+      .provide([stubResponse(call(uploadFileMessageApi, channelId, imageFile.nativeFile, 'root-id'), { id: 'new-id' })])
+      .run();
+
+    expect(returnValue).toEqual({ id: 'new-id' });
+  });
+});
+
+describe(UploadableAttachment, () => {
+  it('uploads an attachment', async () => {
+    const channelId = 'channel-id';
+    const pdfFile = { nativeFile: { type: 'application/pdf' } } as any;
+    const fileUploadResult = {
+      name: 'filename',
+      key: 'file-key',
+      url: 'file-url',
+      type: 'file',
+    } as FileUploadResult;
+    const messageSendResponse = { id: 'new-id' };
+    const uploadable = new UploadableAttachment(pdfFile);
+
+    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, ''))
+      .provide([
+        stubResponse(call(uploadAttachment, pdfFile.nativeFile), fileUploadResult),
+        stubResponse(call(sendFileMessage, channelId, fileUploadResult), messageSendResponse),
+      ])
+      .run();
+
+    expect(returnValue).toEqual({ id: 'new-id' });
+  });
+});
+
+describe(UploadableGiphy, () => {
+  it('creates a giphy message', async () => {
+    const channelId = 'channel-id';
+    const giphy = {
+      name: 'giphy-file',
+      giphy: { images: { original: { url: 'url_giphy' } }, type: 'gif' },
+    };
+    const expectedFileToSend = { url: 'url_giphy', name: 'giphy-file', type: 'gif' };
+    const uploadable = new UploadableGiphy(giphy);
+
+    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, ''))
+      .provide([
+        stubResponse(call(sendFileMessage, channelId, expectedFileToSend as any), { id: 'new-id' }),
+      ])
+      .run();
+
+    expect(returnValue).toEqual({ id: 'new-id' });
+  });
+});

--- a/src/store/messages/uploadable.ts
+++ b/src/store/messages/uploadable.ts
@@ -14,7 +14,7 @@ export const createUploadableFile = (file) => {
   }
 };
 
-interface Uploadable {
+export interface Uploadable {
   upload: (channelId, rootMessageId) => Generator<CallEffect<Message>>;
 }
 

--- a/src/store/messages/uploadable.ts
+++ b/src/store/messages/uploadable.ts
@@ -1,0 +1,43 @@
+import { CallEffect, call } from 'redux-saga/effects';
+
+import { FileType, getFileType } from './utils';
+import { sendFileMessage, uploadAttachment, uploadFileMessage as uploadFileMessageApi } from './api';
+import { Message } from '.';
+
+export const createUploadableFile = (file) => {
+  if (file.nativeFile && getFileType(file.nativeFile) === FileType.Media) {
+    return new UploadableMedia(file);
+  } else if (file.giphy) {
+    return new UploadableGiphy(file);
+  } else {
+    return new UploadableAttachment(file);
+  }
+};
+
+interface Uploadable {
+  upload: (channelId, rootMessageId) => Generator<CallEffect<Message>>;
+}
+
+export class UploadableMedia implements Uploadable {
+  constructor(private file) {}
+  *upload(channelId, rootMessageId) {
+    return yield call(uploadFileMessageApi, channelId, this.file.nativeFile, rootMessageId);
+  }
+}
+
+export class UploadableGiphy implements Uploadable {
+  constructor(private file) {}
+  *upload(channelId, _rootMessageId) {
+    const original = this.file.giphy.images.original;
+    const giphyFile = { url: original.url, name: this.file.name, type: this.file.giphy.type };
+    return yield call(sendFileMessage, channelId, giphyFile);
+  }
+}
+
+export class UploadableAttachment implements Uploadable {
+  constructor(private file) {}
+  *upload(channelId, _rootMessageId) {
+    const uploadResponse = yield call(uploadAttachment, this.file.nativeFile);
+    return yield call(sendFileMessage, channelId, uploadResponse);
+  }
+}


### PR DESCRIPTION
### What does this do?

Moves some of the upload logic to a separate file and pulls the mapping up the call stack

### Why are we making this change?

To allow adding optimistic rendering more easily

