### PR TITLE
feat: edit message display iteration one

### DIFF
--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -17,6 +17,7 @@ export interface PublicProperties {
   id?: string;
   reply?: null | ParentMessage;
   onRemoveReply?: () => void;
+  isEditing?: boolean;
 }
 
 export interface Properties extends PublicProperties {
@@ -57,6 +58,7 @@ export class Container extends React.Component<Properties> {
         viewMode={this.props.viewMode}
         reply={this.props.reply}
         isMessengerFullScreen={this.props.isFullScreen}
+        isEditing={this.props.isEditing}
       />
     );
   }

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -310,22 +310,28 @@ export class MessageInput extends React.Component<Properties, State> {
     const hasInputValue = this.state.value?.length > 0;
 
     return (
-      <div className='message-input__container'>
-        <div className='message-input__icon-outer'>
-          <div className='message-input__icon-wrapper'>
-            <IconButton
-              className={classNames('message-input__icon', 'message-input__icon--giphy')}
-              onClick={this.openGiphy}
-              Icon={IconStickerCircle}
-              size={24}
-            />
-            <Menu
-              onSelected={this.mediaSelected}
-              mimeTypes={this.mimeTypes}
-              maxSize={config.cloudinary.max_file_size}
-            />
+      <div
+        className={classNames('message-input__container', this.props.className, {
+          'message-input__container--editing': this.props.isEditing,
+        })}
+      >
+        {!this.props.isEditing && (
+          <div className='message-input__icon-outer'>
+            <div className='message-input__icon-wrapper'>
+              <IconButton
+                className={classNames('message-input__icon', 'message-input__icon--giphy')}
+                onClick={this.openGiphy}
+                Icon={IconStickerCircle}
+                size={24}
+              />
+              <Menu
+                onSelected={this.mediaSelected}
+                mimeTypes={this.mimeTypes}
+                maxSize={config.cloudinary.max_file_size}
+              />
+            </div>
           </div>
-        </div>
+        )}
 
         <div className='message-input__chat-container'>
           <div className='message-input__scroll-container'>
@@ -386,12 +392,10 @@ export class MessageInput extends React.Component<Properties, State> {
                     >
                       {this.renderMentionTypes()}
                     </MentionsInput>
-
-                    {this.props.renderAfterInput &&
-                      this.props.renderAfterInput(this.state.value, this.state.mentionedUserIds)}
                   </div>
                 )}
               </Dropzone>
+
               <div className='message-input__emoji-icon-outer'>
                 <div className='message-input__icon-wrapper'>
                   <IconButton
@@ -406,18 +410,22 @@ export class MessageInput extends React.Component<Properties, State> {
           </div>
         </div>
 
-        <div className='message-input__icon-outer'>
-          <div className='message-input__icon-wrapper'>
-            <IconButton
-              className={classNames('message-input__icon', 'message-input__icon--end-action', {
-                'message-input__icon--send': hasInputValue,
-              })}
-              onClick={hasInputValue ? this.onSend : this.startMic}
-              Icon={hasInputValue ? IconSend3 : IconMicrophone2}
-              size={24}
-            />
+        {!this.props.isEditing && (
+          <div className='message-input__icon-outer'>
+            <div className='message-input__icon-wrapper'>
+              <IconButton
+                className={classNames('message-input__icon', 'message-input__icon--end-action', {
+                  'message-input__icon--send': hasInputValue,
+                })}
+                onClick={hasInputValue ? this.onSend : this.startMic}
+                Icon={hasInputValue ? IconSend3 : IconMicrophone2}
+                size={24}
+              />
+            </div>
           </div>
-        </div>
+        )}
+
+        {this.props.renderAfterInput && this.props.renderAfterInput(this.state.value, this.state.mentionedUserIds)}
       </div>
     );
   }
@@ -441,6 +449,14 @@ export class MessageInput extends React.Component<Properties, State> {
   };
 
   render() {
-    return <div className={classNames('message-input', this.props.className)}>{this.renderInput()}</div>;
+    return (
+      <div
+        className={classNames('message-input', this.props.className, {
+          'message-input--editing': this.props.isEditing,
+        })}
+      >
+        {this.renderInput()}
+      </div>
+    );
   }
 }

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -36,11 +36,21 @@
   gap: 8px;
   border-top: 1px solid theme.$color-greyscale-transparency-6;
 
