### PR TITLE
fix: remove outdated fix scroll implementation

### DIFF
--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import debounce from 'lodash.debounce';
 import './styles.scss';
-
-const SCROLL_HEIGHT_FIXER_DELAY_MS = 5;
-const SCROLL_HEIGHT_FIXER_ITERATIONS = 1000;
 
 export interface Properties {
   className?: string;
@@ -54,8 +50,6 @@ export class InvertedScroll extends React.Component<Properties, undefined> {
 
   scrollToBottom() {
     this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
-
-    this.scrollFixer();
   }
 
   setScrollWrapper = (element: HTMLElement) => {
@@ -66,24 +60,6 @@ export class InvertedScroll extends React.Component<Properties, undefined> {
     this.scrollWrapper = element;
 
     this.scrollToBottom();
-  };
-
-  fixScroll = debounce((oldScrollHeight: number, iterations: number = 0) => {
-    if (this.scrollWrapper.scrollHeight !== oldScrollHeight) {
-      this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
-      // Schedule another fix scroll again incase more load in with current scroll height
-      this.fixScroll(this.scrollWrapper.scrollHeight);
-    } else if (iterations < SCROLL_HEIGHT_FIXER_ITERATIONS) {
-      // Schedule another until iterations run out
-      // Will be cancelled if scrolling upwards.
-      this.fixScroll(oldScrollHeight, iterations + 1);
-    }
-  }, SCROLL_HEIGHT_FIXER_DELAY_MS);
-
-  scrollFixer = () => {
-    const oldScrollHeight = this.scrollWrapper.scrollHeight;
-
-    this.fixScroll(oldScrollHeight);
   };
 
   render() {


### PR DESCRIPTION
### What does this do?
Proposing the following changes:
- Removes the outdated fixScroll function from the InvertedScroll component.
- Simplifies the scrolling logic, leading to more predictable behaviour.

### Why are we making this change?
- To resolve the unexpected "scroll to bottom" behavior seen when editing messages or loading older messages.
- To improve the performance of the InvertedScroll component by eliminating redundant and excessive function calls.
- To make the component more maintainable by reducing complexity.

### How do I test this?
- Open messenger and when a conversation has loaded, immediately attempt to edit a message, or scroll up to load older messages. The scroll to bottom should no longer occur.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Whats happening - 

https://github.com/zer0-os/zOS/assets/39112648/c3c6fd10-9691-4ce5-8f4f-d11af388e2e3

I identified that the root cause was tied to the fixScroll function in our InvertedScroll component (code that was added 9 months ago). This function was continuously being called up to a 1000 times (for roughly 5-10 seconds) after a particular event, such as a new element containing InvertedScroll was initialised.

Appears to be unnecessary and also created unpredictable and undesirable scrolling behaviours. If any interactions were made on the page during the time fixScroll was excessively executing, unexpected "scroll to bottom" events would be triggered.

It seems the desired functionality is already well-handled by the `adjustScrollPositionForContentChanges` function, so, I've made the decision to remove the outdated fixScroll related code.

https://github.com/zer0-os/zOS/assets/39112648/3353e492-cfa2-4636-9246-4af906411689

