### PR TITLE
feat: add fade-in animation to invite code module

### DIFF
--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -15,6 +15,7 @@ describe('Container', () => {
       invitesUsed: 0,
       maxUses: 0,
       isAMemberOfWorlds: false,
+      isLoading: false,
       fetchInvite: () => null,
       ...props,
     };

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -16,6 +16,7 @@ export interface Properties extends PublicProperties {
   inviteUrl: string;
   assetPath: string;
   isAMemberOfWorlds: boolean;
+  isLoading: boolean;
 
   fetchInvite: () => void;
 }
@@ -34,6 +35,7 @@ export class Container extends React.Component<Properties> {
       invitesUsed: createInvitation.invitesUsed,
       maxUses: createInvitation.maxUses,
       isAMemberOfWorlds: user?.data?.isAMemberOfWorlds,
+      isLoading: createInvitation.isLoading,
     };
   }
 
@@ -55,6 +57,7 @@ export class Container extends React.Component<Properties> {
         assetsPath={this.props.assetPath}
         onClose={this.props.onClose}
         isUserAMemberOfWorlds={this.props.isAMemberOfWorlds}
+        isLoading={this.props.isLoading}
       />
     );
   }

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -14,6 +14,7 @@ describe('InviteDialog', () => {
       maxUses: 0,
       isUserAMemberOfWorlds: false,
       clipboard: { write: () => null },
+      isLoading: false,
       ...props,
     };
 
@@ -49,10 +50,15 @@ describe('InviteDialog', () => {
     expect(wrapper.find('.invite-dialog__inline-button').text()).toEqual('COPY');
   });
 
-  it('renders the loading state if code does not exist', function () {
+  it('does not render the text content if no invite code', function () {
     const wrapper = subject({ inviteCode: '' });
 
-    expect(wrapper).toHaveElement('.invite-dialog__code-block Skeleton');
+    expect(wrapper.find('.invite-dialog__code-block').text()).not.toContain('Here is an invite');
+  });
+
+  it('does not render the text content if isLoading is true ', function () {
+    const wrapper = subject({ inviteCode: '12345', isLoading: true });
+
     expect(wrapper.find('.invite-dialog__code-block').text()).not.toContain('Here is an invite');
   });
 
@@ -85,14 +91,14 @@ describe('InviteDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('displays text in green if no invites remaining', function () {
+  it('displays text in green if invites remaining', function () {
     // 2 invites left
     let wrapper = subject({ inviteCode: '123456', invitesUsed: 3, maxUses: 5 });
-    expect(wrapper.find('.invite-dialog__no-invite-left').exists()).toBeFalse();
+    expect(wrapper.find('.invite-dialog__invite-left').exists()).toBeTrue();
 
     // no invite left
     wrapper = subject({ inviteCode: '123456', invitesUsed: 5, maxUses: 5 });
-    expect(wrapper.find('.invite-dialog__no-invite-left').exists()).toBeTrue();
+    expect(wrapper.find('.invite-dialog__invite-left').exists()).toBeFalse();
   });
 
   it('renders network notification alert if user is in full screen, and is a part of networks', function () {

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -8,9 +8,11 @@ import { IconButton } from '../icon-button';
 
 import './styles.scss';
 
-import { bem } from '../../lib/bem';
+import { bem, bemClassName } from '../../lib/bem';
 import classNames from 'classnames';
+
 const c = bem('invite-dialog');
+const cn = bemClassName('invite-dialog');
 
 export interface Clipboard {
   write: (text: string) => Promise<void>;
@@ -23,6 +25,7 @@ export interface Properties {
   inviteUrl: string;
   assetsPath: string;
   isUserAMemberOfWorlds: boolean;
+  isLoading: boolean;
   clipboard?: Clipboard;
 
   onClose?: () => void;
@@ -68,37 +71,37 @@ export class InviteDialog extends React.Component<Properties, State> {
 
   render() {
     return (
-      <div className={c('')}>
-        <div className={c('title-bar')}>
-          <h3 className={c('title')}>Invite to ZERO Messenger</h3>
-          <IconButton className={c('close')} Icon={IconXClose} onClick={this.props.onClose} />
+      <div {...cn('')}>
+        <div {...cn('title-bar')}>
+          <h3 {...cn('title')}>Invite to ZERO Messenger</h3>
+          <IconButton {...cn('close')} Icon={IconXClose} onClick={this.props.onClose} />
         </div>
-        <div className={c('content')}>
+        <div {...cn('content')}>
           <Image
             src={`${this.props.assetsPath}/InviteFriends.png`}
             alt='Hands reaching out to connect'
-            className={c('image')}
+            {...cn('image')}
           />
 
           {this.props.isUserAMemberOfWorlds && (
-            <Alert variant='info' className={c('network-alert')}>
+            <Alert variant='info' {...cn('network-alert')}>
               This invite will add someone to your direct messages, <b>not</b> your current network.
             </Alert>
           )}
 
-          <div className={c('heading')}>Invite a friend. Chat on ZERO. Earn rewards.</div>
-          <div className={c('byline')}>
+          <div {...cn('heading')}>Invite a friend. Chat on ZERO. Earn rewards.</div>
+          <div {...cn('byline')}>
             The more active you are, the more you earn. Take back ownership of your content and get rewarded.
             <br />
           </div>
-          <div className={c('code-block')}>
-            {this.props.inviteCode ? (
+          <div {...cn('code-block')}>
+            {this.props.inviteCode || !this.props.isLoading ? (
               <textarea readOnly={true} value={this.inviteText} />
             ) : (
               <Skeleton width={'100%'} height={'100px'} />
             )}
             <button
-              className={c('inline-button', 'right')}
+              {...cn('inline-button', 'right')}
               onClick={this.writeInviteToClipboard}
               disabled={!this.props.inviteCode}
             >
@@ -106,11 +109,17 @@ export class InviteDialog extends React.Component<Properties, State> {
             </button>
           </div>
           <div
-            className={classNames(c('remaining-invite'), { [c('no-invite-left')]: this.getInvitesRemaining() === 0 })}
+            className={classNames(c('remaining-invite-container'), {
+              [c('invite-left')]: this.getInvitesRemaining() !== 0 && !this.props.isLoading,
+            })}
           >
             <IconGift1 />
-            <div>
-              <b>{this.getInvitesRemaining()}</b> of <b>{this.props.maxUses}</b> invites remaining
+            <div {...cn(!this.props.isLoading && 'remaining-invite')}>
+              {!this.props.isLoading && (
+                <>
+                  <b>{this.getInvitesRemaining()}</b> of <b>{this.props.maxUses}</b> invites remaining
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/invite-dialog/styles.scss
+++ b/src/components/invite-dialog/styles.scss
@@ -1,5 +1,14 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
 .invite-dialog {
   width: 548px;
 
@@ -77,6 +86,7 @@
       border-radius: inherit;
       outline: none;
       border: none;
+      animation: fadeIn 0.2s ease-in;
 
       &::-webkit-scrollbar {
         display: none;
@@ -140,7 +150,7 @@
     }
   }
 
-  &__remaining-invite {
+  &__remaining-invite-container {
     display: flex;
     flex-direction: row;
     padding: 12px;
@@ -152,7 +162,11 @@
     margin-top: 16px;
   }
 
-  &__no-invite-left {
+  &__remaining-invite {
+    animation: fadeIn 0.2s ease-in;
+  }
+
+  &__invite-left {
     color: theme.$color-success-11;
   }
 }

--- a/src/store/create-invitation/index.ts
+++ b/src/store/create-invitation/index.ts
@@ -12,6 +12,7 @@ export type CreateInvitationState = {
   url: string;
   invitesUsed: number;
   maxUses: number;
+  isLoading: boolean;
 };
 
 const initialState: CreateInvitationState = {
@@ -19,17 +20,21 @@ const initialState: CreateInvitationState = {
   url: '',
   invitesUsed: 0,
   maxUses: 0,
+  isLoading: false,
 };
 
 const slice = createSlice({
   name: 'createInvitation',
   initialState,
   reducers: {
-    setInvite: (state, action: PayloadAction<CreateInvitationState>) => {
+    setInviteDetails: (state, action: PayloadAction<Omit<CreateInvitationState, 'isLoading'>>) => {
       state.code = action.payload.code;
       state.url = action.payload.url;
       state.invitesUsed = action.payload.invitesUsed;
       state.maxUses = action.payload.maxUses;
+    },
+    setLoading: (state, action: PayloadAction<CreateInvitationState['isLoading']>) => {
+      state.isLoading = action.payload;
     },
     reset: (state, _action: PayloadAction) => {
       state.code = initialState.code;
@@ -40,5 +45,5 @@ const slice = createSlice({
   },
 });
 
-export const { setInvite, reset } = slice.actions;
+export const { setInviteDetails, setLoading, reset } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -20,7 +20,7 @@ describe('fetchInvite', () => {
           ],
         ])
         .withReducer(rootReducer, {
-          createInvitation: { code: '', url: '', invitesUsed: 0, maxUses: 0 },
+          createInvitation: { code: '', url: '', invitesUsed: 0, maxUses: 0, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.GetCode })
         .run();
@@ -38,12 +38,12 @@ describe('fetchInvite', () => {
         storeState: { createInvitation },
       } = await expectSaga(fetchInvite)
         .withReducer(rootReducer, {
-          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, maxUses: 3 },
+          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, maxUses: 3, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.Cancel })
         .run();
 
-      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, maxUses: 0 });
+      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, maxUses: 0, isLoading: false });
     });
   });
 });

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -30,6 +30,7 @@ describe('fetchInvite', () => {
         url: 'https://www.example.com/invite',
         invitesUsed: 3,
         maxUses: 6,
+        isLoading: false,
       });
     });
 

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -1,5 +1,5 @@
 import { put, call, takeLeading } from 'redux-saga/effects';
-import { SagaActionTypes, reset, setInvite } from '.';
+import { SagaActionTypes, reset, setInviteDetails, setLoading } from '.';
 import { getInvite } from './api';
 import { config } from '../../config';
 import { takeEveryFromBus } from '../../lib/saga';
@@ -10,11 +10,13 @@ export function* fetchInvite() {
   yield put(reset());
 
   try {
+    yield put(setLoading(true));
+
     const invitation = yield call(getInvite);
 
     // For now, we don't include the code in the url
     yield put(
-      setInvite({
+      setInviteDetails({
         code: invitation.slug,
         url: config.inviteUrl,
         invitesUsed: invitation.invitesUsed,
@@ -24,6 +26,8 @@ export function* fetchInvite() {
     return;
   } catch (e) {
     // Listen again
+  } finally {
+    yield put(setLoading(false));
   }
 }
 


### PR DESCRIPTION
### What does this do?
- checks if data is loading to render elements at the same time. Prior to this the elements were rendering at different times making the elements fade-in at different times.
- fades in the elements as per figma.
- this also reverts the colour of the invites left logic

### Why are we making this change?
- as per figma design. This is to soften the rendering of the the elements

### How do I test this?
- once logged in click the invite button to bring up the invite module.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE:


https://github.com/zer0-os/zOS/assets/39112648/52a78d85-8c64-4efe-afa2-e3039ad7ae15



AFTER:


https://github.com/zer0-os/zOS/assets/39112648/8a7cad06-fefc-488f-85ae-f56d2b5a62fa

