### PR TITLE
feat: update wallet select for sign-up / log-in flow 

### DIFF
--- a/src/authentication/create-wallet-account/styles.scss
+++ b/src/authentication/create-wallet-account/styles.scss
@@ -13,10 +13,6 @@
   }
 
   &__select-wallet {
-    background-color: theme.$color-primary-2;
-    border: 1px solid theme.$color-primary-5;
-    border-radius: 8px;
-    padding: 16px;
     margin-bottom: 8px;
   }
 }

--- a/src/authentication/web3-login/styles.scss
+++ b/src/authentication/web3-login/styles.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 32px;
 }
 
 .web3-login {
@@ -30,10 +29,6 @@
   }
 
   &__select-wallet {
-    background-color: theme.$color-primary-2;
-    border: 1px solid theme.$color-primary-5;
-    border-radius: 8px;
-    padding: 16px 6px 24px;
-    box-sizing: border-box;
+    margin-bottom: 8px;
   }
 }

--- a/src/components/wallet-manager/index.tsx
+++ b/src/components/wallet-manager/index.tsx
@@ -132,6 +132,7 @@ export class Container extends React.Component<Properties> {
             networkName={this.getNetworkNameById}
             onClose={this.closeModal}
             onSelect={this.handleWalletSelected}
+            walletSelectTitle='Connect To A Wallet'
           />
         )}
       </div>

--- a/src/components/wallet-select/index.test.tsx
+++ b/src/components/wallet-select/index.test.tsx
@@ -31,6 +31,19 @@ describe('WalletSelect', () => {
     expect(wrapper.find('.zos-wallet-select__connecting-indicator').exists()).toBe(true);
   });
 
