### PR TITLE
Elevate calculation of converstion preview date

### DIFF
--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -127,6 +127,14 @@ describe('ConversationItem', () => {
     expect(wrapper.find(ContentHighlighter).prop('message')).toEqual(messagePreview);
   });
 
+  it('renders the previewDisplayDate', function () {
+    const previewDisplayDate = 'Aug 1, 2021';
+
+    const wrapper = subject({ conversation: { previewDisplayDate, otherMembers: [] } as any });
+
+    expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(previewDisplayDate);
+  });
+
   describe('status', () => {
     it('renders inactive if no other members are online', function () {
       const wrapper = subject({
@@ -174,48 +182,6 @@ describe('ConversationItem', () => {
       });
 
       expect(wrapper.find('Tooltip').prop('overlay')).toEqual('Johnny Cash, Jackie Chan');
-    });
-  });
-
-  describe('displayDate', () => {
-    const createWrapper = (createdAt: moment.Moment) => {
-      return subject({
-        conversation: {
-          lastMessage: {
-            createdAt: createdAt.valueOf(),
-            sender: { userId: 'id' },
-          },
-          otherMembers: [],
-        } as any,
-      });
-    };
-
-    it('displays the time of day for messages sent on the current day', () => {
-      const now = moment();
-      const wrapper = createWrapper(now);
-
-      expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(now.format('h:mm A'));
-    });
-
-    it('displays the three-letter day abbreviation for messages sent within the preceding 7 days', () => {
-      const sevenDaysAgo = moment().subtract(5, 'days');
-      const wrapper = createWrapper(sevenDaysAgo);
-
-      expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(sevenDaysAgo.format('ddd'));
-    });
-
-    it('displays the three-letter month abbreviation and day of the month for messages sent in the same calendar year prior to the last 7 days', () => {
-      const messageDate = moment().subtract(10, 'days');
-      const wrapper = createWrapper(messageDate);
-
-      expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(messageDate.format('MMM D'));
-    });
-
-    it('displays the three-letter month abbreviation, day of the month, and the year for messages sent before the current calendar year', () => {
-      const messageDate = moment().subtract(1, 'year').subtract(5, 'days');
-      const wrapper = createWrapper(messageDate);
-
-      expect(wrapper.find('.conversation-item__timestamp').text()).toEqual(messageDate.format('MMM D, YYYY'));
     });
   });
 });

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -20,7 +20,7 @@ const cn = bemClassName('conversation-item');
 
 export interface Properties {
   filter: string;
-  conversation: Channel & { messagePreview?: string };
+  conversation: Channel & { messagePreview?: string; previewDisplayDate?: string };
   myUserId: string;
   activeConversationId: string;
 
@@ -112,6 +112,7 @@ export class ConversationItem extends React.Component<Properties> {
 
   render() {
     const { conversation, activeConversationId } = this.props;
+    const { messagePreview, previewDisplayDate } = conversation;
     const hasUnreadMessages = conversation.unreadCount !== 0;
     const isUnread = hasUnreadMessages ? 'true' : 'false';
     const isActive = conversation.id === activeConversationId ? 'true' : 'false';
@@ -141,11 +142,11 @@ export class ConversationItem extends React.Component<Properties> {
               <div {...cn('name')} is-unread={isUnread}>
                 {this.highlightedName()}
               </div>
-              <div {...cn('timestamp')}>{this.displayDate}</div>
+              <div {...cn('timestamp')}>{previewDisplayDate}</div>
             </div>
             <div {...cn('content')}>
               <div {...cn('message')} is-unread={isUnread}>
-                <ContentHighlighter message={this.props.conversation.messagePreview} variant='negative' tabIndex={-1} />
+                <ContentHighlighter message={messagePreview} variant='negative' tabIndex={-1} />
               </div>
               {hasUnreadMessages && <div {...cn('unread-count')}>{conversation.unreadCount}</div>}
             </div>

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -14,6 +14,7 @@ import { RegistrationState } from '../../../store/registration';
 import { LayoutState } from '../../../store/layout/types';
 import { RewardsState } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
+import { previewDisplayDate } from '../../../lib/chat/chat-message';
 
 const mockSearchMyNetworksByName = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -359,6 +360,19 @@ describe('messenger-list', () => {
         'Jack: The last message',
         'Jack: Second message last',
       ]);
+    });
+
+    test('previewDeisplayDate', () => {
+      const date = moment('2023-03-03').valueOf();
+      const state = subject([
+        {
+          id: 'convo-1',
+          lastMessage: { createdAt: date, message: '', sender: {} },
+          isChannel: false,
+        },
+      ]);
+
+      expect(state.conversations.map((c) => c.previewDisplayDate)).toEqual([previewDisplayDate(date)]);
     });
 
     test('isLoading', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -25,7 +25,7 @@ import { StartGroupPanel } from './start-group-panel';
 import { GroupDetailsPanel } from './group-details-panel';
 import { Option } from '../lib/types';
 import { MembersSelectedPayload } from '../../../store/create-conversation/types';
-import { getMessagePreview } from '../../../lib/chat/chat-message';
+import { getMessagePreview, previewDisplayDate } from '../../../lib/chat/chat-message';
 import { enterFullScreenMessenger } from '../../../store/layout';
 import { Modal, ToastNotification } from '@zero-tech/zui/components';
 import { InviteDialogContainer } from '../../invite-dialog/container';
@@ -46,7 +46,7 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   stage: SagaStage;
   groupUsers: Option[];
-  conversations: (Channel & { messagePreview?: string })[];
+  conversations: (Channel & { messagePreview?: string; previewDisplayDate?: string })[];
   isFetchingExistingConversations: boolean;
   isFirstTimeLogin: boolean;
   includeTitleBar: boolean;
@@ -98,7 +98,13 @@ export class Container extends React.Component<Properties, State> {
       .sort((a, b) =>
         compareDatesDesc(a.lastMessage?.createdAt || a.createdAt, b.lastMessage?.createdAt || b.createdAt)
       )
-      .map((conversation) => ({ ...conversation, messagePreview: getMessagePreview(conversation.lastMessage, state) }));
+      .map((conversation) => {
+        return {
+          ...conversation,
+          messagePreview: getMessagePreview(conversation.lastMessage, state),
+          previewDisplayDate: previewDisplayDate(conversation.lastMessage?.createdAt),
+        };
+      });
 
     return {
       conversations,

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -1,7 +1,8 @@
+import moment from 'moment';
 import { AdminMessageType, MediaType, Message, MessageSendStatus } from '../../store/messages';
 import { RootState } from '../../store/reducer';
 import { StoreBuilder } from '../../store/test/store';
-import { adminMessageText, getMessagePreview, map as mapMessage } from './chat-message';
+import { adminMessageText, getMessagePreview, map as mapMessage, previewDisplayDate } from './chat-message';
 
 describe('sendbird events', () => {
   describe('mapMessage', () => {
@@ -338,5 +339,31 @@ describe(getMessagePreview, () => {
     );
 
     expect(preview).toEqual('You: Failed to send');
+  });
+});
+
+describe(previewDisplayDate, () => {
+  it('displays the time of day for messages sent on the current day', () => {
+    const now = moment();
+
+    expect(previewDisplayDate(now.valueOf())).toEqual(now.format('h:mm A'));
+  });
+
+  it('displays the three-letter day abbreviation for messages sent within the preceding 7 days', () => {
+    const sevenDaysAgo = moment().subtract(5, 'days');
+
+    expect(previewDisplayDate(sevenDaysAgo.valueOf())).toEqual(sevenDaysAgo.format('ddd'));
+  });
+
+  it('displays the three-letter month abbreviation and day of the month for messages sent in the same calendar year prior to the last 7 days', () => {
+    const withinCalendarYear = moment().subtract(10, 'days');
+
+    expect(previewDisplayDate(withinCalendarYear.valueOf())).toEqual(withinCalendarYear.format('MMM D'));
+  });
+
+  it('displays the three-letter month abbreviation, day of the month, and the year for messages sent before the current calendar year', () => {
+    const olderThanCalendarYear = moment().subtract(1, 'year').subtract(5, 'days');
+
+    expect(previewDisplayDate(olderThanCalendarYear.valueOf())).toEqual(olderThanCalendarYear.format('MMM D, YYYY'));
   });
 });

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -153,6 +153,10 @@ export function map(sendbirdMessage) {
 }
 
 export function previewDisplayDate(timestamp: number) {
+  if (!timestamp) {
+    return '';
+  }
+
   const messageDate = moment(timestamp);
   const currentDate = moment();
 

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -3,6 +3,8 @@ import { RootState } from '../../store/reducer';
 import { ChatMember } from './types';
 import { denormalize as denormalizeUser } from '../../store/users';
 import { currentUserSelector } from '../../store/authentication/saga';
+import { Moment } from 'moment';
+import moment from 'moment';
 
 const DEFAULT_MEDIA_TYPE = 'image';
 
@@ -148,6 +150,21 @@ export function map(sendbirdMessage) {
     isAdmin: messageType.toLowerCase() === 'admin',
     sendStatus: MessageSendStatus.SUCCESS,
   } as unknown as Message;
+}
+
+export function previewDisplayDate(timestamp: number) {
+  const messageDate = moment(timestamp);
+  const currentDate = moment();
+
+  if (messageDate.isSame(currentDate, 'day')) {
+    return messageDate.format('h:mm A');
+  } else if (messageDate.isAfter(currentDate.clone().subtract(7, 'days'), 'day')) {
+    return messageDate.format('ddd');
+  } else if (messageDate.year() === currentDate.year()) {
+    return messageDate.format('MMM D');
+  }
+
+  return messageDate.format('MMM D, YYYY');
 }
 
 export function getMessagePreview(message: Message, state: RootState) {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -3,7 +3,6 @@ import { RootState } from '../../store/reducer';
 import { ChatMember } from './types';
 import { denormalize as denormalizeUser } from '../../store/users';
 import { currentUserSelector } from '../../store/authentication/saga';
-import { Moment } from 'moment';
 import moment from 'moment';
 
 const DEFAULT_MEDIA_TYPE = 'image';


### PR DESCRIPTION
### What does this do?

Pulls the calculation of the message preview date for the conversation list up a couple of levels

### Why are we making this change?

To allow greater control of which date to use

