### PR TITLE
fix: width of audio control interface

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -106,6 +106,12 @@
     }
   }
 
+  &__block-audio {
+    audio {
+      width: 300px;
+    }
+  }
+
   &__block-video {
     video {
       min-height: 186px;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -108,7 +108,8 @@
 
   &__block-audio {
     audio {
-      width: 300px;
+      width: 100%;
+      min-width: 300px;
     }
   }
 

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -106,12 +106,6 @@
     }
   }
 
-  &__block-audio {
-    audio {
-      width: 100%;
-    }
-  }
-
   &__block-video {
     video {
       min-height: 186px;


### PR DESCRIPTION
### What does this do?
- removes `100%` width set on `block-audio`. By doing this the audio controls width will be set to its default of 300px (for chrome browser).

I decided to set the width to `300px` so its consistent across all browsers.

This also fixes the hidden audio messages sent in succession as shown in the recording below.

### Why are we making this change?
- users are unable to play the audio due to the width of the controls.

<img width="1304" alt="Screenshot 2023-09-01 at 13 35 08" src="https://github.com/zer0-os/zOS/assets/39112648/4bbe905e-e7ab-42c4-b921-73858f5defab">

After removing the `width: 100%` and replacing with `300px`.

<img width="1304" alt="Screenshot 2023-09-01 at 13 35 11" src="https://github.com/zer0-os/zOS/assets/39112648/93291e7a-bc19-4cd8-a98b-47525fe6e137">

<img width="420" alt="Screenshot 2023-09-01 at 13 38 00" src="https://github.com/zer0-os/zOS/assets/39112648/64f5fb0e-0e4b-4110-8173-b5972d10a1c9">

Blank audio messages:

https://github.com/zer0-os/zOS/assets/39112648/80a04239-bac3-4155-a132-05015bdf6abe


https://github.com/zer0-os/zOS/assets/39112648/1af12dc9-8861-4635-80db-defb119d80f6

