### PR TITLE
feat: create wallet account error state and connecting state updates 

### DIFF
--- a/src/authentication/create-account-method/index.tsx
+++ b/src/authentication/create-account-method/index.tsx
@@ -24,9 +24,10 @@ export const CreateAccountMethod: React.FC<CreateAccountMethodProps> = ({ stage,
   ];
 
   const selectedOption = stage === RegistrationStage.WalletAccountCreation ? 'web3' : 'email';
+  const isWalletAccountCreationStage = stage === RegistrationStage.WalletAccountCreation;
 
   return (
-    <div {...cn('')}>
+    <div {...cn('', isConnecting && isWalletAccountCreationStage && 'is-connecting')}>
       <h3 {...cn('heading')}>Create Account</h3>
 
       {!isConnecting && (
@@ -40,8 +41,7 @@ export const CreateAccountMethod: React.FC<CreateAccountMethodProps> = ({ stage,
           isRequired
         />
       )}
-      {stage === RegistrationStage.EmailAccountCreation && <CreateEmailAccountContainer />}
-      {stage === RegistrationStage.WalletAccountCreation && <CreateWalletAccountContainer />}
+      {isWalletAccountCreationStage ? <CreateWalletAccountContainer /> : <CreateEmailAccountContainer />}
     </div>
   );
 };

--- a/src/authentication/create-account-method/styles.scss
+++ b/src/authentication/create-account-method/styles.scss
@@ -1,6 +1,10 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .create-account-method {
+  &--is-connecting {
+    margin: auto;
+  }
+
   &__heading {
     color: theme.$color-greyscale-12;
     text-align: center;

--- a/src/authentication/create-wallet-account/container.test.tsx
+++ b/src/authentication/create-wallet-account/container.test.tsx
@@ -20,7 +20,9 @@ describe('Container', () => {
           registration: { errors: [AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS] } as RegistrationState,
         });
 
-        expect(props.error).toEqual('This address has already been registered');
+        expect(props.error).toEqual(
+          'The wallet you connected is already associated with a ZERO account. Please try a different wallet or log in instead.'
+        );
       });
     });
 

--- a/src/authentication/create-wallet-account/container.tsx
+++ b/src/authentication/create-wallet-account/container.tsx
@@ -34,7 +34,7 @@ export class Container extends React.Component<Properties> {
     }
     const error = errors[0];
     if (error === AccountCreationErrors.PUBLIC_ADDRESS_ALREADY_EXISTS) {
-      return 'This address has already been registered';
+      return 'The wallet you connected is already associated with a ZERO account. Please try a different wallet or log in instead.';
     }
     return error;
   }

--- a/src/authentication/create-wallet-account/index.tsx
+++ b/src/authentication/create-wallet-account/index.tsx
@@ -26,7 +26,13 @@ export class CreateWalletAccount extends React.Component<Properties> {
           <div {...cn('select-wallet')}>
             <WalletSelect isConnecting={this.props.isConnecting} onSelect={this.props.onSelect} />
           </div>
-          {this.showError && <Alert variant='error'>{this.props.error}</Alert>}
+          {this.showError && (
+            <div {...cn('error-container')}>
+              <Alert {...cn('error')} variant='error'>
+                {this.props.error}
+              </Alert>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/authentication/create-wallet-account/styles.scss
+++ b/src/authentication/create-wallet-account/styles.scss
@@ -19,4 +19,14 @@
     padding: 16px;
     margin-bottom: 8px;
   }
+
+  &__error-container {
+    padding-top: 4px;
+  }
+
+  &__error {
+    padding: 4px 8px;
+    font-size: 14px;
+    line-height: 17px;
+  }
 }


### PR DESCRIPTION
### What does this do?
- adjusts the position of the create account method container when connecting wallet via the create wallet account method (as shown in the demo video below) - this position should only change for create wallet account method flow, not the create email account, hence the condition added.
- updates the style and content of the error states on the create wallet account method as per figma designs.

### Why are we making this change?
- as per figma designs.

### How do I test this?
- navigate to `/get-access` page and run through the create wallet account flow. Check against the [figma](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=10746-374167&mode=dev) designs

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


ERROR STATE UPDATE: 
<img width="420" alt="Screenshot 2023-08-02 at 12 09 19" src="https://github.com/zer0-os/zOS/assets/39112648/0abb9b32-430b-43e5-b718-6a64ca693178">


POSITION UPDATE WHEN CONNECTING:


https://github.com/zer0-os/zOS/assets/39112648/daf0119b-cc8c-426a-9a92-c0c92ec8cf60

