### PR TITLE
Render file messages optimistically

### DIFF
--- a/src/components/message-input/utils.ts
+++ b/src/components/message-input/utils.ts
@@ -6,7 +6,7 @@ export interface Media {
   url: string;
   name: string;
   nativeFile?: File;
-  mediaType?: MediaType;
+  mediaType: MediaType;
   giphy?: any;
 }
 export interface UserForMention {

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -65,9 +65,10 @@ export async function editMessageApi(
   return response.status;
 }
 
-export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = '') {
+export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = '', optimisticId = '') {
   const response = await post<any>(`/upload/chatChannels/${channelId}/message`)
     .field('rootMessageId', rootMessageId)
+    .field('optimisticId', optimisticId)
     .attach('file', media);
 
   return response.body;

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -52,13 +52,16 @@ describe(send, () => {
 
   it('creates optimistic file messages then sends files', async () => {
     const channelId = 'channel-id';
-    const uploadableFile = { nativeFile: {} };
+    const uploadableFile = { file: { nativeFile: {} } };
     mockCreateUploadableFile.mockReturnValue(uploadableFile);
     const files = [{ id: 'file-id' }];
 
     testSaga(send, { payload: { channelId, files } })
       .next()
-      .call(uploadFileMessages, channelId, '', [uploadableFile])
+      .next({ optimisticMessage: { id: 'optimistic-message-id' } })
+      .call(uploadFileMessages, channelId, '', [
+        { ...uploadableFile, optimisticMessage: { id: 'optimistic-message-id' } },
+      ])
       .next()
       .isDone();
   });
@@ -72,10 +75,13 @@ describe(send, () => {
 
     testSaga(send, { payload: { channelId, message, files } })
       .next()
-      .next({ optimisticMessage: { id: 'optimistic-message-id' } })
+      .next({ optimisticMessage: { id: 'root-optimistic-message-id' } })
       .next()
       .next({ id: 'root-id' })
-      .call(uploadFileMessages, channelId, 'root-id', [uploadableFile])
+      .next({ optimisticMessage: { id: 'optimistic-message-id' } })
+      .call(uploadFileMessages, channelId, 'root-id', [
+        { ...uploadableFile, optimisticMessage: { id: 'optimistic-message-id' } },
+      ])
       .next()
       .isDone();
   });

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -29,7 +29,7 @@ describe(send, () => {
       'user-id1',
       'user-id2',
     ];
-    const parentMessage = { id: 'parent-id' };
+    const parentMessage = { messageId: 999, userId: 'user' };
 
     testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .next()
@@ -50,7 +50,7 @@ describe(send, () => {
     testSaga(send, { payload: { channelId, message, files } }).next().isDone();
   });
 
-  it('sends files', async () => {
+  it('creates optimistic file messages then sends files', async () => {
     const channelId = 'channel-id';
     const uploadableFile = { nativeFile: {} };
     mockCreateUploadableFile.mockReturnValue(uploadableFile);

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -168,10 +168,7 @@ describe(performSend, () => {
 
     const { storeState } = await expectSaga(performSend, channelId, message, [], null, 'optimistic-id')
       .provide([
-        stubResponse(matchers.call.fn(sendMessagesByChannelId), {
-          id: 'new-id',
-          optimisticId: 'optimistic-id',
-        }),
+        stubResponse(matchers.call.fn(sendMessagesByChannelId), { id: 'new-id', optimisticId: 'optimistic-id' }),
         ...successResponses(),
       ])
       .withReducer(rootReducer, initialState)

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -146,10 +146,12 @@ export function* send(action) {
   const uploadableFiles: Uploadable[] = [];
   if (files?.length) {
     files.forEach((f) => uploadableFiles.push(createUploadableFile(f)));
+    let rootId = rootMessageId;
     for (const index in uploadableFiles) {
       const file = uploadableFiles[index].file;
-      const { optimisticMessage } = yield call(createOptimisticMessage, channelId, '', null, file);
+      const { optimisticMessage } = yield call(createOptimisticMessage, channelId, '', null, file, rootId);
       uploadableFiles[index].optimisticMessage = optimisticMessage;
+      rootId = ''; // only the first file should connect to the root message for now.
     }
   }
 
@@ -158,11 +160,11 @@ export function* send(action) {
   }
 }
 
-export function* createOptimisticMessage(channelId, message, parentMessage, file?) {
+export function* createOptimisticMessage(channelId, message, parentMessage, file?, rootMessageId?) {
   const existingMessages = yield select(rawMessagesSelector(channelId));
   const currentUser = yield select(currentUserSelector());
 
-  const temporaryMessage = createOptimisticMessageObject(message, currentUser, parentMessage, file);
+  const temporaryMessage = createOptimisticMessageObject(message, currentUser, parentMessage, file, rootMessageId);
 
   yield put(
     receive({

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -177,16 +177,21 @@ export function* createOptimisticPreview(channelId: string, optimisticMessage) {
 }
 
 export function* performSend(channelId, message, mentionedUserIds, parentMessage, optimisticId) {
+  const messageCall = call(
+    sendMessagesByChannelId,
+    channelId,
+    message,
+    mentionedUserIds,
+    parentMessage,
+    null,
+    optimisticId
+  );
+  return yield sendMessage(messageCall, channelId, optimisticId);
+}
+
+export function* sendMessage(apiCall, channelId, optimisticId) {
   try {
-    const createdMessage = yield call(
-      sendMessagesByChannelId,
-      channelId,
-      message,
-      mentionedUserIds,
-      parentMessage,
-      null,
-      optimisticId
-    );
+    const createdMessage = yield apiCall;
     const existingMessageIds = yield select(rawMessagesSelector(channelId));
     const messages = yield call(replaceOptimisticMessage, existingMessageIds, createdMessage);
     if (messages) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -1,6 +1,6 @@
 import { currentUserSelector } from './../authentication/saga';
 import getDeepProperty from 'lodash.get';
-import { takeLatest, put, call, select, delay, spawn, apply } from 'redux-saga/effects';
+import { takeLatest, put, call, select, delay, spawn } from 'redux-saga/effects';
 import { EditMessageOptions, Message, SagaActionTypes, schema, removeAll, denormalize, MediaType } from '.';
 import { receive as receiveMessage } from './';
 import { Channel, receive } from '../channels';

--- a/src/store/messages/saga.uploadFileMessage.test.ts
+++ b/src/store/messages/saga.uploadFileMessage.test.ts
@@ -7,28 +7,28 @@ import { denormalize as denormalizeChannel, normalize as normalizeChannel } from
 
 describe(uploadFileMessages, () => {
   it('uploads an uploadable file', async () => {
-    const imageCreationResponse = { id: 'image-message-id' };
+    const imageCreationResponse = { id: 'image-message-id', optimisticId: 'optimistic-id' };
     const upload = jest.fn().mockReturnValue(imageCreationResponse);
-    const uploadable = { upload };
+    const uploadable = { upload, optimisticMessage: { id: 'optimistic-id' } } as any;
     const channelId = 'channel-id';
 
-    const initialState = existingChannelState({ id: channelId, messages: [{ id: 'existing-message' }] });
+    const initialState = existingChannelState({ id: channelId, messages: [{ id: 'optimistic-id' }] });
 
     const { storeState } = await expectSaga(uploadFileMessages, channelId, '', [uploadable])
       .withReducer(rootReducer, initialState as any)
       .run();
 
     const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.messages[0].id).toEqual('existing-message');
-    expect(channel.messages[1]).toEqual(imageCreationResponse);
+    expect(channel.messages).toHaveLength(1);
+    expect(channel.messages[0].id).toEqual('image-message-id');
   });
 
   it('first media file sets its rootMessageId', async () => {
     const imageCreationResponse = { id: 'image-message-id' };
     const upload1 = jest.fn().mockReturnValue(imageCreationResponse);
     const upload2 = jest.fn().mockReturnValue(imageCreationResponse);
-    const uploadable1 = { upload: upload1 };
-    const uploadable2 = { upload: upload2 };
+    const uploadable1 = { upload: upload1, optimisticMessage: { id: 'id-1' } } as any;
+    const uploadable2 = { upload: upload2, optimisticMessage: { id: 'id-2' } } as any;
     const channelId = 'channel-id';
     const rootMessageId = 'root-message-id';
 

--- a/src/store/messages/uploadable.test.ts
+++ b/src/store/messages/uploadable.test.ts
@@ -11,9 +11,14 @@ describe(UploadableMedia, () => {
     const channelId = 'channel-id';
     const imageFile = { nativeFile: { type: 'image/png' } } as any;
     const uploadable = new UploadableMedia(imageFile);
+    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
 
     const { returnValue } = await expectSaga(() => uploadable.upload(channelId, 'root-id'))
-      .provide([stubResponse(call(uploadFileMessageApi, channelId, imageFile.nativeFile, 'root-id'), { id: 'new-id' })])
+      .provide([
+        stubResponse(call(uploadFileMessageApi, channelId, imageFile.nativeFile, 'root-id', 'optimistic-id'), {
+          id: 'new-id',
+        }),
+      ])
       .run();
 
     expect(returnValue).toEqual({ id: 'new-id' });
@@ -32,11 +37,12 @@ describe(UploadableAttachment, () => {
     } as FileUploadResult;
     const messageSendResponse = { id: 'new-id' };
     const uploadable = new UploadableAttachment(pdfFile);
+    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
 
     const { returnValue } = await expectSaga(() => uploadable.upload(channelId, ''))
       .provide([
         stubResponse(call(uploadAttachment, pdfFile.nativeFile), fileUploadResult),
-        stubResponse(call(sendFileMessage, channelId, fileUploadResult), messageSendResponse),
+        stubResponse(call(sendFileMessage, channelId, fileUploadResult, 'optimistic-id'), messageSendResponse),
       ])
       .run();
 
@@ -53,10 +59,11 @@ describe(UploadableGiphy, () => {
     };
     const expectedFileToSend = { url: 'url_giphy', name: 'giphy-file', type: 'gif' };
     const uploadable = new UploadableGiphy(giphy);
+    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
 
     const { returnValue } = await expectSaga(() => uploadable.upload(channelId, ''))
       .provide([
-        stubResponse(call(sendFileMessage, channelId, expectedFileToSend as any), { id: 'new-id' }),
+        stubResponse(call(sendFileMessage, channelId, expectedFileToSend as any, 'optimistic-id'), { id: 'new-id' }),
       ])
       .run();
 

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Message } from './index';
+import { MediaType, Message } from './index';
 import { User } from './../authentication/types';
 import * as linkifyjs from 'linkifyjs';
 import { ParentMessage } from '../../lib/chat/types';
@@ -17,9 +17,24 @@ export interface linkifyType {
 export function createOptimisticMessageObject(
   messageText: string,
   user: User,
-  parentMessage: ParentMessage = null
+  parentMessage: ParentMessage = null,
+  file?: { name: string; url: string; mediaType: MediaType }
 ): Message {
   const id = uuidv4();
+  let media;
+  if (file) {
+    media = {
+      type: file.mediaType,
+      url: file.url,
+      name: file.name,
+      // Not sure why these are in our types as I don't think we use them at all
+      // I'm guessing this is for rendering a loaded message when the image hasn't downloaded yet
+      // but we're not doing that yet.
+      height: 0,
+      width: 0,
+    };
+  }
+
   return {
     createdAt: Date.now(),
     hidePreview: false,
@@ -38,6 +53,7 @@ export function createOptimisticMessageObject(
     },
     updatedAt: 0,
     preview: null,
+    media,
   };
 }
 

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -18,7 +18,8 @@ export function createOptimisticMessageObject(
   messageText: string,
   user: User,
   parentMessage: ParentMessage = null,
-  file?: { name: string; url: string; mediaType: MediaType }
+  file?: { name: string; url: string; mediaType: MediaType },
+  rootMessageId?: string
 ): Message {
   const id = uuidv4();
   let media;
@@ -40,6 +41,7 @@ export function createOptimisticMessageObject(
     hidePreview: false,
     id,
     optimisticId: id,
+    rootMessageId,
     mentionedUserIds: [],
     message: messageText,
     isAdmin: false,


### PR DESCRIPTION
### What does this do?

Renders the image messages optimistically.

Note, scenarios not yet handled perfectly but coming:
* Sending an image with text still waits until the text message is sent before rendering the files (but they render all optimistically once that happens)
* When the final message result arrives from the server there's some rendering blips as the ids change

### Why are we making this change?

Provide immediate feedback to the user and have a more natural feeling of performance.

### How do I test this?

Send messages with files/images and notice they render immediately


https://github.com/zer0-os/zOS/assets/43770/32dbb0aa-a589-40a2-97f8-0130bf5f6029

