### PR TITLE
feat: login with wallet error state and connecting state updates

### DIFF
--- a/src/authentication/web3-login/index.tsx
+++ b/src/authentication/web3-login/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
-import { Alert, Button } from '@zero-tech/zui/components';
-import { IconLoading2 } from '@zero-tech/zui/icons';
+import { Alert } from '@zero-tech/zui/components';
 import { WalletSelect } from '../../components/wallet-select';
 
+import { bemClassName } from '../../lib/bem';
 import './styles.scss';
-import { bem } from '../../lib/bem';
+import { Web3LoginErrors } from '../../store/login';
 
-const c = bem('web3-login');
+const cn = bemClassName('web3-login');
 
 export interface Web3LoginProperties {
   error: string;
@@ -21,22 +21,25 @@ export class Web3Login extends React.Component<Web3LoginProperties, Web3LoginSta
   render() {
     const { error, isConnecting, onSelect } = this.props;
 
+    const errorText =
+      error === Web3LoginErrors.PROFILE_NOT_FOUND
+        ? 'The wallet you connected is not associated with a ZERO account'
+        : error;
+
     return (
-      <div className={c('')}>
-        {isConnecting ? (
-          <div className={c('connecting')}>
-            <Button isDisabled={true} endEnhancer={<IconLoading2 isFilled={true} className={c('spinner')} size={20} />}>
-              Waiting for wallet confirmation
-            </Button>
+      <div {...cn('')}>
+        <div {...cn('login')}>
+          <div {...cn('select-wallet')}>
+            <WalletSelect isConnecting={isConnecting} onSelect={onSelect} />
           </div>
-        ) : (
-          <div className={c('login')}>
-            <div className={c('select-wallet')}>
-              <WalletSelect isConnecting={false} onSelect={onSelect} />
+          {error && (
+            <div {...cn('error-container')}>
+              <Alert {...cn('error')} variant='error'>
+                {errorText}
+              </Alert>
             </div>
-            {error && <Alert variant='error'>{error}</Alert>}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     );
   }

--- a/src/authentication/web3-login/styles.scss
+++ b/src/authentication/web3-login/styles.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 32px;
 }
 
 .web3-login {
@@ -16,24 +15,21 @@
     @include flex();
   }
 
-  &__connecting {
-    @include flex();
-
-    button {
-      text-transform: unset;
-      border: 1px solid theme.$color-greyscale-11;
-    }
-  }
-
-  &__spinner {
-    animation: spin 2s linear infinite;
-  }
-
   &__select-wallet {
     background-color: theme.$color-primary-2;
     border: 1px solid theme.$color-primary-5;
     border-radius: 8px;
     padding: 16px 6px 24px;
     box-sizing: border-box;
+  }
+
+  &__error-container {
+    padding-top: 4px;
+  }
+
+  &__error {
+    padding: 4px 8px;
+    font-size: 14px;
+    line-height: 17px;
   }
 }

--- a/src/components/web3-connect/index.tsx
+++ b/src/components/web3-connect/index.tsx
@@ -123,7 +123,7 @@ export class Container extends React.Component<Properties, State> {
       return 'Wallet request already pending. You may have another window already open.';
     }
 
-    return 'Error connecting';
+    return 'Wallet connection failed. Please try again.';
   }
 
   syncGlobalsForConnectedStatus() {

--- a/src/pages/login/login-component.tsx
+++ b/src/pages/login/login-component.tsx
@@ -35,7 +35,8 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
   render() {
     const { isLoggingIn, stage } = this.props;
 
-    const selectedOption = stage === LoginStage.Web3Login ? 'web3' : 'email';
+    const isWeb3LoginStage = stage === LoginStage.Web3Login;
+    const selectedOption = isWeb3LoginStage ? 'web3' : 'email';
 
     const options = [
       { key: 'web3', label: 'Web3' },
@@ -50,19 +51,21 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
             <div {...cn('logo-container')}>
               <ZeroLogo />
             </div>
-            <div>
-              <h3 {...cn('header')}>Log in</h3>
+            <div {...cn('inner-content-wrapper', isLoggingIn && isWeb3LoginStage && 'is-logging-in')}>
+              <h3 {...cn('header')}>Log In</h3>
 
-              <ToggleGroup
-                {...cn('toggle-group')}
-                options={options}
-                variant='default'
-                onSelectionChange={this.props.handleSelectionChange}
-                selection={selectedOption}
-                selectionType='single'
-                isRequired
-                isDisabled={isLoggingIn}
-              />
+              {!isLoggingIn && (
+                <ToggleGroup
+                  {...cn('toggle-group')}
+                  options={options}
+                  variant='default'
+                  onSelectionChange={this.props.handleSelectionChange}
+                  selection={selectedOption}
+                  selectionType='single'
+                  isRequired
+                  isDisabled={isLoggingIn}
+                />
+              )}
 
               <div {...cn('login-option')}>{this.loginOption}</div>
             </div>

--- a/src/pages/login/login.scss
+++ b/src/pages/login/login.scss
@@ -53,6 +53,12 @@ $login-padding-bottom: 24px;
     margin-bottom: 76px;
   }
 
+  &__inner-content-wrapper {
+    &--is-logging-in {
+      margin: auto;
+    }
+  }
+
   &__toggle-group {
     width: 280px;
     margin-bottom: 32px;


### PR DESCRIPTION
### What does this do?
- adjusts the position of the login with wallet container when connecting wallet via the login with wallet option (as shown in the demo video below) - this position should only change for login with wallet option, not the login with email option, hence the condition added.
- updates the style and content of the error states as per figma design

### Why are we making this change?
- as per figma designs.

### How do I test this?
- navigate to `/login` page and run through the create wallet account flow. Check against the [figma](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=9777-315854&mode=dev) designs

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
