### PR TITLE
feat: update tooltip to only render overlay if there is content

### DIFF
--- a/src/components/tooltip/index.test.tsx
+++ b/src/components/tooltip/index.test.tsx
@@ -20,10 +20,15 @@ describe('Tooltip', () => {
     );
   };
 
-  it('render', function () {
+  it('renders with overlay', function () {
     const wrapper = subject({});
-
     expect(wrapper.find(ReactTooltip).exists()).toBe(true);
+  });
+
+  it('renders without overlay', function () {
+    const wrapper = subject({ overlay: '' });
+    expect(wrapper.find(ReactTooltip).exists()).toBe(false);
+    expect(wrapper.text()).toBe(CHILDREN_TEST);
   });
 
   it('renders all props', function () {

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -10,6 +10,13 @@ export interface Properties extends TooltipProps {
 
 export default class Tooltip extends React.Component<Properties> {
   render() {
+    const { overlay } = this.props;
+    const hasOverlayContent = overlay && overlay !== '';
+
+    if (!hasOverlayContent) {
+      return <>{this.props.children}</>;
+    }
+
     return (
       <ReactTooltip
         overlayClassName={classNames('tooltip', this.props.className)}


### PR DESCRIPTION
### What does this do?
- prevents the tooltip overlay from displaying if overlay content is empty.

### Why are we making this change?
- to prevent an empty overlay displaying when hovering over elements that use the tooltip but have no content to display.

### How do I test this?
- open messenger and hover over conversations in the conversations list panel. As per demos below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

https://github.com/zer0-os/zOS/assets/39112648/c691a1fe-3826-4e8a-888f-9c6cc82c7d9b

After:

https://github.com/zer0-os/zOS/assets/39112648/aea5086e-d525-4cf9-9aed-d2f84592943f

