### PR TITLE
fix: rewards icon button in the sidebar

### DIFF
--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -92,6 +92,28 @@ describe('rewards-bar', () => {
     expect(wrapper.find(TooltipPopup).prop('open')).toBeFalse();
   });
 
+  it('displays rewards icon status when conditions are met', function () {
+    const wrapper = subject({
+      showNewRewards: true,
+      isMessengerFullScreen: true,
+    });
+
+    wrapper.setState({ isRewardsPopupOpen: false });
+
+    expect(wrapper.find('.rewards-bar__rewards-icon__status')).toHaveLength(1);
+  });
+
+  it('does not display rewards icon status when rewards pop up is open', function () {
+    const wrapper = subject({
+      showNewRewards: false,
+      isMessengerFullScreen: true,
+    });
+
+    wrapper.setState({ isRewardsPopupOpen: true });
+
+    expect(wrapper.find('.rewards-bar__rewards-icon__status')).toHaveLength(0);
+  });
+
   it('renders the SettingsMenu as necessary', function () {
     let wrapper = subject({ includeRewardsAvatar: true });
     expect(wrapper).toHaveElement('SettingsMenu');

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -98,18 +98,19 @@ describe('rewards-bar', () => {
       isMessengerFullScreen: true,
     });
 
-    wrapper.setState({ isRewardsPopupOpen: false });
+    wrapper.find('.rewards-bar__rewards-button').simulate('click');
+    wrapper.find(RewardsPopupContainer).simulate('close');
 
     expect(wrapper.find('.rewards-bar__rewards-icon__status')).toHaveLength(1);
   });
 
   it('does not display rewards icon status when rewards pop up is open', function () {
     const wrapper = subject({
-      showNewRewards: false,
+      showNewRewards: true,
       isMessengerFullScreen: true,
     });
 
-    wrapper.setState({ isRewardsPopupOpen: true });
+    wrapper.find('.rewards-bar__rewards-button').simulate('click');
 
     expect(wrapper.find('.rewards-bar__rewards-icon__status')).toHaveLength(0);
   });

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -80,11 +80,7 @@ export class RewardsBar extends React.Component<Properties, State> {
             userAvatarUrl={this.props.userAvatarUrl}
           />
         )}
