### PR TITLE
fix: resolve app context panel transition/animation issue

### DIFF
--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -118,16 +118,16 @@ export class Container extends React.Component<Properties> {
   render() {
     return (
       <Provider store={this.props.store}>
-        <AppLayout className='channels'>
-          <ZUIProvider>
+        <ZUIProvider>
+          <AppLayout className='channels'>
             <AppContextPanel>
               <ScrollbarContainer variant='on-hover'>
                 <ChannelList channels={this.props.channels} currentChannelId={this.props.channelId} />
               </ScrollbarContainer>
             </AppContextPanel>
             <AppContent className='channel-app'>{this.renderChannelView()}</AppContent>
-          </ZUIProvider>
-        </AppLayout>
+          </AppLayout>
+        </ZUIProvider>
       </Provider>
     );
   }


### PR DESCRIPTION
### What does this do?
- moves `ZUIProvider` higher up to resolve the app-context-panel slide in/slide out issue.

### Why are we making this change?
- due to a bug that was introduced when `ZUIProvider` was added recently.

### How do I test this?
- open the app (not in fullscreen) and click the channels panel icon button to open/close. Demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

https://github.com/zer0-os/zOS/assets/39112648/212e4840-bb48-420c-9cbd-a1bfae2922dc


After:

https://github.com/zer0-os/zOS/assets/39112648/75829e79-dc47-48f6-b7e3-d4864ec9e955


