### PR TITLE
feat: remove ability for users that have left a group to continue interacting with that group

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -117,9 +117,6 @@ export class Chat {
       onUserLeft: (channel, user) => {
         events.onUserLeft(this.getChannelId(channel), user.userId);
       },
-      onUserBanned: (channel, user) => {
-        console.log('onUserBanned', channel, user);
-      },
     });
 
     this.sendbird.groupChannel.addGroupChannelHandler('chatHandler', channelHandler);

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -14,6 +14,7 @@ interface RealtimeChatEvents {
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
   onUserReceivedInvitation: (channel) => void;
   invalidChatAccessToken: () => void;
+  onUserLeft: (channelId: string, userId: string) => void;
 }
 
 export class Chat {
@@ -112,6 +113,12 @@ export class Chat {
       },
       onUserReceivedInvitation: (channel) => {
         events.onUserReceivedInvitation(this.getChannelId(channel));
+      },
+      onUserLeft: (channel, user) => {
+        events.onUserLeft(this.getChannelId(channel), user.userId);
+      },
+      onUserBanned: (channel, user) => {
+        console.log('onUserBanned', channel, user);
       },
     });
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -175,6 +175,10 @@ export function* currentUserAddedToChannel(_action) {
   yield fetchConversations();
 }
 
+export function* userLeftChannel(_channelId, _userId) {
+  yield console.log('userLeftChannel');
+}
+
 export function* saga() {
   yield spawn(listenForUserLogin);
   yield spawn(listenForUserLogout);
@@ -186,4 +190,7 @@ export function* saga() {
 
   const chatBus = yield call(getChatBus);
   yield takeEveryFromBus(chatBus, ChatEvents.ChannelInvitationReceived, currentUserAddedToChannel);
+  yield takeEveryFromBus(chatBus, ChatEvents.UserLeftChannel, ({ payload }) =>
+    userLeftChannel(payload.channelId, payload.userId)
+  );
 }

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -11,6 +11,7 @@ export enum Events {
   ReconnectStop = 'chat/reconnectStop',
   InvalidToken = 'chat/invalidToken',
   ChannelInvitationReceived = 'chat/channel/invitationReceived',
+  UserLeftChannel = 'chat/channel/userLeft',
 }
 
 let theBus;
@@ -36,6 +37,7 @@ export function createChatConnection(userId, chatAccessToken) {
     const invalidChatAccessToken = () => emit({ type: Events.InvalidToken, payload: {} });
     const onUserReceivedInvitation = (channelId) =>
       emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
+    const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
 
     chat.initChat({
       reconnectStart,
@@ -46,6 +48,7 @@ export function createChatConnection(userId, chatAccessToken) {
       receiveUnreadCount,
       invalidChatAccessToken,
       onUserReceivedInvitation,
+      onUserLeft,
     });
     chat.connect(userId, chatAccessToken);
 


### PR DESCRIPTION
### What does this do?
- clears the state when a user has left a conversation meaning a user will no longer be able to interact with a group that they had left or been removed from.

### Why are we making this change?
- Previously in Web, users can continue to interact with groups they have left. There was no way to leave groups in Web, but if I leave a group in iOS, a user can continue to interact with that group from the web client.

### How do I test this?
- using mobile and web, log in as the same user on each device. Create a group on web. Leave group on mobile then check that web reflects this change.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Result of leave group -
https://github.com/zer0-os/zOS/assets/39112648/9f686e41-4f62-40e9-949f-4d726cf70ed9


