### PR TITLE
Use optimisticId for first rendering key

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -142,7 +142,7 @@ export class ChatView extends React.Component<Properties, State> {
       } else {
         return (
           <div
-            key={message.id}
+            key={message.optimisticId || message.id}
             className={classNames('messages__message-row', {
               'messages__message-row--owner': this.isUserOwnerOfMessage(message),
             })}


### PR DESCRIPTION
### What does this do?

Uses the `optimisticId` as the first preference for the rendering key when rendering Messages.

### Why are we making this change?

To prevent full re-rendering (and thus flashing) of messages when optimistic data becomes true data.


https://github.com/zer0-os/zOS/assets/43770/2cc5c7d6-7983-4c62-a042-b4e46e29b0ff


https://github.com/zer0-os/zOS/assets/43770/adf62dc4-5487-4214-8b9b-2ce88df6e2df

