### PR TITLE
Zos 539: Display zero as large number and usd value as subtext in rewards modal

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -38,7 +38,6 @@ describe('messenger-list', () => {
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
-      zero: '',
       zeroPreviousDay: '',
       isRewardsLoading: false,
       isInviteNotificationOpen: false,
@@ -399,12 +398,6 @@ describe('messenger-list', () => {
       const state = subject([], {}, undefined, undefined, { loading: true });
 
       expect(state.isRewardsLoading).toEqual(true);
-    });
-
-    test('zero', () => {
-      const state = subject([], {}, undefined, undefined, { zero: '17' });
-
-      expect(state.zero).toEqual('17');
     });
 
     test('activeConversationId', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -51,7 +51,6 @@ export interface Properties extends PublicProperties {
   userName: string;
   userHandle: string;
   userAvatarUrl: string;
-  zero: string;
   zeroPreviousDay: string;
   isMessengerFullScreen: boolean;
   isRewardsLoading: boolean;
@@ -118,7 +117,6 @@ export class Container extends React.Component<Properties, State> {
       userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
       myUserId: user?.data?.id,
-      zero: rewards.zero,
       zeroPreviousDay: rewards.zeroPreviousDay,
       isRewardsLoading: rewards.loading,
       showNewRewards: rewards.showNewRewards,
@@ -225,7 +223,6 @@ export class Container extends React.Component<Properties, State> {
         {this.props.includeTitleBar && this.renderTitleBar()}
 
         <RewardsBar
-          zero={this.props.zero}
           zeroPreviousDay={this.props.zeroPreviousDay}
           isRewardsLoading={this.props.isRewardsLoading}
           isMessengerFullScreen={this.props.isMessengerFullScreen}

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -13,7 +13,6 @@ describe('rewards-bar', () => {
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
-      zero: '',
       zeroPreviousDay: '',
       isRewardsLoading: false,
       showNewRewards: false,
@@ -41,21 +40,6 @@ describe('rewards-bar', () => {
     const wrapper = subject({ isFirstTimeLogin: true });
 
     expect(wrapper).toHaveElement(RewardsPopupContainer);
-  });
-
-  it('parses token number to renderable string', function () {
-    const wrapper = subject({ zero: '9123456789111315168' });
-    wrapper.find('.rewards-bar__rewards-button').simulate('click');
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('9.12');
-
-    wrapper.setProps({ zero: '9123000000000000000' });
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('9.12');
-
-    wrapper.setProps({ zero: '23456789111315168' });
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('0.02');
-
-    wrapper.setProps({ zero: '0' });
-    expect(wrapper.find(RewardsPopupContainer).prop('zero')).toEqual('0');
   });
 
   it('rewards tooltip popup is not rendered if messenger not fullscreen', async function () {
@@ -97,7 +81,6 @@ describe('rewards-bar', () => {
 
   it('closes rewards tooltip popup if clicked on close icon', async function () {
     const wrapper = subject({
-      zero: '9000000000000000000',
       zeroPreviousDay: '1000000000000000000',
       isRewardsLoading: false,
       showNewRewards: true,

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -22,7 +22,6 @@ export interface Properties {
   userHandle: string;
   userAvatarUrl: string;
 
-  zero: string;
   zeroPreviousDay: string;
   isRewardsLoading: boolean;
   showNewRewards: boolean;
@@ -120,7 +119,6 @@ export class RewardsBar extends React.Component<Properties, State> {
           <RewardsPopupContainer
             onClose={this.closeRewards}
             openRewardsFAQModal={this.openRewardsFAQModal} // modal is opened in the popup, after which the popup is closed
-            zero={formatWeiAmount(this.props.zero)}
             isLoading={this.props.isRewardsLoading}
           />
         )}

--- a/src/components/rewards-popup/container.test.tsx
+++ b/src/components/rewards-popup/container.test.tsx
@@ -1,5 +1,8 @@
+import { shallow } from 'enzyme';
+import { Properties } from './container';
 import { RootState } from '../../store/reducer';
 import { Container } from './container';
+import { RewardsPopup } from '.';
 
 jest.mock('react-dom', () => ({
   createPortal: (node, _portalLocation) => {
@@ -8,6 +11,36 @@ jest.mock('react-dom', () => ({
 }));
 
 describe('Container', () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      isLoading: false,
+      isFullScreen: false,
+      withTitleBar: true,
+      zero: '',
+      zeroInUSD: 0,
+      fetchRewards: () => {},
+      onClose: () => {},
+      openRewardsFAQModal: () => {},
+      ...props,
+    };
+
+    return shallow(<Container {...allProps} />);
+  };
+
+  it('parses token number to renderable string', function () {
+    const wrapper = subject({ zero: '9123456789111315168' });
+    expect(wrapper.find(RewardsPopup).prop('zero')).toEqual('9.12');
+
+    wrapper.setProps({ zero: '9123000000000000000' });
+    expect(wrapper.find(RewardsPopup).prop('zero')).toEqual('9.12');
+
+    wrapper.setProps({ zero: '23456789111315168' });
+    expect(wrapper.find(RewardsPopup).prop('zero')).toEqual('0.02');
+
+    wrapper.setProps({ zero: '0' });
+    expect(wrapper.find(RewardsPopup).prop('zero')).toEqual('0');
+  });
+
   describe('mapState', () => {
     function baseState() {
       return {

--- a/src/components/rewards-popup/container.test.tsx
+++ b/src/components/rewards-popup/container.test.tsx
@@ -13,6 +13,7 @@ describe('Container', () => {
       return {
         ...authState(),
         ...layoutState(),
+        ...rewardState(),
       } as RootState;
     }
 
@@ -30,6 +31,22 @@ describe('Container', () => {
 
       state = Container.mapState({ ...baseState(), ...layoutState({ isMessengerFullScreen: true }) } as RootState);
       expect(state.isFullScreen).toEqual(true);
+    });
+
+    test('zero', async () => {
+      let state = Container.mapState({ ...baseState(), ...rewardState() } as RootState);
+      expect(state.zero).toEqual('');
+
+      state = Container.mapState({ ...baseState(), ...rewardState({ zero: '99999999' }) } as RootState);
+      expect(state.zero).toEqual('99999999');
+    });
+
+    test('zeroInUSD', async () => {
+      let state = Container.mapState({ ...baseState(), ...rewardState() } as RootState);
+      expect(state.zeroInUSD).toEqual(0);
+
+      state = Container.mapState({ ...baseState(), ...rewardState({ zeroInUSD: 0.0454243368 }) } as RootState);
+      expect(state.zeroInUSD).toEqual(0.0454243368);
     });
   });
 });
@@ -54,6 +71,16 @@ function layoutState(layout = {}) {
       value: {
         ...layout,
       },
+    },
+  };
+}
+
+function rewardState(reward = {}) {
+  return {
+    rewards: {
+      zero: '',
+      zeroInUSD: 0,
+      ...reward,
     },
   };
 }

--- a/src/components/rewards-popup/container.tsx
+++ b/src/components/rewards-popup/container.tsx
@@ -4,12 +4,12 @@ import { createPortal } from 'react-dom';
 import { connectContainer } from '../../store/redux-container';
 import { RewardsPopup } from '.';
 import { RootState } from '../../store/reducer';
+import { calculateTotalPriceInUSD, formatWeiAmount } from '../../lib/number';
 
 interface PublicProperties {
   onClose: () => void;
   openRewardsFAQModal: () => void;
 
-  zero: string;
   isLoading: boolean;
 }
 
@@ -17,6 +17,8 @@ export interface Properties extends PublicProperties {
   isLoading: boolean;
   isFullScreen: boolean;
   withTitleBar: boolean;
+  zero: string;
+  zeroInUSD: number;
 
   fetchRewards: () => void;
 }
@@ -26,11 +28,14 @@ export class Container extends React.Component<Properties> {
     const {
       authentication: { user },
       layout,
+      rewards,
     } = state;
 
     return {
       withTitleBar: !!user?.data?.isAMemberOfWorlds,
       isFullScreen: layout.value.isMessengerFullScreen,
+      zero: rewards.zero,
+      zeroInUSD: rewards.zeroInUSD,
     };
   }
 
@@ -38,13 +43,22 @@ export class Container extends React.Component<Properties> {
     return {};
   }
 
+  get totalPriceInUSD() {
+    // if there is an error fetching the price, don't show the usd value
+    if (this.props.zeroInUSD === 0) {
+      return '';
+    }
+
+    return calculateTotalPriceInUSD(this.props.zero, this.props.zeroInUSD);
+  }
+
   render() {
     return (
       <>
         {createPortal(
           <RewardsPopup
-            usd={this.props.zero} // Note: Temporarily rendering ZERO in the USD field
-            zero=''
+            usd={this.totalPriceInUSD}
+            zero={formatWeiAmount(this.props.zero)}
             onClose={this.props.onClose}
             openRewardsFAQModal={this.props.openRewardsFAQModal}
             isLoading={this.props.isLoading}

--- a/src/components/rewards-popup/index.test.tsx
+++ b/src/components/rewards-popup/index.test.tsx
@@ -19,19 +19,26 @@ describe('RewardsPopup', () => {
   };
 
   it('renders your rewards count in ZERO', function () {
-    const wrapper = subject({ zero: '838' });
+    const wrapper = subject({ zero: '360.12K' });
 
-    expect(wrapper.find('.rewards-popup__rewards-zero').text()).toEqual('838 $ZERO');
+    let skeleton = wrapper.find('.rewards-popup__rewards-zero SkeletonText');
+    expect((skeleton.prop('asyncText') as any).text).toEqual('360.12K');
+  });
+
+  it('renders your rewards in USD', function () {
+    const wrapper = subject({ usd: '$5,055.00 USD' });
+
+    expect(wrapper.find('.rewards-popup__rewards-usd').text()).toEqual('$5,055.00 USD');
   });
 
   it('sets the skeleton loading attribute', function () {
     const wrapper = subject({ isLoading: true });
 
-    let skeleton = wrapper.find('.rewards-popup__rewards-usd SkeletonText');
+    let skeleton = wrapper.find('.rewards-popup__rewards-zero SkeletonText');
     expect((skeleton.prop('asyncText') as any).isLoading).toEqual(true);
 
     wrapper.setProps({ isLoading: false });
-    skeleton = wrapper.find('.rewards-popup__rewards-usd SkeletonText');
+    skeleton = wrapper.find('.rewards-popup__rewards-zero SkeletonText');
     expect((skeleton.prop('asyncText') as any).isLoading).toEqual(false);
   });
 

--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -65,19 +65,19 @@ export class RewardsPopup extends React.Component<Properties, State> {
               onClick={this.abort}
             />
             <ZeroSymbol height={32} width={32} />
-            <span className={c('heading')}>My Rewards</span>
-            <div className={c('rewards-usd')}>
+            <span className={c('heading')}>$ZERO</span>
+            <div className={c('rewards-zero')}>
               <SkeletonText
                 asyncText={{
                   isLoading: this.props.isLoading,
-                  text: this.props.usd,
+                  text: this.props.zero,
                 }}
                 skeletonOptions={{
                   width: 50,
                 }}
               />
             </div>
-            <div className={c('rewards-zero')}>{this.props.zero} $ZERO</div>
+            <div className={c('rewards-usd')}>{this.props.usd}</div>
             <div className={c('info-card')}>
               <div className={c('info-card__icon')}>
                 <IconGift1 />

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -97,7 +97,7 @@ $content-padding-y: 40px;
     text-transform: uppercase;
   }
 
-  &__rewards-usd {
+  &__rewards-zero {
     font-family: 'Roboto Mono';
     font-weight: 700;
     font-size: 48px;
@@ -107,7 +107,7 @@ $content-padding-y: 40px;
     color: theme.$color-greyscale-12;
   }
 
-  &__rewards-zero {
+  &__rewards-usd {
     font-family: 'Roboto Mono';
     font-weight: 400;
     font-size: 14px;

--- a/src/lib/number.test.ts
+++ b/src/lib/number.test.ts
@@ -1,4 +1,4 @@
-import { formatWeiAmount } from './number';
+import { calculateTotalPriceInUSD, formatWeiAmount } from './number';
 import { parseEther } from 'ethers/lib/utils'; // replace with your actual file name
 
 const get = (num: string) => parseEther(num).toString();
@@ -32,5 +32,39 @@ describe('formatWeiAmount', () => {
   it('should handle negative numbers', () => {
     expect(formatWeiAmount(get('-12345'))).toEqual('-12,345');
     expect(formatWeiAmount(get('-12345678'))).toEqual('-12.35M');
+  });
+});
+
+describe('calculateTotalPriceInUSD', () => {
+  const currentTokenPriceInUSD = 0.041035425;
+
+  it('should calculate the total price correctly for small token amounts', () => {
+    expect(calculateTotalPriceInUSD('360909800000000000000000', currentTokenPriceInUSD)).toEqual('$14,810.09 USD');
+    expect(calculateTotalPriceInUSD('1000000000000000000', currentTokenPriceInUSD)).toEqual('$0.04 USD');
+    expect(calculateTotalPriceInUSD('12345678900000000000', currentTokenPriceInUSD)).toEqual('$0.51 USD');
+  });
+
+  it('should calculate the total price correctly for large token amounts', () => {
+    expect(calculateTotalPriceInUSD('1000000000000000000000000', currentTokenPriceInUSD)).toEqual('$41,035.43 USD');
+    expect(calculateTotalPriceInUSD('98765432109876543210987654321', currentTokenPriceInUSD)).toEqual(
+      '$4,052,881,481.94 USD'
+    );
+    expect(calculateTotalPriceInUSD('1000000000000000000000000000000', currentTokenPriceInUSD)).toEqual(
+      '$41,035,425,000 USD'
+    );
+  });
+
+  it('should display USD value with comma separation', () => {
+    expect(calculateTotalPriceInUSD('123456789000000000000000000', currentTokenPriceInUSD)).toEqual(
+      '$5,066,101.81 USD'
+    );
+    expect(calculateTotalPriceInUSD('12345678900000000000000000', currentTokenPriceInUSD)).toEqual('$506,610.18 USD');
+    expect(calculateTotalPriceInUSD('1234567890000000000000000', currentTokenPriceInUSD)).toEqual('$50,661.02 USD');
+    expect(calculateTotalPriceInUSD('123456789000000000000000', currentTokenPriceInUSD)).toEqual('$5,066.1 USD');
+    expect(calculateTotalPriceInUSD('12345678900000000000000', currentTokenPriceInUSD)).toEqual('$506.61 USD');
+  });
+
+  it('should handle zero token amount', () => {
+    expect(calculateTotalPriceInUSD('0', currentTokenPriceInUSD)).toEqual('$0 USD');
   });
 });

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,15 +1,39 @@
 import millify from 'millify';
 
+export interface TokenAmountWithPrice {
+  formattedTokenAmount: string;
+  totalPriceInUSD: string;
+}
+
+/**
+ * Splits the given number string into its whole and decimal parts, accounting for the
+ * fixed decimal precision of 18.
+ *
+ * @param num - The number string to split into parts.
+ * @returns An array containing the whole part and decimal part of the number as separate strings.
+ * For example, if the input number is "360909800000000000000000", the function will return
+ * ["360", "9098"] representing the whole and decimal parts respectively.
+ */
+function getPartsFromNum(num: string): [string, string] {
+  const stringValue = num.padStart(19, '0');
+  const whole = stringValue.slice(0, -18);
+  const decimal = stringValue.slice(-18).slice(0, 4).replace(/0+$/, '');
+  const decimalString = decimal.length > 0 ? `.${decimal}` : '';
+  return [
+    whole,
+    decimalString,
+  ];
+}
+
 /**
  * Format a number to a string with commas and max 2 decimal places
  * @param num number to format
  */
 export function formatWeiAmount(num: string): string {
-  const stringValue = num.padStart(19, '0');
-  const whole = stringValue.slice(0, -18);
-  const decimal = stringValue.slice(-18).slice(0, 4).replace(/0+$/, '');
-  const decimalString = decimal.length > 0 ? `.${decimal}` : '';
-
+  const [
+    whole,
+    decimalString,
+  ] = getPartsFromNum(num);
   const asString = whole + decimalString;
   const asNum = Number(asString);
 
@@ -18,4 +42,28 @@ export function formatWeiAmount(num: string): string {
   }
 
   return asNum.toLocaleString('en-US', { maximumFractionDigits: 2 });
+}
+
+/**
+ * Calculates the total price in USD based on the given amount of tokens and the current token price in USD.
+ *
+ * @param num - The amount of tokens as a string with 18 decimal precision.
+ * @param currentTokenPriceInUSD - The current token price in USD for 1 token.
+ * @returns The total price in USD as a formatted string with thousand separators and decimal precision.
+ * For example, if the input token amount is "360909800000000000000000" and the current token price is
+ * 0.041035425, the function will return "$14,810.09 USD".
+ */
+export function calculateTotalPriceInUSD(num: string, currentTokenPriceInUSD: number): string {
+  const [
+    whole,
+    decimalString,
+  ] = getPartsFromNum(num);
+  const asString = whole + decimalString;
+  const asNum = Number(asString);
+  const totalPriceInUSD = (asNum * currentTokenPriceInUSD).toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+    useGrouping: true,
+  });
+
+  return `$${totalPriceInUSD} USD`;
 }

--- a/src/lib/number.ts
+++ b/src/lib/number.ts
@@ -1,10 +1,5 @@
 import millify from 'millify';
 
-export interface TokenAmountWithPrice {
-  formattedTokenAmount: string;
-  totalPriceInUSD: string;
-}
-
 /**
  * Splits the given number string into its whole and decimal parts, accounting for the
  * fixed decimal precision of 18.

--- a/src/store/rewards/api.ts
+++ b/src/store/rewards/api.ts
@@ -16,3 +16,11 @@ export async function fetchRewards(_obj: any): Promise<RewardsResp> {
     response: response.body,
   };
 }
+
+export async function fetchCurrentZeroPriceInUSD() {
+  const response = await get('/api/tokens/zero');
+  return {
+    success: true,
+    response: response.body,
+  };
+}

--- a/src/store/rewards/index.ts
+++ b/src/store/rewards/index.ts
@@ -8,6 +8,7 @@ export enum SagaActionTypes {
 export type RewardsState = {
   loading: boolean;
   zero: string;
+  zeroInUSD: number;
   zeroPreviousDay: string;
   showNewRewards: boolean;
 };
@@ -15,6 +16,7 @@ export type RewardsState = {
 export const initialState: RewardsState = {
   loading: false,
   zero: '0',
+  zeroInUSD: 0.0,
   zeroPreviousDay: '0',
   showNewRewards: false,
 };
@@ -32,6 +34,9 @@ const slice = createSlice({
     setZero: (state, action: PayloadAction<RewardsState['zero']>) => {
       state.zero = action.payload;
     },
+    setZeroInUSD: (state, action: PayloadAction<RewardsState['zeroInUSD']>) => {
+      state.zeroInUSD = action.payload;
+    },
     setZeroPreviousDay: (state, action: PayloadAction<RewardsState['zeroPreviousDay']>) => {
       state.zeroPreviousDay = action.payload;
     },
@@ -41,5 +46,5 @@ const slice = createSlice({
   },
 });
 
-export const { setLoading, setZero, setZeroPreviousDay, setShowNewRewards } = slice.actions;
+export const { setLoading, setZero, setZeroPreviousDay, setShowNewRewards, setZeroInUSD } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -86,6 +86,7 @@ function* clearOnLogout() {
   yield put(setLoading(false));
   yield put(setZero('0'));
   yield put(setZeroPreviousDay('0'));
+  yield put(setZeroInUSD(0.0));
   yield put(setShowNewRewards(false));
 }
 

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -1,14 +1,24 @@
-import { call, delay, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
+import { call, delay, put, select, spawn, takeEvery, takeLatest } from 'redux-saga/effects';
 import getDeepProperty from 'lodash.get';
 
-import { SagaActionTypes, setLoading, setShowNewRewards, setZero, setZeroPreviousDay } from '.';
-import { RewardsResp, fetchRewards } from './api';
+import { SagaActionTypes, setLoading, setShowNewRewards, setZero, setZeroInUSD, setZeroPreviousDay } from '.';
+import { RewardsResp, fetchCurrentZeroPriceInUSD as fetchCurrentZeroPriceInUSDAPI, fetchRewards } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
 
 const FETCH_REWARDS_INTERVAL = 60 * 60 * 1000; // 1 hour
+const SYNC_ZERO_TOKEN_PRICE_INTERVAL = 2 * 60 * 1000; // every 2 minutes
 
 const lastViewedRewardsKey = 'last_viewed_rewards';
+
+export function* fetchCurrentZeroPriceInUSD() {
+  try {
+    const result = yield call(fetchCurrentZeroPriceInUSDAPI);
+    if (result.success) {
+      yield put(setZeroInUSD(result.response.price));
+    }
+  } catch (e) {}
+}
 
 export function* fetch(_action) {
   yield put(setLoading(true));
@@ -33,6 +43,19 @@ export function* syncFetchRewards() {
 
     yield delay(FETCH_REWARDS_INTERVAL);
   }
+}
+
+export function* syncZEROPrice() {
+  while (true) {
+    yield call(fetchCurrentZeroPriceInUSD);
+
+    yield delay(SYNC_ZERO_TOKEN_PRICE_INTERVAL);
+  }
+}
+
+export function* syncRewardsAndTokenPrice() {
+  yield spawn(syncFetchRewards);
+  yield spawn(syncZEROPrice);
 }
 
 export function* checkNewRewardsLoaded() {
@@ -67,7 +90,7 @@ function* clearOnLogout() {
 }
 
 export function* saga() {
-  yield takeLatest(SagaActionTypes.Fetch, syncFetchRewards);
+  yield takeLatest(SagaActionTypes.Fetch, syncRewardsAndTokenPrice);
   yield takeEvery(SagaActionTypes.RewardsPopupClosed, rewardsPopupClosed);
   yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
 }


### PR DESCRIPTION
Design Changes

Before

![image](https://github.com/zer0-os/zOS/assets/33264364/1c260064-1428-46ce-a9ca-91ed429d553e)

After:

![image](https://github.com/zer0-os/zOS/assets/33264364/ac04b75d-2b54-4d39-9693-7b1950659eeb)

![image](https://github.com/zer0-os/zOS/assets/33264364/775eb34f-e638-4b52-adf2-5e00a7f6310d)

![image](https://github.com/zer0-os/zOS/assets/33264364/2ce02cd6-bf8c-4382-a4bd-8d9cdde46e6d)

![image](https://github.com/zer0-os/zOS/assets/33264364/181ab83c-d804-413c-ad0e-6f0fa654520c)

EMPTY STATE

![image](https://github.com/zer0-os/zOS/assets/33264364/40e960b0-300a-4317-b1bc-1e4a866c6aea)