### PR TITLE
fix: decrease z-index of reply card

### DIFF
--- a/src/components/reply-card/styles.scss
+++ b/src/components/reply-card/styles.scss
@@ -7,7 +7,7 @@
 
 .reply-card {
   position: relative;
-  z-index: 10;
+  z-index: 9;
   margin-bottom: 8px;
   &__container {
     display: flex;


### PR DESCRIPTION
### What does this do?
- fixes a minor z-index issue for the reply card.

### Why are we making this change?
- some overlap I noticed -

<img width="705" alt="Screenshot 2023-08-24 at 18 43 43" src="https://github.com/zer0-os/zOS/assets/39112648/6bbd1934-1e06-45b9-a6b9-734687ba9631">

### How do I test this?
- open zOS and in a channel, select to reply to a message. When the reply card is visible, open a direct one to one conversation from the conversation list. The reply card should not be layered over the direct-message container.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/15eae57f-b8da-4aef-b429-d538c5e4a42a

