### PR TITLE
fix: invite screen error handling

### DIFF
--- a/src/authentication/_styles.scss
+++ b/src/authentication/_styles.scss
@@ -74,4 +74,5 @@
   gap: 16px;
 
   font-size: 14px;
+  line-height: 17px;
 }

--- a/src/authentication/validate-invite/index.test.tsx
+++ b/src/authentication/validate-invite/index.test.tsx
@@ -78,4 +78,24 @@ describe('Invite', () => {
       'This invite has been used too many times. Please use a new invite code.'
     );
   });
+
+  it('disables the button after error until code is edited', function () {
+    const validateInvite = jest.fn();
+    const code = '123456';
+    const wrapper = subject({ validateInvite });
+
+    wrapper.find('Input').simulate('change', code);
+    wrapper.find('form').simulate('submit', inputEvent());
+
+    wrapper.setProps({ inviteCodeStatus: InviteCodeStatus.INVITE_CODE_USED });
+    expect(wrapper.find('Alert').prop('children')).toEqual(
+      'This invite code has already been redeemed. If you cannot get another invite you can join the waitlist below.'
+    );
+
+    expect(wrapper.find('Button').prop('isDisabled')).toEqual(true);
+
+    wrapper.find('Input').simulate('change', '123457');
+
+    expect(wrapper.find('Button').prop('isDisabled')).toEqual(false);
+  });
 });

--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -20,12 +20,14 @@ const MAX_INVITE_CODE_LENGTH = 14;
 interface State {
   inviteCode: string;
   renderAlert: boolean;
+  lastSubmittedInviteCode: string;
 }
 
 export class Invite extends React.Component<Properties, State> {
   state: State = {
     inviteCode: '',
     renderAlert: false,
+    lastSubmittedInviteCode: '',
   };
 
   onInviteCodeChanged = (code: string) => {
@@ -34,16 +36,9 @@ export class Invite extends React.Component<Properties, State> {
 
   submitForm = async (e) => {
     e.preventDefault();
-    this.setState({ renderAlert: true });
+    this.setState({ renderAlert: true, lastSubmittedInviteCode: this.state.inviteCode });
     this.props.validateInvite({ code: this.state.inviteCode });
   };
-
-  componentDidUpdate(_prevProps: Readonly<Properties>, prevState: Readonly<State>): void {
-    // Hide alert when invite code is changed
-    if (prevState.inviteCode !== this.state.inviteCode && this.state.renderAlert) {
-      this.setState({ renderAlert: false });
-    }
-  }
 
   renderAlert = (status: string) => {
     let errorMessage: string;
@@ -103,7 +98,7 @@ export class Invite extends React.Component<Properties, State> {
             isDisabled={
               !this.state.inviteCode.length ||
               this.state.inviteCode.length > MAX_INVITE_CODE_LENGTH ||
-              this.state.renderAlert
+              this.state.inviteCode === this.state.lastSubmittedInviteCode
             }
             isLoading={this.props.isLoading}
             isSubmit


### PR DESCRIPTION
### What does this do?
- improves/fixes the handling of errors on the invite screen.
- alert remains visible when there has been an error.
- adds the error state of the input when rendering alert.
- disables button when invite code has not been edited as per design.

### Why are we making this change?
- to improve the UI/UX of the invite screen.

### How do I test this?
- navigate to /get-access. enter invalid code. then enter valid code.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


OUTCOME:

https://github.com/zer0-os/zOS/assets/39112648/07620972-5ca8-47a6-a4c2-4917fa73c8ac

