### PR TITLE
feat: remove antiphonal text from searches returning no results

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -7,7 +7,6 @@ import './styles.scss';
 import '../list/styles.scss';
 
 import { highlightFilter, itemToOption } from '../lib/utils';
-import classNames from 'classnames';
 
 export interface Properties {
   search: (query: string) => Promise<Item[]>;
@@ -64,12 +63,6 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           wrapperClassName={'autocomplete-members__search-wrapper force-extra-specificity'}
           inputClassName={'autocomplete-members__search-input'}
         />
-
-        {this.state.results?.length === 0 && this.state.results !== '' && (
-          <div className={classNames('messages-list__empty', 'messages-list__empty-top-padding')}>
-            {`No results for '${this.state.searchString}' `}
-          </div>
-        )}
 
         {this.props.children}
         <div className='autocomplete-members__content'>

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -112,10 +112,6 @@ export class ConversationListPanel extends React.Component<Properties, State> {
                 />
               ))}
 
-              {this.filteredConversations?.length === 0 && this.state.filter !== '' && (
-                <div className='messages-list__empty'>{`No results for '${this.state.filter}' `}</div>
-              )}
-
               {this.state.userSearchResults?.length > 0 && this.state.filter !== '' && (
                 <UserSearchResults
                   results={this.state.userSearchResults}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -65,19 +65,6 @@ $side-padding: 16px;
       height: 1px;
       padding: 0px $side-padding;
     }
-
-    &__empty {
-      padding: 8px;
-      color: theme.$color-greyscale-11;
-      font-size: $font-size-medium;
-      line-height: 17px;
-      word-break: break-word;
-      text-align: center;
-
-      &-top-padding {
-        padding-top: 32px;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
### What does this do?
- removes antiphonal text as shown in the demo below.

### Why are we making this change?
- requested from product/n3o.

### How do I test this?
- enter characters into one of the search inputs in the sidekick until no users are returned. Check that there is nothing rendered when this happens.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

https://github.com/zer0-os/zOS/assets/39112648/891d901d-e2ab-4bc9-a3ea-d59fa468f806

After: 


https://github.com/zer0-os/zOS/assets/39112648/04b16d7f-b68d-4e9d-b6c9-6722be8f8f54

