### PR TITLE
feat: conversation item tab accessibility 

### DIFF
--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -9,6 +9,7 @@ export interface Properties {
   message: string;
   mentionedUserIds?: any[];
   variant?: 'negative';
+  tabIndex?: number;
 }
 
 export class ContentHighlighter extends React.Component<Properties> {
@@ -64,6 +65,7 @@ export class ContentHighlighter extends React.Component<Properties> {
             attributes: {
               target: '_blank',
               class: 'text-message__link',
+              tabIndex: this.props.tabIndex || 0,
             },
           }}
         >

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -66,21 +66,21 @@ export class ConversationItem extends React.Component<Properties> {
     if (this.props.conversation.otherMembers.length === 1) {
       return (
         <Avatar
-          tabIndex={-1}
           size={'regular'}
           type={'circle'}
           imageURL={this.props.conversation.otherMembers[0].profileImage}
           statusType={this.conversationStatus}
+          tabIndex={-1}
         />
       );
     } else if (this.isCustomIcon(this.props.conversation.icon)) {
       return (
         <Avatar
-          tabIndex={-1}
           size={'regular'}
           type={'circle'}
           imageURL={this.props.conversation.icon}
           statusType={this.conversationStatus}
+          tabIndex={-1}
         />
       );
     }
@@ -174,7 +174,7 @@ export class ConversationItem extends React.Component<Properties> {
             </div>
             <div className={c('content')}>
               <div className={c('message')} is-unread={isUnread}>
-                <ContentHighlighter message={this.message} variant='negative' />
+                <ContentHighlighter message={this.message} variant='negative' tabIndex={-1} />
               </div>
               {hasUnreadMessages && <div className={c('unread-count')}>{conversation.unreadCount}</div>}
             </div>

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -66,6 +66,7 @@ export class ConversationItem extends React.Component<Properties> {
     if (this.props.conversation.otherMembers.length === 1) {
       return (
         <Avatar
+          tabIndex={-1}
           size={'regular'}
           type={'circle'}
           imageURL={this.props.conversation.otherMembers[0].profileImage}
@@ -75,6 +76,7 @@ export class ConversationItem extends React.Component<Properties> {
     } else if (this.isCustomIcon(this.props.conversation.icon)) {
       return (
         <Avatar
+          tabIndex={-1}
           size={'regular'}
           type={'circle'}
           imageURL={this.props.conversation.icon}

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -29,6 +29,12 @@ export class ConversationItem extends React.Component<Properties> {
     this.props.onClick(this.props.conversation.id);
   };
 
+  handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      this.props.onClick(this.props.conversation.id);
+    }
+  };
+
   tooltipContent(conversation: Channel) {
     if (conversation.otherMembers && conversation.otherMembers.length === 1) {
       return lastSeenText(conversation.otherMembers[0]);
@@ -148,7 +154,14 @@ export class ConversationItem extends React.Component<Properties> {
           ],
         }}
       >
-        <div className={c('')} onClick={this.handleMemberClick} is-active={isActive}>
+        <div
+          className={c('')}
+          onClick={this.handleMemberClick}
+          onKeyDown={this.handleKeyDown}
+          tabIndex={0}
+          role='button'
+          is-active={isActive}
+        >
           {this.renderAvatar()}
           <div className={c('summary')}>
             <div className={c('header')}>

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -372,9 +372,11 @@ $side-padding: 16px;
   color: theme.$color-greyscale-12;
 
   &:hover,
+  &:focus,
   &[is-active='true'] {
     background-color: theme.$color-primary-3;
     border-radius: 8px;
+    outline: none;
   }
 
   & > * {


### PR DESCRIPTION
### What does this do?
- The `Avatar` is no longer in the tabbing order.

- `ContentHighlighter` can now be passed a tabIndex to control tab ordering. This will prevent any links in the message preview from being focused.

- The behaviour from TAB-ing to select a conversation or search result is for the entire conversation / user preview itself is now highlighted, without any green ring around the avatar.

- Able to select a conversation using the `Enter` Key.

### Why are we making this change?
- Right now, when TAB-bing through search results and conversation list results, only the avatar of the selected result is highlighted (a green ring around the avatar).

### How do I test this?
- Open up the messenger and start keying down the `tab` key. The behaviour should be aligned with the `after` demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before: 

https://github.com/zer0-os/zOS/assets/39112648/7fb3f9e1-eca7-4116-a918-0d2552da900d

After: 


https://github.com/zer0-os/zOS/assets/39112648/929f955a-a8b5-4637-91b4-9d9d5734649d

