### PR TITLE
Add a dev panel for message status testing

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -12,6 +12,8 @@ import classNames from 'classnames';
 import { Sidekick } from './components/sidekick/index';
 import { withContext as withAuthenticationContext } from './components/authentication/context';
 import { MessengerChat } from './components/messenger/chat';
+import { DevPanelContainer } from './components/dev-panel/container';
+import { FeatureFlag } from './components/feature-flag';
 
 export interface Properties {
   hasContextPanel: boolean;
@@ -89,6 +91,9 @@ export class Container extends React.Component<Properties> {
           <>
             <Sidekick className='main__sidekick' />
             <MessengerChat />
+            <FeatureFlag featureFlag='enableDevPanel'>
+              <DevPanelContainer />
+            </FeatureFlag>
           </>
         )}
 

--- a/src/components/dev-panel/container.tsx
+++ b/src/components/dev-panel/container.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
+import { DevPanel } from '.';
+import { denormalize as denormalizeChannel } from '../../store/channels';
+import { Message, MessageSendStatus, receive } from '../../store/messages';
+
+interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  messages: Message[];
+  activeConversationId: string;
+
+  toggleState(): void;
+  updateMessage(message: Partial<Message>): void;
+}
+
+interface State {
+  isOpen: boolean;
+}
+
+export class Container extends React.Component<Properties, State> {
+  state = { isOpen: false };
+
+  static mapState(state: RootState): Partial<Properties> {
+    const {
+      chat: { activeConversationId },
+    } = state;
+
+    if (!activeConversationId) {
+      return { messages: [] };
+    }
+
+    const channel = denormalizeChannel(activeConversationId, state) || null;
+
+    return {
+      messages: channel?.messages || [],
+      activeConversationId,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {
+      updateMessage: receive,
+    };
+  }
+
+  get isOpen() {
+    return this.state.isOpen;
+  }
+
+  toggleState = () => {
+    this.setState({ isOpen: !this.state.isOpen });
+  };
+
+  updateMessageStatus = (id, sendStatus: MessageSendStatus) => {
+    this.props.updateMessage({ id, sendStatus });
+  };
+
+  render() {
+    return (
+      <DevPanel
+        messages={this.props.messages}
+        isOpen={this.isOpen}
+        onMessageStatusChanged={this.updateMessageStatus}
+        toggleState={this.toggleState}
+      />
+    );
+  }
+}
+
+export const DevPanelContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/dev-panel/index.tsx
+++ b/src/components/dev-panel/index.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+
+import { Message, MessageSendStatus } from '../../store/messages';
+import { bemClassName } from '../../lib/bem';
+import './styles.scss';
+import classNames from 'classnames';
+
+const cn = bemClassName('dev-panel');
+
+export interface Properties {
+  messages: Message[];
+  isOpen: boolean;
+  toggleState: () => void;
+  onMessageStatusChanged: (messageId: string, status: MessageSendStatus) => void;
+}
+
+export class DevPanel extends React.Component<Properties> {
+  toggleState = () => {
+    this.props.toggleState();
+  };
+
+  statusChanged = (e, messageId: any) => {
+    const status = e.target.value;
+    this.props.onMessageStatusChanged(messageId, parseInt(status));
+  };
+
+  statusOption(value, label) {
+    return <option value={value}>{label}</option>;
+  }
+
+  render() {
+    return (
+      <>
+        <div
+          className={classNames('dev-panel__toggle', { 'dev-panel__toggle--closed': !this.props.isOpen })}
+          onClick={this.toggleState}
+        ></div>
+        <div className={classNames('dev-panel', { 'dev-panel--closed': !this.props.isOpen })}>
+          <div {...cn('content')}>
+            {this.props.messages.map((message) => {
+              return (
+                <div {...cn('message')} key={message.id}>
+                  <div>{message.message}</div>
+                  <select value={message.sendStatus} onChange={(e) => this.statusChanged(e, message.id)}>
+                    {this.statusOption(MessageSendStatus.SUCCESS, 'Success')}
+                    {this.statusOption(MessageSendStatus.IN_PROGRESS, 'In progress')}
+                    {this.statusOption(MessageSendStatus.FAILED, 'Failed')}
+                  </select>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/src/components/dev-panel/styles.scss
+++ b/src/components/dev-panel/styles.scss
@@ -1,0 +1,35 @@
+.dev-panel {
+  pointer-events: auto; // The platform layer sets this and it's inherited so restore to default
+  box-sizing: border-box;
+  height: 100vh;
+  width: 300px;
+  overflow-y: auto;
+
+  background-color: grey;
+
+  padding: 12px;
+
+  &__toggle {
+    z-index: 5000;
+    position: absolute;
+    pointer-events: auto; // The platform layer sets this and it's inherited so restore to default
+    top: 0px;
+    right: 300px;
+    height: 30px;
+    width: 25px;
+    background-color: green;
+    cursor: pointer;
+
+    &--closed {
+      right: 0px;
+    }
+  }
+
+  &__message {
+    margin-bottom: 12px;
+  }
+
+  &--closed {
+    display: none;
+  }
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -24,6 +24,14 @@ export class FeatureFlags {
   set allowPublicZOS(value: boolean) {
     this._setBoolean('allowPublicZOS', value);
   }
+
+  get enableDevPanel() {
+    return this._getBoolean('enableDevPanel');
+  }
+
+  set enableDevPanel(value: boolean) {
+    this._setBoolean('enableDevPanel', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?

Adds a dev panel to test the various message states. As you can see, very little effort was spent styling :)

### Why are we making this change?

It's frequently difficult to get into the various states a message can be in when it comes to the sending flow. This adds a hidden dev panel that allows a user to toggle the various states so we can quickly see how it impacts the view.

### How do I test this?

Enable via `window.FEATURE_FLAGS.enableDevPanel = true` and refresh


https://github.com/zer0-os/zOS/assets/43770/bf313fbf-96da-40d6-a514-dce8b2e2f392

