### PR TITLE
Only allow deletion of failed messages

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -123,6 +123,20 @@ describe('message', () => {
     expect(props.canDelete).toBe(false);
   });
 
+  it('allows only delete when message send failed', () => {
+    const wrapper = subject({
+      message: 'the message',
+      isOwner: true,
+      sendStatus: MessageSendStatus.FAILED,
+    });
+
+    const props = wrapper.find(MessageMenu).props();
+
+    expect(props.canEdit).toBe(false);
+    expect(props.canReply).toBe(false);
+    expect(props.canDelete).toBe(true);
+  });
+
   it('renders edited indicator', () => {
     const wrapper = subject({
       message: 'the message',

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -120,6 +120,7 @@ describe('message', () => {
 
     expect(props.canEdit).toBe(false);
     expect(props.canReply).toBe(false);
+    expect(props.canDelete).toBe(false);
   });
 
   it('renders edited indicator', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -138,7 +138,11 @@ export class Message extends React.Component<Properties, State> {
   }
 
   canEditMessage = (): boolean => {
-    return this.props.isOwner && this.props.sendStatus !== MessageSendStatus.IN_PROGRESS;
+    return (
+      this.props.isOwner &&
+      this.props.sendStatus !== MessageSendStatus.IN_PROGRESS &&
+      this.props.sendStatus !== MessageSendStatus.FAILED
+    );
   };
 
   canDeleteMessage = (): boolean => {
@@ -189,7 +193,11 @@ export class Message extends React.Component<Properties, State> {
   };
 
   canReply = () => {
-    return !this.props.parentMessageText && this.props.sendStatus !== MessageSendStatus.IN_PROGRESS;
+    return (
+      !this.props.parentMessageText &&
+      this.props.sendStatus !== MessageSendStatus.IN_PROGRESS &&
+      this.props.sendStatus !== MessageSendStatus.FAILED
+    );
   };
 
   renderMenu(): React.ReactElement {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -137,6 +137,10 @@ export class Message extends React.Component<Properties, State> {
     return <div {...cn('time')}>{createdTime}</div>;
   }
 
+  canEditMessage = (): boolean => {
+    return this.props.isOwner && this.props.sendStatus !== MessageSendStatus.IN_PROGRESS;
+  };
+
   canDeleteMessage = (): boolean => {
     return this.props.isOwner && this.props.sendStatus !== MessageSendStatus.IN_PROGRESS;
   };
@@ -199,7 +203,8 @@ export class Message extends React.Component<Properties, State> {
       >
         <MessageMenu
           {...cn('menu-item')}
-          canEdit={this.canDeleteMessage()}
+          canEdit={this.canEditMessage()}
+          canDelete={this.canDeleteMessage()}
           canReply={this.canReply()}
           onDelete={this.deleteMessage}
           onEdit={this.toggleEdit}

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { MessageMenu } from '.';
+import { MessageMenu, Properties } from '.';
 
 describe('Message Menu', () => {
-  const subject = (props: any = {}) => {
+  const subject = (props: Partial<Properties> = {}) => {
     const defaultProps = {
       className: '',
       canEdit: false,
+      canDelete: false,
       canReply: false,
       isMediaMessage: false,
       isMenuOpen: false,
@@ -24,16 +25,16 @@ describe('Message Menu', () => {
   describe('ClassName', () => {
     it('adds className', () => {
       const onDelete = jest.fn();
-      const wrapper = subject({ className: 'message-menu', onDelete, canEdit: true });
+      const wrapper = subject({ className: 'message-menu', onDelete, canDelete: true });
 
       expect(wrapper.hasClass('message-menu')).toBe(true);
     });
   });
 
   describe('Delete Button', () => {
-    it('should render when canEdit is true and onDelete is provided', () => {
+    it('should render when canDelete is true and onDelete is provided', () => {
       const onDelete = jest.fn();
-      const wrapper = subject({ canEdit: true, onDelete }) as ShallowWrapper;
+      const wrapper = subject({ canDelete: true, onDelete }) as ShallowWrapper;
 
       const dropdownMenu = wrapper.find('DropdownMenu');
       const items = dropdownMenu.prop('items') as { id: string; onSelect: () => void }[];
@@ -44,7 +45,7 @@ describe('Message Menu', () => {
 
     it('should open delete modal when delete button is clicked', () => {
       const onDelete = jest.fn();
-      const wrapper = subject({ canEdit: true, onDelete });
+      const wrapper = subject({ canDelete: true, onDelete });
 
       const dropdownMenu = wrapper.find('DropdownMenu');
       const items = dropdownMenu.prop('items') as { id: string; onSelect: () => void }[];

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -7,9 +7,10 @@ import { IconDotsHorizontal, IconEdit5, IconFlipBackward, IconTrash4, IconXClose
 import classNames from 'classnames';
 import './styles.scss';
 
-interface Properties {
+export interface Properties {
   className: string;
   canEdit: boolean;
+  canDelete: boolean;
   canReply?: boolean;
   isMediaMessage?: boolean;
   isMenuOpen?: boolean;
@@ -54,7 +55,7 @@ export class MessageMenu extends React.Component<Properties, State> {
         onSelect: this.props.onReply,
       });
     }
-    if (this.props.onDelete && this.props.canEdit) {
+    if (this.props.onDelete && this.props.canDelete) {
       menuItems.push({
         id: 'delete',
         label: this.renderMenuOption(<IconTrash4 />, 'Delete'),


### PR DESCRIPTION
### What does this do?

Updates the message menu to only allow deletion of failed messages

### Why are we making this change?

Since there's no real message you can't reply or edit.

![image](https://github.com/zer0-os/zOS/assets/43770/2dce4c6c-6ec4-4d07-b172-d9ab92d4ffaa)