+  &--editing {
+    border-top: none;
+    padding: 0;
+    margin-right: none;
+  }
+
   &__container {
     display: flex;
     align-items: flex-end;
     gap: 16px;
     width: 100%;
+
+    &--editing {
+      gap: 8px;
+    }
   }
 
   &__icon-outer {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -121,20 +121,18 @@ export class Message extends React.Component<Properties, State> {
     const isSendStatusFailed = this.props.sendStatus === MessageSendStatus.FAILED;
 
     return (
-      <>
-        <div {...cn('footer')}>
-          {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
-            <span {...cn('edited-flag')}>(Edited)</span>
-          )}
-          {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
-          {isSendStatusFailed && (
-            <div {...cn('failure-message')}>
-              Failed to send&nbsp;
-              <IconAlertCircle size={16} />
-            </div>
-          )}
-        </div>
-      </>
+      <div {...cn('footer')}>
+        {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
+          <span {...cn('edited')}>(Edited)</span>
+        )}
+        {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
+        {isSendStatusFailed && (
+          <div {...cn('failure-message')}>
+            Failed to send&nbsp;
+            <IconAlertCircle size={16} />
+          </div>
+        )}
+      </div>
     );
   }
   renderTime(time): React.ReactElement {
@@ -252,7 +250,7 @@ export class Message extends React.Component<Properties, State> {
             />
           </div>
         )}
-        <div {...cn('block', this.state.isFullWidth && 'fill')}>
+        <div {...cn('block', (this.state.isFullWidth && 'fill', this.state.isEditing && 'edit'))}>
           {(message || media || preview) && (
             <>
               <div {...cn('author-name')}>
@@ -288,12 +286,13 @@ export class Message extends React.Component<Properties, State> {
                   initialValue={this.props.message}
                   onSubmit={this.editMessage}
                   getUsersForMentions={this.props.getUsersForMentions}
+                  isEditing={this.state.isEditing}
                   renderAfterInput={this.editActions}
                 />
               )}
             </>
           )}
-          {this.renderFooter()}
+          {this.props.sendStatus !== MessageSendStatus.FAILED && this.renderFooter()}
         </div>
         {this.renderMenu()}
       </div>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -292,7 +292,7 @@ export class Message extends React.Component<Properties, State> {
               )}
             </>
           )}
-          {this.props.sendStatus !== MessageSendStatus.FAILED && this.renderFooter()}
+          {this.renderFooter()}
         </div>
         {this.renderMenu()}
       </div>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -123,7 +123,7 @@ export class Message extends React.Component<Properties, State> {
     return (
       <div {...cn('footer')}>
         {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
-          <span {...cn('edited')}>(Edited)</span>
+          <span {...cn('edited-flag')}>(Edited)</span>
         )}
         {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
         {isSendStatusFailed && (

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -152,6 +152,10 @@
     padding-top: 4px;
   }
 
+  &__edited-flag {
+    padding-top: 4px;
+  }
+
   &__failure-message {
     display: flex;
     align-items: center;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -55,6 +55,10 @@
 
     border-radius: var(--border-radius); // set in message__message-row
 
+    &--edit {
+      width: 100%;
+    }
+
     &--fill {
       .message__block-image {
         img {
@@ -148,14 +152,14 @@
     padding-top: 4px;
   }
 
-  &__edited-flag {
-    padding-top: 4px;
-  }
-
   &__failure-message {
     display: flex;
     align-items: center;
     color: theme.$color-failure-11;
+    padding-top: 4px;
+  }
+
+  &__edited {
     padding-top: 4px;
   }
 

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -68,6 +68,10 @@ $scrollbar-width: 5px;
 
   .message-input {
     margin-right: calc(var(--layout-app-content-right-padding) + $scrollbar-width);
+
+    &--editing {
+      margin-right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
### What does this do?
- first iteration of edit message display changes

### Why are we making this change?
- as per figma designs.

### How do I test this?
- open messenger and navigate to the edit message flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

*no footer spacing when time is not displayed*
<img width="627" alt="Screenshot 2023-07-21 at 16 54 53" src="https://github.com/zer0-os/zOS/assets/39112648/64fa3641-e6d6-443e-8f15-330dc2adf37d">


*footer with time when displayed*
<img width="627" alt="Screenshot 2023-07-21 at 16 55 43" src="https://github.com/zer0-os/zOS/assets/39112648/fc20e72a-2744-4421-9407-294e4e7f7e4b">

*long message and icon position*
<img width="627" alt="Screenshot 2023-07-21 at 17 00 11" src="https://github.com/zer0-os/zOS/assets/39112648/962cd6f4-8d11-4026-aba6-5b9236734aa2">
