### PR TITLE
Render conversation created admin message

### DIFF
--- a/src/components/admin-message/container.tsx
+++ b/src/components/admin-message/container.tsx
@@ -26,7 +26,7 @@ export class Container extends React.Component<Properties> {
   }
 
   render() {
-    return <AdminMessage message={this.props.text} createdAt={this.props.message.createdAt} />;
+    return <AdminMessage message={this.props.text} />;
   }
 }
 

--- a/src/components/admin-message/index.test.tsx
+++ b/src/components/admin-message/index.test.tsx
@@ -6,16 +6,15 @@ describe('AdminMessage', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       message: '',
-      createdAt: 0,
       ...props,
     };
 
     return shallow(<AdminMessage {...allProps} />);
   };
 
-  it('renders the date', function () {
-    const wrapper = subject({ message: 'test message', createdAt: 1681745762146 });
+  it('renders the message', function () {
+    const wrapper = subject({ message: 'test message' });
 
-    expect(wrapper.find('.admin-message__date').text().trim()).toEqual('17/04/2023');
+    expect(wrapper.find('.admin-message').text().trim()).toEqual('test message');
   });
 });

--- a/src/components/admin-message/index.tsx
+++ b/src/components/admin-message/index.tsx
@@ -2,25 +2,14 @@ import * as React from 'react';
 
 import './styles.scss';
 import { bem } from '../../lib/bem';
-import moment from 'moment';
 const c = bem('admin-message');
 
 export interface Properties {
   message: string;
-  createdAt: number;
 }
 
 export class AdminMessage extends React.PureComponent<Properties> {
-  get formattedDate() {
-    return moment(this.props.createdAt).format('DD/MM/YYYY');
-  }
-
   render() {
-    return (
-      <div className={c('')}>
-        <span className={c('date')}>{this.formattedDate} </span>
-        {this.props.message}
-      </div>
-    );
+    return <div className={c('')}>{this.props.message}</div>;
   }
 }

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -26,9 +26,15 @@ export async function fetchConversations(): Promise<Channel[]> {
 export async function createConversation(
   userIds: string[],
   name: string = '',
-  coverUrl = ''
-): Promise<DirectMessage[]> {
-  const directMessages = await post<Channel[]>('/directMessages').send({ name, userIds, coverUrl });
+  coverUrl = '',
+  optimisticId: string
+): Promise<DirectMessage> {
+  const directMessages = await post<Channel[]>('/directMessages').send({
+    name,
+    userIds,
+    coverUrl,
+    optimisticId,
+  });
   return directMessages.body;
 }
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -113,6 +113,8 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
     groupChannelType: GroupChannelType.Private,
     shouldSyncChannels: false,
   };
+
+  const currentUser = yield select(currentUserSelector());
   const timestamp = Date.now();
   const conversation = {
     ...defaultConversationProperties,
@@ -120,7 +122,15 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
     optimisticId: `${timestamp}`,
     name,
     otherMembers: userIds,
-    messages: [],
+    messages: [
+      {
+        id: `${timestamp}`,
+        message: 'Conversation was started',
+        createdAt: timestamp,
+        isAdmin: true,
+        admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: currentUser.id },
+      },
+    ],
     createdAt: Date.now(),
     conversationStatus: ConversationStatus.CREATING,
   };

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { ChannelType, DirectMessage } from './types';
 import getDeepProperty from 'lodash.get';
 import uniqBy from 'lodash.uniqby';
@@ -20,6 +21,8 @@ import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
 import { ConversationStatus, GroupChannelType, MessagesFetchState, receive as receiveChannel } from '../channels';
+import { AdminMessageType } from '../messages';
+import { rawMessagesSelector, replaceOptimisticMessage } from '../messages/saga';
 
 const FETCH_CHAT_CHANNEL_INTERVAL = 60000;
 
