### PR TITLE
Implement height and spacing fixes for search result list during new conversation creation flow

### DIFF
--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -32,8 +32,8 @@
       text-align: left;
       padding: 8px;
       gap: 16px;
-
-      height: 56px;
+      height: 40px;
+      margin: 4px 0px;
 
       border-radius: 8px;
       overflow: hidden;


### PR DESCRIPTION
### What does this do?

Implements the css fixes when displaying new users in search results.

Before:
<img width="310" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/ab8a2c38-edff-41bd-8b03-c2dd2c236a69">

After:
<img width="280" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/a5e53bc4-c425-4aec-969a-de557f028f31">
