### PR TITLE
feat: improve onboarding sequence and timings

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -187,13 +187,15 @@ export class Container extends React.Component<Properties, State> {
   renderToastNotification = (): JSX.Element => {
     return (
       <ToastNotification
+        viewportClassName='invite-toast-notification'
         title={'Invite your friends'}
         description={'Build your network and message friends to earn more rewards.'}
         actionTitle={'Invite Friends'}
         actionAltText={'invite dialog modal call to action'}
         positionVariant='left'
-        openToast={this.props.isInviteNotificationOpen}
+        openToast
         onClick={this.openInviteDialog}
+        duration={20000}
       />
     );
   };

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -195,7 +195,7 @@ export class Container extends React.Component<Properties, State> {
         positionVariant='left'
         openToast={this.props.isInviteNotificationOpen}
         onClick={this.openInviteDialog}
-        duration={20000}
+        duration={10000}
       />
     );
   };

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -233,6 +233,7 @@ export class Container extends React.Component<Properties, State> {
             onRewardsPopupClose={this.props.rewardsPopupClosed}
             onLogout={this.props.logout}
             showNewRewards={this.props.showNewRewards}
+            hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
           />
         )}
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -188,7 +188,7 @@ export class Container extends React.Component<Properties, State> {
     return (
       <ToastNotification
         title={'Invite your friends'}
-        description={'To get more rewards simply build your friend network and start messaging'}
+        description={'Build your network and message friends to earn more rewards.'}
         actionTitle={'Invite Friends'}
         actionAltText={'invite dialog modal call to action'}
         positionVariant='left'

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -193,7 +193,7 @@ export class Container extends React.Component<Properties, State> {
         actionTitle={'Invite Friends'}
         actionAltText={'invite dialog modal call to action'}
         positionVariant='left'
-        openToast
+        openToast={this.props.isInviteNotificationOpen}
         onClick={this.openInviteDialog}
         duration={20000}
       />

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -55,3 +55,7 @@ $side-padding: 16px;
 .highlighted-text {
   color: theme.$color-primary-11;
 }
+
+.invite-toast-notification {
+  padding: 64px;
+}

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -42,7 +42,7 @@ describe('rewards-bar', () => {
     expect(wrapper).toHaveElement(RewardsPopupContainer);
   });
 
-  it('rewards popup is not rendered on first time login if conversation is not loaded', async function () {
+  it('rewards popup is not render on first time login if conversation is not loaded', async function () {
     const wrapper = subject({ isFirstTimeLogin: true, hasLoadedConversation: false });
     expect(wrapper).not.toHaveElement(RewardsPopupContainer);
   });

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -16,6 +16,7 @@ describe('rewards-bar', () => {
       zeroPreviousDay: '',
       isRewardsLoading: false,
       showNewRewards: false,
+      hasLoadedConversation: false,
       onRewardsPopupClose: () => {},
       onLogout: () => {},
       ...props,
@@ -36,10 +37,14 @@ describe('rewards-bar', () => {
     expect(wrapper).not.toHaveElement(RewardsPopupContainer);
   });
 
-  it('rewards popup is rendered immediately if first time login', async function () {
-    const wrapper = subject({ isFirstTimeLogin: true });
-
+  it('rewards popup is rendered immediately if first time login and conversation is loaded', async function () {
+    const wrapper = subject({ isFirstTimeLogin: true, hasLoadedConversation: true });
     expect(wrapper).toHaveElement(RewardsPopupContainer);
+  });
+
+  it('rewards popup is not rendered on first time login if conversation is not loaded', async function () {
+    const wrapper = subject({ isFirstTimeLogin: true, hasLoadedConversation: false });
+    expect(wrapper).not.toHaveElement(RewardsPopupContainer);
   });
 
   it('rewards tooltip popup is not rendered if messenger not fullscreen', async function () {

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -85,13 +85,15 @@ export class RewardsBar extends React.Component<Properties, State> {
           <button
             onClick={this.openRewards}
             className={classnames(c('rewards-button'), {
-              [c('rewards-button', 'open')]: this.state.isRewardsPopupOpen,
+              [c('rewards-button', 'open')]:
+                this.state.isRewardsPopupOpen && (this.props.hasLoadedConversation || !this.props.isFirstTimeLogin),
             })}
           >
             <div>Rewards</div>
             <div
               className={classnames(c('rewards-icon'), {
-                [c('rewards-icon', 'open')]: this.state.isRewardsPopupOpen,
+                [c('rewards-icon', 'open')]:
+                  this.state.isRewardsPopupOpen && (this.props.hasLoadedConversation || !this.props.isFirstTimeLogin),
               })}
             >
               <IconCurrencyDollar size={16} />

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -17,6 +17,7 @@ export interface Properties {
   isFirstTimeLogin: boolean;
   includeRewardsAvatar: boolean;
   isMessengerFullScreen: boolean;
+  hasLoadedConversation: boolean;
 
   userName: string;
   userHandle: string;
@@ -121,13 +122,14 @@ export class RewardsBar extends React.Component<Properties, State> {
           this.renderRewardsBar()
         )}
 
-        {this.state.isRewardsPopupOpen && (
+        {this.state.isRewardsPopupOpen && (this.props.hasLoadedConversation || !this.props.isFirstTimeLogin) && (
           <RewardsPopupContainer
             onClose={this.closeRewards}
-            openRewardsFAQModal={this.openRewardsFAQModal} // modal is opened in the popup, after which the popup is closed
+            openRewardsFAQModal={this.openRewardsFAQModal}
             isLoading={this.props.isRewardsLoading}
           />
         )}
+
         {this.state.isRewardsFAQModalOpen && (
           <RewardsFAQModal
             isRewardsFAQModalOpen={this.state.isRewardsFAQModalOpen}

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -25,7 +25,7 @@ $content-padding-y: 40px;
       $width: if($is-top, $arrow-size, math.div($arrow-size, 2));
       height: $height;
       width: $width;
-      top: if($is-top, -$content-padding-y - $height, -$content-padding-y + 24px);
+      top: if($is-top, -$content-padding-y - $height, -$content-padding-y + 16px);
       left: if($is-top, calc(100% - $width / 2), -$content-padding-x - $width);
       clip-path: if($is-top, polygon(0 100%, 50% 0, 100% 100%), polygon(100% 0, 0 50%, 100% 100%));
     }
@@ -63,7 +63,7 @@ $content-padding-y: 40px;
 
   &--full-screen {
     .rewards-popup__content {
-      top: 0;
+      top: 8px;
       left: $width-sidekick - 4px;
     }
 
@@ -72,7 +72,7 @@ $content-padding-y: 40px;
 
   &--full-screen.rewards-popup--with-title {
     .rewards-popup__content {
-      top: 0;
+      top: 8px;
     }
   }
 


### PR DESCRIPTION
### What does this do?
- repositions rewards pop up and arrow.
- adds condition to show rewards pop up when conversations have loaded (on first time login).
- updates toast secondary message text.
- adds 20s duration to invite toast notification.
- updates conditions for rewards button styles.
- repositions invite toast notification.

### Why are we making this change?
- as per onboarding flow designs.

### How do I test this?
- create a new account and run through the onboarding flow. compare with designs - [figma](https://www.figma.com/file/aETpyuG2AKjNcQtCjldcX0/ZERO-Messenger-%2F-Web?node-id=9680%3A494047&mode=dev)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/125a54f2-cebf-4279-ad72-24152b520830


