### PR TITLE
Deleting optimistic message

### DIFF
--- a/src/store/messages/saga.deleteMessage.test.ts
+++ b/src/store/messages/saga.deleteMessage.test.ts
@@ -77,6 +77,30 @@ describe(deleteMessage, () => {
       messages[2],
     ]);
   });
+
+  it('deletes optimistic message from store but does not make api call', async () => {
+    const channelId = 'channel-id';
+    const messages = [
+      { id: 'message-1' },
+      { id: 'optimistic-root', message: 'To be deleted. Root Message.', optimisticId: 'optimistic-root' },
+      { id: 'message-2' },
+      { id: 'optimistic-child', rootMessageId: 'optimistic-root', optimisticId: 'optimistic-child' },
+    ];
+
+    const initialState = existingChannelState({ id: channelId, messages });
+
+    const { storeState } = await expectSaga(deleteMessage, { payload: { channelId, messageId: 'optimistic-root' } })
+      .withReducer(rootReducer, initialState)
+      .provide(successResponses())
+      .not.call.like({ fn: deleteMessageApi })
+      .run();
+
+    const channel = denormalizeChannel(channelId, storeState);
+    expect(channel.messages).toEqual([
+      messages[0],
+      messages[2],
+    ]);
+  });
 });
 
 function successResponses() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -306,11 +306,16 @@ export function* deleteMessage(action) {
     })
   );
 
+  const nonOptimisticMessagesIds = fullMessages
+    .filter((m) => messageIdsToDelete.includes(m.id))
+    .filter((m) => m.id !== m.optimisticId)
+    .map((m) => m.id);
+
   // In the future we'd prefer that the api did this so that the front-ends
   // could treat these as independent messages. However, given that we have
   // multiple front ends and they don't all support treating these messages
   // as a single entity yet, this is how we'll do it for now.
-  for (let id of messageIdsToDelete) {
+  for (let id of nonOptimisticMessagesIds) {
     yield call(deleteMessageApi, channelId, id);
   }
 }


### PR DESCRIPTION
### What does this do?

Allows deleting of optimistic messages (i.e., failed to send messages)

### Why are we making this change?

To allow a user to clear their screen in the case of a message failure.

