### PR TITLE
Ensure the rendering of the conversation message input remains when optimistic conversation is replaced

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -11,7 +11,7 @@ describe('messenger-chat', () => {
     const allProps: Properties = {
       activeConversationId: '1',
       setactiveConversationId: jest.fn(),
-      directMessage: null,
+      directMessage: { id: '1', otherMembers: [] } as any,
       isFullScreen: false,
       allowCollapse: false,
       enterFullScreenMessenger: () => null,
@@ -127,12 +127,6 @@ describe('messenger-chat', () => {
 
       expect(tooltip.html()).toContain(otherMembersExpectation);
       expect(tooltip.prop('overlay')).toEqual(otherMembersExpectation);
-    });
-
-    it('nothing as title', function () {
-      const title = subject({ directMessage: undefined }).find('[className$="__title"]');
-
-      expect(title.text()).toEqual('');
     });
   });
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -136,7 +136,7 @@ export class Container extends React.Component<Properties, State> {
   }
 
   render() {
-    if (!this.props.activeConversationId) {
+    if (!this.props.activeConversationId || !this.props.directMessage) {
       return null;
     }
 
@@ -189,7 +189,7 @@ export class Container extends React.Component<Properties, State> {
           </div>
 
           <ChatViewContainer
-            key={this.props.activeConversationId} // Render new component for a new chat
+            key={this.props.directMessage.optimisticId || this.props.directMessage.id} // Render new component for a new chat
             channelId={this.props.activeConversationId}
             className='direct-message-chat__channel'
             isDirectMessage

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -116,6 +116,7 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
   const conversation = {
     ...defaultConversationProperties,
     id: Date.now(),
+    optimisticId: Date.now(),
     name,
     otherMembers: userIds,
     messages: [],
@@ -144,6 +145,7 @@ export function* receiveCreatedConversation(conversation, optimisticConversation
   if (!existingConversationsList.includes(conversation.id)) {
     conversation.hasLoadedMessages = true; // Brand new conversation doesn't have messages to load
     conversation.messagesFetchStatus = MessagesFetchState.SUCCESS;
+    conversation.optimisticId = optimisticConversation.optimisticId;
     listWithoutOptimistic.push(conversation);
   }
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -34,6 +34,7 @@ export enum ConversationStatus {
 
 export interface Channel {
   id: string;
+  optimisticId?: string;
   name: string;
   messages: Message[];
   otherMembers: User[];


### PR DESCRIPTION
### What does this do?

Uses an `optmisticId` as the default rendering key

### Why are we making this change?

To prevent replacing of the message input when the real conversation arrives.

### How do I test this?

Create a new conversation and start typing a message. Verify that when the real result is complete the new message is not cleared.

