### PR TITLE
feat: update image upload text content to be optional

### DIFF
--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 export interface Properties {
   className?: string;
   icon: ReactElement;
-  uploadText: string;
+  uploadText?: string;
   onChange: (file: File) => void;
   isError?: boolean;
   errorMessage?: string;
@@ -77,7 +77,7 @@ export class ImageUpload extends Component<Properties, State> {
       <div {...rootProps} className='image-upload__dropzone'>
         <input {...inputProps} />
         {this.icon}
-        <p className='image-upload__text-content'>{this.textContent}</p>
+        {this.textContent && <p className='image-upload__text-content'>{this.textContent}</p>}
       </div>
     );
   };


### PR DESCRIPTION
### What does this do?
- updates image upload text content to be optional. 

### Why are we making this change?
- as per figma designs. The reason for this is in the create account 'name and avatar' screen designs, there is no text content (placeholder text) in the image upload component, but there is for other use cases of the image upload component.

### How do I test this?
- navigate to one of the image upload components in the app and add the attribute `uploadText` to view text content.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


With `uploadText`:
<img width="190" alt="Screenshot 2023-08-02 at 12 36 42" src="https://github.com/zer0-os/zOS/assets/39112648/3ca86e93-26eb-4c18-b741-e948dea033dc">

Without `uploadText`:
<img width="190" alt="Screenshot 2023-08-02 at 12 37 09" src="https://github.com/zer0-os/zOS/assets/39112648/9e1c3c90-fc2d-4eac-ae4d-47ddd6d86aaf">
