### PR TITLE
Fix inconsistent message bubble width for messages without menu options

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -173,6 +173,8 @@
     transition: opacity 0s ease-in-out, transform 0.1s ease-in-out;
     transform: translateX(-100%);
     opacity: 0;
+    // Sometimes we render an empty menu. This ensures consistency of width of the message bubble.
+    min-width: 32px;
   }
 
   .menu--open {


### PR DESCRIPTION
### What does this do?

When messages have no menu this ensures they render the same width as messages with a menu.

This occurs when a message send is in progress and when another user has sent a message we can't reply to.

### Why are we making this change?

Consistency.

