### PR TITLE
Render the full text with image message optimistically

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -60,16 +60,31 @@ describe('ChannelViewContainer', () => {
 
   it('groups message media with rootId onto parent message', () => {
     const messages = [
-      { id: 'message-root', message: 'what', rootMessageId: '' },
-      { id: 'message-two', message: 'hello', rootMessageId: '' },
-      { id: 'message-child', message: 'what', rootMessageId: 'message-root', media: { some: 'media' } },
+      { id: 'message-root', rootMessageId: '' },
+      { id: 'message-two', rootMessageId: '' },
+      { id: 'message-child', rootMessageId: 'message-root', media: { some: 'media' } },
     ];
 
     const wrapper = subject({ channel: { messages } });
 
     expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([
-      { id: 'message-root', message: 'what', rootMessageId: '', media: { some: 'media' } },
-      { id: 'message-two', message: 'hello', rootMessageId: '' },
+      { ...messages[0], media: { some: 'media' } },
+      messages[1],
+    ]);
+  });
+
+  it('groups message media with optimistic rootId onto parent message', () => {
+    const messages = [
+      { id: 'message-root', optimisticId: 'optimistic-message-root', rootMessageId: '' },
+      { id: 'message-two', rootMessageId: '' },
+      { id: 'message-child', rootMessageId: 'optimistic-message-root', media: { some: 'media' } },
+    ];
+
+    const wrapper = subject({ channel: { messages } });
+
+    expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([
+      { ...messages[0], media: { some: 'media' } },
+      messages[1],
     ]);
   });
 

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -252,6 +252,9 @@ export class Container extends React.Component<Properties, State> {
       } else {
         // Hmm... not sure how we ended up with integers as our message ids. For now, just cast to a string.
         messagesById[m.id.toString()] = m;
+        if (m.id.toString() !== m.optimisticId) {
+          messagesById[m.optimisticId] = m;
+        }
         messages.push(m);
       }
     });

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -39,6 +39,7 @@ describe(send, () => {
       .next()
       .call(performSend, channelId, message, mentionedUserIds, parentMessage, 'optimistic-message-id')
       .next({ id: 'message-id' })
+      .next()
       .isDone();
   });
 
