### PR TITLE
Fix autoscroll behavior occurring in conversation window with edit message function

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -177,6 +177,7 @@ export class ChatView extends React.Component<Properties, State> {
               showSenderAvatar={this.props.showSenderAvatar}
               showTimestamp={messageRenderProps.showTimestamp}
               showAuthorName={messageRenderProps.showAuthorName}
+              scrollContainerRef={this.scrollContainerRef}
               {...message}
             />
           </div>

--- a/src/components/message/edit-message-actions/edit-message-actions.test.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.test.tsx
@@ -12,6 +12,7 @@ describe('EditMessageActions', () => {
       secondaryTooltipText: '',
       onEdit: jest.fn(),
       onCancel: jest.fn(),
+      scrollContainerRef: React.createRef(),
       ...props,
     };
 

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -6,6 +6,7 @@ import { IconCheck, IconXClose } from '@zero-tech/zui/icons';
 import { IconButton, Tooltip } from '@zero-tech/zui/components';
 
 import './styles.scss';
+import InvertedScroll from '../../inverted-scroll';
 
 const cn = bemClassName('edit-message-actions');
 
@@ -16,12 +17,39 @@ export interface Properties {
   secondaryTooltipText: string;
   onEdit: () => void;
   onCancel?: () => void;
+  scrollContainerRef: React.RefObject<InvertedScroll>;
 }
 
 export default class EditMessageActions extends React.Component<Properties> {
   state = {
     tooltipOpen: false,
   };
+
+  editMessageActionRef: React.RefObject<HTMLDivElement>;
+
+  constructor(props: Properties) {
+    super(props);
+    this.editMessageActionRef = React.createRef();
+  }
+
+  // scrolls up if 'x' or 'check' button is hidden in bottom of the screen (while editing a message)
+  fixScroll = () => {
+    const scrollRef = this.props.scrollContainerRef?.current;
+    const editMessageActionRef = this.editMessageActionRef?.current;
+    if (scrollRef && editMessageActionRef) {
+      const clientHeight = scrollRef.scrollWrapper.clientHeight + 64;
+      const bottom = editMessageActionRef.getBoundingClientRect().bottom;
+
+      const diff = clientHeight - bottom;
+      if (diff < 0) {
+        scrollRef.scrollWrapper.scrollTop += Math.abs(diff) + 16;
+      }
+    }
+  };
+
+  componentDidMount(): void {
+    this.fixScroll();
+  }
 
   handleTooltipChange = (open: boolean) => {
     this.setState({ tooltipOpen: !this.isDisabled() && open });
@@ -35,7 +63,7 @@ export default class EditMessageActions extends React.Component<Properties> {
     const isDisabled = this.isDisabled();
 
     return (
-      <div {...cn()}>
+      <div {...cn()} ref={this.editMessageActionRef}>
         <Tooltip content={this.props.secondaryTooltipText}>
           <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size={24} />
         </Tooltip>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -19,11 +19,13 @@ import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
 import { ParentMessage } from './parent-message';
+import InvertedScroll from '../inverted-scroll';
 
 const cn = bemClassName('message');
 
 interface Properties extends MessageModel {
   className: string;
+  scrollContainerRef: React.RefObject<InvertedScroll>;
   onImageClick: (media: any) => void;
   onDelete: (messageId: number) => void;
   onEdit: (
@@ -213,6 +215,7 @@ export class Message extends React.Component<Properties, State> {
         secondaryTooltipText='Discard Changes'
         onEdit={this.editMessage.bind(this, value, mentionedUserIds, { hidePreview: this.props.hidePreview })}
         onCancel={this.toggleEdit}
+        scrollContainerRef={this.props.scrollContainerRef}
       />
     );
   };


### PR DESCRIPTION
### What does this do?

Currently the 'x' or 'tick' icon gets hidden (check before video), if trying to edit a message in the bottom of the screen/viewport. Fixed now (check after video).

I used the `clientHeight` & `ref.getBoundingClientRect()` methods for this to calculate the distance 😅 

Before:

https://github.com/zer0-os/zOS/assets/33264364/bd95f24a-5d41-439c-9b37-a2c273ce2f10

After:

https://github.com/zer0-os/zOS/assets/33264364/170c2d1a-d37c-4abf-a845-5ce7e04282fd



