### PR TITLE
Zos 642 fix bug where creating a new group conversation re triggers daily rewards notification

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -41,7 +41,8 @@ describe('messenger-list', () => {
       isRewardsLoading: false,
       isInviteNotificationOpen: false,
       myUserId: '',
-      showNewRewards: false,
+      showRewardsInTooltip: false,
+      showRewardsInPopup: false,
       openConversation: jest.fn(),
       fetchConversations: jest.fn(),
       createConversation: jest.fn(),
@@ -53,6 +54,7 @@ describe('messenger-list', () => {
       enterFullScreenMessenger: () => null,
       fetchRewards: () => null,
       rewardsPopupClosed: () => null,
+      rewardsTooltipClosed: () => null,
       receiveSearchResults: () => null,
       logout: () => null,
       ...props,
@@ -389,7 +391,7 @@ describe('messenger-list', () => {
       });
     });
 
-    test('previewDeisplayDate', () => {
+    test('previewDisplayDate', () => {
       const date = moment('2023-03-03').valueOf();
       const state = subject([
         {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -62,8 +62,8 @@ export interface Properties extends PublicProperties {
   isInviteNotificationOpen: boolean;
   myUserId: string;
   activeConversationId?: string;
-  showRewardsTooltip: boolean;
-  showRewardsModal: boolean;
+  showRewardsInTooltip: boolean;
+  showRewardsInPopup: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -117,8 +117,8 @@ export class Container extends React.Component<Properties, State> {
       myUserId: user?.data?.id,
       zeroPreviousDay: rewards.zeroPreviousDay,
       isRewardsLoading: rewards.loading,
-      showRewardsTooltip: rewards.showRewardsTooltip,
-      showRewardsModal: rewards.showRewardsModal,
+      showRewardsInTooltip: rewards.showRewardsInTooltip,
+      showRewardsInPopup: rewards.showRewardsInPopup,
     };
   }
 
@@ -231,8 +231,8 @@ export class Container extends React.Component<Properties, State> {
             zeroPreviousDay={this.props.zeroPreviousDay}
             isRewardsLoading={this.props.isRewardsLoading}
             isMessengerFullScreen={this.props.isMessengerFullScreen}
-            showRewardsTooltip={this.props.showRewardsTooltip}
-            showRewardsModal={this.props.showRewardsModal}
+            showRewardsInTooltip={this.props.showRewardsInTooltip}
+            showRewardsInPopup={this.props.showRewardsInPopup}
             isFirstTimeLogin={this.props.isFirstTimeLogin}
             includeRewardsAvatar={this.props.includeRewardsAvatar}
             userName={this.props.userName}

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -29,7 +29,7 @@ import { getMessagePreview, previewDisplayDate } from '../../../lib/chat/chat-me
 import { enterFullScreenMessenger } from '../../../store/layout';
 import { Modal, ToastNotification } from '@zero-tech/zui/components';
 import { InviteDialogContainer } from '../../invite-dialog/container';
-import { fetch as fetchRewards, rewardsPopupClosed } from '../../../store/rewards';
+import { fetch as fetchRewards, rewardsPopupClosed, rewardsTooltipClosed } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
 import { receiveSearchResults } from '../../../store/users';
 
@@ -62,7 +62,8 @@ export interface Properties extends PublicProperties {
   isInviteNotificationOpen: boolean;
   myUserId: string;
   activeConversationId?: string;
-  showNewRewards: boolean;
+  showRewardsTooltip: boolean;
+  showRewardsModal: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -74,6 +75,7 @@ export interface Properties extends PublicProperties {
   enterFullScreenMessenger: () => void;
   fetchRewards: (_obj: any) => void;
   rewardsPopupClosed: () => void;
+  rewardsTooltipClosed: () => void;
   logout: () => void;
   receiveSearchResults: (data) => void;
 }
@@ -115,7 +117,8 @@ export class Container extends React.Component<Properties, State> {
       myUserId: user?.data?.id,
       zeroPreviousDay: rewards.zeroPreviousDay,
       isRewardsLoading: rewards.loading,
-      showNewRewards: rewards.showNewRewards,
+      showRewardsTooltip: rewards.showRewardsTooltip,
+      showRewardsModal: rewards.showRewardsModal,
     };
   }
 
@@ -131,6 +134,7 @@ export class Container extends React.Component<Properties, State> {
       fetchRewards,
       enterFullScreenMessenger: () => enterFullScreenMessenger(),
       rewardsPopupClosed,
+      rewardsTooltipClosed,
       logout,
       receiveSearchResults,
     };
@@ -227,14 +231,16 @@ export class Container extends React.Component<Properties, State> {
             zeroPreviousDay={this.props.zeroPreviousDay}
             isRewardsLoading={this.props.isRewardsLoading}
             isMessengerFullScreen={this.props.isMessengerFullScreen}
+            showRewardsTooltip={this.props.showRewardsTooltip}
+            showRewardsModal={this.props.showRewardsModal}
             isFirstTimeLogin={this.props.isFirstTimeLogin}
             includeRewardsAvatar={this.props.includeRewardsAvatar}
             userName={this.props.userName}
             userHandle={this.props.userHandle}
             userAvatarUrl={this.props.userAvatarUrl}
             onRewardsPopupClose={this.props.rewardsPopupClosed}
+            onRewardsTooltipClose={this.props.rewardsTooltipClosed}
             onLogout={this.props.logout}
-            showNewRewards={this.props.showNewRewards}
             hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
           />
         )}

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -15,9 +15,11 @@ describe('rewards-bar', () => {
       userAvatarUrl: '',
       zeroPreviousDay: '',
       isRewardsLoading: false,
-      showNewRewards: false,
+      showRewardsInTooltip: false,
+      showRewardsInPopup: false,
       hasLoadedConversation: false,
       onRewardsPopupClose: () => {},
+      onRewardsTooltipClose: () => {},
       onLogout: () => {},
       ...props,
     };
@@ -65,7 +67,7 @@ describe('rewards-bar', () => {
     const wrapper = subject({
       zeroPreviousDay: '9000000000000000000',
       isRewardsLoading: false,
-      showNewRewards: true,
+      showRewardsInTooltip: true,
       isMessengerFullScreen: false,
     });
     expect(wrapper).not.toHaveElement(TooltipPopup);
@@ -75,31 +77,32 @@ describe('rewards-bar', () => {
     const wrapper = subject({
       zeroPreviousDay: '9000000000000000000',
       isRewardsLoading: false,
-      showNewRewards: true,
+      showRewardsInTooltip: true,
       isMessengerFullScreen: true,
     });
 
     expect(wrapper.find(TooltipPopup).prop('open')).toBeTrue();
     expect(wrapper.find(TooltipPopup).prop('content')).toEqual('You’ve earned 9 ZERO today');
-    expect(wrapper.state()['isRewardsTooltipOpen']).toBeTrue();
   });
 
   it('closes rewards tooltip popup if clicked on close icon', async function () {
+    const onRewardsTooltipClose = jest.fn();
     const wrapper = subject({
       zeroPreviousDay: '1000000000000000000',
       isRewardsLoading: false,
-      showNewRewards: true,
+      showRewardsInTooltip: true,
       isMessengerFullScreen: true,
+      onRewardsTooltipClose,
     });
     expect(wrapper.find(TooltipPopup).prop('open')).toBeTrue();
 
     wrapper.find(TooltipPopup).simulate('close');
-    expect(wrapper.find(TooltipPopup).prop('open')).toBeFalse();
+    expect(onRewardsTooltipClose).toHaveBeenCalled();
   });
 
   it('displays rewards icon status when conditions are met', function () {
     const wrapper = subject({
-      showNewRewards: true,
+      showRewardsInPopup: true,
       isMessengerFullScreen: true,
     });
 
@@ -111,7 +114,7 @@ describe('rewards-bar', () => {
 
   it('does not display rewards icon status when rewards pop up is open', function () {
     const wrapper = subject({
-      showNewRewards: true,
+      showRewardsInPopup: true,
       isMessengerFullScreen: true,
     });
 

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -25,8 +25,8 @@ export interface Properties {
 
   zeroPreviousDay: string;
   isRewardsLoading: boolean;
-  showRewardsTooltip: boolean;
-  showRewardsModal: boolean;
+  showRewardsInTooltip: boolean;
+  showRewardsInPopup: boolean;
 
   onLogout: () => void;
   onRewardsPopupClose: () => void;
@@ -95,7 +95,7 @@ export class RewardsBar extends React.Component<Properties, State> {
               })}
             >
               <IconCurrencyDollar size={16} />
-              {!this.state.isRewardsPopupOpen && this.props.showRewardsModal && this.props.isMessengerFullScreen && (
+              {!this.state.isRewardsPopupOpen && this.props.showRewardsInPopup && this.props.isMessengerFullScreen && (
                 <Status type='idle' className={c('rewards-icon__status')} />
               )}
             </div>
@@ -108,7 +108,7 @@ export class RewardsBar extends React.Component<Properties, State> {
   render() {
     return (
       <div>
-        {this.props.showRewardsTooltip && this.props.isMessengerFullScreen ? (
+        {this.props.showRewardsInTooltip && this.props.isMessengerFullScreen ? (
           <TooltipPopup
             open={!this.props.isRewardsLoading}
             align='center'

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -25,10 +25,12 @@ export interface Properties {
 
   zeroPreviousDay: string;
   isRewardsLoading: boolean;
-  showNewRewards: boolean;
+  showRewardsTooltip: boolean;
+  showRewardsModal: boolean;
 
   onLogout: () => void;
   onRewardsPopupClose: () => void;
+  onRewardsTooltipClose: () => void;
 }
 
 interface State {
@@ -64,7 +66,10 @@ export class RewardsBar extends React.Component<Properties, State> {
 
   openRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: true });
   closeRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: false });
-  closeRewardsTooltip = () => this.setState({ isRewardsTooltipOpen: false });
+  closeRewardsTooltip = () => {
+    this.setState({ isRewardsTooltipOpen: false });
+    this.props.onRewardsTooltipClose();
+  };
 
   renderRewardsBar() {
     return (
@@ -97,7 +102,7 @@ export class RewardsBar extends React.Component<Properties, State> {
               })}
             >
               <IconCurrencyDollar size={16} />
-              {!this.state.isRewardsPopupOpen && this.props.showNewRewards && this.props.isMessengerFullScreen && (
+              {!this.state.isRewardsPopupOpen && this.props.showRewardsModal && this.props.isMessengerFullScreen && (
                 <Status type='idle' className={c('rewards-icon__status')} />
               )}
             </div>
@@ -110,7 +115,7 @@ export class RewardsBar extends React.Component<Properties, State> {
   render() {
     return (
       <div>
-        {this.props.showNewRewards && this.props.isMessengerFullScreen ? (
+        {this.props.showRewardsTooltip && this.props.isMessengerFullScreen ? (
           <TooltipPopup
             open={!this.props.isRewardsLoading && this.state.isRewardsTooltipOpen}
             align='center'

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -36,26 +36,22 @@ export interface Properties {
 interface State {
   isRewardsPopupOpen: boolean;
   isRewardsFAQModalOpen: boolean;
-  isRewardsTooltipOpen: boolean;
 }
 
 export class RewardsBar extends React.Component<Properties, State> {
   state = {
     isRewardsPopupOpen: false,
     isRewardsFAQModalOpen: false,
-    isRewardsTooltipOpen: true, // initally open, will close after user clicks on 'x' button
   };
 
   constructor(props: Properties) {
     super(props);
     this.state.isRewardsPopupOpen = props.isFirstTimeLogin;
-    this.state.isRewardsTooltipOpen = !props.isFirstTimeLogin;
   }
 
   openRewards = () => {
     this.setState({
       isRewardsPopupOpen: true,
-      isRewardsTooltipOpen: false,
     });
   };
 
@@ -66,10 +62,7 @@ export class RewardsBar extends React.Component<Properties, State> {
 
   openRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: true });
   closeRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: false });
-  closeRewardsTooltip = () => {
-    this.setState({ isRewardsTooltipOpen: false });
-    this.props.onRewardsTooltipClose();
-  };
+  closeRewardsTooltip = () => this.props.onRewardsTooltipClose();
 
   renderRewardsBar() {
     return (
@@ -117,7 +110,7 @@ export class RewardsBar extends React.Component<Properties, State> {
       <div>
         {this.props.showRewardsTooltip && this.props.isMessengerFullScreen ? (
           <TooltipPopup
-            open={!this.props.isRewardsLoading && this.state.isRewardsTooltipOpen}
+            open={!this.props.isRewardsLoading}
             align='center'
             side='left'
             content={`You’ve earned ${formatWeiAmount(this.props.zeroPreviousDay)} ZERO today`}

--- a/src/store/rewards/index.ts
+++ b/src/store/rewards/index.ts
@@ -3,6 +3,7 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 export enum SagaActionTypes {
   Fetch = 'rewards/fetch',
   RewardsPopupClosed = 'registration/rewardsPopupClosed',
+  RewardsTooltipClosed = 'registration/rewardsTooltipClosed',
 }
 
 export type RewardsState = {
@@ -10,7 +11,8 @@ export type RewardsState = {
   zero: string;
   zeroInUSD: number;
   zeroPreviousDay: string;
-  showNewRewards: boolean;
+  showRewardsTooltip: boolean;
+  showRewardsModal: boolean;
 };
 
 export const initialState: RewardsState = {
@@ -18,11 +20,13 @@ export const initialState: RewardsState = {
   zero: '0',
   zeroInUSD: 0.0,
   zeroPreviousDay: '0',
-  showNewRewards: false,
+  showRewardsTooltip: false,
+  showRewardsModal: false,
 };
 
 export const fetch = createAction<{}>(SagaActionTypes.Fetch);
 export const rewardsPopupClosed = createAction(SagaActionTypes.RewardsPopupClosed);
+export const rewardsTooltipClosed = createAction(SagaActionTypes.RewardsTooltipClosed);
 
 const slice = createSlice({
   name: 'rewards',
@@ -40,11 +44,15 @@ const slice = createSlice({
     setZeroPreviousDay: (state, action: PayloadAction<RewardsState['zeroPreviousDay']>) => {
       state.zeroPreviousDay = action.payload;
     },
-    setShowNewRewards: (state, action: PayloadAction<RewardsState['showNewRewards']>) => {
-      state.showNewRewards = action.payload;
+    setShowRewardsTooltip: (state, action: PayloadAction<RewardsState['showRewardsTooltip']>) => {
+      state.showRewardsTooltip = action.payload;
+    },
+    setShowRewardsModal: (state, action: PayloadAction<RewardsState['showRewardsModal']>) => {
+      state.showRewardsModal = action.payload;
     },
   },
 });
 
-export const { setLoading, setZero, setZeroPreviousDay, setShowNewRewards, setZeroInUSD } = slice.actions;
+export const { setLoading, setZero, setZeroPreviousDay, setZeroInUSD, setShowRewardsTooltip, setShowRewardsModal } =
+  slice.actions;
 export const { reducer } = slice;

--- a/src/store/rewards/index.ts
+++ b/src/store/rewards/index.ts
@@ -11,8 +11,8 @@ export type RewardsState = {
   zero: string;
   zeroInUSD: number;
   zeroPreviousDay: string;
-  showRewardsTooltip: boolean;
-  showRewardsModal: boolean;
+  showRewardsInTooltip: boolean;
+  showRewardsInPopup: boolean;
 };
 
 export const initialState: RewardsState = {
@@ -20,8 +20,8 @@ export const initialState: RewardsState = {
   zero: '0',
   zeroInUSD: 0.0,
   zeroPreviousDay: '0',
-  showRewardsTooltip: false,
-  showRewardsModal: false,
+  showRewardsInTooltip: false,
+  showRewardsInPopup: false,
 };
 
 export const fetch = createAction<{}>(SagaActionTypes.Fetch);
@@ -44,15 +44,15 @@ const slice = createSlice({
     setZeroPreviousDay: (state, action: PayloadAction<RewardsState['zeroPreviousDay']>) => {
       state.zeroPreviousDay = action.payload;
     },
-    setShowRewardsTooltip: (state, action: PayloadAction<RewardsState['showRewardsTooltip']>) => {
-      state.showRewardsTooltip = action.payload;
+    setShowRewardsInTooltip: (state, action: PayloadAction<RewardsState['showRewardsInTooltip']>) => {
+      state.showRewardsInTooltip = action.payload;
     },
-    setShowRewardsModal: (state, action: PayloadAction<RewardsState['showRewardsModal']>) => {
-      state.showRewardsModal = action.payload;
+    setShowRewardsInPopup: (state, action: PayloadAction<RewardsState['showRewardsInPopup']>) => {
+      state.showRewardsInPopup = action.payload;
     },
   },
 });
 
-export const { setLoading, setZero, setZeroPreviousDay, setZeroInUSD, setShowRewardsTooltip, setShowRewardsModal } =
+export const { setLoading, setZero, setZeroPreviousDay, setZeroInUSD, setShowRewardsInTooltip, setShowRewardsInPopup } =
   slice.actions;
 export const { reducer } = slice;

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -1,7 +1,15 @@
 import { call, delay, put, select, spawn, takeEvery, takeLatest } from 'redux-saga/effects';
 import getDeepProperty from 'lodash.get';
 
-import { SagaActionTypes, setLoading, setShowNewRewards, setZero, setZeroInUSD, setZeroPreviousDay } from '.';
+import {
+  SagaActionTypes,
+  setShowRewardsTooltip,
+  setLoading,
+  setZero,
+  setZeroInUSD,
+  setZeroPreviousDay,
+  setShowRewardsModal,
+} from '.';
 import { RewardsResp, fetchCurrentZeroPriceInUSD as fetchCurrentZeroPriceInUSDAPI, fetchRewards } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
@@ -9,7 +17,8 @@ import { getAuthChannel, Events as AuthEvents } from '../authentication/channels
 const FETCH_REWARDS_INTERVAL = 60 * 60 * 1000; // 1 hour
 const SYNC_ZERO_TOKEN_PRICE_INTERVAL = 2 * 60 * 1000; // every 2 minutes
 
-const lastViewedRewardsKey = 'last_viewed_rewards';
+const lastDayRewardsKey = 'last_viewed_day_rewards';
+const totalRewardsKey = 'last_viewed_total_rewards';
 
 export function* fetchCurrentZeroPriceInUSD() {
   try {
@@ -60,25 +69,36 @@ export function* syncRewardsAndTokenPrice() {
 
 export function* checkNewRewardsLoaded() {
   const zeroPreviousDay = yield select((state) => getDeepProperty(state, 'rewards.zeroPreviousDay'));
+  const zeroTotal = yield select((state) => getDeepProperty(state, 'rewards.zero'));
   const isFirstTimeLogin = yield select((state) => getDeepProperty(state, 'registration.isFirstTimeLogin'));
   const isMessengerFullScreen = yield select((state) => getDeepProperty(state, 'layout.value.isMessengerFullScreen'));
 
-  if (
-    isMessengerFullScreen &&
-    !isFirstTimeLogin &&
-    zeroPreviousDay !== '0' &&
-    localStorage.getItem(lastViewedRewardsKey) !== zeroPreviousDay
-  ) {
-    yield put(setShowNewRewards(true));
+  if (isMessengerFullScreen && !isFirstTimeLogin && zeroPreviousDay !== '0') {
+    if (localStorage.getItem(lastDayRewardsKey) !== zeroPreviousDay) {
+      yield put(setShowRewardsTooltip(true));
+    }
+
+    if (localStorage.getItem(totalRewardsKey) !== zeroTotal) {
+      yield put(setShowRewardsModal(true));
+    }
   }
 }
 
 export function* rewardsPopupClosed() {
-  // set last viewed rewards to the current rewards when the popup is closed
-  const { zeroPreviousDay, showNewRewards } = yield select((state) => state.rewards);
-  if (showNewRewards) {
-    localStorage.setItem(lastViewedRewardsKey, zeroPreviousDay);
-    yield put(setShowNewRewards(false));
+  // set last viewed "total" rewards to the current rewards when the popup is closed
+  const { zero, showRewardsModal } = yield select((state) => state.rewards);
+  if (showRewardsModal) {
+    localStorage.setItem(totalRewardsKey, zero);
+    yield put(setShowRewardsModal(false));
+  }
+}
+
+export function* rewardsTooltipClosed() {
+  // set last viewed "daily" rewards to the current rewards when the popup is closed
+  const { zeroPreviousDay, showRewardsTooltip } = yield select((state) => state.rewards);
+  if (showRewardsTooltip) {
+    localStorage.setItem(lastDayRewardsKey, zeroPreviousDay);
+    yield put(setShowRewardsTooltip(false));
   }
 }
 
@@ -87,11 +107,13 @@ function* clearOnLogout() {
   yield put(setZero('0'));
   yield put(setZeroPreviousDay('0'));
   yield put(setZeroInUSD(0.0));
-  yield put(setShowNewRewards(false));
+  yield put(setShowRewardsTooltip(false));
+  yield put(setShowRewardsModal(false));
 }
 
 export function* saga() {
   yield takeLatest(SagaActionTypes.Fetch, syncRewardsAndTokenPrice);
   yield takeEvery(SagaActionTypes.RewardsPopupClosed, rewardsPopupClosed);
+  yield takeEvery(SagaActionTypes.RewardsTooltipClosed, rewardsTooltipClosed);
   yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
 }

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -3,12 +3,12 @@ import getDeepProperty from 'lodash.get';
 
 import {
   SagaActionTypes,
-  setShowRewardsTooltip,
+  setShowRewardsInTooltip,
   setLoading,
   setZero,
   setZeroInUSD,
   setZeroPreviousDay,
-  setShowRewardsModal,
+  setShowRewardsInPopup,
 } from '.';
 import { RewardsResp, fetchCurrentZeroPriceInUSD as fetchCurrentZeroPriceInUSDAPI, fetchRewards } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
@@ -75,30 +75,30 @@ export function* checkNewRewardsLoaded() {
 
   if (isMessengerFullScreen && !isFirstTimeLogin && zeroPreviousDay !== '0') {
     if (localStorage.getItem(lastDayRewardsKey) !== zeroPreviousDay) {
-      yield put(setShowRewardsTooltip(true));
+      yield put(setShowRewardsInTooltip(true));
     }
 
     if (localStorage.getItem(totalRewardsKey) !== zeroTotal) {
-      yield put(setShowRewardsModal(true));
+      yield put(setShowRewardsInPopup(true));
     }
   }
 }
 
 export function* rewardsPopupClosed() {
   // set last viewed "total" rewards to the current rewards when the popup is closed
-  const { zero, showRewardsModal } = yield select((state) => state.rewards);
-  if (showRewardsModal) {
+  const { zero, showRewardsInPopup } = yield select((state) => state.rewards);
+  if (showRewardsInPopup) {
     localStorage.setItem(totalRewardsKey, zero);
-    yield put(setShowRewardsModal(false));
+    yield put(setShowRewardsInPopup(false));
   }
 }
 
 export function* rewardsTooltipClosed() {
   // set last viewed "daily" rewards to the current rewards when the popup is closed
-  const { zeroPreviousDay, showRewardsTooltip } = yield select((state) => state.rewards);
-  if (showRewardsTooltip) {
+  const { zeroPreviousDay, showRewardsInTooltip } = yield select((state) => state.rewards);
+  if (showRewardsInTooltip) {
     localStorage.setItem(lastDayRewardsKey, zeroPreviousDay);
-    yield put(setShowRewardsTooltip(false));
+    yield put(setShowRewardsInTooltip(false));
   }
 }
 
@@ -107,8 +107,8 @@ function* clearOnLogout() {
   yield put(setZero('0'));
   yield put(setZeroPreviousDay('0'));
   yield put(setZeroInUSD(0.0));
-  yield put(setShowRewardsTooltip(false));
-  yield put(setShowRewardsModal(false));
+  yield put(setShowRewardsInTooltip(false));
+  yield put(setShowRewardsInPopup(false));
 }
 
 export function* saga() {


### PR DESCRIPTION
### What does this do?

Separates out the states for handling the rewards tooltip display, and the reward popup's status icon display.

### Why are we making this change?

Previously we were seeing some mixed state due to using a single prop (`showNewRewards`), for displaying the rewards. 

But as per my conversation with Kelly
- we should NOT see the rewards tooltip after we have viewed them "once" (during reload, or when you start a group conversation). It should reappear only when new rewards are accumulated.
- we should just see the orange (idle) status icon the rewards bar, if the tooltip is opened, but the rewards popup is not (in case of new rewards).

Here is a video displaying the new behaviour:

https://github.com/zer0-os/zOS/assets/33264364/c4512a37-a803-4741-b8c0-b8c876744642



