### PR TITLE
Remove duplicate setting of the active channel id

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -26,7 +26,6 @@ describe('ChannelViewContainer', () => {
       editMessage: () => undefined,
       startMessageSync: () => undefined,
       stopSyncChannels: () => undefined,
-      setActiveChannelId: () => undefined,
       context: {
         isAuthenticated: false,
       },

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { RootState } from '../../store/reducer';
 
 import { connectContainer } from '../../store/redux-container';
-import { setActiveChannelId } from '../../store/chat';
 import {
   fetch as fetchMessages,
   send as sendMessage,
@@ -29,7 +28,6 @@ import { ParentMessage } from '../../lib/chat/types';
 
 export interface Properties extends PublicProperties {
   channel: Channel;
-  setActiveChannelId: (channelId: string) => void;
   fetchMessages: (payload: PayloadFetchMessages) => void;
   user: AuthenticationState['user'];
   sendMessage: (payload: PayloadSendMessage) => void;
@@ -83,7 +81,6 @@ export class Container extends React.Component<Properties, State> {
       deleteMessage,
       joinChannel,
       editMessage,
-      setActiveChannelId,
     };
   }
 
@@ -92,10 +89,6 @@ export class Container extends React.Component<Properties, State> {
   componentDidMount() {
     const { channelId } = this.props;
     if (channelId) {
-      // only set the active channel ID if it's not a direct message conversation
-      if (!this.props.activeConversationId) {
-        this.props.setActiveChannelId(channelId);
-      }
       this.props.fetchMessages({ channelId });
     }
   }
@@ -106,13 +99,11 @@ export class Container extends React.Component<Properties, State> {
     if (channelId && channelId !== prevProps.channelId) {
       this.props.stopSyncChannels(prevProps);
 
-      this.props.setActiveChannelId(channelId);
       this.props.fetchMessages({ channelId });
       this.setState({ reply: null });
     }
 
     if (channelId && prevProps.user.data === null && this.props.user.data !== null) {
-      this.props.setActiveChannelId(channelId);
       this.props.fetchMessages({ channelId });
     }
 


### PR DESCRIPTION
### What does this do?

Removes some code that's doing duplicate work.

### Why are we making this change?

We're already managing the active channel id in the top level component that reads the channel id from the url.

