### PR TITLE
fix: align giphy container

### DIFF
--- a/src/components/message-input/giphy/styles.scss
+++ b/src/components/message-input/giphy/styles.scss
@@ -3,8 +3,8 @@
 .giphy__container {
   width: 500px;
   position: absolute;
-  bottom: 65px;
-  right: 74px;
+  bottom: 64px;
+  left: 169px;
   background-color: themeDeprecated.$background-color-tertiary;
   padding: 5px;
   border-radius: 5px;
@@ -12,7 +12,8 @@
   z-index: 12;
 
   &--fullscreen {
-    right: 65px;
+    bottom: 63px;
+    left: 374px;
   }
 
   &-grid {

--- a/src/components/message-input/giphy/styles.scss
+++ b/src/components/message-input/giphy/styles.scss
@@ -12,7 +12,6 @@
   z-index: 12;
 
   &--fullscreen {
-    bottom: 63px;
     left: 374px;
   }
 


### PR DESCRIPTION
### What does this do?
- fixes the position of the giphy container.

### Why are we making this change?
- as per figma designs.

### How do I test this?
- open messenger and click giphy icon.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE
<img width="1658" alt="Screenshot 2023-08-22 at 11 43 28" src="https://github.com/zer0-os/zOS/assets/39112648/37f21a64-7561-477a-8885-3e207b696050">


AFTER
<img width="1596" alt="Screenshot 2023-08-22 at 11 42 53" src="https://github.com/zer0-os/zOS/assets/39112648/5684560a-ff82-4c80-988e-82d0dd8e68a6">
