### PR TITLE
feat: update missing sign up / log in flow colours and fixed button widths

### DIFF
--- a/src/authentication/create-account-details/styles.scss
+++ b/src/authentication/create-account-details/styles.scss
@@ -50,6 +50,7 @@
   &__submit-button {
     height: 40px;
     padding: 16px;
+    width: 155px;
 
     div {
       margin: 0;

--- a/src/authentication/create-account-method/styles.scss
+++ b/src/authentication/create-account-method/styles.scss
@@ -15,7 +15,18 @@
   }
 
   &__toggle-group {
+    height: 40px;
+    background: theme.$color-primary-transparency-1;
     width: 280px;
     margin-bottom: 32px;
+
+    > * {
+      border-left: none !important;
+    }
+
+    [data-state='on'] {
+      font-weight: 700;
+      background: theme.$color-primary-transparency-2 !important;
+    }
   }
 }

--- a/src/authentication/validate-invite/styles.scss
+++ b/src/authentication/validate-invite/styles.scss
@@ -44,9 +44,9 @@
   &__submit-button {
     height: 40px;
     padding: 16px;
+    width: 120px;
 
     div {
-      text-transform: none;
       margin: 0;
     }
   }

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -14,7 +14,7 @@
     width: 120px;
     height: 120px;
     border: 1px dashed theme.$color-greyscale-8;
-    background: theme.$color-primary-3;
+    background: theme.$color-primary-transparency-1;
     border-radius: 9999px;
     color: theme.$color-greyscale-8;
     font-size: $font-size-small;

--- a/src/components/wallet-select/styles.scss
+++ b/src/components/wallet-select/styles.scss
@@ -10,7 +10,7 @@ $left-padding: 12px;
   padding: 8px;
   border-radius: 8px;
   color: theme.$color-greyscale-12;
-  background-color: theme.$color-primary-2;
+  background-color: theme.$color-primary-transparency-1;
 
   &__title-bar {
     border-bottom: 1px solid theme.$color-primary-4;
@@ -43,7 +43,7 @@ $left-padding: 12px;
     border-radius: 8px;
 
     &:hover {
-      background-color: theme.$color-primary-4;
+      background-color: theme.$color-primary-transparency-2;
     }
   }
 

--- a/src/pages/login/login.scss
+++ b/src/pages/login/login.scss
@@ -60,8 +60,19 @@ $login-padding-bottom: 24px;
   }
 
   &__toggle-group {
+    height: 40px;
+    background: theme.$color-primary-transparency-1;
     width: 280px;
     margin-bottom: 32px;
+
+    > * {
+      border-left: none !important;
+    }
+
+    [data-state='on'] {
+      font-weight: 700;
+      background: theme.$color-primary-transparency-2 !important;
+    }
   }
 
   &__login-option {


### PR DESCRIPTION
### What does this do?
- updates the remaining colours for the sign up and log in flows.
- fixes button widths for validate invite screen and account details screen

### Why are we making this change?
- as per figma design.

**Important** - design confirmed that we should not change the toggle group in zUI to match the designs of these flows because the toggle group is being used elsewhere. As a result, I am overriding the styles in zOS for the colours to be correct.

### How do I test this?
- run through the sign-up / log-in flows and compare with designs: [designs here](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?type=design&node-id=10502-248046&mode=design&t=CRHrZkXSxiBjyDnR-4)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Updates:

<img width="409" alt="Screenshot 2023-08-02 at 17 07 43" src="https://github.com/zer0-os/zOS/assets/39112648/befcc4a8-b175-4065-8cba-402817777fa9">

<img width="206" alt="Screenshot 2023-08-02 at 16 36 39" src="https://github.com/zer0-os/zOS/assets/39112648/78c0a200-9938-4a80-aeb4-94d7f9c49867">


https://github.com/zer0-os/zOS/assets/39112648/9d778b48-15a5-4a89-9a4d-6fcd6150a090

