### PR TITLE
feat: add reset-password route

### DIFF
--- a/src/authentication/footer/footer.tsx
+++ b/src/authentication/footer/footer.tsx
@@ -5,11 +5,12 @@ import { RegistrationStage } from '../../store/registration';
 
 import { bem } from '../../lib/bem';
 import './styles.scss';
+import { RequestPasswordResetStage } from '../../store/request-password-reset';
 
 const c = bem('authentication-footer');
 
 export interface Properties {
-  stage: RegistrationStage;
+  stage: RegistrationStage | RequestPasswordResetStage;
 }
 
 export class Footer extends React.Component<Properties> {
@@ -18,10 +19,13 @@ export class Footer extends React.Component<Properties> {
       return null;
     }
 
+    const loginPromptText =
+      this.props.stage === RequestPasswordResetStage.SubmitEmail ? 'Back to ' : 'Already on ZERO? ';
+
     return (
       <div className={c('')}>
         <div>
-          <span>Already on ZERO? </span>
+          <span>{loginPromptText}</span>
           <Link to='/login'>Log in</Link>
         </div>
 

--- a/src/authentication/request-password-reset/index.tsx
+++ b/src/authentication/request-password-reset/index.tsx
@@ -98,20 +98,21 @@ export class RequestPasswordReset extends React.Component<Properties, State> {
 
   render() {
     const { stage } = this.props;
+    const isResetPasswordDone = stage === RequestPasswordResetStage.Done;
 
     return (
       <>
         <div {...cn('')}>
           <div {...cn('heading-container')}>
             <h3 {...cn('heading')}>Reset Password</h3>
-            {stage === RequestPasswordResetStage.Done && this.renderSuccessMessage()}
+            {isResetPasswordDone && this.renderSuccessMessage()}
 
-            {stage !== RequestPasswordResetStage.Done && (
+            {!isResetPasswordDone && (
               <div {...cn('sub-heading')}>Enter your ZERO account email and we’ll send a reset link</div>
             )}
           </div>
 
-          {stage !== RequestPasswordResetStage.Done && this.renderForm()}
+          {!isResetPasswordDone && this.renderForm()}
         </div>
         <Footer stage={this.props.stage} />
       </>

--- a/src/authentication/request-password-reset/index.tsx
+++ b/src/authentication/request-password-reset/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Footer } from '../footer/footer';
 import { Button, Input, Alert } from '@zero-tech/zui/components';
 
 import { bem, bemClassName } from '../../lib/bem';
@@ -99,18 +100,21 @@ export class RequestPasswordReset extends React.Component<Properties, State> {
     const { stage } = this.props;
 
     return (
-      <div {...cn('')}>
-        <div {...cn('heading-container')}>
-          <h3 {...cn('heading')}>Reset Password</h3>
-          {stage === RequestPasswordResetStage.Done && this.renderSuccessMessage()}
+      <>
+        <div {...cn('')}>
+          <div {...cn('heading-container')}>
+            <h3 {...cn('heading')}>Reset Password</h3>
+            {stage === RequestPasswordResetStage.Done && this.renderSuccessMessage()}
 
-          {stage !== RequestPasswordResetStage.Done && (
-            <div {...cn('sub-heading')}>Enter your ZERO account email and we’ll send a reset link</div>
-          )}
+            {stage !== RequestPasswordResetStage.Done && (
+              <div {...cn('sub-heading')}>Enter your ZERO account email and we’ll send a reset link</div>
+            )}
+          </div>
+
+          {stage !== RequestPasswordResetStage.Done && this.renderForm()}
         </div>
-
-        {stage !== RequestPasswordResetStage.Done && this.renderForm()}
-      </div>
+        <Footer stage={this.props.stage} />
+      </>
     );
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import { AppSandboxContainer } from './app-sandbox/container';
 import '../node_modules/@zer0-os/zos-component-library/dist/index.css';
 import './index.scss';
 import { Invite } from './invite';
+import { ResetPassword } from './reset-password';
 import { LoginPage } from './pages';
 import { Web3Connect } from './components/web3-connect';
 import { getHistory } from './lib/browser';
@@ -33,6 +34,7 @@ const redirectToDefaults = ({ match: { params } }) => {
   const route = params.znsRoute || `0.${config.defaultZnsRoute}`;
   if (route === 'get-access') return <Redirect to={'/get-access'} />;
   if (route === 'login') return <Redirect to={'/login'} />;
+  if (route === 'reset-password') return <Redirect to={'/reset-password'} />;
 
   return <Redirect to={`/${route}/${config.defaultApp}`} />;
 };
@@ -47,6 +49,7 @@ ReactDOM.render(
               <Web3Connect>
                 <Route path='/get-access' exact component={Invite} />
                 <Route path='/login' exact component={LoginPage} />
+                <Route path='/reset-password' exact component={ResetPassword} />
                 <Route path='/:znsRoute?/' exact render={redirectToDefaults} />
                 <Route path='/:znsRoute/:app' component={ZnsRouteConnect} />
               </Web3Connect>

--- a/src/pages/login/login-component.tsx
+++ b/src/pages/login/login-component.tsx
@@ -67,7 +67,7 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
         <FeatureFlag featureFlag={'resetPasswordPage'}>
           {stage === LoginStage.EmailLogin && (
             <span>
-              Forgot your password? <Link to='/get-access'>Reset</Link>
+              Forgot your password? <Link to='/reset-password'>Reset</Link>
             </span>
           )}
         </FeatureFlag>

--- a/src/reset-password.scss
+++ b/src/reset-password.scss
@@ -1,0 +1,40 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.reset-password-main {
+  display: flex;
+  flex-direction: column;
+  padding: 24px 0;
+  box-sizing: border-box;
+
+  justify-content: space-between;
+  align-content: flex-start;
+  align-items: center;
+
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)),
+    radial-gradient(66.52% 66.52% at 0% 0%, #26072d 0%, rgba(38, 7, 45, 0) 100%)
+      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
+    radial-gradient(93.63% 93.63% at 100% 0%, #9d0097 0%, rgba(157, 0, 151, 0) 100%)
+      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
+    radial-gradient(91.27% 91.27% at 112.3% 83.55%, #52a9ff 0%, rgba(82, 169, 255, 0) 100%)
+      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
+    radial-gradient(65.88% 65.88% at -1.79% 99.21%, #4f0895 0%, rgba(79, 8, 149, 0) 100%)
+      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
+    #290634;
+
+  position: absolute;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  z-index: 10;
+
+  > * {
+    flex-shrink: 0;
+  }
+
+  &__logo-container {
+    padding-left: 8px;
+  }
+}

--- a/src/reset-password.scss
+++ b/src/reset-password.scss
@@ -11,15 +11,10 @@
   align-items: center;
 
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)),
-    radial-gradient(66.52% 66.52% at 0% 0%, #26072d 0%, rgba(38, 7, 45, 0) 100%)
-      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
-    radial-gradient(93.63% 93.63% at 100% 0%, #9d0097 0%, rgba(157, 0, 151, 0) 100%)
-      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
-    radial-gradient(91.27% 91.27% at 112.3% 83.55%, #52a9ff 0%, rgba(82, 169, 255, 0) 100%)
-      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
-    radial-gradient(65.88% 65.88% at -1.79% 99.21%, #4f0895 0%, rgba(79, 8, 149, 0) 100%)
-      /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */,
-    #290634;
+    radial-gradient(66.52% 66.52% at 0% 0%, #26072d 0%, rgba(38, 7, 45, 0) 100%),
+    radial-gradient(93.63% 93.63% at 100% 0%, #9d0097 0%, rgba(157, 0, 151, 0) 100%),
+    radial-gradient(91.27% 91.27% at 112.3% 83.55%, #52a9ff 0%, rgba(82, 169, 255, 0) 100%),
+    radial-gradient(65.88% 65.88% at -1.79% 99.21%, #4f0895 0%, rgba(79, 8, 149, 0) 100%), #290634;
 
   position: absolute;
   overflow-y: auto;

--- a/src/reset-password.tsx
+++ b/src/reset-password.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { RootState } from './store/reducer';
+import { connectContainer } from './store/redux-container';
+import { RequestPasswordResetContainer } from './authentication/request-password-reset/container';
+
+import { ReactComponent as ZeroLogo } from './zero-logo.svg';
+import { ThemeEngine, Themes } from '@zero-tech/zui/components/ThemeEngine';
+
+import { bemClassName } from './lib/bem';
+import './reset-password.scss';
+
+const cn = bemClassName('reset-password-main');
+
+export interface Properties {
+  shouldRender: boolean;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    const { pageload } = state;
+    return {
+      shouldRender: pageload.isComplete,
+    };
+  }
+
+  static mapActions() {
+    return {};
+  }
+
+  render() {
+    if (!this.props.shouldRender) {
+      return null;
+    }
+
+    return (
+      <>
+        <ThemeEngine theme={Themes.Dark} />
+        <div {...cn('')}>
+          <div {...cn('logo-container')}>
+            <ZeroLogo />
+          </div>
+
+          <RequestPasswordResetContainer />
+          {/* TODO: Add ResetPasswordConfirmation - this will redirect user to login*/}
+        </div>
+      </>
+    );
+  }
+}
+
+export const ResetPassword = connectContainer<{}>(Container);

--- a/src/store/login/index.ts
+++ b/src/store/login/index.ts
@@ -16,7 +16,6 @@ export type LoginState = {
 export enum LoginStage {
   EmailLogin = 'email',
   Web3Login = 'web3',
-  RequestPasswordReset = 'request-password-reset',
   Done = 'done',
 }
 

--- a/src/store/page-load/saga.test.ts
+++ b/src/store/page-load/saga.test.ts
@@ -106,6 +106,33 @@ describe('page-load saga', () => {
     expect(storeState.pageload.isComplete).toBe(true);
     expect(history.replace).not.toHaveBeenCalledWith({ pathname: '/login' });
   });
+
+  it('redirects authenticated user from /reset-password to main page', async () => {
+    const initialState = { pageload: { isComplete: false } };
+
+    let history = new StubHistory('/reset-password');
+    const { storeState: resetPasswordStoreState } = await expectSaga(saga)
+      .withReducer(rootReducer, initialState as any)
+      .provide(stubResponses(history, true))
+      .run();
+
+    // redirected from /reset-password to /0.wilder.channels
+    expect(history.replace).toHaveBeenCalledWith({ pathname: '/0.wilder/channels' });
+    expect(resetPasswordStoreState.pageload.isComplete).toBe(true);
+  });
+
+  it('allows unauthenticated user to stay on /reset-password page', async () => {
+    const initialState = { pageload: { isComplete: false } };
+
+    let history = new StubHistory('/reset-password');
+    const { storeState: resetPasswordStoreState } = await expectSaga(saga)
+      .withReducer(rootReducer, initialState as any)
+      .provide(stubResponses(history, false))
+      .run();
+
+    expect(resetPasswordStoreState.pageload.isComplete).toBe(true);
+    expect(history.replace).not.toHaveBeenCalled();
+  });
 });
 
 const stubResponses = (history, success) => {

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -9,6 +9,7 @@ import { config } from '../../config';
 const anonymousPaths = [
   '/get-access',
   '/login',
+  '/reset-password',
 ];
 
 export function* saga() {

--- a/src/store/request-password-reset/saga.test.ts
+++ b/src/store/request-password-reset/saga.test.ts
@@ -3,7 +3,7 @@ import { call } from 'redux-saga/effects';
 import { rootReducer } from '../reducer';
 import { throwError } from 'redux-saga-test-plan/providers';
 
-import { requestPasswordReset, validateRequestPasswordResetEmail } from './saga';
+import { requestPasswordReset, validateRequestPasswordResetEmail, watchRequestPasswordReset } from './saga';
 import { requestPasswordReset as requestPasswordResetApi } from './api';
 import {
   RequestPasswordResetErrors,
@@ -89,6 +89,20 @@ describe('requestPasswordReset saga', () => {
 
     expect(requestPasswordState.errors).toContain(RequestPasswordResetErrors.API_ERROR);
     expect(requestPasswordState.loading).toBeFalsy();
+  });
+
+  describe('watchRequestPasswordReset saga', () => {
+    it('should reset the stage upon entering the reset page', async () => {
+      const {
+        storeState: { requestPasswordReset: requestPasswordState },
+      } = await expectSaga(watchRequestPasswordReset)
+        .withReducer(rootReducer, initialState({ stage: RequestPasswordResetStage.Done }))
+        .put({ type: 'request-password-reset/setStage', payload: RequestPasswordResetStage.SubmitEmail })
+        .dispatch({ type: 'enterRequestPasswordResetPage' })
+        .run();
+
+      expect(requestPasswordState.stage).toEqual(RequestPasswordResetStage.SubmitEmail);
+    });
   });
 });
 

--- a/src/store/request-password-reset/saga.ts
+++ b/src/store/request-password-reset/saga.ts
@@ -43,6 +43,10 @@ export function* requestPasswordReset() {
 export function* watchRequestPasswordReset() {
   while (true) {
     yield take(SagaActionTypes.EnterRequestPasswordResetPage);
+
+    // set the stage back to the initial stage
+    yield put(setStage(RequestPasswordResetStage.SubmitEmail));
+
     const task = yield fork(requestPasswordReset);
     yield take(SagaActionTypes.LeaveRequestPasswordResetPage);
     yield cancel(task);


### PR DESCRIPTION
### What does this do?
- adds `/reset-password` route/page.
- updates authentication footer to be used in request password reset ui
- redirects authenticated user away from `/reset-password`.
- updates tests
- resets request password reset when enter request password reset page

### Why are we making this change?
- to handle reset-password flow on its own route/page.

### How do I test this?
- run the app. go to login page. select email. select `reset` in footer. you will be directed to the `/reset-password` page.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


`/reset-password`

https://github.com/zer0-os/zOS/assets/39112648/35e53ec2-b7f2-47cb-ad2c-199bb5b83e86

