### PR TITLE
feat: handle save edit disabled state and add test coverage

### DIFF
--- a/src/components/message/edit-message-actions/edit-message-actions.test.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { shallow } from 'enzyme';
+import EditMessageActions, { Properties } from './edit-message-actions';
+import { Tooltip } from '@zero-tech/zui/components';
+
+describe('EditMessageActions', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      value: '',
+      primaryTooltipText: '',
+      secondaryTooltipText: '',
+      onEdit: jest.fn(),
+      onCancel: jest.fn(),
+      ...props,
+    };
+
+    return shallow(<EditMessageActions {...allProps} />);
+  };
+
+  it('should call onCancel when Discard Changes icon is clicked', () => {
+    const onCancel = jest.fn();
+    const wrapper = subject({ onCancel });
+
+    wrapper.find('.edit-message-actions__icon').first().simulate('click');
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should call onEdit when Save Changes icon is clicked', () => {
+    const onEdit = jest.fn();
+    const wrapper = subject({ onEdit });
+
+    wrapper.find('.edit-message-actions__icon').at(1).simulate('click');
+
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it('should disable Save Changes icon when value is empty', () => {
+    const wrapper = subject({ value: '' });
+
+    const isDisabled = wrapper.find('.edit-message-actions__icon').at(1).prop('isDisabled');
+    expect(isDisabled).toBe(true);
+  });
+
+  it('should enable Save Changes icon when value is not empty', () => {
+    const wrapper = subject({ value: 'not empty' });
+
+    const isDisabled = wrapper.find('.edit-message-actions__icon').at(1).prop('isDisabled');
+    expect(isDisabled).toBe(false);
+  });
+
+  it('should render secondaryTooltipText for the first Tooltip', () => {
+    const secondaryTooltipText = 'Discard Changes';
+    const wrapper = subject({ secondaryTooltipText });
+
+    const tooltipContent = wrapper.find(Tooltip).first().prop('content');
+
+    expect(tooltipContent).toBe(secondaryTooltipText);
+  });
+
+  it('should render primaryTooltipText for the second Tooltip', () => {
+    const primaryTooltipText = 'Save Changes';
+    const wrapper = subject({ primaryTooltipText });
+
+    const tooltipContent = wrapper.find(Tooltip).at(1).prop('content');
+
+    expect(tooltipContent).toBe(primaryTooltipText);
+  });
+});

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -11,19 +11,47 @@ const cn = bemClassName('edit-message-actions');
 
 export interface Properties {
   className?: string;
+  value: string;
+  primaryTooltipText: string;
+  secondaryTooltipText: string;
   onEdit: () => void;
   onCancel?: () => void;
 }
 
 export default class EditMessageActions extends React.Component<Properties> {
+  state = {
+    tooltipOpen: false,
+  };
+
+  handleTooltipChange = (open: boolean) => {
+    this.setState({ tooltipOpen: !this.isDisabled() && open });
+  };
+
+  isDisabled = () => {
+    return !this.props.value.trim();
+  };
+
   render() {
+    const isDisabled = this.isDisabled();
+
     return (
       <div {...cn()}>
-        <Tooltip content='Discard Changes'>
+        <Tooltip content={this.props.secondaryTooltipText}>
           <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size={24} />
         </Tooltip>
-        <Tooltip content='Save Changes'>
-          <IconButton {...cn('icon')} onClick={this.props.onEdit} Icon={IconCheck} isFilled size={24} />
+        <Tooltip
+          content={this.props.primaryTooltipText}
+          open={this.state.tooltipOpen}
+          onOpenChange={this.handleTooltipChange}
+        >
+          <IconButton
+            {...cn('icon', isDisabled && 'disabled')}
+            onClick={this.props.onEdit}
+            Icon={IconCheck}
+            isDisabled={isDisabled}
+            isFilled
+            size={24}
+          />
         </Tooltip>
       </div>
     );

--- a/src/components/message/edit-message-actions/styles.scss
+++ b/src/components/message/edit-message-actions/styles.scss
@@ -12,5 +12,14 @@
     height: 32px;
     width: 32px;
     color: theme.$color-greyscale-12;
+
+    &--disabled {
+      color: theme.$color-greyscale-9;
+      cursor: not-allowed;
+
+      &:hover {
+        background-color: unset;
+      }
+    }
   }
 }

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -191,6 +191,9 @@ export class Message extends React.Component<Properties, State> {
   editActions = (value: string, mentionedUserIds: string[]) => {
     return (
       <EditMessageActions
+        value={value}
+        primaryTooltipText='Save Changes'
+        secondaryTooltipText='Discard Changes'
         onEdit={this.editMessage.bind(this, value, mentionedUserIds, {
           hidePreview: this.props.hidePreview,
           mentionedUsers: this.props.mentionedUserIds,


### PR DESCRIPTION
### What does this do?
- handles save edit disabled state.
- adds test coverage for edit message actions sub-component.

### Why are we making this change?
- as per design/product discussion.

### How do I test this?
- when editing a message, delete the message content and check the save (check icon) is disabled and the tooltip is not displayed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  

*Disabled State*


https://github.com/zer0-os/zOS/assets/39112648/4da03c19-ecb0-48e4-8acd-9fc999695c94

