### PR TITLE
Translate typed emojis to unicode

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -9,7 +9,6 @@ import Dropzone from 'react-dropzone';
 import { config } from '../../config';
 import ReplyCard from '../reply-card/reply-card';
 import { ViewModes } from '../../shared-components/theme-engine';
-import { EmojiPicker } from './emoji-picker/emoji-picker';
 import MessageAudioRecorder from '../message-audio-recorder';
 import { Giphy } from './giphy/giphy';
 import ImageCards from '../../platform-apps/channels/image-cards';
@@ -260,15 +259,16 @@ describe('MessageInput', () => {
   });
 
   describe('Emojis', () => {
-    const getEmojiPicker = () => {
-      const wrapper = subject({});
-      return wrapper.find(Dropzone).shallow().find(EmojiPicker);
-    };
+    it('translates typed colon emojis to unicode emojis', () => {
+      const onSubmit = jest.fn();
+      const wrapper = subject({ onSubmit });
+      const dropzone = wrapper.find(Dropzone).shallow();
 
-    it('renders', function () {
-      const emojiPicker = getEmojiPicker();
+      const message = 'Message with :smile:';
+      dropzone.find(MentionsInput).simulate('change', { target: { value: message } });
+      wrapper.find('.message-input__icon--send').simulate('click');
 
-      expect(emojiPicker.exists()).toBe(true);
+      expect(onSubmit).toHaveBeenCalledWith('Message with 😄', [], []);
     });
   });
 

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -24,6 +24,7 @@ import { Avatar } from '@zero-tech/zui/components';
 
 import classNames from 'classnames';
 import './styles.scss';
+import { textToPlainEmojis } from '../content-highlighter/text-to-emojis';
 
 export interface PublicProperties extends PublicPropertiesContainer {}
 
@@ -159,10 +160,11 @@ export class MessageInput extends React.Component<Properties, State> {
   };
 
   contentChanged = (event): void => {
-    const {
+    let {
       target: { value },
     } = event;
 
+    value = textToPlainEmojis(value);
     const mentionedUserIds = this.extractUserIds(value);
     this.setState({ value, mentionedUserIds });
   };


### PR DESCRIPTION
### What does this do?

Translates typed colon based emojis to unicode (eg, :tada:)

### Why are we making this change?

This is so other front ends can render the emoji properly without having to add parsing. We don't allow custom emojis so we should just let the standard unicode characters behave properly.

### How do I test this?

Type a message with `:tada:` in zOS and then view the message on mobile. It should appear as a proper emoji.

