### PR TITLE
feat: hide emoji icon and emoji picker if editing message

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -398,12 +398,14 @@ export class MessageInput extends React.Component<Properties, State> {
 
               <div className='message-input__emoji-icon-outer'>
                 <div className='message-input__icon-wrapper'>
-                  <IconButton
-                    className={classNames('message-input__icon', ' message-input__icon--emoji')}
-                    onClick={this.openEmojis}
-                    Icon={IconFaceSmile}
-                    size={24}
-                  />
+                  {!this.props.isEditing && (
+                    <IconButton
+                      className={classNames('message-input__icon', ' message-input__icon--emoji')}
+                      onClick={this.openEmojis}
+                      Icon={IconFaceSmile}
+                      size={24}
+                    />
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -399,26 +399,15 @@ export class MessageInput extends React.Component<Properties, State> {
 
                 <div className='message-input__emoji-icon-outer'>
                   <div className='message-input__icon-wrapper'>
-                    <IconButton
-                      className={classNames('message-input__icon', ' message-input__icon--emoji')}
-                      onClick={this.openEmojis}
-                      Icon={IconFaceSmile}
-                      size={24}
-                    />
+                    {!this.props.isEditing && (
+                      <IconButton
+                        className={classNames('message-input__icon', ' message-input__icon--emoji')}
+                        onClick={this.openEmojis}
+                        Icon={IconFaceSmile}
+                        size={24}
+                      />
+                    )}
                   </div>
-                )}
-              </Dropzone>
-
-              <div className='message-input__emoji-icon-outer'>
-                <div className='message-input__icon-wrapper'>
-                  {!this.props.isEditing && (
-                    <IconButton
-                      className={classNames('message-input__icon', ' message-input__icon--emoji')}
-                      onClick={this.openEmojis}
-                      Icon={IconFaceSmile}
-                      size={24}
-                    />
-                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### What does this do?
- hides emoji icon / picker when editing a message.

### Why are we making this change?
- hiding the emoji icon / picker when editing due to broken layout of the emoji picker container and parent containers. The dev time at the moment is not worth the value of making these changes that will potentially cause a number of bugs. As discussed with team, we shall remove this for now when editing.

### How do I test this?
- follow the edit flow and check that the emoji picker icon is not present when editing.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/42432efd-1d9d-4837-b2d1-2b629445280a

