### PR TITLE
chore: bump zui version (`0.26.3`) -> (`0.26.4`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^0.26.3",
+        "@zero-tech/zui": "^0.26.4",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8385,9 +8385,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.3.tgz",
-      "integrity": "sha512-kBrDvKQVLof1TTDurlzdZoWRKeYYH4JGUBmH3pmULQgbgNwndaz4xPoIF1JFxKFGgHlcAnT3X/IGvu15Iv8+Eg==",
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.4.tgz",
+      "integrity": "sha512-cjxeQ/Mmh4ZlJ6Ic8wT/hxhyd9Wx55R0PE6d1KNjxUPv+wmxPJJ5uBfAeDVcI1l5ruUkgS8yE6kKJ3isdrrKEA==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -37774,9 +37774,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.3.tgz",
-      "integrity": "sha512-kBrDvKQVLof1TTDurlzdZoWRKeYYH4JGUBmH3pmULQgbgNwndaz4xPoIF1JFxKFGgHlcAnT3X/IGvu15Iv8+Eg==",
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.26.4.tgz",
+      "integrity": "sha512-cjxeQ/Mmh4ZlJ6Ic8wT/hxhyd9Wx55R0PE6d1KNjxUPv+wmxPJJ5uBfAeDVcI1l5ruUkgS8yE6kKJ3isdrrKEA==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^0.26.3",
+    "@zero-tech/zui": "^0.26.4",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
### What does this do?
- bumping zUI version 

### Why are we making this change?
- pulls in latest version of zUI which contains some ToastNotification updates.

### How do I test this?
- search toast notification > check that attribute `duration` is available.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="619" alt="Screenshot 2023-08-22 at 09 16 21" src="https://github.com/zer0-os/zOS/assets/39112648/6e89dbc1-c4ba-4950-951b-a5a1780be51e">

