### PR TITLE
Simplify the channel message polling when in public ZOS mode

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -24,8 +24,7 @@ describe('ChannelViewContainer', () => {
       uploadFileMessage: () => undefined,
       deleteMessage: () => undefined,
       editMessage: () => undefined,
-      startMessageSync: () => undefined,
-      stopSyncChannels: () => undefined,
+      setActiveChannelId: () => undefined,
       context: {
         isAuthenticated: false,
       },
@@ -138,11 +137,9 @@ describe('ChannelViewContainer', () => {
 
   it('fetches messages when channel id is set', () => {
     const fetchMessages = jest.fn();
-    const stopSyncChannels = jest.fn();
 
     const wrapper = subject({
       fetchMessages,
-      stopSyncChannels,
       channelId: '',
       channel: { name: 'first channel', shouldSyncChannels: false },
     });
@@ -154,11 +151,9 @@ describe('ChannelViewContainer', () => {
 
   it('fetches messages when channel id is updated', () => {
     const fetchMessages = jest.fn();
-    const stopSyncChannels = jest.fn();
 
     const wrapper = subject({
       fetchMessages,
-      stopSyncChannels,
       channelId: 'the-first-channel-id',
       channel: { name: 'first channel', shouldSyncChannels: false },
     });
@@ -283,45 +278,6 @@ describe('ChannelViewContainer', () => {
     wrapper.find(ChatView).first().prop('editMessage')(messageId, message, mentionedUserIds);
 
     expect(editMessage).toHaveBeenCalledOnce();
-  });
-
-  it('startMessageSync messages when channel id is set', () => {
-    const startMessageSync = jest.fn();
-    const stopSyncChannels = jest.fn();
-
-    const wrapper = subject({
-      startMessageSync,
-      stopSyncChannels,
-      channelId: '',
-      channel: { name: 'first channel', shouldSyncChannels: false },
-    });
-
-    wrapper.setProps({ channelId: 'the-channel-id', channel: { shouldSyncChannels: true } });
-
-    expect(startMessageSync).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
-  });
-
-  it('should sync channel when user is authenticated', () => {
-    const startMessageSync = jest.fn();
-
-    const wrapper = subject({
-      startMessageSync,
-      channelId: '',
-      channel: { name: 'first channel', shouldSyncChannels: false },
-      context: {
-        isAuthenticated: false,
-      },
-    });
-
-    wrapper.setProps({
-      channelId: 'the-channel-id',
-      channel: { shouldSyncChannels: true },
-      context: {
-        isAuthenticated: true,
-      },
-    });
-
-    expect(startMessageSync).not.toHaveBeenCalled();
   });
 
   it('should not call fetchMore when hasMore is false', () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -9,8 +9,6 @@ import {
   deleteMessage,
   editMessage,
   Message,
-  startMessageSync,
-  stopSyncChannels,
   EditMessageOptions,
 } from '../../store/messages';
 import { Channel, ConversationStatus, denormalize, joinChannel } from '../../store/channels';
@@ -34,8 +32,6 @@ export interface Properties extends PublicProperties {
   deleteMessage: (payload: PayloadFetchMessages) => void;
   editMessage: (payload: EditPayload) => void;
   joinChannel: (payload: PayloadJoinChannel) => void;
-  startMessageSync: (payload: PayloadFetchMessages) => void;
-  stopSyncChannels: (payload: PayloadFetchMessages) => void;
   activeConversationId?: string;
   isMessengerFullScreen: boolean;
   context: {
@@ -76,8 +72,6 @@ export class Container extends React.Component<Properties, State> {
     return {
       fetchMessages,
       sendMessage,
-      startMessageSync,
-      stopSyncChannels,
       deleteMessage,
       joinChannel,
       editMessage,
@@ -97,8 +91,6 @@ export class Container extends React.Component<Properties, State> {
     const { channelId, channel } = this.props;
 
     if (channelId && channelId !== prevProps.channelId) {
-      this.props.stopSyncChannels(prevProps);
-
       this.props.fetchMessages({ channelId });
       this.setState({ reply: null });
     }
@@ -107,24 +99,10 @@ export class Container extends React.Component<Properties, State> {
       this.props.fetchMessages({ channelId });
     }
 
-    if (
-      !this.props.context.isAuthenticated &&
-      channel &&
-      channel.shouldSyncChannels &&
-      (!prevProps.channel || !prevProps.channel?.shouldSyncChannels)
-    ) {
-      this.props.startMessageSync({ channelId });
-    }
-
     if (this.textareaRef && channel && Boolean(channel.messages)) {
       this.onMessageInputRendered(this.textareaRef);
       this.textareaRef = null;
     }
-  }
-
-  componentWillUnmount() {
-    const { channelId } = this.props;
-    this.props.stopSyncChannels({ channelId });
   }
 
   getOldestTimestamp(messages: Message[] = []): number {

--- a/src/store/channels-list/saga.createConversation.test.ts
+++ b/src/store/channels-list/saga.createConversation.test.ts
@@ -127,7 +127,6 @@ describe(createOptimisticConversation, () => {
         hasLoadedMessages: true,
         messagesFetchStatus: MessagesFetchState.SUCCESS,
         groupChannelType: GroupChannelType.Private,
-        shouldSyncChannels: false,
       })
     );
   });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -102,7 +102,6 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
     hasLoadedMessages: true,
     messagesFetchStatus: MessagesFetchState.SUCCESS,
     groupChannelType: GroupChannelType.Private,
-    shouldSyncChannels: false,
   };
 
   const currentUser = yield select(currentUserSelector());

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -42,7 +42,6 @@ export interface Channel {
   createdAt: number;
   lastMessage: Message;
   category?: string;
-  shouldSyncChannels: boolean;
   unreadCount?: number;
   hasJoined?: boolean;
   groupChannelType: GroupChannelType;

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -8,6 +8,7 @@ import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { ChannelEvents, conversationsChannel } from '../channels-list/channels';
 import { currentUserSelector } from '../authentication/saga';
 import { fetch as fetchMessages } from '../messages/saga';
+import { activeChannelIdSelector } from '../chat/selectors';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -45,7 +46,7 @@ export function* markAllMessagesAsRead(channelId, userId) {
 
 // mark all messages as read in current active channel (only if you're not in full screen mode)
 export function* markChannelAsReadIfActive(channelId) {
-  const activeChannelId = yield select((state) => state.chat.activeChannelId);
+  const activeChannelId = yield select(activeChannelIdSelector);
   if (channelId !== activeChannelId) {
     return;
   }

--- a/src/store/chat/selectors.ts
+++ b/src/store/chat/selectors.ts
@@ -1,0 +1,5 @@
+import { RootState } from '../reducer';
+
+export function activeChannelIdSelector(state: RootState) {
+  return state.chat.activeChannelId;
+}

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -89,16 +89,12 @@ export enum SagaActionTypes {
   Send = 'messages/saga/send',
   DeleteMessage = 'messages/saga/deleteMessage',
   EditMessage = 'messages/saga/editMessage',
-  startMessageSync = 'messages/saga/startMessageSync',
-  stopSyncChannels = 'messages/saga/stopSyncChannels',
 }
 
 const fetch = createAction<Payload>(SagaActionTypes.Fetch);
 const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
-const startMessageSync = createAction<Payload>(SagaActionTypes.startMessageSync);
-const stopSyncChannels = createAction<Payload>(SagaActionTypes.stopSyncChannels);
 
 const slice = createNormalizedSlice({
   name: 'messages',
@@ -106,4 +102,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { fetch, send, startMessageSync, stopSyncChannels, deleteMessage, editMessage, removeAll };
+export { fetch, send, deleteMessage, editMessage, removeAll };

--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -109,21 +109,6 @@ describe(fetch, () => {
     expect(denormalize(channel.id, storeState).hasLoadedMessages).toBe(true);
   });
 
-  it('forces shouldSyncChannels to be true', async () => {
-    const channel = { id: 'channel-id', shouldSyncChannels: false };
-    const messageResponse = { shouldSyncChannels: false };
-
-    const { storeState } = await expectSaga(fetch, { payload: { channelId: channel.id } })
-      .provide([
-        stubResponse(matchers.call.fn(chat.get), chatClient),
-        stubResponse(matchers.call.fn(chatClient.getMessagesByChannelId), messageResponse),
-      ])
-      .withReducer(rootReducer, initialChannelState(channel) as any)
-      .run();
-
-    expect(denormalize(channel.id, storeState).shouldSyncChannels).toBe(true);
-  });
-
   it('adds messages to channel', async () => {
     const channel = { id: 'channel-id', messages: ['old-message-id'] };
     const messageResponse = {

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -3,7 +3,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { editMessageApi } from './api';
 import {
-  stopSyncChannels,
   receiveDelete,
   editMessage,
   getPreview,
@@ -181,32 +180,6 @@ describe('messages saga', () => {
       messages[0].id,
       messages[2].id,
     ]);
-  });
-
-  it('stop syncChannels when calling stopSyncChannels', async () => {
-    const channelId = 'channel-id';
-
-    const initialState = {
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            hasMore: true,
-            shouldSyncChannels: true,
-          },
-        },
-      },
-    };
-
-    const {
-      storeState: {
-        normalized: { channels },
-      },
-    } = await expectSaga(stopSyncChannels, { payload: { channelId } })
-      .withReducer(rootReducer, initialState as any)
-      .run();
-
-    expect(channels[channelId].shouldSyncChannels).toBe(false);
   });
 
   describe('getPreview', () => {


### PR DESCRIPTION
### What does this do?

Simplifies the logic for polling for new messages in public ZOS mode by just always running a poll. If there's no user and we have an active channel then they must be viewing it in public mode.

### Why are we making this change?

Simplifies the code as we don't have to react to all the various state changes

### How do I test this?

When in public ZOS mode verify that new messages that are sent from someone else show up within the poll interval

