### PR TITLE
fix: gap between sidebar and rewards modal & arrow placement

### DIFF
--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -24,7 +24,7 @@ $content-padding-y: 40px;
       $width: if($is-top, $arrow-size, $arrow-size / 2);
       height: $height;
       width: $width;
-      top: if($is-top, -$content-padding-y - $height, -$content-padding-y + 16px);
+      top: if($is-top, -$content-padding-y - $height, -$content-padding-y + 24px);
       left: if($is-top, calc(100% - $width / 2), -$content-padding-x - $width);
       clip-path: if($is-top, polygon(0 100%, 50% 0, 100% 100%), polygon(100% 0, 0 50%, 100% 100%));
     }
@@ -62,8 +62,8 @@ $content-padding-y: 40px;
 
   &--full-screen {
     .rewards-popup__content {
-      top: 2px;
-      left: $width-sidekick + $width-world-navigation + 2px;
+      top: 0;
+      left: $width-sidekick - 4px;
     }
 
     @include arrow('left');
@@ -71,7 +71,7 @@ $content-padding-y: 40px;
 
   &--full-screen.rewards-popup--with-title {
     .rewards-popup__content {
-      top: 40px;
+      top: 0;
     }
   }
 


### PR DESCRIPTION
### What does this do?
- fixes gap between sidebar and rewards modal & arrow placement.
- fixes position of rewards pop up arrow.

### Why are we making this change?
- as per figma designs.

### How do I test this?
- open messenger in full screen and click the rewards button to open the rewards pop up modal. Check positions as per design: https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?node-id=7019%3A313890&mode=dev

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

<img width="1769" alt="Screenshot 2023-07-25 at 11 54 54" src="https://github.com/zer0-os/zOS/assets/39112648/8963a01a-9e8f-4869-8871-8f72657d853b">


After:

<img width="1769" alt="Screenshot 2023-07-25 at 11 54 35" src="https://github.com/zer0-os/zOS/assets/39112648/43ab7ae9-8b7b-4f7d-b989-ada8a561ae3e">
