### PR TITLE
Remove management of lastMessage on channels

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -146,7 +146,6 @@ export class MatrixClient implements IChatClient {
     isOneOnOne: false,
     otherMembers: [],
     lastMessage: null,
-    lastMessageCreatedAt: null,
     groupChannelType: GroupChannelType.Public,
     category: '',
     unreadCount: 0,

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -157,7 +157,6 @@ describe('channels list saga', () => {
       createdAt: 7000,
       otherMembers: [],
       lastMessage: {},
-      lastMessageCreatedAt: null,
       groupChannelType: '',
     };
 
@@ -172,7 +171,6 @@ describe('channels list saga', () => {
       createdAt: 5000,
       otherMembers: [],
       lastMessage: {},
-      lastMessageCreatedAt: null,
       groupChannelType: '',
     };
 
@@ -289,9 +287,9 @@ describe(userLeftChannel, () => {
     const initialState = new StoreBuilder()
       .withCurrentUserId(userId)
       .withConversationList(
-        { id: 'conversation-1', lastMessageCreatedAt: 10000000 },
+        { id: 'conversation-1', lastMessage: { createdAt: 10000000 } as any },
         { id: channelId },
-        { id: 'conversation-2', lastMessageCreatedAt: 10000001 }
+        { id: 'conversation-2', lastMessage: { createdAt: 10000001 } as any }
       )
       .withActiveConversation({ id: channelId })
       .build();

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -243,7 +243,7 @@ describe('channels list saga', () => {
         channelsList,
         normalized: { channels, notifications },
       })
-      .run(0);
+      .run();
 
     expect(normalized).toEqual({
       channels: {},
@@ -337,29 +337,10 @@ describe(fetchConversations, () => {
       .run();
   });
 
-  it('maintains lastMessage information if a local message is newer', async () => {
-    const optimisticMessage = { id: 'message-id' } as any;
-    const channelWithOptimisticMessage = {
-      id: 'conversation-id',
-      lastMessage: optimisticMessage,
-      lastMessageCreatedAt: 10000001,
-    };
-    const fetchedChannel = { id: 'conversation-id', lastMessage: { id: 'old-message', createdAt: 10000000 } };
-
-    const initialState = new StoreBuilder().withConversationList(channelWithOptimisticMessage).build();
-
-    const { storeState } = await expectSaga(fetchConversations)
-      .provide([stubResponse(matchers.call.fn(fetchConversationsApi), [fetchedChannel])])
-      .withReducer(rootReducer, initialState)
-      .run();
-
-    expect(denormalizeChannel('conversation-id', storeState).lastMessage).toBe(optimisticMessage);
-  });
-
   it('retains conversations that are not CREATED', async () => {
     const optimisticChannel1 = { id: 'optimistic-id-1', conversationStatus: ConversationStatus.CREATING } as any;
     const optimisticChannel2 = { id: 'optimistic-id-2', conversationStatus: ConversationStatus.ERROR } as any;
-    const fetchedChannel = { id: 'conversation-id', lastMessage: { id: 'old-message', createdAt: 10000000 } };
+    const fetchedChannel = { id: 'conversation-id' };
 
     const initialState = new StoreBuilder().withConversationList(optimisticChannel1, optimisticChannel2).build();
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -292,7 +292,7 @@ function* currentUserLeftChannel(channelId) {
     const conversations = yield select(denormalizeConversations);
 
     if (conversations.length > 0) {
-      const sorted = conversations.sort((a, b) => (b.lastMessageCreatedAt || 0) - (a.lastMessageCreatedAt || 0));
+      const sorted = conversations.sort((a, b) => (b.lastMessage?.createdAt || 0) - (a.lastMessage?.createdAt || 0));
       yield put(setactiveConversationId(sorted[0].id));
     } else {
       // Probably not possible but handled just in case

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -60,23 +60,6 @@ export function* fetchConversations() {
   const conversationsList = conversations.map((currentChannel) => toLocalChannel(currentChannel));
 
   const existingConversationList = yield select(denormalizeConversations);
-  const newConversationList = conversationsList.map((conversation) => {
-    const existingConversation = existingConversationList.find((existing) => existing.id === conversation.id);
-    if (
-      !existingConversation ||
-      !existingConversation.lastMessageCreatedAt ||
-      (conversation.lastMessageCreatedAt ?? 0) > existingConversation.lastMessageCreatedAt
-    ) {
-      return conversation;
-    }
-
-    return {
-      ...conversation,
-      lastMessage: existingConversation.lastMessage,
-      lastMessageCreatedAt: existingConversation.lastMessageCreatedAt,
-    };
-  });
-
   const optimisticConversationIds = existingConversationList
     .filter((c) => c.conversationStatus !== ConversationStatus.CREATED)
     .map((c) => c.id);
@@ -86,7 +69,7 @@ export function* fetchConversations() {
     receive([
       ...channelsList,
       ...optimisticConversationIds,
-      ...newConversationList,
+      ...conversationsList,
     ])
   );
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -158,8 +158,6 @@ export function* receiveCreatedConversation(conversation, optimisticConversation
       const channelMessages = yield call(replaceOptimisticMessage, existingMessageIds, firstMessage);
       if (channelMessages) {
         conversation.messages = channelMessages;
-        conversation.lastMessage = firstMessage;
-        conversation.lastMessageCreatedAt = firstMessage.createdAt;
       }
     }
     listWithoutOptimistic.push(conversation);

--- a/src/store/channels-list/utils.test.ts
+++ b/src/store/channels-list/utils.test.ts
@@ -44,24 +44,6 @@ describe(toLocalChannel, () => {
     });
   });
 
-  describe('lastMessageCreatedAt', () => {
-    it('is the last message created at if exists', async function () {
-      const apiResponse = { lastMessage: { createdAt: 100007 } };
-
-      const channel = toLocalChannel(apiResponse);
-
-      expect(channel.lastMessageCreatedAt).toEqual(100007);
-    });
-
-    it('is null if last message does NOT exist from api', async function () {
-      const apiResponse = {};
-
-      const channel = toLocalChannel(apiResponse);
-
-      expect(channel.lastMessageCreatedAt).toEqual(null);
-    });
-  });
-
   describe('groupChannelType', () => {
     it('maps directly if exists from api', async function () {
       const apiResponse = { groupChannelType: 'private' };

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -30,7 +30,6 @@ export const toLocalChannel = (input): Partial<Channel> => {
     createdAt: input.createdAt,
     otherMembers,
     lastMessage: input.lastMessage || null,
-    lastMessageCreatedAt: input.lastMessage?.createdAt || null,
     isChannel,
     groupChannelType: input.groupChannelType || '', // Is this the right default to use?
     conversationStatus: ConversationStatus.CREATED,

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -41,7 +41,6 @@ export interface Channel {
   hasMore: boolean;
   createdAt: number;
   lastMessage: Message;
-  lastMessageCreatedAt: number;
   category?: string;
   shouldSyncChannels: boolean;
   unreadCount?: number;

--- a/src/store/messages/saga.receiveNewMessage.test.ts
+++ b/src/store/messages/saga.receiveNewMessage.test.ts
@@ -71,53 +71,6 @@ describe(receiveNewMessage, () => {
       .run();
   });
 
-  it('sets the lastMessage and lastMessageCreatedAt if it is now the most recent message', async () => {
-    const channelId = 'channel-id';
-    const message = { id: 'new-message', message: '', createdAt: 10000007 };
-    const existingMessages = [
-      { id: 'other-message', message: '', createdAt: 10000005 },
-    ] as any;
-    const initialState = new StoreBuilder().withConversationList({
-      id: channelId,
-      messages: existingMessages,
-      lastMessage: existingMessages[0],
-      lastMessageCreatedAt: existingMessages[0].createdAt,
-    });
-
-    const { storeState } = await expectSaga(receiveNewMessage, { payload: { channelId, message } })
-      .provide(successResponses())
-      .withReducer(rootReducer, initialState.build())
-      .run();
-
-    const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.lastMessage).toEqual(message);
-    expect(channel.lastMessageCreatedAt).toEqual(message.createdAt);
-  });
-
-  it('does not set the lastMessage and lastMessageAt if the received message is earlier than the latest', async () => {
-    const channelId = 'channel-id';
-    const message = { id: 'new-message', message: 'message text', createdAt: 10000001 };
-    const existingMessages = [
-      { id: 'other-message', message: 'message_0001', createdAt: 10000005 },
-    ] as any;
-
-    const initialState = new StoreBuilder().withConversationList({
-      id: channelId,
-      messages: existingMessages,
-      lastMessage: existingMessages[0],
-      lastMessageCreatedAt: existingMessages[0].createdAt,
-    });
-
-    const { storeState } = await expectSaga(receiveNewMessage, { payload: { channelId, message } })
-      .provide(successResponses())
-      .withReducer(rootReducer, initialState.build())
-      .run();
-
-    const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.lastMessage).toEqual(existingMessages[0]);
-    expect(channel.lastMessageCreatedAt).toEqual(existingMessages[0].createdAt);
-  });
-
   it('sends a browser notification', async () => {
     const message = { id: 'message-id', message: '' };
     const initialState = new StoreBuilder().withConversationList({ id: 'channel-id' });

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -228,7 +228,7 @@ describe('messages saga', () => {
       .withState({
         normalized: { messages, channels },
       })
-      .run(0);
+      .run();
 
     expect(normalized).toEqual({
       messages: {},

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -13,24 +13,9 @@ import {
   receiveUpdateMessage,
 } from './saga';
 
-import { chat } from '../../lib/chat';
-
 import { RootState, rootReducer } from '../reducer';
 import { mapMessage, send as sendBrowserMessage } from '../../lib/browser';
 import { call } from 'redux-saga/effects';
-
-const getChatClientForMessageResponse = (props = {}) => ({
-  getMessagesByChannelId: () => ({
-    hasMore: true,
-    messages: [
-      { id: 'message 1', message: 'message_0001', createdAt: 10000000007 },
-      { id: 'message 2', message: 'message_0002', createdAt: 10000000008 },
-      { id: 'message 3', message: 'message_0003', createdAt: 10000000009 },
-    ],
-    lastMessageCreatedAt: 10000000009,
-    ...props,
-  }),
-});
 
 describe('messages saga', () => {
   it('sends a browser notification for a conversation', async () => {
@@ -197,38 +182,6 @@ describe('messages saga', () => {
       messages[0].id,
       messages[2].id,
     ]);
-  });
-
-  it('sets lastMessageCreatedAt on channel', async () => {
-    const channelId = 'channel-id';
-
-    const initialState = {
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            hasMore: true,
-            lastMessageCreatedAt: 10000000008,
-          },
-        },
-      },
-    };
-
-    const {
-      storeState: {
-        normalized: { channels },
-      },
-    } = await expectSaga(fetchNewMessages, { payload: { channelId } })
-      .withReducer(rootReducer, initialState as any)
-      .provide([
-        [
-          matchers.call.fn(chat.get),
-          getChatClientForMessageResponse({ lastMessageCreatedAt: 10000000009 }),
-        ],
-      ])
-      .run();
-
-    expect(channels[channelId].lastMessageCreatedAt).toStrictEqual(10000000009);
   });
 
   it('stop syncChannels when calling stopSyncChannels', async () => {

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -3,7 +3,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { editMessageApi } from './api';
 import {
-  fetchNewMessages,
   stopSyncChannels,
   receiveDelete,
   editMessage,

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -220,7 +220,6 @@ export function* createOptimisticMessage(channelId, message, parentMessage, file
         temporaryMessage,
       ],
       lastMessage: temporaryMessage,
-      lastMessageCreatedAt: temporaryMessage.createdAt,
     })
   );
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -452,13 +452,7 @@ export function* receiveNewMessage(action) {
     ];
   }
 
-  const updatedChannel: Partial<Channel> = { id: channelId, messages: newMessages };
-  if (!channel.lastMessageCreatedAt || message.createdAt > channel.lastMessageCreatedAt) {
-    updatedChannel.lastMessage = message;
-    updatedChannel.lastMessageCreatedAt = message.createdAt;
-  }
-
-  yield put(receive(updatedChannel));
+  yield put(receive({ id: channelId, messages: newMessages }));
   yield spawn(sendBrowserNotification, channelId, message);
 
   const isChannel = yield select(_isChannel(channelId));

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -219,7 +219,6 @@ export function* createOptimisticMessage(channelId, message, parentMessage, file
         ...existingMessages,
         temporaryMessage,
       ],
-      lastMessage: temporaryMessage,
     })
   );
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -80,9 +80,6 @@ const messageSelector = (messageId) => (state) => {
   return getDeepProperty(state, `normalized.messages[${messageId}]`, null);
 };
 
-const rawLastMessageSelector = (channelId) => (state) => {
-  return getDeepProperty(state, `normalized.channels[${channelId}].lastMessageCreatedAt`, 0);
-};
 const rawShouldSyncChannels = (channelId) => (state) =>
   getDeepProperty(state, `normalized.channels[${channelId}].shouldSyncChannels`, false);
 
@@ -290,16 +287,11 @@ export function* fetchNewMessages(action) {
       channelId
     );
 
-    const lastMessageCreatedAt = yield select(rawLastMessageSelector(channelId));
-    const lastMessage = filteredLastMessage(messagesResponse.messages);
-
     yield put(
       receive({
         id: channelId,
         messages: messagesResponse.messages,
         hasMore: messagesResponse.hasMore,
-        lastMessageCreatedAt:
-          lastMessage && lastMessage.createdAt > lastMessageCreatedAt ? lastMessage.createdAt : lastMessageCreatedAt,
         messagesFetchStatus: MessagesFetchState.SUCCESS,
       })
     );
@@ -485,10 +477,6 @@ export function* getPreview(message) {
   if (!link.length) return;
 
   return yield call(getLinkPreviews, link[0].href);
-}
-
-function filteredLastMessage(messages: Message[]): Message {
-  return messages[Object.keys(messages).pop()];
 }
 
 function* syncChannelsTask(action) {


### PR DESCRIPTION
### What does this do?

Removes the management of the `lastMessage` and `lastMessageCreatedAt` properties of a channel

### Why are we making this change?

In #926 we removed the reliance on the shortcut property `lastMessage`. That means we no longer need to juggle that field every time messages arrive/change. It is only used on first load of conversatiosn to render the preview if we haven't loaded messages yet.

### How do I test this?

Use the Messenger in various ways and verify that the preview and sorting in the conversation list maintains correctness.

