### PR TITLE
Remove redundant event listener for creating conversations

### DIFF
--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -2,12 +2,11 @@ import { createAction } from '@reduxjs/toolkit';
 import { createNormalizedListSlice } from '../normalized';
 
 import { schema } from '../channels';
-import { ChannelsReceivedPayload, CreateMessengerConversation } from './types';
+import { ChannelsReceivedPayload } from './types';
 
 export enum SagaActionTypes {
   FetchChannels = 'channelsList/saga/fetchChannels',
   FetchConversations = 'channelsList/saga/fetchConversations',
-  CreateConversation = 'channelsList/saga/createConversations',
   StartChannelsAndConversationsAutoRefresh = 'channelsList/saga/startChannelsAndConversationsAutoRefresh',
   StopChannelsAndConversationsAutoRefresh = 'channelsList/saga/stopChannelsAndConversationsAutoRefresh',
   ChannelsReceived = 'channelsList/saga/received',
@@ -15,7 +14,6 @@ export enum SagaActionTypes {
 
 const fetchChannels = createAction<string>(SagaActionTypes.FetchChannels);
 const fetchConversations = createAction<string>(SagaActionTypes.FetchConversations);
-const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
 const channelsReceived = createAction<ChannelsReceivedPayload>(SagaActionTypes.ChannelsReceived);
 const startChannelsAndConversationsAutoRefresh = createAction(SagaActionTypes.StartChannelsAndConversationsAutoRefresh);
 
@@ -26,13 +24,7 @@ const slice = createNormalizedListSlice({
 
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
-export {
-  fetchChannels,
-  fetchConversations,
-  createConversation,
-  channelsReceived,
-  startChannelsAndConversationsAutoRefresh,
-};
+export { fetchChannels, fetchConversations, channelsReceived, startChannelsAndConversationsAutoRefresh };
 
 export function denormalizeChannels(state) {
   return denormalizeChannelsAndConversations(state).filter((c) => c.isChannel);

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -228,7 +228,6 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.FetchChannels, fetchChannels);
   yield takeLatest(SagaActionTypes.StartChannelsAndConversationsAutoRefresh, startChannelsAndConversationsRefresh);
   yield takeLatest(SagaActionTypes.FetchConversations, fetchConversations);
-  yield takeLatest(SagaActionTypes.CreateConversation, createConversation);
   yield takeLatest(SagaActionTypes.ChannelsReceived, channelsReceived);
 
   const chatBus = yield call(getChatBus);

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -56,7 +56,6 @@ export function* createConversation(action) {
 
 export function* saga() {
   yield fork(authWatcher);
-  yield fork(handleCreateConversation);
 
   while (true) {
     const { startEvent, createConversationEvent } = yield race({
@@ -111,13 +110,6 @@ const PREVIOUS_STAGES = {
   [Stage.StartGroupChat]: Stage.CreateOneOnOne,
   [Stage.GroupDetails]: Stage.StartGroupChat,
 };
-
-function* handleCreateConversation() {
-  while (true) {
-    const action = yield take(SagaActionTypes.CreateConversation);
-    yield call(createConversation, action);
-  }
-}
 
 function* handleOneOnOne() {
   const action = yield take([


### PR DESCRIPTION
### What does this do?

Removes an extra event listener that already existed

### Why are we making this change?

We had 2 listeners to the same event under the same conditions which was causing us to send 2 api calls for the same thing.

### How do I test this?

Create new conversations in the various ways (particularly one on ones)

