### PR TITLE
feat: update message footer

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -153,7 +153,7 @@ describe('message', () => {
       updatedAt: 86276372,
     });
 
-    expect(wrapper.find('.message__edited').exists()).toBe(true);
+    expect(wrapper.find('.message__edited-flag').exists()).toBe(true);
   });
 
   it('renders reply message', () => {

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -153,7 +153,7 @@ describe('message', () => {
       updatedAt: 86276372,
     });
 
-    expect(wrapper.find('.message__block-edited').exists()).toBe(true);
+    expect(wrapper.find('.message__edited').exists()).toBe(true);
   });
 
   it('renders reply message', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -118,11 +118,14 @@ export class Message extends React.Component<Properties, State> {
   }
 
   renderFooter() {
+    const isSendStatusFailed = this.props.sendStatus === MessageSendStatus.FAILED;
+
     return (
       <>
         <div {...cn('footer')}>
-          {this.props.sendStatus !== MessageSendStatus.FAILED && this.renderTime(this.props.createdAt)}
-          {this.props.sendStatus === MessageSendStatus.FAILED && (
+          {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && <span>(Edited)</span>}
+          {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
+          {isSendStatusFailed && (
             <div {...cn('failure-message')}>
               Failed to send&nbsp;
               <IconAlertCircle size={16} />
@@ -277,7 +280,7 @@ export class Message extends React.Component<Properties, State> {
                   )}
                 </div>
               )}
-              {!!this.props.updatedAt && !this.state.isEditing && <span {...cn('block-edited')}>(edited)</span>}
+
               {this.state.isEditing && this.props.message && (
                 <MessageInput
                   initialValue={this.props.message}

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -124,7 +124,7 @@ export class Message extends React.Component<Properties, State> {
       <>
         <div {...cn('footer')}>
           {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
-            <span {...cn('edited')}>(Edited)</span>
+            <span {...cn('edited-flag')}>(Edited)</span>
           )}
           {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
           {isSendStatusFailed && (

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -123,7 +123,9 @@ export class Message extends React.Component<Properties, State> {
     return (
       <>
         <div {...cn('footer')}>
-          {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && <span>(Edited)</span>}
+          {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
+            <span {...cn('edited')}>(Edited)</span>
+          )}
           {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
           {isSendStatusFailed && (
             <div {...cn('failure-message')}>

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -148,6 +148,10 @@
     padding-top: 4px;
   }
 
+  &__edited-flag {
+    padding-top: 4px;
+  }
+
   &__failure-message {
     display: flex;
     align-items: center;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -90,14 +90,6 @@
     line-height: 15px;
   }
 
-  &__block-edited {
-    padding-left: 7px;
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 14px;
-    color: themeDeprecated.$actionable-inactive-color;
-  }
-
   &__block-preview {
     display: flex;
     flex-direction: row;
@@ -141,24 +133,24 @@
 
   &__footer {
     display: flex;
+    flex-direction: row;
     justify-content: flex-end;
-    margin: 0px;
+    align-items: flex-end;
+    gap: 4px;
+    padding-top: 4px;
     color: theme.$color-greyscale-11;
     font-size: 12px;
     font-weight: 400;
-    font-size: 12px;
-    line-height: 15px;
+    line-height: 14px;
   }
 
   &__time {
     display: var(--message-timestamp-display);
-    padding-top: 4px;
   }
 
   &__failure-message {
     display: flex;
     align-items: center;
-    padding-top: 4px;
     color: theme.$color-failure-11;
   }
 

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -137,7 +137,6 @@
     justify-content: flex-end;
     align-items: flex-end;
     gap: 4px;
-    padding-top: 4px;
     color: theme.$color-greyscale-11;
     font-size: 12px;
     font-weight: 400;
@@ -146,12 +145,14 @@
 
   &__time {
     display: var(--message-timestamp-display);
+    padding-top: 4px;
   }
 
   &__failure-message {
     display: flex;
     align-items: center;
     color: theme.$color-failure-11;
+    padding-top: 4px;
   }
 
   &__menu {


### PR DESCRIPTION

### What does this do?
- updates the message footer to align with figma design.
- ensures failure message position does not change.
- edited flag in line with time.


### Why are we making this change?
- as per figma design.

### How do I test this?
- open messenger and edit a message to see changes as per screenshot below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before: 

<img width="627" alt="Screenshot 2023-07-21 at 13 37 03" src="https://github.com/zer0-os/zOS/assets/39112648/e3c7d5d4-9b67-4dc9-9c3f-bba20e162d2d">


After:

<img width="627" alt="Screenshot 2023-07-21 at 13 37 26" src="https://github.com/zer0-os/zOS/assets/39112648/754578ae-d293-4992-af56-a857e36550cf">

*failure position check*

<img width="627" alt="Screenshot 2023-07-21 at 13 38 19" src="https://github.com/zer0-os/zOS/assets/39112648/b92b92c3-d298-429d-8f85-5fd9bef47a8b">

*messages in quick succession*
<img width="627" alt="Screenshot 2023-07-21 at 14 01 05" src="https://github.com/zer0-os/zOS/assets/39112648/b12c51a1-bd4f-4ca4-a090-e5f50e2f5124">
