### PR TITLE
Error state for message send failures

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Message } from '.';
-import { MediaType } from '../../store/messages';
+import { MediaType, MessageSendStatus } from '../../store/messages';
 import { LinkPreview } from '../link-preview';
 import { LinkPreviewType } from '../../lib/link-preview';
 import { MessageInput } from '../message-input/container';
@@ -70,13 +70,25 @@ describe('message', () => {
     expect(wrapper.find('.message__block-image').exists()).toBe(false);
   });
 
-  it('renders time', () => {
+  it('renders time if status not failed', () => {
     const wrapper = subject({
       message: 'the message',
       createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
     });
 
     expect(wrapper.find('.message__time').text()).toStrictEqual('5:04 PM');
+    expect(wrapper).not.toHaveElement('.message__failure-message');
+  });
+
+  it('renders failure message instead of time if status is failed', () => {
+    const wrapper = subject({
+      message: 'the message',
+      createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
+      sendStatus: MessageSendStatus.FAILED,
+    });
+
+    expect(wrapper).not.toHaveElement('.message__time');
+    expect(wrapper).toHaveElement('.message__failure-message');
   });
 
   it('renders message menu of items', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Message as MessageModel, MediaType, EditMessageOptions } from '../../store/messages';
+import { Message as MessageModel, MediaType, EditMessageOptions, MessageSendStatus } from '../../store/messages';
 import { download } from '../../lib/api/attachment';
 import { LinkPreview } from '../link-preview';
 import { getProvider } from '../../lib/cloudinary/provider';
@@ -12,7 +12,7 @@ import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
-import { IconXClose } from '@zero-tech/zui/icons';
+import { IconAlertCircle, IconXClose } from '@zero-tech/zui/icons';
 import { IconButton } from '../icon-button';
 import { ContentHighlighter } from '../content-highlighter';
 import { bemClassName } from '../../lib/bem';
@@ -117,6 +117,21 @@ export class Message extends React.Component<Properties, State> {
     return '';
   }
 
+  renderFooter() {
+    return (
+      <>
+        <div {...cn('footer')}>
+          {this.props.sendStatus !== MessageSendStatus.FAILED && this.renderTime(this.props.createdAt)}
+          {this.props.sendStatus === MessageSendStatus.FAILED && (
+            <div {...cn('failure-message')}>
+              Failed to send&nbsp;
+              <IconAlertCircle size={16} />
+            </div>
+          )}
+        </div>
+      </>
+    );
+  }
   renderTime(time): React.ReactElement {
     const createdTime = moment(time).format('h:mm A');
     return <div {...cn('time')}>{createdTime}</div>;
@@ -195,7 +210,7 @@ export class Message extends React.Component<Properties, State> {
   }
 
   render() {
-    const { message, media, preview, createdAt, sender, isOwner, hidePreview } = this.props;
+    const { message, media, preview, sender, isOwner, hidePreview } = this.props;
     return (
       <div
         className={classNames('message', this.props.className, {
@@ -251,7 +266,7 @@ export class Message extends React.Component<Properties, State> {
               )}
             </>
           )}
-          <div {...cn('footer')}>{this.renderTime(createdAt)}</div>
+          {this.renderFooter()}
         </div>
         {this.renderMenu()}
       </div>

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -140,21 +140,26 @@
   }
 
   &__footer {
-    display: var(--message-footer-display);
+    display: flex;
     justify-content: flex-end;
     margin: 0px;
-  }
-
-  &__time {
-    display: block;
+    color: theme.$color-greyscale-11;
     font-size: 12px;
-    color: themeDeprecated.$font-color-time;
-    text-align: right;
     font-weight: 400;
     font-size: 12px;
     line-height: 15px;
-    margin: 0px;
+  }
+
+  &__time {
+    display: var(--message-timestamp-display);
     padding-top: 4px;
+  }
+
+  &__failure-message {
+    display: flex;
+    align-items: center;
+    padding-top: 4px;
+    color: theme.$color-failure-11;
   }
 
   &__menu {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -1,4 +1,4 @@
-import { AdminMessageType, Message } from '../../store/messages';
+import { AdminMessageType, Message, MessageSendStatus } from '../../store/messages';
 import { RootState } from '../../store/reducer';
 import { ChatMember } from './types';
 import { denormalize as denormalizeUser } from '../../store/users';
@@ -130,6 +130,7 @@ export function map(sendbirdMessage) {
     sender: getSender(sender),
     ...extractMessageData(data, messageType.toLowerCase() === 'file'),
     isAdmin: messageType.toLowerCase() === 'admin',
+    sendStatus: MessageSendStatus.SUCCESS,
   } as unknown as Message;
 }
 

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -245,7 +245,7 @@ $scrollbar-width: 5px;
       display: flex;
       clear: both;
       margin: 4px 16px;
-      --message-footer-display: none;
+      --message-timestamp-display: none;
       --message-author-name-display: none;
       --border-radius: 2px 8px 8px 2px;
 
@@ -274,7 +274,7 @@ $scrollbar-width: 5px;
 
     &__message-row:last-child {
       margin-bottom: 16px;
-      --message-footer-display: flex;
+      --message-timestamp-display: flex;
       --border-radius: 2px 8px 8px 0px;
     }
 

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -48,6 +48,12 @@ export enum AdminMessageType {
   JOINED_ZERO = 'JOINED_ZERO',
 }
 
+export enum MessageSendStatus {
+  SUCCESS,
+  IN_PROGRESS,
+  FAILED,
+}
+
 export interface Message {
   id: number;
   message?: string;
@@ -68,6 +74,7 @@ export interface Message {
   };
   optimisticId?: string;
   rootMessageId?: string;
+  sendStatus: MessageSendStatus;
 }
 
 export interface EditMessageOptions {

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { MediaType, Message } from './index';
+import { MediaType, Message, MessageSendStatus } from './index';
 import { User } from './../authentication/types';
 import * as linkifyjs from 'linkifyjs';
 import { ParentMessage } from '../../lib/chat/types';
@@ -56,6 +56,7 @@ export function createOptimisticMessageObject(
     updatedAt: 0,
     preview: null,
     media,
+    sendStatus: MessageSendStatus.IN_PROGRESS,
   };
 }
 


### PR DESCRIPTION
### What does this do?

Adds an error state for when messages fail to send.

This is the first step which sets the state and renders a failure note on messages.

### Why are we making this change?

Since we optimistically render we need a way to notify the user if a message fails to send.

![image](https://github.com/zer0-os/zOS/assets/43770/ad5e9171-db4f-4c16-8d9d-19d8e8fe4b4f)