@@ -90,7 +93,7 @@ export function* createConversation(userIds: string[], name: string = null, imag
   const optimisticConversation = yield call(createOptimisticConversation, userIds, name, image);
   yield put(setactiveConversationId(optimisticConversation.id));
   try {
-    const conversation = yield call(sendCreateConversationRequest, userIds, name, image);
+    const conversation = yield call(sendCreateConversationRequest, userIds, name, image, optimisticConversation.id);
     yield call(receiveCreatedConversation, conversation, optimisticConversation);
     return conversation;
   } catch {
@@ -115,24 +118,27 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
   };
 
   const currentUser = yield select(currentUserSelector());
+  const id = uuidv4();
   const timestamp = Date.now();
+  const adminMessage = {
+    id,
+    optimisticId: id,
+    message: 'Conversation was started',
+    createdAt: timestamp,
+    isAdmin: true,
+    admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: currentUser.id },
+  };
   const conversation = {
     ...defaultConversationProperties,
-    id: `${timestamp}`,
-    optimisticId: `${timestamp}`,
+    id,
+    optimisticId: id,
     name,
     otherMembers: userIds,
-    messages: [
-      {
-        id: `${timestamp}`,
-        message: 'Conversation was started',
-        createdAt: timestamp,
-        isAdmin: true,
-        admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: currentUser.id },
-      },
-    ],
+    messages: [adminMessage],
     createdAt: Date.now(),
     conversationStatus: ConversationStatus.CREATING,
+    lastMessage: adminMessage,
+    lastMessageAt: adminMessage.createdAt,
   };
 
   const existingConversationsList = yield select(rawConversationsList());
@@ -157,6 +163,15 @@ export function* receiveCreatedConversation(conversation, optimisticConversation
     conversation.hasLoadedMessages = true; // Brand new conversation doesn't have messages to load
     conversation.messagesFetchStatus = MessagesFetchState.SUCCESS;
     conversation.optimisticId = optimisticConversation.optimisticId;
+
+    const existingMessageIds = yield select(rawMessagesSelector(optimisticConversation.id));
+    const firstMessage = conversation.messages[0];
+    const channelMessages = yield call(replaceOptimisticMessage, existingMessageIds, firstMessage);
+    if (channelMessages) {
+      conversation.messages = channelMessages;
+      conversation.lastMessage = firstMessage;
+      conversation.lastMessageCreatedAt = firstMessage.createdAt;
+    }
     listWithoutOptimistic.push(conversation);
   }
 
@@ -171,7 +186,12 @@ export function* receiveCreatedConversation(conversation, optimisticConversation
   yield put(setactiveConversationId(conversation.id));
 }
 
-export function* sendCreateConversationRequest(userIds: string[], name: string = null, image: File = null) {
+export function* sendCreateConversationRequest(
+  userIds: string[],
+  name: string = null,
+  image: File = null,
+  optimisticId: string
+) {
   let coverUrl = '';
   if (image) {
     try {
@@ -183,9 +203,13 @@ export function* sendCreateConversationRequest(userIds: string[], name: string =
     }
   }
 
-  const response: DirectMessage = yield call(createConversationMessageApi, userIds, name, coverUrl);
+  const response: DirectMessage = yield call(createConversationMessageApi, userIds, name, coverUrl, optimisticId);
 
-  return channelMapper(response);
+  const result = channelMapper(response);
+  if (response.messages) {
+    result.messages = response.messages;
+  }
+  return result;
 }
 
 export function* clearChannelsAndConversations() {

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -46,6 +46,7 @@ export interface InfoUploadResponse {
 
 export enum AdminMessageType {
   JOINED_ZERO = 'JOINED_ZERO',
+  CONVERSATION_STARTED = 'CONVERSATION_STARTED',
 }
 
 export enum MessageSendStatus {
@@ -71,6 +72,7 @@ export interface Message {
     type: AdminMessageType;
     inviterId?: string;
     inviteeId?: string;
+    creatorId?: string;
   };
   optimisticId?: string;
   rootMessageId?: string;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -77,7 +77,7 @@ interface MediaInfo {
   mediaType: MediaType;
 }
 
-const rawMessagesSelector = (channelId) => (state) => {
+export const rawMessagesSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels[${channelId}].messages`, []);
 };
 


### PR DESCRIPTION
### What does this do?

* Renders the "conversation created" admin message more specifically based on the current user.
* Renders the admin message optimistically

### How do I test this?

Start a new conversation with a user and verify the admin message is correct.

