### PR TITLE
Disable message menu when message is in progress

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -109,6 +109,19 @@ describe('message', () => {
     expect(wrapper.find(MessageInput).exists()).toBe(true);
   });
 
+  it('disables all menu abilities when in progress', () => {
+    const wrapper = subject({
+      message: 'the message',
+      isOwner: true,
+      sendStatus: MessageSendStatus.IN_PROGRESS,
+    });
+
+    const props = wrapper.find(MessageMenu).props();
+
+    expect(props.canEdit).toBe(false);
+    expect(props.canReply).toBe(false);
+  });
+
   it('renders edited indicator', () => {
     const wrapper = subject({
       message: 'the message',

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -138,7 +138,7 @@ export class Message extends React.Component<Properties, State> {
   }
 
   canDeleteMessage = (): boolean => {
-    return this.props.isOwner;
+    return this.props.isOwner && this.props.sendStatus !== MessageSendStatus.IN_PROGRESS;
   };
 
   isMediaMessage = (): boolean => {
@@ -184,6 +184,10 @@ export class Message extends React.Component<Properties, State> {
     this.setState({ isMessageMenuOpen: false });
   };
 
+  canReply = () => {
+    return !this.props.parentMessageText && this.props.sendStatus !== MessageSendStatus.IN_PROGRESS;
+  };
+
   renderMenu(): React.ReactElement {
     return (
       <div
@@ -196,7 +200,7 @@ export class Message extends React.Component<Properties, State> {
         <MessageMenu
           {...cn('menu-item')}
           canEdit={this.canDeleteMessage()}
-          canReply={!this.props.parentMessageText}
+          canReply={this.canReply()}
           onDelete={this.deleteMessage}
           onEdit={this.toggleEdit}
           onReply={this.onReply}


### PR DESCRIPTION
### What does this do?

When a message is in progress we no longer render the message menu

### Why are we making this change?

To prevent people from trying to perform operations on an object that doesn't truly exist yet.

### How do I test this?

Use the dev panel to set messages into the 'In progress' state and verify there's no menu available.

