### PR TITLE
feat: set cursor if replying to a message

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -85,12 +85,16 @@ export class MessageInput extends React.Component<Properties, State> {
     return this.props.clipboard || windowClipboard();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     if (this.props.onMessageInputRendered) {
       this.props.onMessageInputRendered(this.textareaRef);
     }
     if (this.state.isSendTooltipOpen && this.isSendingEnabled) {
       this.setState({ isSendTooltipOpen: false });
+    }
+
+    if (this.props.reply && !prevProps.reply) {
+      this.focusInput();
     }
   }
 
@@ -127,7 +131,7 @@ export class MessageInput extends React.Component<Properties, State> {
 
   focusInput() {
     if (this.textareaRef && this.textareaRef.current) {
-      this.textareaRef.current.focus();
+      setTimeout(() => this.textareaRef.current.focus(), 1);
     }
   }
 
@@ -340,10 +344,6 @@ export class MessageInput extends React.Component<Properties, State> {
   renderInput() {
     const hasInputValue = this.state.value?.length > 0;
     const reply = this.props.reply;
-
-    if (this.props.reply) {
-      setTimeout(() => this.focusInput(), 100);
-    }
 
     return (
       <div {...cn('container')}>

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -85,16 +85,12 @@ export class MessageInput extends React.Component<Properties, State> {
     return this.props.clipboard || windowClipboard();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     if (this.props.onMessageInputRendered) {
       this.props.onMessageInputRendered(this.textareaRef);
     }
     if (this.state.isSendTooltipOpen && this.isSendingEnabled) {
       this.setState({ isSendTooltipOpen: false });
-    }
-
-    if (this.props.reply && !prevProps.reply) {
-      this.focusInput();
     }
   }
 
@@ -131,7 +127,7 @@ export class MessageInput extends React.Component<Properties, State> {
 
   focusInput() {
     if (this.textareaRef && this.textareaRef.current) {
-      setTimeout(() => this.textareaRef.current.focus(), 1);
+      this.textareaRef.current.focus();
     }
   }
 

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -341,6 +341,10 @@ export class MessageInput extends React.Component<Properties, State> {
     const hasInputValue = this.state.value?.length > 0;
     const reply = this.props.reply;
 
+    if (this.props.reply) {
+      setTimeout(() => this.focusInput(), 100);
+    }
+
     return (
       <div {...cn('container')}>
         <div {...cn('addon-row')}>

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -70,7 +70,7 @@ describe('Message Menu', () => {
       expect(editItem).toBeDefined();
     });
 
-    it('should call edit message when clicked', () => {
+    it('should call edit message when clicked after releasing the thread', async () => {
       const onEdit = jest.fn();
       const wrapper = subject({ canEdit: true, onEdit }) as ShallowWrapper;
 
@@ -80,6 +80,9 @@ describe('Message Menu', () => {
 
       editItem.onSelect();
 
+      expect(onEdit).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(onEdit).toHaveBeenCalled();
     });
   });
@@ -96,7 +99,7 @@ describe('Message Menu', () => {
       expect(replyItem).toBeDefined();
     });
 
-    it('should call reply message when clicked', () => {
+    it('should call reply message when clicked after releasing the thread', async () => {
       const onReply = jest.fn();
       const wrapper = subject({ canReply: true, onReply }) as ShallowWrapper;
 
@@ -105,7 +108,9 @@ describe('Message Menu', () => {
       const replyItem = items.find((item) => item.id === 'reply');
 
       replyItem.onSelect();
+      expect(onReply).not.toHaveBeenCalled();
 
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(onReply).toHaveBeenCalled();
     });
   });

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -39,20 +39,27 @@ export class MessageMenu extends React.Component<Properties, State> {
     );
   }
 
+  // Our zUI DropdownMenu component actively steals focus.
+  // In order to allow actions to change focus without the dropdown menu stealing it back,
+  // we delay publishing the event by releasing the thread for a single tick.
+  delayEvent = (handler) => setTimeout(handler, 1);
+  onEdit = () => this.delayEvent(this.props.onEdit);
+  onReply = () => this.delayEvent(this.props.onReply);
+
   renderItems = () => {
     const menuItems = [];
     if (this.props.onEdit && this.props.canEdit && !this.props.isMediaMessage) {
       menuItems.push({
         id: 'edit',
         label: this.renderMenuOption(<IconEdit5 />, 'Edit'),
-        onSelect: this.props.onEdit,
+        onSelect: this.onEdit,
       });
     }
     if (this.props.onReply && this.props.canReply && !this.props.isMediaMessage) {
       menuItems.push({
         id: 'reply',
         label: this.renderMenuOption(<IconFlipBackward />, 'Reply'),
-        onSelect: this.props.onReply,
+        onSelect: this.onReply,
       });
     }
     if (this.props.onDelete && this.props.canDelete) {


### PR DESCRIPTION
### What does this do?
- focuses on the message input when reply prop exists

### Why are we making this change?
- so the user can starting typing immediately without an additional mouse event.

### How do I test this?
- select reply to a message from the message menu and check if the message input is focussed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/22149e15-2b94-4c7d-af58-54cb706f1822

