### PR TITLE
Use message list for preview rendering in conversation list

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -342,24 +342,51 @@ describe('messenger-list', () => {
       ]);
     });
 
-    test('messagePreview', () => {
-      const state = subject([
-        {
-          id: 'convo-1',
-          lastMessage: { message: 'The last message', sender: { firstName: 'Jack' } },
-          isChannel: false,
-        },
-        {
-          id: 'convo-2',
-          lastMessage: { message: 'Second message last', sender: { firstName: 'Jack' } },
-          isChannel: false,
-        },
-      ]);
+    describe('messagePreview', () => {
+      it('sets the preview for all conversations', () => {
+        const state = subject([
+          {
+            id: 'convo-1',
+            lastMessage: { message: 'The last message', sender: { firstName: 'Jack' } },
+            isChannel: false,
+          },
+          {
+            id: 'convo-2',
+            lastMessage: { message: 'Second message last', sender: { firstName: 'Jack' } },
+            isChannel: false,
+          },
+        ]);
 
-      expect(state.conversations.map((c) => c.messagePreview)).toEqual([
-        'Jack: The last message',
-        'Jack: Second message last',
-      ]);
+        expect(state.conversations.map((c) => c.messagePreview)).toEqual([
+          'Jack: The last message',
+          'Jack: Second message last',
+        ]);
+      });
+
+      it('uses most recent of last message in list or lastMessage on conversation', () => {
+        const state = subject([
+          {
+            id: 'convo-1',
+            lastMessage: { message: 'lastMessage', createdAt: 10003, sender: { firstName: 'Jack' } },
+            messages: [
+              { id: '1', message: 'recent message', createdAt: 10005, sender: { firstName: 'Jack' } },
+              { id: '2', message: 'old message', createdAt: 10002 },
+            ],
+            isChannel: false,
+          },
+          {
+            id: 'convo-2',
+            lastMessage: { message: 'lastMessage', createdAt: 20007, sender: { firstName: 'Jack' } },
+            messages: [],
+            isChannel: false,
+          },
+        ]);
+
+        expect(state.conversations.map((c) => c.messagePreview)).toEqual([
+          'Jack: lastMessage',
+          'Jack: recent message',
+        ]);
+      });
     });
 
     test('previewDeisplayDate', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -95,14 +95,19 @@ export class Container extends React.Component<Properties, State> {
     const hasWallet = user?.data?.wallets?.length > 0;
 
     const conversations = denormalizeConversations(state)
+      .map((conversation) => {
+        const sortedMessages = conversation.messages?.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
+        let mostRecentMessage = sortedMessages[0] || conversation.lastMessage;
+        return { ...conversation, mostRecentMessage };
+      })
       .sort((a, b) =>
-        compareDatesDesc(a.lastMessage?.createdAt || a.createdAt, b.lastMessage?.createdAt || b.createdAt)
+        compareDatesDesc(a.mostRecentMessage?.createdAt || a.createdAt, b.mostRecentMessage?.createdAt || b.createdAt)
       )
       .map((conversation) => {
         return {
           ...conversation,
-          messagePreview: getMessagePreview(conversation.lastMessage, state),
-          previewDisplayDate: previewDisplayDate(conversation.lastMessage?.createdAt),
+          messagePreview: getMessagePreview(conversation.mostRecentMessage, state),
+          previewDisplayDate: previewDisplayDate(conversation.mostRecentMessage?.createdAt),
         };
       });
 


### PR DESCRIPTION
### What does this do?

Uses the message list as the first option when rendering the message preview in the conversation list.

### Why are we making this change?

The lastMessage property on a conversation is really meant to be a shortcut for rendering previews without fetching a conversation's messages. However, in cases where we actually have the message data, using the most recent message in the list makes more sense and saves a lot of juggling of trying to manage the lastMessage property.


https://github.com/zer0-os/zOS/assets/43770/75f73777-f1f1-4136-b021-9bd30cec2230


https://github.com/zer0-os/zOS/assets/43770/d2af8cba-d0b5-4056-8c36-83969d693f10

