### PR TITLE
Remove unused property from edit message data

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -200,10 +200,7 @@ export class Message extends React.Component<Properties, State> {
         value={value}
         primaryTooltipText='Save Changes'
         secondaryTooltipText='Discard Changes'
-        onEdit={this.editMessage.bind(this, value, mentionedUserIds, {
-          hidePreview: this.props.hidePreview,
-          mentionedUsers: this.props.mentionedUserIds,
-        })}
+        onEdit={this.editMessage.bind(this, value, mentionedUserIds, { hidePreview: this.props.hidePreview })}
         onCancel={this.toggleEdit}
       />
     );

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -81,7 +81,6 @@ export interface Message {
 
 export interface EditMessageOptions {
   hidePreview: Boolean;
-  mentionedUsers: string[];
 }
 
 export enum SagaActionTypes {


### PR DESCRIPTION
### What does this do?

Removes a property (`mentionedUserIds`) from the Edit Message payload that we're not using and was always send as undefined. It is passed as an independent parameter already.