-        <div
-          className={classnames(c('rewards-button-container'), {
-            [c('rewards-button-container', 'open')]: this.state.isRewardsPopupOpen,
-          })}
-        >
+        <div className={c('rewards-button-container')}>
           <button
             onClick={this.openRewards}
             className={classnames(c('rewards-button'), {

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -98,7 +98,7 @@ export class RewardsBar extends React.Component<Properties, State> {
               })}
             >
               <IconCurrencyDollar size={16} />
-              {this.props.showNewRewards && this.props.isMessengerFullScreen && (
+              {!this.state.isRewardsPopupOpen && this.props.showNewRewards && this.props.isMessengerFullScreen && (
                 <Status type='idle' className={c('rewards-icon__status')} />
               )}
             </div>

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -80,20 +80,30 @@ export class RewardsBar extends React.Component<Properties, State> {
             userAvatarUrl={this.props.userAvatarUrl}
           />
         )}
-        <button
-          onClick={this.openRewards}
-          className={classnames(c('rewards-button'), {
-            [c('rewards-button', 'open')]: this.state.isRewardsPopupOpen,
+        <div
+          className={classnames(c('rewards-button-container'), {
+            [c('rewards-button-container', 'open')]: this.state.isRewardsPopupOpen,
           })}
         >
-          <div>Rewards</div>
-          <div className={c('rewards-icon')}>
-            <IconCurrencyDollar size={16} />
-            {this.props.showNewRewards && this.props.isMessengerFullScreen && (
-              <Status type='idle' className={c('rewards-icon__status')} />
-            )}
-          </div>
-        </button>
+          <button
+            onClick={this.openRewards}
+            className={classnames(c('rewards-button'), {
+              [c('rewards-button', 'open')]: this.state.isRewardsPopupOpen,
+            })}
+          >
+            <div>Rewards</div>
+            <div
+              className={classnames(c('rewards-icon'), {
+                [c('rewards-icon', 'open')]: this.state.isRewardsPopupOpen,
+              })}
+            >
+              <IconCurrencyDollar size={16} />
+              {this.props.showNewRewards && this.props.isMessengerFullScreen && (
+                <Status type='idle' className={c('rewards-icon__status')} />
+              )}
+            </div>
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/components/rewards-bar/styles.scss
+++ b/src/components/rewards-bar/styles.scss
@@ -20,8 +20,7 @@
   &__rewards-button-container {
     padding: 8px;
 
-    &:hover,
-    &--open {
+    &:hover {
       border-radius: 64px;
       background-color: theme.$color-primary-4;
     }

--- a/src/components/rewards-bar/styles.scss
+++ b/src/components/rewards-bar/styles.scss
@@ -8,12 +8,22 @@
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    padding: 0px 16px;
+    padding: 0px 8px 0 16px;
 
     height: 64px;
 
     &--with-avatar {
       justify-content: space-between;
+    }
+  }
+
+  &__rewards-button-container {
+    padding: 8px;
+
+    &:hover,
+    &--open {
+      border-radius: 64px;
+      background-color: theme.$color-primary-4;
     }
   }
 
@@ -27,27 +37,15 @@
     justify-content: center;
     align-items: center;
 
-    gap: 16px;
+    gap: 4px;
 
     font-weight: 400;
     font-size: 12px;
     line-height: 15px;
     color: theme.$color-primary-transparency-11;
 
-    &:hover {
-      font-weight: 700;
-    }
-
     &--open {
-      font-weight: 700;
       color: theme.$color-primary-11;
-
-      .messenger-list__rewards-icon {
-        background: radial-gradient(66.52% 66.52% at 0% 0%, #b900e3 0%, rgba(111, 25, 131, 0) 100%),
-          radial-gradient(93.63% 93.63% at 100% 0%, #de1cd7 0%, rgba(232, 0, 223, 0) 100%),
-          radial-gradient(99.71% 99.71% at 104.51% 75.11%, #71b8ff 0%, rgba(116, 186, 255, 0) 100%),
-          radial-gradient(65.88% 65.88% at -1.79% 99.21%, #7d12e7 0%, rgba(162, 68, 255, 0) 100%), #290634;
-      }
     }
   }
 
@@ -60,6 +58,17 @@
     justify-content: center;
     align-items: center;
     color: theme.$color-primary-12;
+
+    &--open {
+      background: var(
+        --dark-gradient-primary-3,
+        radial-gradient(79.83% 79.83% at -0% 0%, #b900e3 0%, rgba(111, 25, 131, 0) 100%),
+        radial-gradient(121.07% 121.07% at 100% 0%, #de1cd7 0%, rgba(232, 0, 223, 0) 100%),
+        radial-gradient(109.02% 109.02% at 104.51% 75.11%, #71b8ff 0%, rgba(116, 186, 255, 0) 100%),
+        radial-gradient(83.71% 83.71% at -1.79% 99.21%, #7d12e7 0%, rgba(162, 68, 255, 0) 100%),
+        #290634
+      );
+    }
 
     &__status {
       position: absolute;

--- a/src/components/rewards-bar/styles.scss
+++ b/src/components/rewards-bar/styles.scss
@@ -73,8 +73,7 @@
     &__status {
       position: absolute;
       top: 16px;
-      right: 13px;
-      border: 2px solid theme.$color-primary-1;
+      right: 16px;
     }
   }
 }


### PR DESCRIPTION
### What does this do?
- Update the space between the word “Rewards” and the Rewards icon to be 4 px
- Update the hover text to no longer be bold on hover
- Update the text to no longer be bold when active
- Update the hover state to match the specification in the above Figma file
- Orange badge should hide as soon as rewards modal is opened
- Update rewards bar buttons as per design
- Updates rewards button icon status design
- Adds test coverage

### Why are we making this change?
- as per design (https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=6797-369406&mode=dev)

### How do I test this?
- open full messenger and check rewards bar/rewards button. Compare with design linked above.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

*Updated design*


https://github.com/zer0-os/zOS/assets/39112648/5ad75599-9491-473d-bcb9-151b413225e0

