### PR TITLE
Render loading skeleton during infinite scroll load

### DIFF
--- a/src/components/chat-view-container/chat-skeleton.test.tsx
+++ b/src/components/chat-view-container/chat-skeleton.test.tsx
@@ -44,4 +44,10 @@ describe(ChatSkeleton, () => {
     wrapper.setProps({ conversationId: 'should restart' });
     expect(wrapper).toHaveElement('ChatSkeleton1');
   });
+
+  it('renders a shortened skeleton', () => {
+    const wrapper = subject({ conversationId: 'aaa', short: true });
+
+    expect(wrapper.childAt(0).prop('short')).toBe(true);
+  });
 });

--- a/src/components/chat-view-container/chat-skeleton.tsx
+++ b/src/components/chat-view-container/chat-skeleton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Skeleton } from '@zero-tech/zui/components';
 import { bem } from '../../lib/bem';
@@ -7,6 +7,7 @@ const c = bem('chat-skeleton');
 
 export interface Properties {
   conversationId: string;
+  short?: boolean;
 }
 
 interface State {
@@ -39,207 +40,216 @@ export class ChatSkeleton extends React.Component<Properties, State> {
   render() {
     return (
       <div className={c('')}>
-        {this.state.skeletonId === 0 && <ChatSkeleton1 />}
-        {this.state.skeletonId === 1 && <ChatSkeleton2 />}
-        {this.state.skeletonId >= 2 && <ChatSkeleton3 />}
+        {this.state.skeletonId === 0 && <ChatSkeleton1 short={!!this.props.short} />}
+        {this.state.skeletonId === 1 && <ChatSkeleton2 short={!!this.props.short} />}
+        {this.state.skeletonId >= 2 && <ChatSkeleton3 short={!!this.props.short} />}
       </div>
     );
   }
 }
 
-class ChatSkeleton1 extends React.PureComponent {
+class ChatSkeleton1 extends React.PureComponent<{ short: boolean }> {
+  get nodes() {
+    return [
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='65px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='520px' height='99px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='202px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='520px' height='69px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='310px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='181px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='520px' height='71px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='217px' height='33px' />
+      </div>,
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+    ];
+  }
+
   render() {
-    return (
-      <>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='65px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='520px' height='99px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='202px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='520px' height='69px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='310px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='181px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='520px' height='71px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='217px' height='33px' />
-        </div>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-      </>
-    );
+    const renderNodes = this.props.short ? this.nodes.slice(-3) : this.nodes;
+    return renderNodes.map((n, index) => <Fragment key={index}>{n}</Fragment>);
   }
 }
 
-class ChatSkeleton2 extends React.PureComponent {
+class ChatSkeleton2 extends React.PureComponent<{ short: boolean }> {
+  get nodes() {
+    return [
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='65px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='520px' height='75px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='336px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='202px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='310px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='249px' height='33px' />
+      </div>,
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='206px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='520px' height='71px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='142px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='520px' height='33px' />
+      </div>,
+    ];
+  }
+
   render() {
-    return (
-      <>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='65px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='520px' height='75px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='336px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='202px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='310px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='249px' height='33px' />
-        </div>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='206px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='520px' height='71px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='142px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='520px' height='33px' />
-        </div>
-      </>
-    );
+    const renderNodes = this.props.short ? this.nodes.slice(-3) : this.nodes;
+    return renderNodes.map((n, index) => <Fragment key={index}>{n}</Fragment>);
   }
 }
 
-class ChatSkeleton3 extends React.PureComponent {
+class ChatSkeleton3 extends React.PureComponent<{ short: boolean }> {
+  get nodes() {
+    return [
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='65px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='520px' height='99px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='202px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='310px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='249px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='206px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='520px' height='135px' />
+      </div>,
+      <div className={c('date')}>
+        <div>
+          <Skeleton width='100%' height='100%' />
+        </div>
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+      <div className={c('message')}>
+        <Skeleton width='520px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='206px' height='33px' />
+      </div>,
+      <div className={c('message', 'owner')}>
+        <Skeleton width='270px' height='33px' />
+      </div>,
+    ];
+  }
+
   render() {
-    return (
-      <>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='65px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='520px' height='99px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='202px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='310px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='249px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='206px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='520px' height='135px' />
-        </div>
-        <div className={c('date')}>
-          <div>
-            <Skeleton width='100%' height='100%' />
-          </div>
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-        <div className={c('message')}>
-          <Skeleton width='520px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='206px' height='33px' />
-        </div>
-        <div className={c('message', 'owner')}>
-          <Skeleton width='270px' height='33px' />
-        </div>
-      </>
-    );
+    const renderNodes = this.props.short ? this.nodes.slice(-3) : this.nodes;
+    return renderNodes.map((n, index) => <Fragment key={index}>{n}</Fragment>);
   }
 }

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -270,6 +270,11 @@ export class ChatView extends React.Component<Properties, State> {
                 <span>This is the start of the channel.</span>
               </div>
             )}
+            {this.props.hasLoadedMessages && this.props.messagesFetchStatus === MessagesFetchState.IN_PROGRESS && (
+              <div {...cn('scroll-skeleton')}>
+                <ChatSkeleton conversationId={this.props.id} short />
+              </div>
+            )}
             {this.props.messages.length > 0 && (
               <div {...cn('infinite-scroll-waypoint')}>
                 <Waypoint onEnter={this.props.onFetchMore} />

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -15,7 +15,8 @@
   }
 }
 
-.message__header {
+.message__header,
+.chat-view__scroll-skeleton {
   // This node can move when new content comes in so don't use it to pin the scroll position.
   overflow-anchor: none;
 }


### PR DESCRIPTION
### What does this do?

Renders a loading skeleton when scrolling up in a conversation causes a fetch for more messages.

### Why are we making this change?

To give the user information that more data is loading.

### How do I test this?

Open a conversation with a lot of messages. Scroll up to trigger a load of the next page. Verify the skeleton is shown while loading.

