### PR TITLE
feat: update messages to use sender avatar

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -350,15 +350,28 @@ describe('message', () => {
     );
   });
 
+  // it('renders author avatar', () => {
+  //   const wrapper = subject({
+  //     message: 'text',
+  //     showSenderAvatar: true,
+  //   });
+
+  //   const authorAvatarElement = wrapper.find('.message__author-avatar');
+
+  //   expect(authorAvatarElement.prop('style').backgroundImage).toEqual(`url(${sender.profileImage})`);
+  // });
+
   it('renders author avatar', () => {
     const wrapper = subject({
       message: 'text',
       showSenderAvatar: true,
     });
 
-    const authorAvatarElement = wrapper.find('.message__author-avatar');
+    const avatarComponent = wrapper.find('.message__author-avatar Avatar');
 
-    expect(authorAvatarElement.prop('style').backgroundImage).toEqual(`url(${sender.profileImage})`);
+    expect(avatarComponent.exists()).toBe(true);
+
+    expect(avatarComponent.prop('imageURL')).toEqual(`${sender.profileImage}`);
   });
 
   it('renders with a tag', () => {

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -350,17 +350,6 @@ describe('message', () => {
     );
   });
 
-  // it('renders author avatar', () => {
-  //   const wrapper = subject({
-  //     message: 'text',
-  //     showSenderAvatar: true,
-  //   });
-
-  //   const authorAvatarElement = wrapper.find('.message__author-avatar');
-
-  //   expect(authorAvatarElement.prop('style').backgroundImage).toEqual(`url(${sender.profileImage})`);
-  // });
-
   it('renders author avatar', () => {
     const wrapper = subject({
       message: 'text',

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -13,7 +13,7 @@ import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
 import { IconAlertCircle, IconXClose } from '@zero-tech/zui/icons';
-import { IconButton } from '@zero-tech/zui/components';
+import { Avatar, IconButton } from '@zero-tech/zui/components';
 import { ContentHighlighter } from '../content-highlighter';
 import { bemClassName } from '../../lib/bem';
 
@@ -293,10 +293,14 @@ export class Message extends React.Component<Properties, State> {
       >
         {this.props.showSenderAvatar && (
           <div {...cn('left')}>
-            <div
-              style={{ backgroundImage: `url(${getProvider().getSourceUrl(sender.profileImage)})` }}
-              {...cn('author-avatar')}
-            />
+            <div {...cn('author-avatar')}>
+              <Avatar
+                size='medium'
+                type='circle'
+                imageURL={`${getProvider().getSourceUrl(sender.profileImage)}`}
+                tabIndex={-1}
+              />
+            </div>
           </div>
         )}
         <div {...cn('block', this.state.isEditing && 'edit')}>

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -173,7 +173,7 @@
   &__author-avatar {
     visibility: hidden;
 
-    > div:first-child {
+    > *:first-child {
       cursor: default;
     }
   }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -172,13 +172,10 @@
 
   &__author-avatar {
     visibility: hidden;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    width: 32px;
-    height: 32px;
-    overflow: hidden;
-    border-radius: 50%;
+
+    > div:first-child {
+      cursor: default;
+    }
   }
 
   &__author-name {


### PR DESCRIPTION
### What does this do?
- replaces div with background img with zUI Avatar component.

### Why are we making this change?
- should be using the re-usable Avatar component available.

### How do I test this?
- open a group chat and check the sender Avatars 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1091" alt="Screenshot 2023-08-31 at 09 38 48" src="https://github.com/zer0-os/zOS/assets/39112648/8a53332c-f3fb-42ed-9a55-f0e78b776982">
