### PR TITLE
chore: bump zui (`0.25.3`) -> (`0.26.1`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@zero-tech/zapp-daos": "latest",
         "@zero-tech/zapp-nfts": "latest",
         "@zero-tech/zapp-staking": "latest",
-        "@zero-tech/zui": "^0.25.3",
+        "@zero-tech/zui": "^0.26.1",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -10873,9 +10873,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.25.3.tgz",
-      "integrity": "sha512-P0h5NxnVcVxJw5ZSwCj79vut8hUs0hYFbxxAhTqbohGvV/9XJUJNjkFdI1GDREIHBMa6hfduOh+p0Xz7TyePOQ==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.1.tgz",
+      "integrity": "sha512-LarLhwO9+7UI4ESxCXkxCnRA41gWj+dTUIGFuNFrwmNrNa+KgvbiRMLW3BgUHSw5GyoTEbMyoP/YVYmZ+wqTBg==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -42047,7 +42047,7 @@
       "integrity": "sha512-vYYN02Jx+M2MVCjjQYsY/NJrGousc9+WY0Z/6UxCtsk19SKQ7RshuxJxIUDcQ0IyxwOFWI/ssMQ1u82UB7rkGQ==",
       "requires": {
         "@zero-tech/zns-sdk": "0.8.9",
-        "@zero-tech/zui": "^0.25.3",
+        "@zero-tech/zui": "^0.26.1",
         "classnames": "^2.3.1",
         "react-query": "^3.39.1"
       },
@@ -42103,7 +42103,7 @@
         "@zero-tech/zapp-utils": "0.6.5",
         "@zero-tech/zdao-sdk": "0.14.1",
         "@zero-tech/zns-sdk": "0.10.2",
-        "@zero-tech/zui": "^0.25.3",
+        "@zero-tech/zui": "^0.26.1",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "markdown-to-text": "^0.1.1",
@@ -42352,7 +42352,7 @@
         "@zero-tech/zns-sdk": "0.10.1",
         "@zero-tech/zsale-sdk": "0.1.6",
         "@zero-tech/ztoken-sdk": "^0.0.3",
-        "@zero-tech/zui": "^0.25.3",
+        "@zero-tech/zui": "^0.26.1",
         "classnames": "^2.3.1",
         "formik": "^2.2.9",
         "moment": "^2.29.4",
@@ -42434,7 +42434,7 @@
         "@zero-tech/zapp-utils": "^0.6.5",
         "@zero-tech/zfi-sdk": "0.2.1",
         "@zero-tech/zns-sdk": "0.6.1",
-        "@zero-tech/zui": "^0.25.3",
+        "@zero-tech/zui": "^0.26.1",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "millify": "^5.0.1",
@@ -43127,9 +43127,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.25.3.tgz",
-      "integrity": "sha512-P0h5NxnVcVxJw5ZSwCj79vut8hUs0hYFbxxAhTqbohGvV/9XJUJNjkFdI1GDREIHBMa6hfduOh+p0Xz7TyePOQ==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.1.tgz",
+      "integrity": "sha512-LarLhwO9+7UI4ESxCXkxCnRA41gWj+dTUIGFuNFrwmNrNa+KgvbiRMLW3BgUHSw5GyoTEbMyoP/YVYmZ+wqTBg==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@zero-tech/zapp-daos": "latest",
     "@zero-tech/zapp-nfts": "latest",
     "@zero-tech/zapp-staking": "latest",
-    "@zero-tech/zui": "^0.25.3",
+    "@zero-tech/zui": "^0.26.1",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
### What does this do?
- bumps zUI version from (`0.25.3`) to (`0.26.1`). 
- this includes fixes to the zUI IconButton component

### Why are we making this change?
- to pull in the latest changes from zUI, with the aim of improving the use of IconButton component in zOS and deprecate other versions/duplicates of IconButton.

### How do I test this?
- check node modules for correct zUI version.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

- risk - unlikely, but some icons could be distorted due to creating a pr to bump version and pull in zUI changes prior to adjusting existing uses.