@@ -47,7 +48,7 @@ describe(send, () => {
     const message = '   ';
     const files = [];
 
-    testSaga(send, { payload: { channelId, message, files } }).next().isDone();
+    testSaga(send, { payload: { channelId, message, files } }).next().next().isDone();
   });
 
   it('creates optimistic file messages then sends files', async () => {

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -5,6 +5,7 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { getLinkPreviews, sendMessagesByChannelId } from './api';
 import {
   createOptimisticMessage,
+  createOptimisticMessages,
   createOptimisticPreview,
   messageSendFailed,
   performSend,
@@ -22,7 +23,7 @@ jest.mock('./uploadable', () => ({
 }));
 
 describe(send, () => {
-  it('creates optimistic message then fetches preview and sends the message in parallel', async () => {
+  it('creates optimistic messages then fetches preview and sends the message in parallel', async () => {
     const channelId = 'channel-id';
     const message = 'hello';
     const mentionedUserIds = [
@@ -33,8 +34,8 @@ describe(send, () => {
 
     testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .next()
-      .call(createOptimisticMessage, channelId, message, parentMessage)
-      .next({ optimisticMessage: { id: 'optimistic-message-id' } })
+      .call(createOptimisticMessages, channelId, message, parentMessage, [])
+      .next({ optimisticRootMessage: { id: 'optimistic-message-id' } })
       .spawn(createOptimisticPreview, channelId, { id: 'optimistic-message-id' })
       .next()
       .call(performSend, channelId, message, mentionedUserIds, parentMessage, 'optimistic-message-id')
@@ -43,48 +44,72 @@ describe(send, () => {
       .isDone();
   });
 
-  it('ignores messages with no text or files', async () => {
-    const channelId = 'channel-id';
-    const message = '   ';
-    const files = [];
-
-    testSaga(send, { payload: { channelId, message, files } }).next().next().isDone();
-  });
-
   it('creates optimistic file messages then sends files', async () => {
     const channelId = 'channel-id';
     const uploadableFile = { file: { nativeFile: {} } };
-    mockCreateUploadableFile.mockReturnValue(uploadableFile);
     const files = [{ id: 'file-id' }];
 
     testSaga(send, { payload: { channelId, files } })
       .next()
-      .next({ optimisticMessage: { id: 'optimistic-message-id' } })
-      .call(uploadFileMessages, channelId, '', [
-        { ...uploadableFile, optimisticMessage: { id: 'optimistic-message-id' } },
-      ])
+      .call(createOptimisticMessages, channelId, undefined, undefined, files)
+      .next({ uploadableFiles: [uploadableFile] })
+      .call(uploadFileMessages, channelId, '', [uploadableFile])
       .next()
       .isDone();
   });
 
   it('sends files with a rootMessageId if text is included', async () => {
     const channelId = 'channel-id';
-    const files = [{ id: 'file-id' }];
     const uploadableFile = { nativeFile: {} };
-    mockCreateUploadableFile.mockReturnValue(uploadableFile);
-    const message = 'hello';
+    const files = [{ id: 'file-id' }];
 
-    testSaga(send, { payload: { channelId, message, files } })
+    testSaga(send, { payload: { channelId, files } })
       .next()
-      .next({ optimisticMessage: { id: 'root-optimistic-message-id' } })
+      .next({ optimisticRootMessage: { id: 'root-id' }, uploadableFiles: [uploadableFile] })
       .next()
       .next({ id: 'root-id' })
-      .next({ optimisticMessage: { id: 'optimistic-message-id' } })
-      .call(uploadFileMessages, channelId, 'root-id', [
-        { ...uploadableFile, optimisticMessage: { id: 'optimistic-message-id' } },
-      ])
+      .call(uploadFileMessages, channelId, 'root-id', [uploadableFile])
       .next()
       .isDone();
+  });
+});
+
+describe(createOptimisticMessages, () => {
+  it('creates the root message', async () => {
+    const channelId = 'channel-id';
+    const message = 'test message';
+
+    const { returnValue, storeState } = await expectSaga(createOptimisticMessages, channelId, message, undefined, [])
+      .withReducer(rootReducer, defaultState())
+      .run();
+
+    const channel = denormalizeChannel(channelId, storeState);
+    expect(channel.messages[0].message).toEqual(message);
+    expect(channel.messages[0].id).not.toBeNull();
+    expect(channel.messages[0].sender).not.toBeNull();
+    expect(returnValue.optimisticRootMessage).toEqual(expect.objectContaining({ message: 'test message' }));
+  });
+
+  it('creates the uploadable files with optimistic message', async () => {
+    const channelId = 'channel-id';
+    const message = 'test message';
+    const file = { nativeFile: {} };
+    const uploadableFile = { file: { name: 'media-file' } };
+    mockCreateUploadableFile.mockReturnValue(uploadableFile);
+
+    const { returnValue, storeState } = await expectSaga(createOptimisticMessages, channelId, message, undefined, [
+      file,
+    ])
+      .withReducer(rootReducer, defaultState())
+      .run();
+
+    const channel = denormalizeChannel(channelId, storeState);
+    expect(channel.messages[0].message).toEqual(message);
+    expect(channel.messages[0].id).not.toBeNull();
+    expect(channel.messages[0].sender).not.toBeNull();
+    expect(returnValue.uploadableFiles[0].optimisticMessage.media).toEqual(
+      expect.objectContaining({ name: 'media-file' })
+    );
   });
 });
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -155,9 +155,7 @@ export function* send(action) {
     }
   }
 
-  if (uploadableFiles?.length) {
-    yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
-  }
+  yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
 }
 
 export function* createOptimisticMessage(channelId, message, parentMessage, file?, rootMessageId?) {


### PR DESCRIPTION
### What does this do?

When we send a file message with text it will now render both pieces of the message optimistically before sending any api requests

### Why are we making this change?

Smooth experience

