### PR TITLE
Don't replace optimistic messages when conversation poll happens

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -68,10 +68,15 @@ export function* fetchConversations() {
     };
   });
 
+  const optimisticConversationIds = existingConversationList
+    .filter((c) => c.conversationStatus !== ConversationStatus.CREATED)
+    .map((c) => c.id);
+
   const channelsList = yield select(rawChannelsList());
   yield put(
     receive([
       ...channelsList,
+      ...optimisticConversationIds,
       ...newConversationList,
     ])
   );


### PR DESCRIPTION
### What does this do?

Ensure we don't remove optimistic conversations from the list when the automatic poll happens

### Why are we making this change?

To make sure the UI doesn't rip an "in progress" conversation out of the UI for the user

### How do I test this?

Force a conversation creation to take a long time (longer than 1 minute). Verify that when the background poll happens the conversation does not disappear.

