### PR TITLE
feat: populate messages from the bottom up

### DIFF
--- a/src/components/inverted-scroll/styles.scss
+++ b/src/components/inverted-scroll/styles.scss
@@ -3,6 +3,10 @@
   overflow-x: hidden;
 
   .scroll-container__children {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    min-height: 100%;
     overflow: hidden;
   }
 }


### PR DESCRIPTION
### What does this do?
- populates messages (where the container uses `InvertedScroll` from the bottom up.

### Why are we making this change?
- as per figma designs / product request.

### How do I test this?
- open messenger fullscreen or collapsed direct message and check that messages are populated from the bottom up - as per screenshots below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before: 

<img width="2297" alt="Screenshot 2023-07-25 at 15 42 57" src="https://github.com/zer0-os/zOS/assets/39112648/d8cce45a-deb0-47af-9c10-d8415ef449d1">

After:

<img width="2297" alt="Screenshot 2023-07-25 at 15 43 27" src="https://github.com/zer0-os/zOS/assets/39112648/1983400e-222c-4ad2-843d-ab4b076ef72b">
