### PR TITLE
feat: login with email screen error state and connecting state updates

### DIFF
--- a/src/authentication/email-login/index.tsx
+++ b/src/authentication/email-login/index.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 
 import { Alert, Button, Input, PasswordInput } from '@zero-tech/zui/components';
 
+import { bem, bemClassName } from '../../lib/bem';
+
 import './styles.scss';
+
+const c = bem('email-login');
+const cn = bemClassName('email-login');
 
 export interface Properties {
   isLoading: boolean;
@@ -51,30 +56,42 @@ export class EmailLogin extends React.Component<Properties, State> {
 
   render() {
     return (
-      <form className={'email-login'} onSubmit={this.publishOnSubmit}>
-        <Input
-          className='input'
-          label='Email Address'
-          name='email'
-          value={this.state.email}
-          onChange={this.trackEmail}
-          error={!!this.emailError}
-          alert={this.emailError}
-        />
-        <PasswordInput
-          className='input'
-          label='Password'
-          name='password'
-          value={this.state.password}
-          onChange={this.trackPassword}
-          error={!!this.passwordError}
-          alert={this.passwordError}
-        />
-        {this.generalError && <Alert variant='error'>{this.generalError}</Alert>}
-        <Button isLoading={this.props.isLoading} isSubmit>
-          Login
-        </Button>
-      </form>
+      <div {...cn('')}>
+        <form {...cn('form')} onSubmit={this.publishOnSubmit}>
+          <div {...cn('input-container')}>
+            <Input
+              {...cn('input')}
+              alertClassName={c('input-alert')}
+              label='Email Address'
+              name='email'
+              value={this.state.email}
+              onChange={this.trackEmail}
+              error={!!this.emailError}
+              alert={this.emailError}
+            />
+            <PasswordInput
+              {...cn('input')}
+              alertClassName={c('input-alert')}
+              label='Password'
+              name='password'
+              value={this.state.password}
+              onChange={this.trackPassword}
+              error={!!this.passwordError}
+              alert={this.passwordError}
+            />
+          </div>
+          {this.generalError && (
+            <div {...cn('error-container')}>
+              <Alert {...cn('error')} variant='error'>
+                {this.generalError}
+              </Alert>
+            </div>
+          )}
+          <Button {...cn('submit-button')} isLoading={this.props.isLoading} isSubmit>
+            Log in
+          </Button>
+        </form>
+      </div>
     );
   }
 }

--- a/src/authentication/email-login/styles.scss
+++ b/src/authentication/email-login/styles.scss
@@ -1,9 +1,55 @@
 @import '../styles';
 
 .email-login {
-  @include form();
-}
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 280px;
 
-.input {
-  @include input();
+  &__form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  &__input-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    margin-bottom: 16px;
+  }
+
+  &__input {
+    @include input();
+  }
+
+  &__input-alert {
+    margin-top: 4px;
+    padding: 4px 8px;
+  }
+
+  &__submit-button {
+    height: 40px;
+    padding: 16px;
+    width: 85px;
+    margin-top: 16px;
+
+    div {
+      margin: 0;
+    }
+  }
+
+  &__error-container {
+    width: 100%;
+    padding-top: 8px;
+  }
+
+  &__error {
+    padding: 4px 8px;
+    font-size: 14px;
+    line-height: 17px;
+  }
 }

--- a/src/pages/login/login-component.tsx
+++ b/src/pages/login/login-component.tsx
@@ -21,7 +21,7 @@ interface LoginComponentProperties {
 }
 
 export class LoginComponent extends React.Component<LoginComponentProperties> {
-  get loginOption() {
+  renderLoginOption() {
     switch (this.props.stage) {
       case LoginStage.Web3Login:
         return <Web3LoginContainer />;
@@ -32,16 +32,49 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
     }
   }
 
-  render() {
-    const { isLoggingIn, stage } = this.props;
-
-    const isWeb3LoginStage = stage === LoginStage.Web3Login;
-    const selectedOption = isWeb3LoginStage ? 'web3' : 'email';
-
+  renderToggleGroup(isLoggingIn, selectedOption) {
     const options = [
       { key: 'web3', label: 'Web3' },
       { key: 'email', label: 'Email' },
     ];
+
+    return (
+      !isLoggingIn && (
+        <ToggleGroup
+          {...cn('toggle-group')}
+          options={options}
+          variant='default'
+          onSelectionChange={this.props.handleSelectionChange}
+          selection={selectedOption}
+          selectionType='single'
+          isRequired
+        />
+      )
+    );
+  }
+
+  renderFooter(stage) {
+    return (
+      <div {...cn('other')}>
+        <span>
+          {stage === LoginStage.EmailLogin ? (
+            <>
+              Forgot your password? <Link to='/get-access'>Reset</Link>
+            </>
+          ) : (
+            <>
+              Not on ZERO? <Link to='/get-access'>Create account</Link>
+            </>
+          )}
+        </span>
+      </div>
+    );
+  }
+
+  render() {
+    const { isLoggingIn, stage } = this.props;
+    const isWeb3LoginStage = stage === LoginStage.Web3Login;
+    const selectedOption = isWeb3LoginStage ? 'web3' : 'email';
 
     return (
       <>
@@ -53,27 +86,10 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
             </div>
             <div {...cn('inner-content-wrapper', isLoggingIn && isWeb3LoginStage && 'is-logging-in')}>
               <h3 {...cn('header')}>Log In</h3>
-
-              {!isLoggingIn && (
-                <ToggleGroup
-                  {...cn('toggle-group')}
-                  options={options}
-                  variant='default'
-                  onSelectionChange={this.props.handleSelectionChange}
-                  selection={selectedOption}
-                  selectionType='single'
-                  isRequired
-                />
-              )}
-
-              <div {...cn('login-option')}>{this.loginOption}</div>
+              {this.renderToggleGroup(isLoggingIn, selectedOption)}
+              <div {...cn('login-option')}>{this.renderLoginOption()}</div>
             </div>
-
-            <div {...cn('other')}>
-              <span>
-                New to ZERO? <Link to='/get-access'>Create an account</Link>
-              </span>
-            </div>
+            {this.renderFooter(stage)}
           </main>
         </div>
       </>

--- a/src/pages/login/login.scss
+++ b/src/pages/login/login.scss
@@ -93,7 +93,7 @@ $login-padding-bottom: 24px;
       > a {
         color: theme.$color-greyscale-12;
         text-decoration: underline;
-        text-underline-offset: 4px;
+        text-underline-offset: 2px;
       }
     }
   }


### PR DESCRIPTION
### What does this do?
- updates the log in with email screen including error states and connecting states

### Why are we making this change?
- as per figma designs

### How do I test this?
- navigate to the `/login` screen and click the email option on the toggle. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/f161bcb6-b7e3-4ec0-9a82-48cf55d227f2

