### PR TITLE
Fix scroll to bottom issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "if-emoji": "^0.1.0",
     "linkify-react": "^4.0.2",
     "linkifyjs": "^4.0.2",
-    "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
     "lodash.uniqby": "^4.7.0",

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -193,8 +193,13 @@ export class ChatView extends React.Component<Properties, State> {
         <div className='message__header'>
           <div className='message__header-date'>{this.formatDayHeader(day)}</div>
         </div>
-        {groups.map((group, index) => {
-          const groupKey = `group_${groups.length - index}`;
+        {groups.map((group) => {
+          // Good enough approximation of a unique key to allow consistent enough
+          // rendering of the message groups to not mess up the scroll position.
+          // An alternative would be to not render the group wrapper at all and
+          // style the groups messages via separate classes/attributes.
+          const lastMessage = group.at(-1);
+          const groupKey = `group_${lastMessage.optimisticId || lastMessage.id}`;
           return (
             <div key={groupKey} className='message__group'>
               {this.renderMessageGroup(group)}
@@ -265,7 +270,6 @@ export class ChatView extends React.Component<Properties, State> {
                 <span>This is the start of the channel.</span>
               </div>
             )}
-
             {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
             {this.props.messages.length > 0 && this.renderMessages()}
             {!this.props.hasLoadedMessages && this.props.messagesFetchStatus !== MessagesFetchState.FAILED && (

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -239,12 +239,6 @@ export class ChatView extends React.Component<Properties, State> {
     }
   }
 
-  preventHigherScroll = () => {
-    if (this.scrollContainerRef.current) {
-      this.scrollContainerRef.current.scroll(0, 1);
-    }
-  };
-
   render() {
     const { isLightboxOpen, lightboxMedia, lightboxStartIndex } = this.state;
     const { hasJoined: isMemberOfChannel } = this.props;
@@ -264,7 +258,6 @@ export class ChatView extends React.Component<Properties, State> {
           />
         )}
         <InvertedScroll className='channel-view__inverted-scroll' ref={this.scrollContainerRef}>
-          <Waypoint onEnter={this.preventHigherScroll} />
           <div className='channel-view__main'>
             {!this.props.isDirectMessage && (
               <div className='channel-view__name'>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -69,12 +69,11 @@ export interface State {
   lightboxMedia: any[];
   lightboxStartIndex: number;
   isLightboxOpen: boolean;
-  pinnedBottom: boolean;
 }
 
 export class ChatView extends React.Component<Properties, State> {
   scrollContainerRef: React.RefObject<InvertedScroll>;
-  state = { lightboxMedia: [], lightboxStartIndex: 0, isLightboxOpen: false, pinnedBottom: false };
+  state = { lightboxMedia: [], lightboxStartIndex: 0, isLightboxOpen: false };
 
   constructor(props) {
     super(props);
@@ -82,7 +81,6 @@ export class ChatView extends React.Component<Properties, State> {
   }
 
   scrollToBottom = () => {
-    this.pinBottom();
     if (this.scrollContainerRef.current) {
       this.scrollContainerRef.current.scrollToBottom();
     }
@@ -246,8 +244,6 @@ export class ChatView extends React.Component<Properties, State> {
       this.scrollContainerRef.current.scroll(0, 1);
     }
   };
-  pinBottom = () => this.setState({ pinnedBottom: true });
-  unpinBottom = () => this.setState({ pinnedBottom: false });
 
   render() {
     const { isLightboxOpen, lightboxMedia, lightboxStartIndex } = this.state;
@@ -269,11 +265,7 @@ export class ChatView extends React.Component<Properties, State> {
         )}
         <InvertedScroll className='channel-view__inverted-scroll' ref={this.scrollContainerRef}>
           <Waypoint onEnter={this.preventHigherScroll} />
-          <div
-            className={classNames('channel-view__main', {
-              'messages__container--pinned-bottom': this.state.pinnedBottom,
-            })}
-          >
+          <div className='channel-view__main'>
             {!this.props.isDirectMessage && (
               <div className='channel-view__name'>
                 <h1>Welcome to #{this.props.name}</h1>
@@ -290,9 +282,6 @@ export class ChatView extends React.Component<Properties, State> {
             {!this.props.hasLoadedMessages && this.props.messagesFetchStatus !== MessagesFetchState.FAILED && (
               <ChatSkeleton conversationId={this.props.id} />
             )}
-          </div>
-          <div {...cn('bottom-anchor')}>
-            <Waypoint onEnter={this.pinBottom} onLeave={this.unpinBottom} />
           </div>
         </InvertedScroll>
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -266,11 +266,7 @@ export class ChatView extends React.Component<Properties, State> {
               </div>
             )}
 
-            {this.props.messages.length > 0 && (
-              <div {...cn('way')}>
-                <Waypoint onEnter={this.props.onFetchMore} />
-              </div>
-            )}
+            {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
             {this.props.messages.length > 0 && this.renderMessages()}
             {!this.props.hasLoadedMessages && this.props.messagesFetchStatus !== MessagesFetchState.FAILED && (
               <ChatSkeleton conversationId={this.props.id} />

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -15,6 +15,42 @@
   }
 }
 
+.chat-view__way {
+  height: 10px;
+  background-color: blue;
+  position: relative;
+  top: 505px;
+  overflow-anchor: none;
+}
+
+.channel-view__inverted-scroll {
+  overflow-anchor: auto;
+
+  * {
+    overflow-anchor: none;
+  }
+
+  .channel-view__main.messages__container--pinned-bottom {
+    overflow-anchor: none;
+  }
+
+  .channel-view__main,
+  .messages__container,
+  .messages,
+  .message__group,
+  .messages__message-row,
+  .messages__message {
+    overflow-anchor: auto;
+  }
+
+  .chat-view__bottom-anchor {
+    overflow-anchor: auto;
+    height: 10px;
+    margin: 0px 10px;
+    background-color: yellow;
+  }
+}
+
 .chat-skeleton {
   animation: fadein 1s ease-in forwards;
   width: 100%;

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -15,14 +15,6 @@
   }
 }
 
-.chat-view__way {
-  height: 10px;
-  background-color: blue;
-  position: relative;
-  top: 505px;
-  overflow-anchor: none;
-}
-
 .message__header {
   // This node can move when new content comes in so don't use it to pin the scroll position.
   overflow-anchor: none;

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -23,37 +23,15 @@
   overflow-anchor: none;
 }
 
-.channel-view__inverted-scroll {
-  overflow-anchor: auto;
-
-  * {
-    overflow-anchor: none;
-  }
-
-  .channel-view__main.messages__container--pinned-bottom {
-    overflow-anchor: none;
-  }
-
-  .channel-view__main,
-  .messages__container,
-  .messages,
-  .message__group,
-  .messages__message-row,
-  .messages__message {
-    overflow-anchor: auto;
-  }
-
-  .chat-view__bottom-anchor {
-    overflow-anchor: auto;
-    height: 10px;
-    margin: 0px 10px;
-    background-color: yellow;
-  }
+.message__header {
+  // This node can move when new content comes in so don't use it to pin the scroll position.
+  overflow-anchor: none;
 }
 
 .chat-skeleton {
   animation: fadein 1s ease-in forwards;
   width: 100%;
+  overflow: hidden;
 
   &__date {
     clear: both;

--- a/src/components/inverted-scroll/index.test.tsx
+++ b/src/components/inverted-scroll/index.test.tsx
@@ -13,13 +13,6 @@ describe('inverted-scroll', () => {
     return shallow(<InvertedScroll {...allProps}>{child}</InvertedScroll>);
   };
 
-  it('renders component', function () {
-    const wrapper = subject({});
-
-    expect(wrapper.hasClass('scroll-container')).toBe(true);
-    expect(wrapper.find('.scroll-container__children').exists()).toBe(true);
-  });
-
   it('renders children', function () {
     const wrapper = subject({}, <div className='coffee-component' />);
 

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 import classNames from 'classnames';
 import './styles.scss';
+import { bemClassName } from '../../lib/bem';
+import { Waypoint } from 'react-waypoint';
+
+const cn = bemClassName('inverted-scroll');
 
 export interface Properties {
   className?: string;
 }
 
-export class InvertedScroll extends React.Component<Properties, undefined> {
+interface State {
+  pinnedBottom: boolean;
+}
+
+export class InvertedScroll extends React.Component<Properties, State> {
+  state = { pinnedBottom: false };
   scrollWrapper: HTMLElement;
 
   scrollToBottom() {
     console.log('manual scroll');
+    this.pinBottom();
     this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
   }
 
@@ -29,6 +39,9 @@ export class InvertedScroll extends React.Component<Properties, undefined> {
     this.scrollToBottom();
   };
 
+  pinBottom = () => this.setState({ pinnedBottom: true });
+  unpinBottom = () => this.setState({ pinnedBottom: false });
+
   render() {
     return (
       <div
@@ -36,7 +49,10 @@ export class InvertedScroll extends React.Component<Properties, undefined> {
         className={classNames('scroll-container', this.props.className)}
         ref={this.setScrollWrapper}
       >
-        {this.props.children}
+        <div {...cn('content', this.state.pinnedBottom && 'pinned-bottom')}>{this.props.children}</div>
+        <div {...cn('bottom-anchor')}>
+          <Waypoint onEnter={this.pinBottom} onLeave={this.unpinBottom} />
+        </div>
       </div>
     );
   }

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import debounce from 'lodash.debounce';
 import './styles.scss';
-
-const SCROLL_HEIGHT_FIXER_DELAY_MS = 5;
-const SCROLL_HEIGHT_FIXER_ITERATIONS = 1000;
 
 export interface Properties {
   className?: string;
@@ -12,52 +8,17 @@ export interface Properties {
 
 export class InvertedScroll extends React.Component<Properties, undefined> {
   scrollWrapper: HTMLElement;
-  cancelScrollFixer: boolean = false;
-
-  getSnapshotBeforeUpdate() {
-    if (this.scrollWrapper) {
-      return {
-        scrollHeight: this.scrollWrapper.scrollHeight,
-        scrollTop: this.scrollWrapper.scrollTop,
-        clientHeight: this.scrollWrapper.clientHeight,
-      };
-    }
-
-    return null;
-  }
-
-  componentDidUpdate(_prevProps, _prevState, snapshot) {
-    if (snapshot) {
-      this.adjustScrollPositionForContentChanges(snapshot);
-    }
-  }
-
-  adjustScrollPositionForContentChanges(snapshot?: { scrollHeight: number; scrollTop: number; clientHeight: number }) {
-    const addedContentHeight = this.scrollWrapper.scrollHeight - snapshot.scrollHeight;
-
-    // The bottom point of the scrolled view port as a percentage
-    const distanceFromBottomPixels = snapshot
-      ? snapshot.scrollHeight - (snapshot.scrollTop + snapshot.clientHeight)
-      : 0;
-
-    const isSnapshotHeightSame = snapshot && snapshot.scrollHeight === this.scrollWrapper.scrollHeight;
-
-    if (distanceFromBottomPixels < 200) {
-      if (!isSnapshotHeightSame) {
-        this.scrollToBottom();
-      }
-    } else if (addedContentHeight > 61) {
-      // should mostly avoid jumping when new messages come in unless more than 2 lines long.
-      this.scrollWrapper.scrollTop = snapshot.scrollTop + addedContentHeight;
-    }
-  }
 
   scrollToBottom() {
+    console.log('manual scroll');
     this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
-
-    this.scrollFixer();
   }
 
+  scroll(x, y) {
+    this.scrollWrapper.scroll(x, y);
+  }
+
+  // XXX: do we need this really?
   setScrollWrapper = (element: HTMLElement) => {
     if (!element) {
       return;
@@ -68,28 +29,14 @@ export class InvertedScroll extends React.Component<Properties, undefined> {
     this.scrollToBottom();
   };
 
-  fixScroll = debounce((oldScrollHeight: number, iterations: number = 0) => {
-    if (this.scrollWrapper.scrollHeight !== oldScrollHeight) {
-      this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
-      // Schedule another fix scroll again incase more load in with current scroll height
-      this.fixScroll(this.scrollWrapper.scrollHeight);
-    } else if (iterations < SCROLL_HEIGHT_FIXER_ITERATIONS) {
-      // Schedule another until iterations run out
-      // Will be cancelled if scrolling upwards.
-      this.fixScroll(oldScrollHeight, iterations + 1);
-    }
-  }, SCROLL_HEIGHT_FIXER_DELAY_MS);
-
-  scrollFixer = () => {
-    const oldScrollHeight = this.scrollWrapper.scrollHeight;
-
-    this.fixScroll(oldScrollHeight);
-  };
-
   render() {
     return (
-      <div className={classNames('scroll-container', this.props.className)} ref={this.setScrollWrapper}>
-        <div className='scroll-container__children'>{this.props.children}</div>
+      <div
+        id='invert-scroll'
+        className={classNames('scroll-container', this.props.className)}
+        ref={this.setScrollWrapper}
+      >
+        {this.props.children}
       </div>
     );
   }

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -19,24 +19,25 @@ export class InvertedScroll extends React.Component<Properties, State> {
   scrollWrapper: HTMLElement;
 
   scrollToBottom() {
-    console.log('manual scroll');
     this.pinBottom();
     this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
   }
 
-  scroll(x, y) {
-    this.scrollWrapper.scroll(x, y);
-  }
-
-  // XXX: do we need this really?
   setScrollWrapper = (element: HTMLElement) => {
     if (!element) {
       return;
     }
 
     this.scrollWrapper = element;
-
     this.scrollToBottom();
+  };
+
+  preventHigherScroll = () => {
+    // If we get fully scrolled to the top, scroll down a bit to prevent
+    // the browser from pinning our position to the top of the scroll view.
+    if (this.scrollWrapper) {
+      this.scrollWrapper.scroll(0, 1);
+    }
   };
 
   pinBottom = () => this.setState({ pinnedBottom: true });
@@ -49,6 +50,7 @@ export class InvertedScroll extends React.Component<Properties, State> {
         className={classNames('scroll-container', this.props.className)}
         ref={this.setScrollWrapper}
       >
+        <Waypoint onEnter={this.preventHigherScroll} />
         <div {...cn('content', this.state.pinnedBottom && 'pinned-bottom')}>{this.props.children}</div>
         <div {...cn('bottom-anchor')}>
           <Waypoint onEnter={this.pinBottom} onLeave={this.unpinBottom} />

--- a/src/components/inverted-scroll/styles.scss
+++ b/src/components/inverted-scroll/styles.scss
@@ -14,8 +14,6 @@
 
   &__bottom-anchor {
     overflow-anchor: auto;
-    height: 10px;
-    margin: 0px 10px;
-    background-color: yellow;
+    height: 1px;
   }
 }

--- a/src/components/inverted-scroll/styles.scss
+++ b/src/components/inverted-scroll/styles.scss
@@ -1,12 +1,4 @@
 .scroll-container {
   overflow-y: scroll;
   overflow-x: hidden;
-
-  .scroll-container__children {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    min-height: 100%;
-    overflow: hidden;
-  }
 }

--- a/src/components/inverted-scroll/styles.scss
+++ b/src/components/inverted-scroll/styles.scss
@@ -2,3 +2,20 @@
   overflow-y: scroll;
   overflow-x: hidden;
 }
+
+.inverted-scroll {
+  &__content {
+    overflow-anchor: auto;
+  }
+
+  &__content.inverted-scroll__content--pinned-bottom {
+    overflow-anchor: none;
+  }
+
+  &__bottom-anchor {
+    overflow-anchor: auto;
+    height: 10px;
+    margin: 0px 10px;
+    background-color: yellow;
+  }
+}


### PR DESCRIPTION
### What does this do?

This removes a lot of the manual scroll position management that was happening in the InvertedScroll component and replaces it with mechanisms more built into the browsers.

Notes:
* There's still an edge case when infinite scrolling up. To be handled in another story.
* Pinning to the bottom may not quite work correctly in Safari as the overflow-anchor doesn't appear to be supported.

### Why are we making this change?

We've been having issues with the chat window randomly scrolling to the bottom of the history. Smooth out the user experience.

### How do I test this?

Exercise various scroll states and events in a conversation:
* When opening the converstation it shoudl be scrolled to the bottom
* When scrolled to the bottom the conversation should stay pinned there. New messages "push the conversation up".
* Scroll up a bit and then receive a new message. The conversation view should remain mostly stationary.
* Scroll all the way up to trigger a fetch for more messages then quickly scroll slightly downwards. When the new data comes in the view should remain mostly stationary (Note: this scenario will get better in the next story)

