### PR TITLE
feat: edit message display iteration two 

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -310,123 +310,124 @@ export class MessageInput extends React.Component<Properties, State> {
     const hasInputValue = this.state.value?.length > 0;
 
     return (
-      <div
-        className={classNames('message-input__container', this.props.className, {
-          'message-input__container--editing': this.props.isEditing,
-        })}
-      >
-        {!this.props.isEditing && (
-          <div className='message-input__icon-outer'>
-            <div className='message-input__icon-wrapper'>
-              <IconButton
-                className={classNames('message-input__icon', 'message-input__icon--giphy')}
-                onClick={this.openGiphy}
-                Icon={IconStickerCircle}
-                size={24}
-              />
-              <Menu
-                onSelected={this.mediaSelected}
-                mimeTypes={this.mimeTypes}
-                maxSize={config.cloudinary.max_file_size}
-              />
+      <>
+        <div
+          className={classNames('message-input__container', this.props.className, {
+            'message-input__container--editing': this.props.isEditing,
+          })}
+        >
+          {!this.props.isEditing && (
+            <div className='message-input__icon-outer'>
+              <div className='message-input__icon-wrapper'>
+                <IconButton
+                  className={classNames('message-input__icon', 'message-input__icon--giphy')}
+                  onClick={this.openGiphy}
+                  Icon={IconStickerCircle}
+                  size={24}
+                />
+                <Menu
+                  onSelected={this.mediaSelected}
+                  mimeTypes={this.mimeTypes}
+                  maxSize={config.cloudinary.max_file_size}
+                />
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        <div className='message-input__chat-container'>
-          <div className='message-input__scroll-container'>
-            <div className='message-input__text-and-emoji-wrapper'>
-              <Dropzone
-                onDrop={this.imagesSelected}
-                noClick
-                accept={this.mimeTypes}
-                maxSize={config.cloudinary.max_file_size}
-              >
-                {({ getRootProps }) => (
-                  <div {...getRootProps({ className: 'message-input__mentions-text-area' })}>
-                    <ImageCards images={this.images} onRemoveImage={this.removeMediaPreview} size='small' />
-                    <AudioCards audios={this.audios} onRemove={this.removeMediaPreview} />
-                    <AttachmentCards attachments={this.files} type='file' onRemove={this.removeMediaPreview} />
-                    <AttachmentCards attachments={this.videos} type='video' onRemove={this.removeMediaPreview} />
-                    {this.props.reply && <ReplyCard message={this.props.reply.message} onRemove={this.removeReply} />}
+          <div className='message-input__chat-container'>
+            <div className='message-input__scroll-container'>
+              <div className='message-input__text-and-emoji-wrapper'>
+                <Dropzone
+                  onDrop={this.imagesSelected}
+                  noClick
+                  accept={this.mimeTypes}
+                  maxSize={config.cloudinary.max_file_size}
+                >
+                  {({ getRootProps }) => (
+                    <div {...getRootProps({ className: 'message-input__mentions-text-area' })}>
+                      <ImageCards images={this.images} onRemoveImage={this.removeMediaPreview} size='small' />
+                      <AudioCards audios={this.audios} onRemove={this.removeMediaPreview} />
+                      <AttachmentCards attachments={this.files} type='file' onRemove={this.removeMediaPreview} />
+                      <AttachmentCards attachments={this.videos} type='video' onRemove={this.removeMediaPreview} />
+                      {this.props.reply && <ReplyCard message={this.props.reply.message} onRemove={this.removeReply} />}
 
-                    <div
-                      className={classNames('message-input__emoji-picker-container', {
-                        'message-input__emoji-picker-container--fullscreen': this.props.isMessengerFullScreen,
-                      })}
-                    >
-                      <EmojiPicker
-                        textareaRef={this.textareaRef}
-                        isOpen={this.state.isEmojisActive}
-                        onOpen={this.openEmojis}
-                        onClose={this.closeEmojis}
-                        value={this.state.value}
-                        viewMode={this.props.viewMode}
-                        onSelect={this.onInsertEmoji}
-                      />
-                    </div>
-                    {this.state.isGiphyActive && (
-                      <Giphy
-                        onClickGif={this.onInsertGiphy}
-                        onClose={this.closeGiphy}
-                        isMessengerFullScreen={this.props.isMessengerFullScreen}
-                      />
-                    )}
-                    {this.state.isMicActive && (
-                      <div>
-                        <MessageAudioRecorder onClose={this.cancelRecording} onMediaSelected={this.createAudioClip} />
+                      <div
+                        className={classNames('message-input__emoji-picker-container', {
+                          'message-input__emoji-picker-container--fullscreen': this.props.isMessengerFullScreen,
+                        })}
+                      >
+                        <EmojiPicker
+                          textareaRef={this.textareaRef}
+                          isOpen={this.state.isEmojisActive}
+                          onOpen={this.openEmojis}
+                          onClose={this.closeEmojis}
+                          value={this.state.value}
+                          viewMode={this.props.viewMode}
+                          onSelect={this.onInsertEmoji}
+                        />
                       </div>
-                    )}
+                      {this.state.isGiphyActive && (
+                        <Giphy
+                          onClickGif={this.onInsertGiphy}
+                          onClose={this.closeGiphy}
+                          isMessengerFullScreen={this.props.isMessengerFullScreen}
+                        />
+                      )}
+                      {this.state.isMicActive && (
+                        <div>
+                          <MessageAudioRecorder onClose={this.cancelRecording} onMediaSelected={this.createAudioClip} />
+                        </div>
+                      )}
 
-                    <MentionsInput
-                      inputRef={this.textareaRef}
-                      className='message-input__mentions-text-area-wrap'
-                      id={this.props.id}
-                      placeholder={this.props.placeholder}
-                      onKeyDown={this.onKeyDown}
-                      onChange={this.contentChanged}
-                      onBlur={this._handleBlur}
-                      value={this.state.value}
-                      allowSuggestionsAboveCursor
-                      suggestionsPortalHost={document.body}
-                    >
-                      {this.renderMentionTypes()}
-                    </MentionsInput>
+                      <MentionsInput
+                        inputRef={this.textareaRef}
+                        className='message-input__mentions-text-area-wrap'
+                        id={this.props.id}
+                        placeholder={this.props.placeholder}
+                        onKeyDown={this.onKeyDown}
+                        onChange={this.contentChanged}
+                        onBlur={this._handleBlur}
+                        value={this.state.value}
+                        allowSuggestionsAboveCursor
+                        suggestionsPortalHost={document.body}
+                      >
+                        {this.renderMentionTypes()}
+                      </MentionsInput>
+                    </div>
+                  )}
+                </Dropzone>
+
+                <div className='message-input__emoji-icon-outer'>
+                  <div className='message-input__icon-wrapper'>
+                    <IconButton
+                      className={classNames('message-input__icon', ' message-input__icon--emoji')}
+                      onClick={this.openEmojis}
+                      Icon={IconFaceSmile}
+                      size={24}
+                    />
                   </div>
-                )}
-              </Dropzone>
-
-              <div className='message-input__emoji-icon-outer'>
-                <div className='message-input__icon-wrapper'>
-                  <IconButton
-                    className={classNames('message-input__icon', ' message-input__icon--emoji')}
-                    onClick={this.openEmojis}
-                    Icon={IconFaceSmile}
-                    size={24}
-                  />
                 </div>
               </div>
             </div>
           </div>
-        </div>
 
-        {!this.props.isEditing && (
-          <div className='message-input__icon-outer'>
-            <div className='message-input__icon-wrapper'>
-              <IconButton
-                className={classNames('message-input__icon', 'message-input__icon--end-action', {
-                  'message-input__icon--send': hasInputValue,
-                })}
-                onClick={hasInputValue ? this.onSend : this.startMic}
-                Icon={hasInputValue ? IconSend3 : IconMicrophone2}
-                size={24}
-              />
+          {!this.props.isEditing && (
+            <div className='message-input__icon-outer'>
+              <div className='message-input__icon-wrapper'>
+                <IconButton
+                  className={classNames('message-input__icon', 'message-input__icon--end-action', {
+                    'message-input__icon--send': hasInputValue,
+                  })}
+                  onClick={hasInputValue ? this.onSend : this.startMic}
+                  Icon={hasInputValue ? IconSend3 : IconMicrophone2}
+                  size={24}
+                />
+              </div>
             </div>
-          </div>
-        )}
-
+          )}
+        </div>
         {this.props.renderAfterInput && this.props.renderAfterInput(this.state.value, this.state.mentionedUserIds)}
-      </div>
+      </>
     );
   }
 

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -19,8 +19,8 @@ export default class EditMessageActions extends React.Component<Properties> {
   render() {
     return (
       <div {...cn()}>
-        <IconButton {...cn('icon')} onClick={this.props.onEdit} Icon={IconCheck} size={24} />
-        <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} size={24} />
+        <IconButton {...cn('icon')} onClick={this.props.onEdit} Icon={IconCheck} isFilled size={24} />
+        <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size={24} />
       </div>
     );
   }

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -19,8 +19,8 @@ export default class EditMessageActions extends React.Component<Properties> {
   render() {
     return (
       <div {...cn()}>
-        <IconButton {...cn('icon')} onClick={this.props.onEdit} Icon={IconCheck} isFilled size={24} />
         <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size={24} />
+        <IconButton {...cn('icon')} onClick={this.props.onEdit} Icon={IconCheck} isFilled size={24} />
       </div>
     );
   }

--- a/src/components/message/edit-message-actions/styles.scss
+++ b/src/components/message/edit-message-actions/styles.scss
@@ -2,8 +2,7 @@
 
 .edit-message-actions {
   display: flex;
-  align-items: center;
-  align-self: center;
+  justify-content: flex-end;
   gap: 8px;
 
   &__icon {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -125,7 +125,7 @@ export class Message extends React.Component<Properties, State> {
         {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
           <span {...cn('edited-flag')}>(Edited)</span>
         )}
-        {!isSendStatusFailed && this.renderTime(this.props.createdAt)}
+        {!isSendStatusFailed && !this.state.isEditing && this.renderTime(this.props.createdAt)}
         {isSendStatusFailed && (
           <div {...cn('failure-message')}>
             Failed to send&nbsp;

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -126,7 +126,7 @@ export class Message extends React.Component<Properties, State> {
           <span {...cn('edited-flag')}>(Edited)</span>
         )}
         {!isSendStatusFailed && !this.state.isEditing && this.renderTime(this.props.createdAt)}
-        {isSendStatusFailed && (
+        {isSendStatusFailed && !this.state.isEditing && (
           <div {...cn('failure-message')}>
             Failed to send&nbsp;
             <IconAlertCircle size={16} />

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -35,6 +35,10 @@
       background-color: theme.$color-secondary-3;
       border-radius: var(--border-owner-radius); // set in message__message-row
 
+      &--edit {
+        border-radius: 8px 2px 0px 8px;
+      }
+
       .message__author-name {
         display: none;
       }


### PR DESCRIPTION
### What does this do?
- second iteration of edit message display changes.
- includes border change on editing message bubble.
- includes re-order of edit action icons.
- includes hiding time updated if editing.
- includes hiding error message (the whole footer) when editing.

### Why are we making this change?
- as per figma designs (recently changed)

### How do I test this?
- open messenger and navigate to the edit message flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

*updated design*
<img width="1080" alt="Screenshot 2023-07-24 at 15 19 22" src="https://github.com/zer0-os/zOS/assets/39112648/948cf3b5-b2a6-409d-b8ca-0fdca5409071">

