### PR TITLE
Spacing between search input and '+' icon should be 8 px

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -37,7 +37,7 @@ $side-padding: 16px;
       &-actions {
         display: flex;
         align-items: center;
-        gap: 16px;
+        gap: 8px;
         padding: 0 $side-padding;
       }
 


### PR DESCRIPTION
Before:
![image](https://github.com/zer0-os/zOS/assets/33264364/b03dcd99-212d-4f30-b457-5b8e29bf2e8d)


After:
![image](https://github.com/zer0-os/zOS/assets/33264364/26614ff8-a7c7-42db-850a-abc6e4c36f0d)
