### PR TITLE
Remove unreachable state in chat initialization

### DIFF
--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -35,10 +35,6 @@ function* connectOnLogin() {
   const userId = yield select((state) => getDeepProperty(state, 'authentication.user.data.id', null));
   const chatAccessToken = yield select((state) => getDeepProperty(state, 'chat.chatAccessToken.value', null));
 
-  if (!userId || !chatAccessToken) {
-    yield spawn(connectOnLogin); // Wait again
-  }
-
   yield initChat(userId, chatAccessToken);
 }
 


### PR DESCRIPTION
### What does this do?

Removes an unnecessary check during login event handling

### Why are we making this change?

Since the events have been split out to specific Login and Logout events and the auth/login code now only publishes if we have a full user, these checks are unnecessary.

