### PR TITLE
feat: add tab accessibility to autocomplete member search

### DIFF
--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -60,6 +60,22 @@ describe('autocomplete-members', () => {
 
     expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1' });
   });
+
+  it('fires onSelect when enter is pressed on a result', async () => {
+    const search = jest.fn();
+    when(search).mockResolvedValue([
+      { name: 'Result 1', id: 'result-1' },
+    ]);
+    const onSelect = jest.fn();
+    const wrapper = subject({ search, onSelect });
+    await searchFor(wrapper, 'name');
+
+    wrapper
+      .find('.autocomplete-members__search-results > div')
+      .simulate('keydown', { key: 'Enter', currentTarget: { dataset: { id: 'result-1' } } });
+
+    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1' });
+  });
 });
 
 async function searchFor(wrapper, searchString) {

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -33,11 +33,21 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     this.setState({ results: items.map(itemToOption) });
   };
 
-  itemClicked = (event: any) => {
+  itemClicked = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     const clickedId = event.currentTarget.dataset.id;
     const selectedUser = this.state.results.find((r) => r.value === clickedId);
     if (selectedUser) {
       this.props.onSelect(selectedUser);
+    }
+  };
+
+  handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter') {
+      const clickedId = event.currentTarget.dataset.id;
+      const selectedUser = this.state.results.find((r) => r.value === clickedId);
+      if (selectedUser) {
+        this.props.onSelect(selectedUser);
+      }
     }
   };
 
@@ -66,8 +76,15 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           {this.state.results && this.state.results.length > 0 && (
             <div className='autocomplete-members__search-results'>
               {this.state.results.map((r) => (
-                <div key={r.value} data-id={r.value} onClick={this.itemClicked}>
-                  <Avatar size='regular' type='circle' imageURL={r.image} />
+                <div
+                  key={r.value}
+                  data-id={r.value}
+                  tabIndex={0}
+                  role='button'
+                  onKeyDown={this.handleKeyDown}
+                  onClick={this.itemClicked}
+                >
+                  <Avatar size='regular' type='circle' imageURL={r.image} tabIndex={-1} />
                   <div>{highlightFilter(r.label, this.state.searchString)}</div>
                 </div>
               ))}

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -39,8 +39,11 @@
       overflow: hidden;
       cursor: pointer;
 
-      &:hover {
+      &:hover,
+      &:focus {
         background-color: theme.$color-primary-3;
+        border-radius: 8px;
+        outline: none;
       }
     }
   }


### PR DESCRIPTION
Following conversation panel screens (start conversation via '+' icon and start group conversation)

### What does this do?
- The Avatar is no longer in the tabbing order - given tabIndex -1.

- The behaviour from TAB-ing to start a conversation from a user search result is for the entire user preview itself is now highlighted, without any green ring around the avatar.

- Able to create a conversation using the Enter Key.

### Why are we making this change?
- accessibility and as per design

### How do I test this?
- Press the '+' icon in the conversation list panel. Enter a name to render search results, key down tab to navigate through the results.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

https://github.com/zer0-os/zOS/assets/39112648/3b0fe063-5a23-4b4c-a1ed-305cefaea64c

After:

https://github.com/zer0-os/zOS/assets/39112648/9f79572e-4a77-4e69-81f3-da9777f79476
