### PR TITLE
Refactor: predetermine whether to render author and timestamp in messages based on group position

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -265,6 +265,8 @@ export class Container extends React.Component<Properties, State> {
   render() {
     if (!this.props.channel) return null;
 
+    const isOneOnOne = this.props.channel?.otherMembers?.length === 1;
+
     return (
       <>
         <ChatView
@@ -289,6 +291,7 @@ export class Container extends React.Component<Properties, State> {
           onMessageInputRendered={this.onMessageInputRendered}
           isDirectMessage={this.props.isDirectMessage}
           showSenderAvatar={this.props.showSenderAvatar}
+          isOneOnOne={isOneOnOne}
           reply={this.state.reply}
           onReply={this.onReply}
           onRemove={this.removeReply}

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -55,6 +55,7 @@ describe('ChatView', () => {
       messagesFetchStatus: MessagesFetchState.SUCCESS,
       otherMembers: [],
       fetchMessages: () => null,
+      isOneOnOne: false,
       ...props,
     };
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -58,6 +58,7 @@ export interface Properties {
   isDirectMessage: boolean;
   showSenderAvatar?: boolean;
   isMessengerFullScreen: boolean;
+  isOneOnOne: boolean;
 }
 
 export interface State {
@@ -145,7 +146,7 @@ export class ChatView extends React.Component<Properties, State> {
       if (message.isAdmin) {
         return <AdminMessageContainer key={message.id} message={message} />;
       } else {
-        const messageRenderProps = getMessageRenderProps(index, groupMessages.length);
+        const messageRenderProps = getMessageRenderProps(index, groupMessages.length, this.props.isOneOnOne);
         return (
           <div
             key={message.optimisticId || message.id}

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -146,7 +146,12 @@ export class ChatView extends React.Component<Properties, State> {
       if (message.isAdmin) {
         return <AdminMessageContainer key={message.id} message={message} />;
       } else {
-        const messageRenderProps = getMessageRenderProps(index, groupMessages.length, this.props.isOneOnOne);
+        const messageRenderProps = getMessageRenderProps(
+          index,
+          groupMessages.length,
+          this.props.isOneOnOne,
+          this.isUserOwnerOfMessage(message)
+        );
         return (
           <div
             key={message.optimisticId || message.id}

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -168,6 +168,7 @@ export class ChatView extends React.Component<Properties, State> {
               getUsersForMentions={this.searchMentionableUsers}
               showSenderAvatar={this.props.showSenderAvatar}
               showTimestamp={messageRenderProps.showTimestamp}
+              showAuthorName={messageRenderProps.showAuthorName}
               {...message}
             />
           </div>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -21,7 +21,7 @@ import { AdminMessageContainer } from '../admin-message/container';
 import { Payload as PayloadFetchMessages } from '../../store/messages/saga';
 import './styles.scss';
 import { ChatSkeleton } from './chat-skeleton';
-import { createMessageGroups } from './utils';
+import { createMessageGroups, getMessageRenderProps } from './utils';
 import { MessagesFetchState } from '../../store/channels';
 
 interface ChatMessageGroups {
@@ -140,11 +140,12 @@ export class ChatView extends React.Component<Properties, State> {
     return this.props.user && message.sender && this.props.user.id == message.sender.userId;
   }
 
-  renderMessageGroup(allMessages) {
-    return allMessages.map((message, index) => {
+  renderMessageGroup(groupMessages) {
+    return groupMessages.map((message, index) => {
       if (message.isAdmin) {
         return <AdminMessageContainer key={message.id} message={message} />;
       } else {
+        const messageRenderProps = getMessageRenderProps(index, groupMessages.length);
         return (
           <div
             key={message.optimisticId || message.id}
@@ -154,7 +155,7 @@ export class ChatView extends React.Component<Properties, State> {
           >
             <Message
               className={classNames('messages__message', {
-                'messages__message--last-in-group': this.props.showSenderAvatar && index === allMessages.length - 1,
+                'messages__message--last-in-group': this.props.showSenderAvatar && index === groupMessages.length - 1,
               })}
               onImageClick={this.openLightbox}
               messageId={message.id}
@@ -166,6 +167,7 @@ export class ChatView extends React.Component<Properties, State> {
               parentMessageText={message.parentMessageText}
               getUsersForMentions={this.searchMentionableUsers}
               showSenderAvatar={this.props.showSenderAvatar}
+              showTimestamp={messageRenderProps.showTimestamp}
               {...message}
             />
           </div>

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -74,7 +74,7 @@ describe(getMessageRenderProps, () => {
       const index = 4;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength, false);
+      const props = getProps({ index, groupLength });
 
       expect(props.showTimestamp).toEqual(true);
     });
@@ -83,7 +83,7 @@ describe(getMessageRenderProps, () => {
       const index = 2;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength, false);
+      const props = getProps({ index, groupLength });
 
       expect(props.showTimestamp).toEqual(false);
     });
@@ -94,7 +94,7 @@ describe(getMessageRenderProps, () => {
       const index = 0;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength, false);
+      const props = getProps({ index, groupLength });
 
       expect(props.showAuthorName).toEqual(true);
     });
@@ -103,7 +103,7 @@ describe(getMessageRenderProps, () => {
       const index = 2;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength, false);
+      const props = getProps({ index, groupLength });
 
       expect(props.showAuthorName).toEqual(false);
     });
@@ -112,11 +112,34 @@ describe(getMessageRenderProps, () => {
       const index = 0;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength, true);
+      const props = getProps({ index, groupLength, isOneOnOne: true });
+
+      expect(props.showAuthorName).toEqual(false);
+    });
+
+    it('is false if the current owner is the sender', () => {
+      const index = 0;
+      const groupLength = 5;
+
+      const props = getProps({ index, groupLength, isOwner: true });
 
       expect(props.showAuthorName).toEqual(false);
     });
   });
+
+  function getProps({
+    index,
+    groupLength,
+    isOneOnOne = false,
+    isOwner = false,
+  }: {
+    index: number;
+    groupLength: number;
+    isOneOnOne?: boolean;
+    isOwner?: boolean;
+  }) {
+    return getMessageRenderProps(index, groupLength, isOneOnOne, isOwner);
+  }
 });
 
 function stubMessage(attrs: Partial<MessageModel> = {}) {

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -88,6 +88,26 @@ describe(getMessageRenderProps, () => {
       expect(props.showTimestamp).toEqual(false);
     });
   });
+
+  describe('showAuthorName', () => {
+    it('is true if the message is the first in the group', () => {
+      const index = 0;
+      const groupLength = 5;
+
+      const props = getMessageRenderProps(index, groupLength);
+
+      expect(props.showAuthorName).toEqual(true);
+    });
+
+    it('is false if the message is _not_ the first in the group', () => {
+      const index = 2;
+      const groupLength = 5;
+
+      const props = getMessageRenderProps(index, groupLength);
+
+      expect(props.showAuthorName).toEqual(false);
+    });
+  });
 });
 
 function stubMessage(attrs: Partial<MessageModel> = {}) {

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { Message as MessageModel } from '../../store/messages';
-import { createMessageGroups } from './utils';
+import { createMessageGroups, getMessageRenderProps } from './utils';
 
 describe(createMessageGroups, () => {
   it('returns an empty group list when input is empty', () => {
@@ -65,6 +65,28 @@ describe(createMessageGroups, () => {
       ],
       [third],
     ]);
+  });
+});
+
+describe(getMessageRenderProps, () => {
+  describe('showTimestamp', () => {
+    it('is true if the message is the last in the group', () => {
+      const index = 4;
+      const groupLength = 5;
+
+      const props = getMessageRenderProps(index, groupLength);
+
+      expect(props.showTimestamp).toEqual(true);
+    });
+
+    it('is false if the message is _not_ the last in the group', () => {
+      const index = 2;
+      const groupLength = 5;
+
+      const props = getMessageRenderProps(index, groupLength);
+
+      expect(props.showTimestamp).toEqual(false);
+    });
   });
 });
 

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -1,0 +1,84 @@
+import moment from 'moment';
+
+import { Message as MessageModel } from '../../store/messages';
+import { createMessageGroups } from './utils';
+
+describe(createMessageGroups, () => {
+  it('returns an empty group list when input is empty', () => {
+    const groups = createMessageGroups([]);
+
+    expect(groups).toEqual([]);
+  });
+
+  it('creates separate groups for admin messages', () => {
+    const firstTime = moment();
+    const firstMessage = stubMessage({ isAdmin: true, createdAt: firstTime.valueOf() });
+    const secondMessage = stubMessage({ isAdmin: true, createdAt: firstTime.add(1, 'minute').valueOf() });
+
+    const groups = createMessageGroups([
+      firstMessage,
+      secondMessage,
+    ]);
+
+    expect(groups).toEqual([
+      [firstMessage],
+      [secondMessage],
+    ]);
+  });
+
+  it('creates separate groups for separate senders', () => {
+    const firstTime = moment();
+    const firstMessage = stubMessage({ sender: stubUser({ userId: '1' }), createdAt: firstTime.valueOf() });
+    const secondMessage = stubMessage({
+      sender: stubUser({ userId: '2' }),
+      createdAt: firstTime.add(1, 'minute').valueOf(),
+    });
+
+    const groups = createMessageGroups([
+      firstMessage,
+      secondMessage,
+    ]);
+
+    expect(groups).toEqual([
+      [firstMessage],
+      [secondMessage],
+    ]);
+  });
+
+  it('groups messages within 5 minutes from the same sender', () => {
+    const firstTime = moment();
+    const sender = stubUser();
+    const first = stubMessage({ sender, createdAt: firstTime.valueOf() });
+    const second = stubMessage({ sender, createdAt: firstTime.add(1, 'minute').valueOf() });
+    const third = stubMessage({ sender, createdAt: firstTime.add(7, 'minute').valueOf() });
+
+    const groups = createMessageGroups([
+      first,
+      second,
+      third,
+    ]);
+
+    expect(groups).toEqual([
+      [
+        first,
+        second,
+      ],
+      [third],
+    ]);
+  });
+});
+
+function stubMessage(attrs: Partial<MessageModel> = {}) {
+  return {
+    id: 1,
+    isAdmin: false,
+    ...attrs,
+  } as MessageModel;
+}
+
+function stubUser(attrs = {}) {
+  return {
+    userId: 'stub-user-id',
+    ...attrs,
+  } as MessageModel['sender'];
+}

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -74,7 +74,7 @@ describe(getMessageRenderProps, () => {
       const index = 4;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength);
+      const props = getMessageRenderProps(index, groupLength, false);
 
       expect(props.showTimestamp).toEqual(true);
     });
@@ -83,7 +83,7 @@ describe(getMessageRenderProps, () => {
       const index = 2;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength);
+      const props = getMessageRenderProps(index, groupLength, false);
 
       expect(props.showTimestamp).toEqual(false);
     });
@@ -94,7 +94,7 @@ describe(getMessageRenderProps, () => {
       const index = 0;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength);
+      const props = getMessageRenderProps(index, groupLength, false);
 
       expect(props.showAuthorName).toEqual(true);
     });
@@ -103,7 +103,16 @@ describe(getMessageRenderProps, () => {
       const index = 2;
       const groupLength = 5;
 
-      const props = getMessageRenderProps(index, groupLength);
+      const props = getMessageRenderProps(index, groupLength, false);
+
+      expect(props.showAuthorName).toEqual(false);
+    });
+
+    it('is false if the message is in a one on one chat', () => {
+      const index = 0;
+      const groupLength = 5;
+
+      const props = getMessageRenderProps(index, groupLength, true);
 
       expect(props.showAuthorName).toEqual(false);
     });

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -31,3 +31,10 @@ function isRelated(message1, message2) {
     Math.abs(moment(message1.createdAt).diff(moment(message2.createdAt), 'minutes')) < 5
   );
 }
+
+export function getMessageRenderProps(index, groupLength) {
+  const lastIndex = groupLength - 1;
+  return {
+    showTimestamp: index === lastIndex,
+  };
+}

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -35,6 +35,7 @@ function isRelated(message1, message2) {
 export function getMessageRenderProps(index, groupLength) {
   const lastIndex = groupLength - 1;
   return {
+    showAuthorName: index === 0,
     showTimestamp: index === lastIndex,
   };
 }

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -32,10 +32,11 @@ function isRelated(message1, message2) {
   );
 }
 
-export function getMessageRenderProps(index, groupLength) {
+export function getMessageRenderProps(index: number, groupLength: number, isOneOnOne: boolean) {
   const lastIndex = groupLength - 1;
+
   return {
-    showAuthorName: index === 0,
+    showAuthorName: index === 0 && !isOneOnOne,
     showTimestamp: index === lastIndex,
   };
 }

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -32,11 +32,11 @@ function isRelated(message1, message2) {
   );
 }
 
-export function getMessageRenderProps(index: number, groupLength: number, isOneOnOne: boolean) {
+export function getMessageRenderProps(index: number, groupLength: number, isOneOnOne: boolean, isOwner: boolean) {
   const lastIndex = groupLength - 1;
 
   return {
-    showAuthorName: index === 0 && !isOneOnOne,
+    showAuthorName: index === 0 && !isOwner && !isOneOnOne,
     showTimestamp: index === lastIndex,
   };
 }

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -70,10 +70,29 @@ describe('message', () => {
     expect(wrapper.find('.message__block-image').exists()).toBe(false);
   });
 
+  it('renders time if specified', () => {
+    const wrapper = subject({
+      createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
+      showTimestamp: true,
+    });
+
+    expect(wrapper.find('.message__time').text()).toStrictEqual('5:04 PM');
+  });
+
+  it('does not render time if not specified', () => {
+    const wrapper = subject({
+      createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
+      showTimestamp: false,
+    });
+
+    expect(wrapper).not.toHaveElement('.message__time');
+  });
+
   it('renders time if status not failed', () => {
     const wrapper = subject({
       message: 'the message',
       createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
+      showTimestamp: true,
     });
 
     expect(wrapper.find('.message__time').text()).toStrictEqual('5:04 PM');
@@ -85,6 +104,7 @@ describe('message', () => {
       message: 'the message',
       createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
       sendStatus: MessageSendStatus.FAILED,
+      showTimestamp: true,
     });
 
     expect(wrapper).not.toHaveElement('.message__time');

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -88,6 +88,26 @@ describe('message', () => {
     expect(wrapper).not.toHaveElement('.message__time');
   });
 
+  it('renders author name if specified', () => {
+    const wrapper = subject({
+      sender: { firstName: 'first', lastName: 'last' },
+      showAuthorName: true,
+      message: 'the message',
+    });
+
+    expect(wrapper.find('.message__author-name').text()).toStrictEqual('first last');
+  });
+
+  it('does not render author name if not specified', () => {
+    const wrapper = subject({
+      sender: { firstName: 'first', lastName: 'last' },
+      showAuthorName: false,
+      message: 'the message',
+    });
+
+    expect(wrapper).not.toHaveElement('.message__author-name');
+  });
+
   it('renders time if status not failed', () => {
     const wrapper = subject({
       message: 'the message',

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -39,6 +39,7 @@ interface Properties extends MessageModel {
   getUsersForMentions: (search: string) => Promise<UserForMention[]>;
   showSenderAvatar?: boolean;
   showTimestamp: boolean;
+  showAuthorName: boolean;
 }
 
 export interface State {
@@ -139,6 +140,14 @@ export class Message extends React.Component<Properties, State> {
   renderTime(time): React.ReactElement {
     const createdTime = moment(time).format('h:mm A');
     return <div {...cn('time')}>{createdTime}</div>;
+  }
+
+  renderAuthorName(): React.ReactElement {
+    return (
+      <div {...cn('author-name')}>
+        {this.props.sender.firstName} {this.props.sender.lastName}
+      </div>
+    );
   }
 
   canEditMessage = (): boolean => {
@@ -254,9 +263,7 @@ export class Message extends React.Component<Properties, State> {
         <div {...cn('block', (this.state.isFullWidth && 'fill', this.state.isEditing && 'edit'))}>
           {(message || media || preview) && (
             <>
-              <div {...cn('author-name')}>
-                {sender.firstName} {sender.lastName}
-              </div>
+              {this.props.showAuthorName && this.renderAuthorName()}
               {!this.state.isEditing && (
                 <div {...cn('block-body')}>
                   {media && this.renderMedia(media)}

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -38,6 +38,7 @@ interface Properties extends MessageModel {
   parentMessageText?: string;
   getUsersForMentions: (search: string) => Promise<UserForMention[]>;
   showSenderAvatar?: boolean;
+  showTimestamp: boolean;
 }
 
 export interface State {
@@ -125,7 +126,7 @@ export class Message extends React.Component<Properties, State> {
         {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
           <span {...cn('edited-flag')}>(Edited)</span>
         )}
-        {!isSendStatusFailed && !this.state.isEditing && this.renderTime(this.props.createdAt)}
+        {!isSendStatusFailed && !this.state.isEditing && this.props.showTimestamp && this.renderTime(this.props.createdAt)}
         {isSendStatusFailed && !this.state.isEditing && (
           <div {...cn('failure-message')}>
             Failed to send&nbsp;

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -127,7 +127,10 @@ export class Message extends React.Component<Properties, State> {
         {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
           <span {...cn('edited-flag')}>(Edited)</span>
         )}
-        {!isSendStatusFailed && !this.state.isEditing && this.props.showTimestamp && this.renderTime(this.props.createdAt)}
+        {!isSendStatusFailed &&
+          !this.state.isEditing &&
+          this.props.showTimestamp &&
+          this.renderTime(this.props.createdAt)}
         {isSendStatusFailed && !this.state.isEditing && (
           <div {...cn('failure-message')}>
             Failed to send&nbsp;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -38,10 +38,6 @@
       &--edit {
         border-radius: 8px 2px 0px 8px;
       }
-
-      .message__author-name {
-        display: none;
-      }
     }
 
     .message__menu {

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -205,7 +205,7 @@
   }
 
   &__author-name {
-    display: var(--message-author-name-display);
+    display: flex;
     font-weight: 700;
     font-size: 12px;
     line-height: 15px;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -152,7 +152,7 @@
   }
 
   &__time {
-    display: var(--message-timestamp-display);
+    display: flex;
     padding-top: 4px;
   }
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -146,7 +146,6 @@ export class Container extends React.Component<Properties, State> {
           'direct-message-chat--transition': this.props.isFullScreen !== null || this.state.isMinimized,
           'direct-message-chat--full-screen': this.props.isFullScreen,
           'direct-message-chat--minimized': this.state.isMinimized,
-          'direct-message-chat--one-on-one': this.isOneOnOne(),
         })}
       >
         <div className='direct-message-chat__content'>

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -193,10 +193,4 @@ $recent-indicator-size: 8px;
   &--minimized {
     bottom: calc($title-bar-height + $header-height - $window-height);
   }
-
-  &--one-on-one {
-    .message__author-name {
-      display: none;
-    }
-  }
 }

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -268,7 +268,6 @@ $scrollbar-width: 5px;
       display: flex;
       clear: both;
       margin: 4px 16px;
-      --message-timestamp-display: none;
       --message-author-name-display: none;
       --border-radius: 2px 8px 8px 2px;
 
@@ -297,7 +296,6 @@ $scrollbar-width: 5px;
 
     &__message-row:last-child {
       margin-bottom: 16px;
-      --message-timestamp-display: flex;
       --border-radius: 2px 8px 8px 0px;
     }
 

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -268,7 +268,6 @@ $scrollbar-width: 5px;
       display: flex;
       clear: both;
       margin: 4px 16px;
-      --message-author-name-display: none;
       --border-radius: 2px 8px 8px 2px;
 
       &--owner {
@@ -290,7 +289,6 @@ $scrollbar-width: 5px;
     }
 
     &__message-row:first-child {
-      --message-author-name-display: flex;
       --border-radius: 8px 8px 8px 2px;
     }
 


### PR DESCRIPTION
### What does this do?

Instead of using css positioning for the author name and timestamp rendering this switches to calculating that in code.

### Why are we making this change?

Rendering images as full width will require knowing whether things in the footer were rendered or not. This is difficult to determine when their appearance is handled in css.

