### PR TITLE
Render failed message in conversation list

### DIFF
--- a/src/components/messenger/list/conversation-item.test.tsx
+++ b/src/components/messenger/list/conversation-item.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { ConversationItem, Properties } from './conversation-item';
 import moment from 'moment';
 import { ContentHighlighter } from '../../content-highlighter';
-import { MediaType } from '../../../store/messages';
+import { MediaType, MessageSendStatus } from '../../../store/messages';
 
 describe('ConversationItem', () => {
   const subject = (props: Partial<Properties>) => {
@@ -206,6 +206,21 @@ describe('ConversationItem', () => {
       myUserId: 'my-user-id',
     });
     expect(wrapper.find(ContentHighlighter).prop('message')).toEqual('You: received an image');
+  });
+
+  it('renders failed to send message if the last message failed', function () {
+    const messagePreview = 'I said something here';
+
+    const wrapper = subject({
+      myUserId: 'id',
+      conversation: {
+        messagePreview,
+        otherMembers: [],
+        lastMessage: { sender: { userId: 'id', firstName: 'Johnny' }, sendStatus: MessageSendStatus.FAILED },
+      } as any,
+    });
+
+    expect(wrapper.find(ContentHighlighter).prop('message')).toEqual('You: Failed to send');
   });
 
   describe('status', () => {

--- a/src/components/messenger/list/conversation-item.tsx
+++ b/src/components/messenger/list/conversation-item.tsx
@@ -12,7 +12,7 @@ import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bem } from '../../../lib/bem';
 import moment from 'moment';
 import { ContentHighlighter } from '../../content-highlighter';
-import { MediaType } from '../../../store/messages';
+import { MediaType, MessageSendStatus } from '../../../store/messages';
 const c = bem('conversation-item');
 
 export interface Properties {
@@ -128,6 +128,11 @@ export class ConversationItem extends React.Component<Properties> {
     }
 
     const { messagePreview, lastMessage } = this.props.conversation;
+
+    if (lastMessage.sendStatus === MessageSendStatus.FAILED) {
+      return 'You: Failed to send';
+    }
+
     if (messagePreview) {
       const isAdminMessage = lastMessage?.admin && Object.keys(lastMessage.admin).length > 0;
       if (isAdminMessage) return messagePreview;


### PR DESCRIPTION
### What does this do?

Renders the last message preview with a failed message if the most recent send failed

![image](https://github.com/zer0-os/zOS/assets/43770/16b202ce-8a93-4bb7-994e-9eb1845908b2)

