### PR TITLE
Fix the type of optimistic fields

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -113,10 +113,11 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
     groupChannelType: GroupChannelType.Private,
     shouldSyncChannels: false,
   };
+  const timestamp = Date.now();
   const conversation = {
     ...defaultConversationProperties,
-    id: Date.now(),
-    optimisticId: Date.now(),
+    id: `${timestamp}`,
+    optimisticId: `${timestamp}`,
     name,
     otherMembers: userIds,
     messages: [],


### PR DESCRIPTION
### What does this do?

Fixes the data type of the optimistic conversation id fields

### Why are we making this change?

They were the wrong type which was causing the automatic input focus to not work

### How do I test this?

Create a new conversation and verify the message input is immediately focused.