+  it('does not render walletSelectTitle by default', () => {
+    const wrapper = subject();
+
+    expect(wrapper).not.toHaveElement('.zos-wallet-select__title');
+  });
+
+  it('renders title when walletSelectTitle is provided', () => {
+    const title = 'Connect To A Wallet';
+    const wrapper = subject({ walletSelectTitle: title });
+
+    expect(wrapper.find('.zos-wallet-select__title').text()).toBe(title);
+  });
+
   it('does not render footer when connecting', () => {
     const wrapper = subject({ isConnecting: true, wallets: [WalletType.Metamask] });
 

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -75,11 +75,6 @@ export class WalletSelect extends React.Component<Properties> {
   render() {
     return (
       <div {...cn(classNames('', this.props.className))}>
-        {!this.props.isConnecting && (
-          <div {...cn('title-bar')}>
-            <h3 {...cn('title')}>Connect To A Wallet</h3>
-          </div>
-        )}
         {this.renderContent()}
         {!this.props.isConnecting && (
           <div {...cn('footer')}>

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -4,12 +4,11 @@ import classNames from 'classnames';
 import { wallets, WalletType } from './wallets';
 
 import './styles.scss';
-import { bem } from '../../lib/bem';
+import { bemClassName } from '../../lib/bem';
 import { Button } from '@zero-tech/zui/components';
 import { IconLinkExternal1 } from '@zero-tech/zui/icons';
 
-// Temporarily use different base class name to avoid conflicts with zos-component-library
-const c = bem('zos-wallet-select');
+const cn = bemClassName('zos-wallet-select');
 
 export interface Properties {
   isConnecting: boolean;
@@ -44,9 +43,9 @@ export class WalletSelect extends React.Component<Properties> {
   renderContent() {
     if (this.props.isConnecting) {
       return (
-        <div className={c('connecting-indicator')}>
-          <div className={c('connecting-wallet-name')}>{this.state.selectedWalletName}</div>
-          <Button className={c('connecting-wallet-button-spinner')} isLoading={this.props.isConnecting} variant='text'>
+        <div {...cn('connecting-indicator')}>
+          <div {...cn('connecting-wallet-name')}>{this.state.selectedWalletName}</div>
+          <Button {...cn('connecting-wallet-button-spinner')} isLoading={this.props.isConnecting} variant='text'>
             {}
           </Button>
         </div>
@@ -61,10 +60,10 @@ export class WalletSelect extends React.Component<Properties> {
       const { type, name, imageSource } = wallets[walletType];
 
       return (
-        <li key={type} className={c('wallet-provider')} onClick={this.getClickHandler(type)}>
-          <span className={c('wallet-name')}>{name}</span>
+        <li key={type} {...cn('wallet-provider')} onClick={this.getClickHandler(type)}>
+          <span {...cn('wallet-name')}>{name}</span>
           <div>
-            <div className={c('wallet-provider-logo')}>
+            <div {...cn('wallet-provider-logo')}>
               <img src={imageSource} alt={name} />
             </div>
           </div>
@@ -75,19 +74,19 @@ export class WalletSelect extends React.Component<Properties> {
 
   render() {
     return (
-      <div className={classNames(c(''), this.props.className)}>
+      <div {...cn(classNames('', this.props.className))}>
         {!this.props.isConnecting && (
-          <div className={c('title-bar')}>
-            <h3 className={c('title')}>Connect To A Wallet</h3>
+          <div {...cn('title-bar')}>
+            <h3 {...cn('title')}>Connect To A Wallet</h3>
           </div>
         )}
         {this.renderContent()}
         {!this.props.isConnecting && (
-          <div className={c('footer')}>
+          <div {...cn('footer')}>
             New to Ethereum?
-            <div className={c('footer-link')}>
+            <div {...cn('footer-link')}>
               <a href='https://ethereum.org/en/wallets/' target='_blank' rel='noreferrer'>
-                Learn more about wallets <IconLinkExternal1 className={c('external-icon')} size={12} />
+                Learn more about wallets <IconLinkExternal1 {...cn('external-icon')} size={12} />
               </a>
             </div>
           </div>

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -12,6 +12,7 @@ const cn = bemClassName('zos-wallet-select');
 
 export interface Properties {
   isConnecting: boolean;
+  walletSelectTitle?: string;
   className?: string;
   wallets?: WalletType[];
 
@@ -78,6 +79,11 @@ export class WalletSelect extends React.Component<Properties> {
 
     return (
       <div className={combinedClassNames}>
+        {!this.props.isConnecting && this.props.walletSelectTitle && (
+          <div {...cn('title-bar')}>
+            <h3 {...cn('title')}>{this.props.walletSelectTitle}</h3>
+          </div>
+        )}
         {this.renderContent()}
         {!this.props.isConnecting && (
           <div {...cn('footer')}>

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -73,8 +73,11 @@ export class WalletSelect extends React.Component<Properties> {
   }
 
   render() {
+    const baseClass = cn('');
+    const combinedClassNames = classNames(baseClass.className, this.props.className);
+
     return (
-      <div {...cn(classNames('', this.props.className))}>
+      <div className={combinedClassNames}>
         {this.renderContent()}
         {!this.props.isConnecting && (
           <div {...cn('footer')}>

--- a/src/components/wallet-select/modal.tsx
+++ b/src/components/wallet-select/modal.tsx
@@ -10,6 +10,7 @@ export interface Properties extends WalletSelectProperties {
   isConnecting: boolean;
   isNotSupportedNetwork: boolean;
   wallets: WalletType[];
+  walletSelectTitle?: string;
   className?: string;
   networkName: string;
   onClose?: () => void;
@@ -38,6 +39,7 @@ export class WalletSelectModal extends React.Component<Properties> {
           wallets={this.props.wallets}
           isConnecting={this.props.isConnecting}
           onSelect={this.props.onSelect}
+          walletSelectTitle={this.props.walletSelectTitle}
         />
         {this.supportedNetwork && <ErrorNetwork supportedNetwork={this.props.networkName} />}
       </Modal>

--- a/src/components/wallet-select/styles.scss
+++ b/src/components/wallet-select/styles.scss
@@ -12,6 +12,21 @@ $left-padding: 12px;
   color: theme.$color-greyscale-12;
   background-color: theme.$color-primary-2;
 
+  &__title-bar {
+    border-bottom: 1px solid theme.$color-primary-4;
+    padding-bottom: 16px;
+    padding-left: $left-padding;
+  }
+
+  &__title {
+    margin: 0px;
+    padding: 0px;
+
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 24px;
+  }
+
   ul {
     margin: 0px;
     padding: 0px;

--- a/src/components/wallet-select/styles.scss
+++ b/src/components/wallet-select/styles.scss
@@ -7,22 +7,10 @@ $left-padding: 12px;
 }
 
 .zos-wallet-select {
+  padding: 8px;
+  border-radius: 8px;
   color: theme.$color-greyscale-12;
-
-  &__title-bar {
-    border-bottom: 1px solid theme.$color-primary-4;
-    padding-bottom: 16px;
-    padding-left: $left-padding;
-  }
-
-  &__title {
-    margin: 0px;
-    padding: 0px;
-
-    font-weight: 700;
-    font-size: 16px;
-    line-height: 24px;
-  }
+  background-color: theme.$color-primary-2;
 
   ul {
     margin: 0px;
@@ -64,8 +52,7 @@ $left-padding: 12px;
 
   &__footer {
     border-top: 1px solid theme.$color-primary-4;
-    padding-top: 16px;
-    padding-left: $left-padding;
+    padding: 24px 16px 16px;
 
     color: theme.$color-greyscale-11;
     font-weight: 400;


### PR DESCRIPTION
### What does this do?
- some minor updates to the update wallet select component

### Why are we making this change?
- as per figma design

### How do I test this?
- run through the sign-up/log-in flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE:
<img width="329" alt="Screenshot 2023-08-02 at 11 16 29" src="https://github.com/zer0-os/zOS/assets/39112648/4ddc4c5a-c5be-4683-8708-752a23c50b1d">

AFTER
<img width="329" alt="Screenshot 2023-08-02 at 11 15 54" src="https://github.com/zer0-os/zOS/assets/39112648/1ec3aafd-dc20-4446-9aab-bcd11f8423e6">



The Wallet Select Modal when in app (not messenger) will remain the same due to adding the `walletSelectTitle` prop:
<img width="1514" alt="Screenshot 2023-08-02 at 11 24 40" src="https://github.com/zer0-os/zOS/assets/39112648/fceb2b42-69a3-477f-8b70-b5ba21b33c1a">
