### PR TITLE
Force the menu trigger to be visible for failed messages

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -137,6 +137,16 @@ describe('message', () => {
     expect(props.canDelete).toBe(true);
   });
 
+  it('displays the menu when message send failed', () => {
+    const wrapper = subject({
+      message: 'the message',
+      isOwner: true,
+      sendStatus: MessageSendStatus.FAILED,
+    });
+
+    expect(wrapper).toHaveElement('.menu--force-visible');
+  });
+
   it('renders edited indicator', () => {
     const wrapper = subject({
       message: 'the message',

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -200,12 +200,17 @@ export class Message extends React.Component<Properties, State> {
     );
   };
 
+  isMenuTriggerAlwaysVisible = () => {
+    return this.props.sendStatus === MessageSendStatus.FAILED;
+  };
+
   renderMenu(): React.ReactElement {
     return (
       <div
         {...cn(
           classNames('menu', {
             'menu--open': this.state.isMessageMenuOpen,
+            'menu--force-visible': this.isMenuTriggerAlwaysVisible(),
           })
         )}
       >

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -174,6 +174,11 @@
     opacity: 1;
   }
 
+  .menu--force-visible {
+    transform: unset;
+    opacity: 1;
+  }
+
   &__left {
     width: 32px;
     align-self: flex-end;


### PR DESCRIPTION
### What does this do?

Forces the menu trigger for failed messages to always be visible

### Why are we making this change?

To draw the user's attention to the options available to them.


https://github.com/zer0-os/zOS/assets/43770/342a1896-5145-43c3-9650-e21813b49eaf

