### PR TITLE
fix: condition for valid invite input error state

### DIFF
--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -71,6 +71,8 @@ export class Invite extends React.Component<Properties, State> {
   };
 
   render() {
+    const isError = this.state.renderAlert && this.props.inviteCodeStatus !== InviteCodeStatus.VALID;
+
     return (
       <div className={c('')}>
         <div className={c('heading-container')}>
@@ -84,12 +86,10 @@ export class Invite extends React.Component<Properties, State> {
               placeholder='e.g 123456'
               value={this.state.inviteCode}
               type='text'
-              error={this.state.renderAlert}
+              error={isError}
             />
 
-            {this.state.renderAlert &&
-              this.props.inviteCodeStatus !== InviteCodeStatus.VALID &&
-              this.renderAlert(this.props.inviteCodeStatus)}
+            {isError && this.renderAlert(this.props.inviteCodeStatus)}
           </div>
 
           <Button


### PR DESCRIPTION
### What does this do?
- fixes the error state for the invite code input.

### Why are we making this change?
- input error state was being triggered when submitting an invite code.

### How do I test this?
- navigate to `/get-access` page and enter a valid input code. You should not see the error state for the input being triggered.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE

https://github.com/zer0-os/zOS/assets/39112648/74fa05b9-3132-46aa-9c8b-fbd367e55b47


AFTER

https://github.com/zer0-os/zOS/assets/39112648/16a3395f-ae14-499e-9e67-0f37ba6bd00a

