### PR TITLE
Fix: search results no longer returning all group conversations containing members matching search input

### DIFF
--- a/src/components/messenger/list/conversation-list-panel.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel.test.tsx
@@ -111,6 +111,67 @@ describe('ConversationListPanel', () => {
     ]);
   });
 
+  it('filters conversations based on direct and indirect matches', () => {
+    const conversations = [
+      {
+        id: 'convo-id-1',
+        name: 'convo-1',
+        otherMembers: [{ firstName: 'jack' }],
+      },
+      {
+        id: 'convo-id-2',
+        name: 'convo-2',
+        otherMembers: [{ firstName: 'bob' }],
+      },
+      {
+        id: 'convo-id-3',
+        name: 'convo-3',
+        otherMembers: [{ firstName: 'jacklyn' }],
+      },
+      {
+        id: 'convo-id-4',
+        name: 'convo-4',
+        otherMembers: [
+          { firstName: 'user1' },
+          { firstName: 'user2' },
+        ],
+      },
+      {
+        id: 'convo-id-5',
+        name: 'user1 and user2',
+        otherMembers: [
+          { firstName: 'user1' },
+          { firstName: 'user2' },
+        ],
+      },
+    ];
+
+    const wrapper = subject({ conversations: conversations as any });
+
+    // Test filter by name
+    wrapper.find('Input').simulate('change', 'convo-1');
+    let displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual(['convo-1']);
+
+    // Test filter by otherMembers (one-to-one conversation)
+    wrapper.find('Input').simulate('change', 'bob');
+    displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual(['convo-2']);
+
+    // Test filter by otherMembers (indirect match in group conversation)
+    wrapper.find('Input').simulate('change', 'jacklyn');
+    displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual(['convo-3']);
+
+    // Test filter by both name and otherMembers (direct match takes priority)
+    wrapper.find('Input').simulate('change', 'user1');
+    displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+    expect(displayChatNames).toStrictEqual([
+      'user1 and user2',
+      'convo-4',
+    ]);
+  });
+
   it('selecting an existing conversation announces click event', async function () {
     const onConversationClick = jest.fn();
     const conversations = [

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -57,12 +57,26 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     }
 
     const searchRegEx = new RegExp(escapeRegExp(this.state.filter), 'i');
-    return this.props.conversations.filter(
-      (conversation) =>
-        conversation.otherMembers.length === 1
-          ? searchRegEx.test(otherMembersToString(conversation.otherMembers)) // for one-to-one
-          : searchRegEx.test(conversation.name ?? '') // for group
-    );
+
+    const directMatches = [];
+    const inDirectMatches = [];
+
+    for (const conversation of this.props.conversations) {
+      const isNameMatch = searchRegEx.test(conversation.name ?? '');
+      const isDirectMatch =
+        conversation.otherMembers.length === 1 && searchRegEx.test(otherMembersToString(conversation.otherMembers));
+
+      if (isNameMatch || isDirectMatch) {
+        directMatches.push(conversation);
+      } else if (searchRegEx.test(otherMembersToString(conversation.otherMembers))) {
+        inDirectMatches.push(conversation);
+      }
+    }
+
+    return [
+      ...directMatches,
+      ...inDirectMatches,
+    ];
   }
 
   openInviteDialog = (): void => {


### PR DESCRIPTION
Now after searching:

(returns both direct + group match)
![image](https://github.com/zer0-os/zOS/assets/33264364/9ae6540b-a9d1-456c-9c03-27ff3d27483a)


(direct matches are prioritized first, and then group conversation matches by otherMember names)
![image](https://github.com/zer0-os/zOS/assets/33264364/adda53a4-c153-4d21-9299-e6af5c84b95c)

![image](https://github.com/zer0-os/zOS/assets/33264364/22798f39-4a81-4d65-86aa-736870b2d831)
