### PR TITLE
Disable sending messages while conversation is being created

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,8 @@
   "rules": {
     "quotes": [
       "error",
-      "single"
-    ],
+      "single",
+      { "avoidEscape": true }],
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -6,7 +6,6 @@ import { Container } from './chat-view-container';
 import { ChatView } from './chat-view';
 import { Message } from '../../store/messages';
 import { Media } from '../message-input/utils';
-import { ConnectionState } from '@sendbird/chat';
 import { ConversationStatus } from '../../store/channels';
 
 describe('ChannelViewContainer', () => {

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -423,18 +423,41 @@ describe('ChannelViewContainer', () => {
     expect(textareaRef.current.focus).toHaveBeenCalled();
   });
 
-  it('has an empty disabled message if the channel is created', () => {
-    const wrapper = subject({ channel: { conversationStatus: ConversationStatus.CREATED } });
+  describe('sendDisabledMessage', () => {
+    it('is empty if the channel is created', () => {
+      const wrapper = subject({ channel: { conversationStatus: ConversationStatus.CREATED } });
 
-    expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual('');
-  });
+      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual('');
+    });
 
-  it('sets the disabled message if the channel is not yet created', () => {
-    const wrapper = subject({ channel: { conversationStatus: ConversationStatus.CREATING } });
+    it('includes user name if one on one', () => {
+      const otherMembers = [{ userId: '1', firstName: 'Jack', lastName: 'Black' }];
+      const wrapper = subject({ channel: { otherMembers, conversationStatus: ConversationStatus.CREATING } });
 
-    expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
-      "We're connecting you. Try again in a few seconds."
-    );
+      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
+        "We're connecting you with Jack Black. Try again in a few seconds."
+      );
+    });
+
+    it('includes conversation name if exists', () => {
+      const wrapper = subject({ channel: { name: 'NamedGroup', conversationStatus: ConversationStatus.CREATING } });
+
+      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
+        "We're connecting you with NamedGroup. Try again in a few seconds."
+      );
+    });
+
+    it('references group if more than one member', () => {
+      const otherMembers = [
+        { userId: '1' },
+        { userId: '2' },
+      ];
+      const wrapper = subject({ channel: { otherMembers, conversationStatus: ConversationStatus.CREATING } });
+
+      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
+        "We're connecting you with the group. Try again in a few seconds."
+      );
+    });
   });
 
   describe('mapState', () => {

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -6,6 +6,8 @@ import { Container } from './chat-view-container';
 import { ChatView } from './chat-view';
 import { Message } from '../../store/messages';
 import { Media } from '../message-input/utils';
+import { ConnectionState } from '@sendbird/chat';
+import { ConversationStatus } from '../../store/channels';
 
 describe('ChannelViewContainer', () => {
   const subject = (props: any = {}) => {
@@ -420,6 +422,20 @@ describe('ChannelViewContainer', () => {
     (wrapper.instance() as any).onMessageInputRendered(textareaRef);
 
     expect(textareaRef.current.focus).toHaveBeenCalled();
+  });
+
+  it('has an empty disabled message if the channel is created', () => {
+    const wrapper = subject({ channel: { conversationStatus: ConversationStatus.CREATED } });
+
+    expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual('');
+  });
+
+  it('sets the disabled message if the channel is not yet created', () => {
+    const wrapper = subject({ channel: { conversationStatus: ConversationStatus.CREATING } });
+
+    expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
+      "We're connecting you. Try again in a few seconds."
+    );
   });
 
   describe('mapState', () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -14,7 +14,7 @@ import {
   stopSyncChannels,
   EditMessageOptions,
 } from '../../store/messages';
-import { Channel, denormalize, joinChannel } from '../../store/channels';
+import { Channel, ConversationStatus, denormalize, joinChannel } from '../../store/channels';
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
 import {
@@ -262,6 +262,13 @@ export class Container extends React.Component<Properties, State> {
     return messages;
   }
 
+  get sendDisabledMessage() {
+    if (this.props.channel.conversationStatus === ConversationStatus.CREATED) {
+      return '';
+    }
+    return "We're connecting you. Try again in a few seconds.";
+  }
+
   render() {
     if (!this.props.channel) return null;
 
@@ -295,6 +302,7 @@ export class Container extends React.Component<Properties, State> {
           reply={this.state.reply}
           onReply={this.onReply}
           onRemove={this.removeReply}
+          sendDisabledMessage={this.sendDisabledMessage}
         />
       </>
     );

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -266,13 +266,26 @@ export class Container extends React.Component<Properties, State> {
     if (this.props.channel.conversationStatus === ConversationStatus.CREATED) {
       return '';
     }
-    return "We're connecting you. Try again in a few seconds.";
+
+    let reference = ' with the group';
+    if (this.props.channel.name) {
+      reference = ` with ${this.props.channel.name}`;
+    } else if (this.isOneOnOne) {
+      const otherMember = this.props.channel.otherMembers[0];
+      reference = ` with ${otherMember.firstName} ${otherMember.lastName}`;
+    }
+
+    return `We're connecting you${reference}. Try again in a few seconds.`;
+  }
+
+  get isOneOnOne() {
+    return this.props.channel?.otherMembers?.length === 1;
   }
 
   render() {
     if (!this.props.channel) return null;
 
-    const isOneOnOne = this.props.channel?.otherMembers?.length === 1;
+    const isOneOnOne = this.isOneOnOne;
 
     return (
       <>

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -56,6 +56,7 @@ describe('ChatView', () => {
       otherMembers: [],
       fetchMessages: () => null,
       isOneOnOne: false,
+      sendDisabledMessage: '',
       ...props,
     };
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -59,6 +59,7 @@ export interface Properties {
   showSenderAvatar?: boolean;
   isMessengerFullScreen: boolean;
   isOneOnOne: boolean;
+  sendDisabledMessage: string;
 }
 
 export interface State {
@@ -298,6 +299,7 @@ export class ChatView extends React.Component<Properties, State> {
               getUsersForMentions={this.searchMentionableUsers}
               reply={this.props.reply}
               onRemoveReply={this.props.onRemove}
+              sendDisabledMessage={this.props.sendDisabledMessage}
             />
           )}
           {!isMemberOfChannel && this.renderJoinButton()}

--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -18,6 +18,7 @@ export interface PublicProperties {
   reply?: null | ParentMessage;
   onRemoveReply?: () => void;
   isEditing?: boolean;
+  sendDisabledMessage?: string;
 }
 
 export interface Properties extends PublicProperties {
@@ -59,6 +60,7 @@ export class Container extends React.Component<Properties> {
         reply={this.props.reply}
         isMessengerFullScreen={this.props.isFullScreen}
         isEditing={this.props.isEditing}
+        sendDisabledMessage={this.props.sendDisabledMessage}
       />
     );
   }

--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -103,12 +103,8 @@ describe('MessageInput', () => {
 
   it('submits message when send icon is clicked', () => {
     const onSubmit = jest.fn();
-    const wrapper = subject({ onSubmit, placeholder: 'Speak' });
-    const dropzone = wrapper.find(Dropzone).shallow();
-    const input = dropzone.find(MentionsInput);
-    input.simulate('change', { target: { value: 'Hello' } });
-
-    wrapper.update();
+    const wrapper = subject({ onSubmit });
+    setInput(wrapper, 'Hello');
 
     const sendIcon = wrapper.find('.message-input__icon--end-action');
     sendIcon.simulate('click');
@@ -118,26 +114,32 @@ describe('MessageInput', () => {
   });
 
   it('shows send icon when input has value', () => {
-    const onSubmit = jest.fn();
-    const wrapper = subject({ onSubmit, placeholder: 'Speak' });
-    const dropzone = wrapper.find(Dropzone).shallow();
-    const input = dropzone.find(MentionsInput);
-    input.simulate('change', { target: { value: 'Hello' } });
-
-    wrapper.update();
+    const wrapper = subject({});
+    setInput(wrapper, 'Hello');
 
     const sendIcon = wrapper.find('.message-input__icon--end-action');
 
     expect(sendIcon.prop('Icon')).toEqual(IconSend3);
   });
 
-  it('renders end action icon', () => {
-    const onSubmit = jest.fn();
-    const wrapper = subject({ onSubmit, placeholder: 'Speak' });
+  it('send icon is highlighted when input has a value and there is no disabled message', () => {
+    const wrapper = subject({ sendDisabledMessage: '' });
+    setInput(wrapper, 'Hello');
 
-    const endActionIcon = wrapper.find('.message-input__icon--end-action');
+    expect(wrapper).toHaveElement('.message-input__icon--highlighted');
+  });
 
-    expect(endActionIcon.exists()).toBe(true);
+  it('send icon is not highlighted if there is no input', () => {
+    const wrapper = subject({});
+
+    expect(wrapper).not.toHaveElement('.message-input__icon--highlighted');
+  });
+
+  it('send icon is not highlighted if there is a disabled message', () => {
+    const wrapper = subject({ sendDisabledMessage: 'you cannot send yet' });
+    setInput(wrapper, 'Hello');
+
+    expect(wrapper).not.toHaveElement('.message-input__icon--highlighted');
   });
 
   it('submit message when click on textarea', () => {
@@ -150,6 +152,25 @@ describe('MessageInput', () => {
     input.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
 
     expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it('opens tooltip if disable message is set and user tries to submit', () => {
+    const wrapper = subject({ sendDisabledMessage: 'you cannot send yet' });
+    setInput(wrapper, 'Hello');
+
+    wrapper.find('.message-input__icon--end-action').simulate('click');
+
+    expect(wrapper.find('Tooltip').prop('open')).toBe(true);
+  });
+
+  it('closes tooltip if disable message clears', () => {
+    const wrapper = subject({ sendDisabledMessage: 'you cannot send yet' });
+    setInput(wrapper, 'Hello');
+
+    wrapper.find('.message-input__icon--end-action').simulate('click');
+    wrapper.setProps({ sendDisabledMessage: '' });
+
+    expect(wrapper.find('Tooltip').prop('open')).toBe(false);
   });
 
   it('call after render', () => {
@@ -327,3 +348,8 @@ describe('MessageInput', () => {
     return searchResults;
   }
 });
+
+function setInput(wrapper, input) {
+  const dropzone = wrapper.find(Dropzone).shallow();
+  dropzone.find(MentionsInput).simulate('change', { target: { value: input } });
+}

--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -12,6 +12,7 @@ import { ViewModes } from '../../shared-components/theme-engine';
 import MessageAudioRecorder from '../message-audio-recorder';
 import { Giphy } from './giphy/giphy';
 import ImageCards from '../../platform-apps/channels/image-cards';
+import { IconSend3 } from '@zero-tech/zui/icons';
 
 describe('MessageInput', () => {
   const subject = (props: Partial<Properties>, child: any = <div />) => {
@@ -109,7 +110,7 @@ describe('MessageInput', () => {
 
     wrapper.update();
 
-    const sendIcon = wrapper.find('.message-input__icon--send');
+    const sendIcon = wrapper.find('.message-input__icon--end-action');
     sendIcon.simulate('click');
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -125,9 +126,9 @@ describe('MessageInput', () => {
 
     wrapper.update();
 
-    const sendIcon = wrapper.find('.message-input__icon--send');
+    const sendIcon = wrapper.find('.message-input__icon--end-action');
 
-    expect(sendIcon.exists()).toBe(true);
+    expect(sendIcon.prop('Icon')).toEqual(IconSend3);
   });
 
   it('renders end action icon', () => {
@@ -266,7 +267,7 @@ describe('MessageInput', () => {
 
       const message = 'Message with :smile:';
       dropzone.find(MentionsInput).simulate('change', { target: { value: message } });
-      wrapper.find('.message-input__icon--send').simulate('click');
+      wrapper.find('.message-input__icon--end-action').simulate('click');
 
       expect(onSubmit).toHaveBeenCalledWith('Message with 😄', [], []);
     });

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -308,6 +308,10 @@ export class MessageInput extends React.Component<Properties, State> {
     this.focusInput();
   };
 
+  sendHighlighted = () => {
+    return this.state.value?.length > 0;
+  };
+
   renderInput() {
     const hasInputValue = this.state.value?.length > 0;
 
@@ -420,7 +424,7 @@ export class MessageInput extends React.Component<Properties, State> {
               <div className='message-input__icon-wrapper'>
                 <IconButton
                   className={classNames('message-input__icon', 'message-input__icon--end-action', {
-                    'message-input__icon--send': hasInputValue,
+                    'message-input__icon--highlighted': this.sendHighlighted(),
                   })}
                   onClick={hasInputValue ? this.onSend : this.startMic}
                   Icon={hasInputValue ? IconSend3 : IconMicrophone2}

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -20,15 +20,20 @@ import ImageCards from '../../platform-apps/channels/image-cards';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
 import { PublicProperties as PublicPropertiesContainer } from './container';
 import { IconFaceSmile, IconSend3, IconMicrophone2, IconStickerCircle } from '@zero-tech/zui/icons';
-import { Avatar } from '@zero-tech/zui/components';
+import { Avatar, Tooltip } from '@zero-tech/zui/components';
 
 import classNames from 'classnames';
 import './styles.scss';
 import { textToPlainEmojis } from '../content-highlighter/text-to-emojis';
+import { bemClassName } from '../../lib/bem';
 
-export interface PublicProperties extends PublicPropertiesContainer {}
+const cn = bemClassName('message-input');
 
-export interface Properties extends PublicPropertiesContainer {
+export interface PublicProperties extends PublicPropertiesContainer {
+  sendDisabledMessage?: string;
+}
+
+export interface Properties extends PublicProperties {
   viewMode: ViewModes;
   isMessengerFullScreen?: boolean;
   placeholder?: string;
@@ -47,6 +52,7 @@ interface State {
   isEmojisActive: boolean;
   isGiphyActive: boolean;
   isMicActive: boolean;
+  isSendTooltipOpen: boolean;
 }
 
 export class MessageInput extends React.Component<Properties, State> {
@@ -58,6 +64,7 @@ export class MessageInput extends React.Component<Properties, State> {
     isMicActive: false,
     isEmojisActive: false,
     isGiphyActive: false,
+    isSendTooltipOpen: false,
   };
 
   private textareaRef: RefObject<HTMLTextAreaElement>;
@@ -82,6 +89,9 @@ export class MessageInput extends React.Component<Properties, State> {
   componentDidUpdate() {
     if (this.props.onMessageInputRendered) {
       this.props.onMessageInputRendered(this.textareaRef);
+    }
+    if (this.state.isSendTooltipOpen && this.isSendingEnabled) {
+      this.setState({ isSendTooltipOpen: false });
     }
   }
 
@@ -122,7 +132,19 @@ export class MessageInput extends React.Component<Properties, State> {
     }
   }
 
+  get isSendingDisabled() {
+    return !this.isSendingEnabled;
+  }
+
+  get isSendingEnabled() {
+    return !this.props.sendDisabledMessage?.trim();
+  }
+
   onSend = (): void => {
+    if (this.isSendingDisabled) {
+      return this.setState({ isSendTooltipOpen: true });
+    }
+
     const { mentionedUserIds, value, media } = this.state;
     if (value || media.length) {
       this.props.onSubmit(value, mentionedUserIds, media);
@@ -309,8 +331,12 @@ export class MessageInput extends React.Component<Properties, State> {
   };
 
   sendHighlighted = () => {
-    return this.state.value?.length > 0;
+    return this.state.value?.length > 0 && this.isSendingEnabled;
   };
+
+  get sendDisabledTooltipContent() {
+    return <div {...cn('disabled-tooltip')}>{this.props.sendDisabledMessage}</div>;
+  }
 
   renderInput() {
     const hasInputValue = this.state.value?.length > 0;
@@ -422,14 +448,16 @@ export class MessageInput extends React.Component<Properties, State> {
           {!this.props.isEditing && (
             <div className='message-input__icon-outer'>
               <div className='message-input__icon-wrapper'>
-                <IconButton
-                  className={classNames('message-input__icon', 'message-input__icon--end-action', {
-                    'message-input__icon--highlighted': this.sendHighlighted(),
-                  })}
-                  onClick={hasInputValue ? this.onSend : this.startMic}
-                  Icon={hasInputValue ? IconSend3 : IconMicrophone2}
-                  size={24}
-                />
+                <Tooltip content={this.sendDisabledTooltipContent} open={this.state.isSendTooltipOpen}>
+                  <IconButton
+                    className={classNames('message-input__icon', 'message-input__icon--end-action', {
+                      'message-input__icon--highlighted': this.sendHighlighted(),
+                    })}
+                    onClick={hasInputValue ? this.onSend : this.startMic}
+                    Icon={hasInputValue ? IconSend3 : IconMicrophone2}
+                    size={24}
+                  />
+                </Tooltip>
               </div>
             </div>
           )}

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -246,4 +246,11 @@
       right: 65px;
     }
   }
+
+  &__disabled-tooltip {
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 24px;
+    color: theme.$color-warning-11;
+  }
 }

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -81,7 +81,7 @@
     width: 32px;
     color: theme.$color-greyscale-12;
 
-    &--send {
+    &--highlighted {
       color: theme.$color-secondary-11;
     }
 


### PR DESCRIPTION
### What does this do?

This shows a warning message to the user if they try to send a messaage in an optimistically rendered conversation.

### Why are we making this change?

When we optimistically render we have to account for users trying to do things before data is real.

![image](https://github.com/zer0-os/zOS/assets/43770/49519da3-02fc-429a-9ed9-f2289571758f)
