### PR TITLE
Style media messages full width

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -74,6 +74,7 @@ describe('message', () => {
     const wrapper = subject({
       createdAt: new Date('December 17, 1995 17:04:00').valueOf(),
       showTimestamp: true,
+      message: 'message',
     });
 
     expect(wrapper.find('.message__time').text()).toStrictEqual('5:04 PM');

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -194,7 +194,7 @@ describe('message', () => {
       updatedAt: 86276372,
     });
 
-    expect(wrapper.find('.message__edited-flag').exists()).toBe(true);
+    expect(wrapper.find('.message__footer').text()).toEqual('(Edited)');
   });
 
   it('renders reply message', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -89,6 +89,8 @@ export class Message extends React.Component<Properties, State> {
     this.handleMediaAspectRatio(width, height);
   };
 
+  isMediaOnly() {}
+
   renderMedia(media) {
     const { type, url, name } = media;
     if (MediaType.Image === type) {
@@ -128,7 +130,7 @@ export class Message extends React.Component<Properties, State> {
     const footerElements = [];
 
     if (!!this.props.updatedAt && !isSendStatusFailed) {
-      footerElements.push(<span {...cn('edited-flag')}>(Edited)</span>);
+      footerElements.push(<span>(Edited)</span>);
     }
     if (!isSendStatusFailed && this.props.showTimestamp) {
       footerElements.push(this.renderTime(this.props.createdAt));
@@ -264,8 +266,38 @@ export class Message extends React.Component<Properties, State> {
     );
   }
 
+  renderBody() {
+    const { message, preview, isOwner, hidePreview } = this.props;
+
+    return (
+      <div {...cn('block-body')}>
+        {this.props.showAuthorName && this.renderAuthorName()}
+        {this.props.parentMessageText && (
+          <div {...cn('block-reply')}>
+            <span {...cn('block-reply-text')}>
+              <ContentHighlighter
+                message={this.props.parentMessageText}
+                mentionedUserIds={this.props.mentionedUserIds}
+              />
+            </span>
+          </div>
+        )}
+        {message && <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />}
+        {preview && !hidePreview && (
+          <div {...cn('block-preview')}>
+            <LinkPreview url={preview.url} {...preview} />
+            {isOwner && (
+              <IconButton Icon={IconXClose} onClick={this.onRemovePreview} className='remove-preview__icon' />
+            )}
+          </div>
+        )}
+        {this.renderFooter()}
+      </div>
+    );
+  }
+
   render() {
-    const { message, media, preview, sender, isOwner, hidePreview } = this.props;
+    const { message, media, preview, sender, isOwner } = this.props;
     return (
       <div
         className={classNames('message', this.props.className, {
@@ -283,30 +315,11 @@ export class Message extends React.Component<Properties, State> {
         <div {...cn('block', (this.state.isFullWidth && 'fill', this.state.isEditing && 'edit'))}>
           {(message || media || preview) && (
             <>
-              {this.props.showAuthorName && this.renderAuthorName()}
               {!this.state.isEditing && (
-                <div {...cn('block-body')}>
+                <>
                   {media && this.renderMedia(media)}
-                  {this.props.parentMessageText && (
-                    <div {...cn('block-reply')}>
-                      <span {...cn('block-reply-text')}>
-                        <ContentHighlighter
-                          message={this.props.parentMessageText}
-                          mentionedUserIds={this.props.mentionedUserIds}
-                        />
-                      </span>
-                    </div>
-                  )}
-                  {message && <ContentHighlighter message={message} mentionedUserIds={this.props.mentionedUserIds} />}
-                  {preview && !hidePreview && (
-                    <div {...cn('block-preview')}>
-                      <LinkPreview url={preview.url} {...preview} />
-                      {isOwner && (
-                        <IconButton Icon={IconXClose} onClick={this.onRemovePreview} className='remove-preview__icon' />
-                      )}
-                    </div>
-                  )}
-                </div>
+                  {this.renderBody()}
+                </>
               )}
 
               {this.state.isEditing && this.props.message && (
@@ -320,7 +333,6 @@ export class Message extends React.Component<Properties, State> {
               )}
             </>
           )}
-          {this.renderFooter()}
         </div>
         {this.renderMenu()}
       </div>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -120,23 +120,37 @@ export class Message extends React.Component<Properties, State> {
   }
 
   renderFooter() {
+    if (this.state.isEditing) {
+      return;
+    }
+
     const isSendStatusFailed = this.props.sendStatus === MessageSendStatus.FAILED;
+    const footerElements = [];
+
+    if (!!this.props.updatedAt && !isSendStatusFailed) {
+      footerElements.push(<span {...cn('edited-flag')}>(Edited)</span>);
+    }
+    if (!isSendStatusFailed && this.props.showTimestamp) {
+      footerElements.push(this.renderTime(this.props.createdAt));
+    }
+    if (isSendStatusFailed) {
+      footerElements.push(
+        <div {...cn('failure-message')}>
+          Failed to send&nbsp;
+          <IconAlertCircle size={16} />
+        </div>
+      );
+    }
+
+    if (footerElements.length === 0) {
+      return;
+    }
 
     return (
       <div {...cn('footer')}>
-        {!!this.props.updatedAt && !this.state.isEditing && !isSendStatusFailed && (
-          <span {...cn('edited-flag')}>(Edited)</span>
-        )}
-        {!isSendStatusFailed &&
-          !this.state.isEditing &&
-          this.props.showTimestamp &&
-          this.renderTime(this.props.createdAt)}
-        {isSendStatusFailed && !this.state.isEditing && (
-          <div {...cn('failure-message')}>
-            Failed to send&nbsp;
-            <IconAlertCircle size={16} />
-          </div>
-        )}
+        {footerElements[0]}
+        {footerElements[1]}
+        {footerElements[2]}
       </div>
     );
   }

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -323,13 +323,17 @@ export class Message extends React.Component<Properties, State> {
               )}
 
               {this.state.isEditing && this.props.message && (
-                <MessageInput
-                  initialValue={this.props.message}
-                  onSubmit={this.editMessage}
-                  getUsersForMentions={this.props.getUsersForMentions}
-                  isEditing={this.state.isEditing}
-                  renderAfterInput={this.editActions}
-                />
+                <>
+                  <div {...cn('block-edit')}>
+                    <MessageInput
+                      initialValue={this.props.message}
+                      onSubmit={this.editMessage}
+                      getUsersForMentions={this.props.getUsersForMentions}
+                      isEditing={this.state.isEditing}
+                      renderAfterInput={this.editActions}
+                    />
+                  </div>
+                </>
               )}
             </>
           )}

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -271,7 +271,6 @@ export class Message extends React.Component<Properties, State> {
 
     return (
       <div {...cn('block-body')}>
-        {this.props.showAuthorName && this.renderAuthorName()}
         {this.props.parentMessageText && (
           <div {...cn('block-reply')}>
             <span {...cn('block-reply-text')}>
@@ -317,6 +316,7 @@ export class Message extends React.Component<Properties, State> {
             <>
               {!this.state.isEditing && (
                 <>
+                  {this.props.showAuthorName && this.renderAuthorName()}
                   {media && this.renderMedia(media)}
                   {this.renderBody()}
                 </>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -89,8 +89,6 @@ export class Message extends React.Component<Properties, State> {
     this.handleMediaAspectRatio(width, height);
   };
 
-  isMediaOnly() {}
-
   renderMedia(media) {
     const { type, url, name } = media;
     if (MediaType.Image === type) {

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -139,6 +139,10 @@
     }
   }
 
+  &__block-edit {
+    padding: 8px;
+  }
+
   &__footer {
     display: flex;
     flex-direction: row;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -73,11 +73,12 @@
     font-size: 14px;
     line-height: 17px;
     color: theme.$color-greyscale-12;
-    margin: 0;
-    padding: 8px;
     display: flex;
     flex-direction: column;
     gap: 4px;
+
+    margin: 8px 0 0px 0;
+    padding: 0px 8px 8px 8px;
 
     &:empty {
       display: none;
@@ -199,6 +200,8 @@
     font-size: 12px;
     line-height: 15px;
     color: theme.$color-greyscale-12;
+    margin: 0 0 8px 0;
+    padding: 8px 8px 0px 8px;
   }
 
   &.messages__message--last-in-group {

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -80,6 +80,9 @@
     margin: 8px 0 0px 0;
     padding: 0px 8px 8px 8px;
 
+    white-space: pre-wrap;
+    word-break: break-word;
+
     &:empty {
       display: none;
     }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -48,7 +48,7 @@
   &__block {
     background-color: theme.$color-primary-3;
     position: relative;
-    padding: 8px;
+    padding: 0px;
     color: themeDeprecated.$card-text-color;
     overflow: hidden;
     z-index: 1;
@@ -69,14 +69,19 @@
   }
 
   &__block-body {
-    display: block;
-    white-space: pre-wrap;
-    word-break: break-word;
     font-weight: 400;
     font-size: 14px;
     line-height: 17px;
     color: theme.$color-greyscale-12;
     margin: 0;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    &:empty {
+      display: none;
+    }
   }
 
   &__block-reply {
@@ -109,7 +114,6 @@
 
   &__block-image {
     position: relative;
-    display: inline-block;
     cursor: pointer;
     width: 100%;
 
@@ -117,7 +121,6 @@
       display: block;
       margin: auto;
       max-width: 100%;
-      border-radius: 8px;
     }
   }
 
@@ -149,22 +152,12 @@
 
   &__time {
     display: flex;
-    padding-top: 4px;
-  }
-
-  &__edited-flag {
-    padding-top: 4px;
   }
 
   &__failure-message {
     display: flex;
     align-items: center;
     color: theme.$color-failure-11;
-    padding-top: 4px;
-  }
-
-  &__edited {
-    padding-top: 4px;
   }
 
   &__menu {
@@ -206,7 +199,6 @@
     font-size: 12px;
     line-height: 15px;
     color: theme.$color-greyscale-12;
-    padding-bottom: 8px;
   }
 
   &.messages__message--last-in-group {


### PR DESCRIPTION
### What does this do?

Tries to get the message bubble closer to the designs. In particular, this PR is related to some basic structural changes and rendering media to the borders of the message bubble.

### Why are we making this change?

Design enhancements

### How do I test this?

Send various messages of all kinds of types both in succession and not.

![image](https://github.com/zer0-os/zOS/assets/43770/8a1896cd-690a-4ef3-a90b-c433adf45d57)

![image](https://github.com/zer0-os/zOS/assets/43770/2f6df202-fe18-41a4-b282-9b9617e9cc35)
