### PR TITLE
chore: bump zui version (`0.26.2`) -> (`0.26.3`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^0.26.2",
+        "@zero-tech/zui": "^0.26.3",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8385,9 +8385,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.2.tgz",
-      "integrity": "sha512-8NJQV7FYCRJhMe8paprB9ujr1xOBlf5gvAZJuwlCN+MxqTQRnkjjc8sR2rlTGWfP/1jha7yFnyGAeW8uX8TRBA==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.3.tgz",
+      "integrity": "sha512-kBrDvKQVLof1TTDurlzdZoWRKeYYH4JGUBmH3pmULQgbgNwndaz4xPoIF1JFxKFGgHlcAnT3X/IGvu15Iv8+Eg==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -37774,9 +37774,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.2.tgz",
-      "integrity": "sha512-8NJQV7FYCRJhMe8paprB9ujr1xOBlf5gvAZJuwlCN+MxqTQRnkjjc8sR2rlTGWfP/1jha7yFnyGAeW8uX8TRBA==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.3.tgz",
+      "integrity": "sha512-kBrDvKQVLof1TTDurlzdZoWRKeYYH4JGUBmH3pmULQgbgNwndaz4xPoIF1JFxKFGgHlcAnT3X/IGvu15Iv8+Eg==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^0.26.2",
+    "@zero-tech/zui": "^0.26.3",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
### What does this do?
- bumps zui version number

### Why are we making this change?
-  to pull in latest version of zui that contain toast notification updates

### How do I test this?
- import ToastNotification and ensure the new attribute `viewportClassName` is available to use.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="1131" alt="Screenshot 2023-08-21 at 16 31 22" src="https://github.com/zer0-os/zOS/assets/39112648/4b59a13f-9773-4ad1-9cd7-dec38e85d52e">
