### PR TITLE
Begin new page fetch earlier

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -270,7 +270,11 @@ export class ChatView extends React.Component<Properties, State> {
                 <span>This is the start of the channel.</span>
               </div>
             )}
-            {this.props.messages.length > 0 && <Waypoint onEnter={this.props.onFetchMore} />}
+            {this.props.messages.length > 0 && (
+              <div {...cn('infinite-scroll-waypoint')}>
+                <Waypoint onEnter={this.props.onFetchMore} />
+              </div>
+            )}
             {this.props.messages.length > 0 && this.renderMessages()}
             {!this.props.hasLoadedMessages && this.props.messagesFetchStatus !== MessagesFetchState.FAILED && (
               <ChatSkeleton conversationId={this.props.id} />

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -20,6 +20,12 @@
   overflow-anchor: none;
 }
 
+.chat-view__infinite-scroll-waypoint {
+  overflow-anchor: none;
+  position: relative;
+  top: 700px;
+}
+
 .chat-skeleton {
   animation: fadein 1s ease-in forwards;
   width: 100%;


### PR DESCRIPTION
### What does this do?

Moves the infinite scroll waypoint down by 700px to start the message fetch earlier

### Why are we making this change?

Infinite scroll tuning

