### PR TITLE
Tweak antiphonal text for empty searches

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -7,6 +7,7 @@ import './styles.scss';
 import '../list/styles.scss';
 
 import { highlightFilter, itemToOption } from '../lib/utils';
+import classNames from 'classnames';
 
 export interface Properties {
   search: (query: string) => Promise<Item[]>;
@@ -63,6 +64,12 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
           wrapperClassName={'autocomplete-members__search-wrapper force-extra-specificity'}
           inputClassName={'autocomplete-members__search-input'}
         />
+
+        {this.state.results?.length === 0 && this.state.results !== '' && (
+          <div className={classNames('messages-list__empty', 'messages-list__empty-top-padding')}>
+            {`No results for '${this.state.searchString}' `}
+          </div>
+        )}
 
         {this.props.children}
         <div className='autocomplete-members__content'>

--- a/src/components/messenger/list/conversation-list-panel.tsx
+++ b/src/components/messenger/list/conversation-list-panel.tsx
@@ -136,6 +136,12 @@ export class ConversationListPanel extends React.Component<Properties, State> {
                 />
               ))}
 
+              {this.filteredConversations?.length === 0 &&
+                this.state.userSearchResults?.length === 0 &&
+                this.state.filter !== '' && (
+                  <div className='messages-list__empty'>{`No results for '${this.state.filter}' `}</div>
+                )}
+
               {this.state.userSearchResults?.length > 0 && this.state.filter !== '' && (
                 <UserSearchResults
                   results={this.state.userSearchResults}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -8,6 +8,7 @@
   0% {
     right: 0;
   }
+
   100% {
     right: $width-sidekick;
   }
@@ -21,8 +22,10 @@ $side-padding: 16px;
   flex-direction: column;
   padding-bottom: 16px;
 
-  user-select: none; /* Prevent text highlighting */
-  pointer-events: auto; /* Enable pointer events for click event */
+  /* Prevent text highlighting */
+  user-select: none;
+  /* Enable pointer events for click event */
+  pointer-events: auto;
 
   .messages-list {
     &__items {
@@ -64,6 +67,19 @@ $side-padding: 16px;
       // Forcing a height here allows the flex-grow to fill the size without growing too big
       height: 1px;
       padding: 0px $side-padding;
+    }
+
+    &__empty {
+      padding: 8px;
+      color: theme.$color-greyscale-11;
+      font-size: $font-size-medium;
+      line-height: 17px;
+      word-break: break-word;
+      text-align: center;
+
+      &-top-padding {
+        padding-top: 32px;
+      }
     }
   }
 }
@@ -431,7 +447,8 @@ $side-padding: 16px;
     }
 
     a {
-      pointer-events: none; /* Disable pointer events for clicking urls */
+      pointer-events: none;
+      /* Disable pointer events for clicking urls */
     }
   }
 


### PR DESCRIPTION
### What does this do?

+ Re-adds `No results for 'xyz'` text, in case of NO results founds in existing conversations + start new conversation.
+ Re-adds `No results for 'xyz'` text, in case of NO results found in "create new conversation" flow.
+ Re-adds `No results for 'xyz'` text, in case of NO results found in "start a new group chat" flow.

https://github.com/zer0-os/zOS/assets/33264364/103c84d1-7421-4b28-9519-96af62cb7ff9

