### PR TITLE
feat: implement scroll to bottom on message send

### DIFF
--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -138,6 +138,22 @@ describe('ChatView', () => {
     expect(wrapper.find(InvertedScroll).hasClass('channel-view__inverted-scroll')).toBe(true);
   });
 
+  it('scrollToBottom is called when a message is sent', async function () {
+    const sendMessageMock = jest.fn().mockResolvedValue({});
+    const wrapper: any = subject({ sendMessage: sendMessageMock });
+
+    wrapper.instance().scrollContainerRef = {
+      current: {
+        scrollToBottom: jest.fn(),
+      },
+    } as any;
+
+    await wrapper.instance().handleSendMessage('Hello', [], []);
+
+    const scrollContainerRef = wrapper.instance().scrollContainerRef;
+    expect(scrollContainerRef.current.scrollToBottom).toHaveBeenCalled();
+  });
+
   it('render MessageInput', () => {
     const wrapper = subject({ messages: MESSAGES_TEST, hasJoined: true });
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -72,7 +72,24 @@ export interface State {
 }
 
 export class ChatView extends React.Component<Properties, State> {
+  scrollContainerRef: React.RefObject<InvertedScroll>;
   state = { lightboxMedia: [], lightboxStartIndex: 0, isLightboxOpen: false };
+
+  constructor(props) {
+    super(props);
+    this.scrollContainerRef = React.createRef();
+  }
+
+  scrollToBottom = () => {
+    if (this.scrollContainerRef.current) {
+      this.scrollContainerRef.current.scrollToBottom();
+    }
+  };
+
+  handleSendMessage = (message: string, mentionedUserIds: string[], media: Media[]) => {
+    this.props.sendMessage(message, mentionedUserIds, media);
+    this.scrollToBottom();
+  };
 
   getMessagesByDay() {
     return this.props.messages.reduce((prev, current) => {
@@ -236,7 +253,7 @@ export class ChatView extends React.Component<Properties, State> {
             onClose={this.closeLightBox}
           />
         )}
-        <InvertedScroll className='channel-view__inverted-scroll'>
+        <InvertedScroll className='channel-view__inverted-scroll' ref={this.scrollContainerRef}>
           <div className='channel-view__main'>
             {!this.props.isDirectMessage && (
               <div className='channel-view__name'>
@@ -273,7 +290,7 @@ export class ChatView extends React.Component<Properties, State> {
               <MessageInput
                 onMessageInputRendered={this.props.onMessageInputRendered}
                 id={this.props.id}
-                onSubmit={this.props.sendMessage}
+                onSubmit={this.handleSendMessage}
                 getUsersForMentions={this.searchMentionableUsers}
                 reply={this.props.reply}
                 onRemoveReply={this.props.onRemove}


### PR DESCRIPTION
### What does this do?
- when a message is sent the chat view container will scroll to the bottom to the most recently sent message.

### Why are we making this change?
- so when replying to a message, the chat view container will scroll to the bottom to the most recently sent message.

### How do I test this?
- open a chat, scroll to a higher message, reply to that message and press send.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  

 

https://github.com/zer0-os/zOS/assets/39112648/fe44d015-ca14-4089-8b39-4dafe9bc1b07

