### PR TITLE
refactor: create account method container/presentation-component structure

### DIFF
--- a/src/authentication/create-account-method/container.test.tsx
+++ b/src/authentication/create-account-method/container.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Action } from 'redux';
+
+import { RegistrationStage } from '../../store/registration';
+import { Container, CreateAccountMethodProps } from './container';
+
+describe('CreateAccountMethodContainer', () => {
+  const registerWithEmailMock = jest.fn() as jest.MockedFunction<() => Action<string>>;
+  const registerWithWalletMock = jest.fn() as jest.MockedFunction<() => Action<string>>;
+
+  const subject = (props: Partial<CreateAccountMethodProps>) => {
+    const allProps: CreateAccountMethodProps = {
+      stage: RegistrationStage.WalletAccountCreation,
+      isConnecting: false,
+      registerWithEmail: registerWithEmailMock,
+      registerWithWallet: registerWithWalletMock,
+      ...props,
+    };
+
+    return shallow(<Container {...allProps} />);
+  };
+
+  describe('render', () => {
+    it('passes props down to CreateAccountMethod component', () => {
+      const wrapper = subject({ isConnecting: true, stage: RegistrationStage.EmailAccountCreation });
+      const createAccountMethodProps = wrapper.find('CreateAccountMethod').props();
+
+      expect(createAccountMethodProps).toEqual(
+        expect.objectContaining({
+          isConnecting: true,
+          stage: RegistrationStage.EmailAccountCreation,
+        })
+      );
+    });
+  });
+
+  describe('handleSelectionChange', () => {
+    it('calls registerWithWallet when selected option is web3', () => {
+      const wrapper = subject({});
+      const instance = wrapper.instance() as Container;
+
+      instance.handleSelectionChange('web3');
+      expect(registerWithWalletMock).toHaveBeenCalled();
+    });
+
+    it('calls registerWithEmail when selected option is email', () => {
+      const wrapper = subject({});
+      const instance = wrapper.instance() as Container;
+
+      instance.handleSelectionChange('email');
+      expect(registerWithEmailMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/authentication/create-account-method/container.tsx
+++ b/src/authentication/create-account-method/container.tsx
@@ -29,8 +29,6 @@ export class Container extends React.Component<CreateAccountMethodProps> {
   }
 
   handleSelectionChange = (selectedOption: string) => {
-    this.setState({ selectedOption });
-
     if (selectedOption === 'web3') {
       this.props.registerWithWallet();
     } else if (selectedOption === 'email') {

--- a/src/authentication/create-account-method/container.tsx
+++ b/src/authentication/create-account-method/container.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { Action } from 'redux';
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
+import { RegistrationStage, registerWithEmail, registerWithWallet } from '../../store/registration';
+
+import { CreateAccountMethod } from '.';
+
+export interface CreateAccountMethodProps {
+  stage: RegistrationStage;
+  isConnecting: boolean;
+
+  registerWithEmail: () => Action<string>;
+  registerWithWallet: () => Action<string>;
+}
+
+export class Container extends React.Component<CreateAccountMethodProps> {
+  static mapState(state: RootState): Partial<CreateAccountMethodProps> {
+    const { registration } = state;
+    return {
+      stage: registration.stage,
+      isConnecting: registration.loading,
+    };
+  }
+
+  static mapActions(_props: CreateAccountMethodProps): Partial<CreateAccountMethodProps> {
+    return { registerWithEmail: registerWithEmail, registerWithWallet: registerWithWallet };
+  }
+
+  handleSelectionChange = (selectedOption: string) => {
+    this.setState({ selectedOption });
+
+    if (selectedOption === 'web3') {
+      this.props.registerWithWallet();
+    } else if (selectedOption === 'email') {
+      this.props.registerWithEmail();
+    }
+  };
+
+  render() {
+    return (
+      <CreateAccountMethod
+        stage={this.props.stage}
+        isConnecting={this.props.isConnecting}
+        onSelectionChange={this.handleSelectionChange}
+      />
+    );
+  }
+}
+
+export const CreateAccountMethodContainer = connectContainer<{}>(Container);

--- a/src/authentication/create-account-method/index.test.tsx
+++ b/src/authentication/create-account-method/index.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { RegistrationStage } from '../../store/registration';
+
+import { CreateAccountMethod, CreateAccountMethodProps } from '.';
+import { CreateEmailAccountContainer } from '../create-email-account/container';
+import { CreateWalletAccountContainer } from '../create-wallet-account/container';
+
+describe('CreateAccountMethod', () => {
+  const defaultProps: CreateAccountMethodProps = {
+    stage: RegistrationStage.EmailAccountCreation,
+    isConnecting: false,
+    onSelectionChange: jest.fn(),
+  };
+
+  const subject = (props: Partial<CreateAccountMethodProps> = {}) => {
+    const allProps: CreateAccountMethodProps = {
+      ...defaultProps,
+      ...props,
+    };
+
+    return shallow(<CreateAccountMethod {...allProps} />);
+  };
+
+  it('calls onSelectionChange when ToggleGroup selection changes', () => {
+    const onSelectionChange = jest.fn();
+    const wrapper = subject({ onSelectionChange });
+
+    wrapper.find('ToggleGroup').simulate('selectionChange', 'web3');
+    expect(onSelectionChange).toHaveBeenCalledWith('web3');
+  });
+
+  it('renders CreateEmailAccountContainer when stage is EmailAccountCreation', () => {
+    const wrapper = subject({ stage: RegistrationStage.EmailAccountCreation });
+    expect(wrapper.find(CreateEmailAccountContainer)).toHaveLength(1);
+    expect(wrapper.find(CreateWalletAccountContainer)).toHaveLength(0);
+  });
+
+  it('renders CreateWalletAccountContainer when stage is WalletAccountCreation', () => {
+    const wrapper = subject({ stage: RegistrationStage.WalletAccountCreation });
+    expect(wrapper.find(CreateEmailAccountContainer)).toHaveLength(0);
+    expect(wrapper.find(CreateWalletAccountContainer)).toHaveLength(1);
+  });
+});

--- a/src/authentication/create-account-method/index.test.tsx
+++ b/src/authentication/create-account-method/index.test.tsx
@@ -32,13 +32,13 @@ describe('CreateAccountMethod', () => {
 
   it('renders CreateEmailAccountContainer when stage is EmailAccountCreation', () => {
     const wrapper = subject({ stage: RegistrationStage.EmailAccountCreation });
-    expect(wrapper.find(CreateEmailAccountContainer)).toHaveLength(1);
-    expect(wrapper.find(CreateWalletAccountContainer)).toHaveLength(0);
+    expect(wrapper).toHaveElement(CreateEmailAccountContainer);
+    expect(wrapper).not.toHaveElement(CreateWalletAccountContainer);
   });
 
   it('renders CreateWalletAccountContainer when stage is WalletAccountCreation', () => {
     const wrapper = subject({ stage: RegistrationStage.WalletAccountCreation });
-    expect(wrapper.find(CreateEmailAccountContainer)).toHaveLength(0);
-    expect(wrapper.find(CreateWalletAccountContainer)).toHaveLength(1);
+    expect(wrapper).not.toHaveElement(CreateEmailAccountContainer);
+    expect(wrapper).toHaveElement(CreateWalletAccountContainer);
   });
 });

--- a/src/authentication/create-account-method/index.tsx
+++ b/src/authentication/create-account-method/index.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import { ToggleGroup } from '@zero-tech/zui/components';
+import * as React from 'react';
+import { RegistrationStage } from '../../store/registration';
 import { CreateEmailAccountContainer } from '../../authentication/create-email-account/container';
 import { CreateWalletAccountContainer } from '../../authentication/create-wallet-account/container';
-import { RegistrationStage } from '../../store/registration';
+
+import { ToggleGroup } from '@zero-tech/zui/components';
+
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
@@ -11,34 +13,35 @@ const cn = bemClassName('create-account-method');
 
 export interface CreateAccountMethodProps {
   stage: RegistrationStage;
-  selectedOption: string;
-  handleSelectionChange: (selectedOption: string) => void;
+  isConnecting: boolean;
+  onSelectionChange: (selectedOption: string) => void;
 }
 
-export class CreateAccountMethod extends React.Component<CreateAccountMethodProps> {
-  render() {
-    const options = [
-      { key: 'web3', label: 'Web3' },
-      { key: 'email', label: 'Email' },
-    ];
+export const CreateAccountMethod: React.FC<CreateAccountMethodProps> = ({ stage, isConnecting, onSelectionChange }) => {
+  const options = [
+    { key: 'web3', label: 'Web3' },
+    { key: 'email', label: 'Email' },
+  ];
 
-    return (
-      <>
-        <h3 {...cn('heading')}>Create Account</h3>
+  const selectedOption = stage === RegistrationStage.WalletAccountCreation ? 'web3' : 'email';
 
+  return (
+    <div {...cn('')}>
+      <h3 {...cn('heading')}>Create Account</h3>
+
+      {!isConnecting && (
         <ToggleGroup
           {...cn('toggle-group')}
           options={options}
-          // variant deprecated but required
           variant='default'
-          onSelectionChange={this.props.handleSelectionChange}
-          selection={this.props.selectedOption}
+          onSelectionChange={onSelectionChange}
+          selection={selectedOption}
           selectionType='single'
           isRequired
         />
-        {this.props.stage === RegistrationStage.EmailAccountCreation && <CreateEmailAccountContainer />}
-        {this.props.stage === RegistrationStage.WalletAccountCreation && <CreateWalletAccountContainer />}
-      </>
-    );
-  }
-}
+      )}
+      {stage === RegistrationStage.EmailAccountCreation && <CreateEmailAccountContainer />}
+      {stage === RegistrationStage.WalletAccountCreation && <CreateWalletAccountContainer />}
+    </div>
+  );
+};

--- a/src/authentication/footer/styles.scss
+++ b/src/authentication/footer/styles.scss
@@ -6,6 +6,7 @@
   display: inline-flex;
   flex-direction: column;
   align-items: center;
+  margin: auto 0 0;
 
   gap: 16px;
 

--- a/src/authentication/validate-invite/styles.scss
+++ b/src/authentication/validate-invite/styles.scss
@@ -2,7 +2,7 @@
 @import '../styles';
 
 .validate-invite {
-  margin: auto 0;
+  margin: auto 0 0;
 
   @include base();
 

--- a/src/invite.tsx
+++ b/src/invite.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { Action } from 'redux';
 import { Redirect } from 'react-router-dom';
 
 import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
-import { RegistrationStage, registerWithEmail, registerWithWallet } from './store/registration';
+import { RegistrationStage } from './store/registration';
 import { InviteContainer } from './authentication/validate-invite/container';
-import { CreateAccountMethod } from './authentication/create-account-method';
+import { CreateAccountMethodContainer } from './authentication/create-account-method/container';
 import { CreateAccountDetailsContainer } from './authentication/create-account-details/container';
 import { Footer } from './authentication/footer/footer';
 
@@ -21,20 +20,9 @@ const cn = bemClassName('invite-main');
 export interface Properties {
   stage: RegistrationStage;
   shouldRender: boolean;
-
-  registerWithEmail: () => Action<string>;
-  registerWithWallet: () => Action<string>;
-}
-
-export interface State {
-  selectedOption: string;
 }
 
 export class Container extends React.Component<Properties> {
-  state: State = {
-    selectedOption: 'web3',
-  };
-
   static mapState(state: RootState): Partial<Properties> {
     const { registration, pageload } = state;
     return {
@@ -43,19 +31,9 @@ export class Container extends React.Component<Properties> {
     };
   }
 
-  static mapActions(_props: Properties): Partial<Properties> {
-    return { registerWithEmail: registerWithEmail, registerWithWallet: registerWithWallet };
+  static mapActions() {
+    return {};
   }
-
-  handleSelectionChange = (selectedOption: string) => {
-    this.setState({ selectedOption });
-
-    if (selectedOption === 'web3') {
-      this.props.registerWithWallet();
-    } else if (selectedOption === 'email') {
-      this.props.registerWithEmail();
-    }
-  };
 
   render() {
     if (!this.props.shouldRender) {
@@ -80,13 +58,7 @@ export class Container extends React.Component<Properties> {
           {this.props.stage === RegistrationStage.ValidateInvite && <InviteContainer />}
 
           {(this.props.stage === RegistrationStage.EmailAccountCreation ||
-            this.props.stage === RegistrationStage.WalletAccountCreation) && (
-            <CreateAccountMethod
-              stage={this.props.stage}
-              selectedOption={this.state.selectedOption}
-              handleSelectionChange={this.handleSelectionChange}
-            />
-          )}
+            this.props.stage === RegistrationStage.WalletAccountCreation) && <CreateAccountMethodContainer />}
 
           {this.props.stage === RegistrationStage.ProfileDetails && <CreateAccountDetailsContainer />}
           {this.props.stage === RegistrationStage.Done && <Redirect to='/' />}


### PR DESCRIPTION
### What does this do?
- refactors the create account method container to follow the container / presentation-component structure that we are using in the authentication folder.
- adds test coverage for the container and component.
- refactors other areas of the code for a tidy up.

### Why are we making this change?
- to follow existing practices/conventions.
- to improve the code quality.
- to add test coverage to the container and component.
- to ensure registration state can be accessed for the ToggleGroup component (i.e. is loading - display elements / hide elements).

### How do I test this?
- ensure all tests are passing and functionality for the sign-up flow is working as expected by visiting the `/get-access` page.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
