### PR TITLE
Close the group panel right away when creating a group

### DIFF
--- a/src/components/messenger/list/group-details-panel.test.tsx
+++ b/src/components/messenger/list/group-details-panel.test.tsx
@@ -9,7 +9,6 @@ describe('GroupDetailsPanel', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       users: [],
-      isCreating: false,
       onBack: () => null,
       onCreate: () => null,
       ...props,
@@ -90,12 +89,6 @@ describe('GroupDetailsPanel', () => {
     wrapper.find('Button').simulate('press');
 
     expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ image }));
-  });
-
-  it('sets button to loading state if creating', function () {
-    const wrapper = subject({ isCreating: true });
-
-    expect(wrapper.find('Button').prop('isLoading')).toBeTrue();
   });
 });
 

--- a/src/components/messenger/list/group-details-panel.tsx
+++ b/src/components/messenger/list/group-details-panel.tsx
@@ -14,7 +14,6 @@ const c = bem('group-details-panel');
 
 export interface Properties {
   users: Option[];
-  isCreating: boolean;
 
   onBack: () => void;
   onCreate: (data: { name: string; users: Option[]; image: File }) => void;
@@ -82,7 +81,7 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
           </div>
 
           <div>
-            <Button onPress={this.createGroup} className={c('create')} isLoading={this.props.isCreating}>
+            <Button onPress={this.createGroup} className={c('create')}>
               <IconMessagePlusSquare isFilled size={18} />
               Create Group
             </Button>

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -28,7 +28,6 @@ describe('messenger-list', () => {
       groupUsers: [],
       conversations: [],
       isFetchingExistingConversations: false,
-      isGroupCreating: false,
       isFirstTimeLogin: false,
       includeTitleBar: true,
       allowClose: true,
@@ -216,21 +215,6 @@ describe('messenger-list', () => {
     expect(wrapper.find(StartGroupPanel).prop('initialSelections')).toEqual([{ value: 'user-id' }]);
   });
 
-  it('sets the group details props', async function () {
-    const wrapper = subject({
-      stage: Stage.GroupDetails,
-      groupUsers: [{ value: 'user-id' } as any],
-      isGroupCreating: true,
-    });
-
-    expect(wrapper.find(GroupDetailsPanel).props()).toEqual(
-      expect.objectContaining({
-        users: [{ value: 'user-id' }],
-        isCreating: true,
-      })
-    );
-  });
-
   it('renders the title bar based on property', function () {
     const wrapper = subject({ includeTitleBar: true });
     expect(wrapper).toHaveElement('.messenger-list__header');
@@ -344,16 +328,6 @@ describe('messenger-list', () => {
         'convo-1',
         'convo-3',
       ]);
-    });
-
-    test('gets group details from state', () => {
-      const state = subject([], {
-        groupDetails: {
-          isCreating: true,
-        },
-      });
-
-      expect(state.isGroupCreating).toEqual(true);
     });
 
     test('messagePreview', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -43,7 +43,6 @@ export interface Properties extends PublicProperties {
   groupUsers: Option[];
   conversations: (Channel & { messagePreview?: string })[];
   isFetchingExistingConversations: boolean;
-  isGroupCreating: boolean;
   isFirstTimeLogin: boolean;
   includeTitleBar: boolean;
   allowClose: boolean;
@@ -106,7 +105,6 @@ export class Container extends React.Component<Properties, State> {
       activeConversationId,
       stage: createConversation.stage,
       groupUsers: createConversation.groupUsers,
-      isGroupCreating: createConversation.groupDetails.isCreating,
       isFetchingExistingConversations: createConversation.startGroupChat.isLoading,
       isFirstTimeLogin: registration.isFirstTimeLogin,
       isInviteNotificationOpen: registration.isInviteToastOpen,
@@ -270,12 +268,7 @@ export class Container extends React.Component<Properties, State> {
             />
           )}
           {this.props.stage === SagaStage.GroupDetails && (
-            <GroupDetailsPanel
-              users={this.props.groupUsers}
-              onCreate={this.createGroup}
-              onBack={this.props.back}
-              isCreating={this.props.isGroupCreating}
-            />
+            <GroupDetailsPanel users={this.props.groupUsers} onCreate={this.createGroup} onBack={this.props.back} />
           )}
           {this.state.isInviteDialogOpen && this.renderInviteDialog()}
           {this.renderToastNotification()}

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,4 +1,4 @@
-import { put, call, select, race, take, fork } from 'redux-saga/effects';
+import { put, call, select, race, take, fork, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, setGroupUsers, setStage } from '.';
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
 import { fetchConversationsWithUsers } from '../channels-list/api';
@@ -132,7 +132,7 @@ function* handleStartGroup() {
 
 function* handleGroupDetails() {
   const action = yield take(SagaActionTypes.CreateConversation);
-  yield call(createConversation, action);
+  yield spawn(createConversation, action);
   return Stage.None;
 }
 


### PR DESCRIPTION
### What does this do?

Closes the group details panel immediately when creating a conversation

### Why are we making this change?

We previously had a loading state on the button while the conversation is created but since we now have optimistic rendering we can close this immediately.

