### PR TITLE
Remove users from search results after they've been added to a pending group chat

### DIFF
--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -31,6 +31,64 @@ describe('autocomplete-members', () => {
     expect(wrapper.find('.autocomplete-members__search-results Avatar').prop('imageURL')).toEqual('image-1');
   });
 
+  it('displays filtered results excluding selected options', async () => {
+    const search = jest.fn();
+    when(search)
+      .calledWith('name')
+      .mockResolvedValue([
+        { name: 'Result 1', id: 'result-1' },
+        { name: 'Result 2', id: 'result-2' },
+      ]);
+
+    // Define selected options
+    const selectedOptions = [
+      { value: 'result-1', label: 'Result 1', image: undefined },
+    ];
+
+    const wrapper = subject({ search, selectedOptions });
+
+    // Simulate a non-empty search
+    await searchFor(wrapper, 'name');
+
+    // Ensure that state.results is correctly updated with filtered results
+    expect(wrapper.state('results')).toEqual([
+      { value: 'result-2', label: 'Result 2', image: undefined },
+    ]);
+
+    // Ensure that the component renders the filtered result
+    expect(wrapper.find('.autocomplete-members__search-results')).toHaveLength(1);
+    expect(wrapper.find('.autocomplete-members__search-results').text()).toContain('Result 2');
+
+    // Ensure that the selected option is not displayed in the component
+    expect(wrapper.find('.autocomplete-members__search-results').text()).not.toContain('Result 1');
+  });
+
+  it('excludes the selected option from search results', async () => {
+    const search = jest.fn();
+    when(search).mockResolvedValue([
+      { name: 'Result 1', id: 'result-1' },
+      { name: 'Result 2', id: 'result-2' },
+    ]);
+
+    const onSelect = jest.fn();
+    const wrapper = subject({ search, onSelect });
+    await searchFor(wrapper, 'name');
+
+    // Simulate selecting an option
+    wrapper
+      .find('.autocomplete-members__search-results > div')
+      .first()
+      .simulate('click', { currentTarget: { dataset: { id: 'result-1' } } });
+
+    // Ensure that the selected option is excluded from state.results
+    expect(wrapper.state('results')).toEqual([
+      { value: 'result-2', label: 'Result 2', image: undefined },
+    ]);
+
+    // Ensure that the selected option is not displayed in the component
+    expect(wrapper.find('.autocomplete-members__search-results > div').text()).not.toContain('Result 1');
+  });
+
   it('search with empty string clears results', async () => {
     const search = jest.fn();
     when(search)

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -30,13 +30,13 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     }
 
     const items = await this.props.search(searchString);
-    const itemsToOption = items.map(itemToOption);
+    const options = items.map(itemToOption);
     const selectedOptions = this.props.selectedOptions || [];
-    const filteredOptions = itemsToOption.filter((o) => !selectedOptions.find((s) => s.value === o.value));
+    const filteredOptions = options.filter((o) => !selectedOptions.find((s) => s.value === o.value));
     this.setState({ results: filteredOptions });
   };
 
-  onSelect(event) {
+  itemSelected(event) {
     const clickedId = event.currentTarget.dataset.id;
     const selectedUser = this.state.results.find((r) => r.value === clickedId);
 
@@ -50,12 +50,12 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
   }
 
   itemClicked = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    this.onSelect(event);
+    this.itemSelected(event);
   };
 
   handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter') {
-      this.onSelect(event);
+      this.itemSelected(event);
     }
   };
 

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 
 export interface Properties {
   search: (query: string) => Promise<Item[]>;
+  selectedOptions?: Option[];
   onSelect: (selected: Option) => void;
 }
 
@@ -29,25 +30,32 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     }
 
     const items = await this.props.search(searchString);
-
-    this.setState({ results: items.map(itemToOption) });
+    const itemsToOption = items.map(itemToOption);
+    const selectedOptions = this.props.selectedOptions || [];
+    const filteredOptions = itemsToOption.filter((o) => !selectedOptions.find((s) => s.value === o.value));
+    this.setState({ results: filteredOptions });
   };
 
-  itemClicked = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  onSelect(event) {
     const clickedId = event.currentTarget.dataset.id;
     const selectedUser = this.state.results.find((r) => r.value === clickedId);
+
     if (selectedUser) {
       this.props.onSelect(selectedUser);
+      // exclude selected user from results
+      this.setState({
+        results: this.state.results.filter((r) => r.value !== clickedId),
+      });
     }
+  }
+
+  itemClicked = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    this.onSelect(event);
   };
 
   handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter') {
-      const clickedId = event.currentTarget.dataset.id;
-      const selectedUser = this.state.results.find((r) => r.value === clickedId);
-      if (selectedUser) {
-        this.props.onSelect(selectedUser);
-      }
+      this.onSelect(event);
     }
   };
 

--- a/src/components/messenger/list/start-group-panel/index.tsx
+++ b/src/components/messenger/list/start-group-panel/index.tsx
@@ -67,7 +67,11 @@ export class StartGroupPanel extends React.Component<Properties, State> {
       <>
         <PanelHeader title='Select members' onBack={this.props.onBack} />
         <div {...cn('search')}>
-          <AutocompleteMembers search={this.props.searchUsers} onSelect={this.selectOption}>
+          <AutocompleteMembers
+            search={this.props.searchUsers}
+            onSelect={this.selectOption}
+            selectedOptions={this.state.selectedOptions}
+          >
             <div {...cn('selected-count')}>
               <span {...cn('selected-number')}>{this.state.selectedOptions.length}</span> member
               {this.state.selectedOptions.length === 1 ? '' : 's'} selected


### PR DESCRIPTION
### What does this do?

If you have selected a user to "start a group chat", then it won't be displayed in the search results.

Before (user is selected & also displayed in the search results):
<img width="298" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/ad52f684-59c4-44bb-bb50-5849318aa841">

After (selectedUser is NOT displayed in the results):
<img width="314" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/58ea2a13-6b7f-40b2-afd9-fe5e414de50d">
