### PR TITLE
fix: elements displayed in block body

### DIFF
--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -69,7 +69,7 @@ export class ContentHighlighter extends React.Component<Properties> {
             },
           }}
         >
-          {this.renderContent(this.props.message)}
+          <div>{this.renderContent(this.props.message)}</div>
         </Linkify>
       );
     } else {

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -65,7 +65,7 @@
     font-size: 14px;
     line-height: 17px;
     color: theme.$color-greyscale-12;
-    display: inherit;
+    display: flex;
     flex-direction: column;
     gap: 4px;
 

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -65,7 +65,7 @@
     font-size: 14px;
     line-height: 17px;
     color: theme.$color-greyscale-12;
-    display: flex;
+    display: inherit;
     flex-direction: column;
     gap: 4px;
 


### PR DESCRIPTION
### What does this do?
- fixes a current issue where elements displayed in the message block body are forced onto new lines when links are included in the message. 
- small change that inherits the display, resulting in a correct lay out of elements in the message block body.

### Why are we making this change?
- bug found in production. messages are not being displayed as expected. See screenshots below.

### How do I test this?
- open messenger and compose messages with a number of elements including highlight and tagging, and urls etc.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


BEFORE:
- channels
<img width="626" alt="Screenshot 2023-08-14 at 09 42 26" src="https://github.com/zer0-os/zOS/assets/39112648/4ae1cffe-83d8-4036-9ac0-51e9adaa459c">

- collapsed chat
<img width="626" alt="Screenshot 2023-08-14 at 09 42 54" src="https://github.com/zer0-os/zOS/assets/39112648/58bddf0d-677c-435e-a35f-0ddceb6f5c8c">

- full screen
<img width="1148" alt="Screenshot 2023-08-14 at 09 43 31" src="https://github.com/zer0-os/zOS/assets/39112648/490444c3-cc54-4eea-9261-9e29b8c56d43">

AFTER:
- channels
<img width="814" alt="Screenshot 2023-08-14 at 09 44 06" src="https://github.com/zer0-os/zOS/assets/39112648/99145542-fe11-447e-8dd6-dbad6905f083">

- collapsed chat
<img width="583" alt="Screenshot 2023-08-14 at 09 44 54" src="https://github.com/zer0-os/zOS/assets/39112648/8d424698-a2e9-4a74-a0c0-92026516103a">

- full screen
<img width="844" alt="Screenshot 2023-08-14 at 09 45 11" src="https://github.com/zer0-os/zOS/assets/39112648/3c1fb726-a77d-4d9c-8e54-61675207021c">
