### PR TITLE
Clear active conversation and channel on logout

### DIFF
--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -2,7 +2,7 @@ import { put, select, call, take, takeEvery, spawn } from 'redux-saga/effects';
 import { takeEveryFromBus } from '../../lib/saga';
 import getDeepProperty from 'lodash.get';
 
-import { setReconnecting } from '.';
+import { setActiveChannelId, setReconnecting, setactiveConversationId } from '.';
 import { startChannelsAndConversationsAutoRefresh } from '../channels-list';
 import { Events, createChatConnection, getChatBus } from './bus';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
@@ -48,8 +48,14 @@ function* closeConnectionOnLogout(chatConnection) {
   yield spawn(connectOnLogin);
 }
 
+function* clearOnLogout() {
+  yield put(setActiveChannelId(null));
+  yield put(setactiveConversationId(null));
+}
+
 export function* saga() {
   yield spawn(connectOnLogin);
+  yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
 
   const chatBus = yield call(getChatBus);
   yield takeEveryFromBus(chatBus, Events.ReconnectStart, listenForReconnectStart);


### PR DESCRIPTION
### What does this do?

Clears the state for the active conversation id and active channel id when a user logout event occurs.

### Why are we making this change?

Future logins can fail if these values are set to channels that are unavailable to the newlyy logged in user. It's also not good to leave active state layin' around.

### How do I test this?

* Login as a user and wait for the first conversation to load
* Logout
* Login as a different user who wasn't involved in the conversation above
* Verify the app loads up and loads the first conversation for the new user

