### PR TITLE
Wrap callbacks to hide event information

### DIFF
--- a/src/components/messenger/list/create-conversation-panel/index.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.tsx
@@ -22,6 +22,10 @@ export default class CreateConversationPanel extends React.Component<Properties>
     this.props.onCreate(option.value);
   };
 
+  startGroupChat = (_e) => {
+    this.props.onStartGroupChat();
+  };
+
   render() {
     return (
       <>
@@ -30,7 +34,7 @@ export default class CreateConversationPanel extends React.Component<Properties>
         <div {...cn('')}>
           <div {...cn('search')}>
             <AutocompleteMembers search={this.props.search} onSelect={this.userSelected}>
-              <div {...cn('group-button')} onClick={this.props.onStartGroupChat}>
+              <div {...cn('group-button')} onClick={this.startGroupChat}>
                 <div {...cn('group-icon')}>
                   <IconUsersPlus size={25} />
                 </div>

--- a/src/components/messenger/list/panel-header/index.tsx
+++ b/src/components/messenger/list/panel-header/index.tsx
@@ -13,10 +13,14 @@ export interface Properties {
 }
 
 export class PanelHeader extends React.Component<Properties> {
+  goBack = (_e) => {
+    this.props.onBack();
+  };
+
   render() {
     return (
       <div {...cn('header')}>
-        <span {...cn('back')} onClick={this.props.onBack}>
+        <span {...cn('back')} onClick={this.goBack}>
           <IconArrowNarrowLeft size={24} isFilled />
         </span>
         <div {...cn('title')}>{this.props.title}</div>


### PR DESCRIPTION
### What does this do?

Wraps some callbacks connected to click events to prevent serialization of the event to redux

### Why are we making this change?

Turns out these warnings actually cost quite a bit of time. I started noticing it when navigating the conversation panels as shown in the videos.


https://github.com/zer0-os/zOS/assets/43770/a95a90a1-5e1b-42ba-9aa1-ff2da0335a9f


https://github.com/zer0-os/zOS/assets/43770/3d50e631-d0b3-4b9e-a88b-f81c2064441d

