### PR TITLE
feat: tab accessibility for start conversation user results search

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -517,9 +517,11 @@ $side-padding: 16px;
     gap: 16px;
     cursor: pointer;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: theme.$color-primary-3;
       border-radius: 8px;
+      outline: none;
     }
   }
 

--- a/src/components/messenger/list/user-search-results.test.tsx
+++ b/src/components/messenger/list/user-search-results.test.tsx
@@ -50,4 +50,16 @@ describe('UserSearchResults', () => {
 
     expect(handleCreate).toHaveBeenCalledWith(userResults[0].value);
   });
+
+  it('triggers onCreate when enter key is pressed', function () {
+    const handleCreate = jest.fn();
+    const userResults = [
+      { value: 'user-1', label: 'jack', image: 'image-1' },
+    ];
+    const wrapper = subject({ results: userResults, onCreate: handleCreate });
+
+    wrapper.find('.user-search-results__item').simulate('keydown', { key: 'Enter' });
+
+    expect(handleCreate).toHaveBeenCalledWith(userResults[0].value);
+  });
 });

--- a/src/components/messenger/list/user-search-results.tsx
+++ b/src/components/messenger/list/user-search-results.tsx
@@ -20,6 +20,12 @@ export class UserSearchResults extends React.Component<Properties> {
     this.props.onCreate(id);
   };
 
+  handleKeyDown = (id: string) => (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter') {
+      this.props.onCreate(id);
+    }
+  };
+
   render() {
     const { filter, results } = this.props;
 
@@ -27,8 +33,15 @@ export class UserSearchResults extends React.Component<Properties> {
       <div {...cn()}>
         <div {...cn('title')}>Start a new conversation:</div>
         {results.map((userResult) => (
-          <div {...cn('item')} onClick={() => this.handleUserClick(userResult.value)} key={userResult.value}>
-            <Avatar size='regular' type='circle' imageURL={userResult.image} />
+          <div
+            {...cn('item')}
+            tabIndex={0}
+            role='button'
+            onKeyDown={this.handleKeyDown(userResult.value)}
+            onClick={() => this.handleUserClick(userResult.value)}
+            key={userResult.value}
+          >
+            <Avatar size='regular' type='circle' imageURL={userResult.image} tabIndex={-1} />
             <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
           </div>
         ))}


### PR DESCRIPTION
### What does this do?
- The Avatar is no longer in the tabbing order - given tabIndex -1.

- The behaviour from TAB-ing to create a conversation from a user search result is for the entire user preview itself is now highlighted, without any green ring around the avatar.

- Able to create a conversation using the Enter Key.

### Why are we making this change?
- accessibility and as per design

### How do I test this?
- search for user in the conversation list panel. When there are user search results, key down tab to navigate through the results.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before: 

https://github.com/zer0-os/zOS/assets/39112648/c4030685-6431-4a66-a0a0-aeea389c1a17

After: 

https://github.com/zer0-os/zOS/assets/39112648/8aa37d97-bd56-4c74-abbc-7122fc7d0849

