### PR TITLE
Remove message group wrapper node

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -158,27 +158,29 @@ export class ChatView extends React.Component<Properties, State> {
               'messages__message-row--owner': this.isUserOwnerOfMessage(message),
             })}
           >
-            <Message
-              className={classNames('messages__message', {
-                'messages__message--last-in-group': this.props.showSenderAvatar && index === groupMessages.length - 1,
-              })}
-              onImageClick={this.openLightbox}
-              messageId={message.id}
-              updatedAt={message.updatedAt}
-              isOwner={this.isUserOwnerOfMessage(message)}
-              onDelete={this.props.deleteMessage}
-              onEdit={this.props.editMessage}
-              onReply={this.props.onReply}
-              parentMessageText={message.parentMessageText}
-              parentSenderIsCurrentUser={this.isUserOwnerOfMessage(message.parentMessage)}
-              parentSenderFirstName={message.parentMessage?.sender?.firstName}
-              parentSenderLastName={message.parentMessage?.sender?.lastName}
-              getUsersForMentions={this.searchMentionableUsers}
-              showSenderAvatar={this.props.showSenderAvatar}
-              showTimestamp={messageRenderProps.showTimestamp}
-              showAuthorName={messageRenderProps.showAuthorName}
-              {...message}
-            />
+            <div {...cn('group-message', messageRenderProps.position)}>
+              <Message
+                className={classNames('messages__message', {
+                  'messages__message--last-in-group': this.props.showSenderAvatar && index === groupMessages.length - 1,
+                })}
+                onImageClick={this.openLightbox}
+                messageId={message.id}
+                updatedAt={message.updatedAt}
+                isOwner={this.isUserOwnerOfMessage(message)}
+                onDelete={this.props.deleteMessage}
+                onEdit={this.props.editMessage}
+                onReply={this.props.onReply}
+                parentMessageText={message.parentMessageText}
+                parentSenderIsCurrentUser={this.isUserOwnerOfMessage(message.parentMessage)}
+                parentSenderFirstName={message.parentMessage?.sender?.firstName}
+                parentSenderLastName={message.parentMessage?.sender?.lastName}
+                getUsersForMentions={this.searchMentionableUsers}
+                showSenderAvatar={this.props.showSenderAvatar}
+                showTimestamp={messageRenderProps.showTimestamp}
+                showAuthorName={messageRenderProps.showAuthorName}
+                {...message}
+              />
+            </div>
           </div>
         );
       }
@@ -193,19 +195,7 @@ export class ChatView extends React.Component<Properties, State> {
         <div className='message__header'>
           <div className='message__header-date'>{this.formatDayHeader(day)}</div>
         </div>
-        {groups.map((group) => {
-          // Good enough approximation of a unique key to allow consistent enough
-          // rendering of the message groups to not mess up the scroll position.
-          // An alternative would be to not render the group wrapper at all and
-          // style the groups messages via separate classes/attributes.
-          const lastMessage = group.at(-1);
-          const groupKey = `group_${lastMessage.optimisticId || lastMessage.id}`;
-          return (
-            <div key={groupKey} className='message__group'>
-              {this.renderMessageGroup(group)}
-            </div>
-          );
-        })}
+        {groups.map((group) => this.renderMessageGroup(group)).flat()}
       </div>
     );
   }

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -13,6 +13,44 @@
     font-weight: 400;
     line-height: normal;
   }
+
+  &__group-message {
+    --border-radius: 2px 8px 8px 2px;
+  }
+
+  &__group-message--first {
+    --border-radius: 8px 8px 8px 2px;
+  }
+
+  &__group-message--last {
+    margin-bottom: 16px;
+    --border-radius: 2px 8px 8px 0px;
+  }
+
+  &__group-message--only {
+    margin-bottom: 16px;
+    --border-radius: 8px 8px 8px 0px;
+  }
+}
+
+.messages__message-row--owner {
+  .chat-view {
+    &__group-message {
+      --border-owner-radius: 8px 2px 2px 8px;
+    }
+
+    &__group-message--first {
+      --border-owner-radius: 8px 8px 2px 8px;
+    }
+
+    &__group-message--last {
+      --border-owner-radius: 8px 2px 0px 8px;
+    }
+
+    &__group-message--only {
+      --border-owner-radius: 8px 8px 2px 8px;
+    }
+  }
 }
 
 .message__header,

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -127,6 +127,44 @@ describe(getMessageRenderProps, () => {
     });
   });
 
+  describe('position', () => {
+    it('is "only" if there is only one message', () => {
+      const index = 0;
+      const groupLength = 1;
+
+      const props = getProps({ index, groupLength });
+
+      expect(props.position).toEqual('only');
+    });
+
+    it('is "first" if it is the first in the group', () => {
+      const index = 0;
+      const groupLength = 2;
+
+      const props = getProps({ index, groupLength });
+
+      expect(props.position).toEqual('first');
+    });
+
+    it('is "last" if it is the last in the group', () => {
+      const index = 3;
+      const groupLength = 4;
+
+      const props = getProps({ index, groupLength });
+
+      expect(props.position).toEqual('last');
+    });
+
+    it('is empty if it is in the middle', () => {
+      const index = 2;
+      const groupLength = 4;
+
+      const props = getProps({ index, groupLength });
+
+      expect(props.position).toEqual('');
+    });
+  });
+
   function getProps({
     index,
     groupLength,

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -34,9 +34,18 @@ function isRelated(message1, message2) {
 
 export function getMessageRenderProps(index: number, groupLength: number, isOneOnOne: boolean, isOwner: boolean) {
   const lastIndex = groupLength - 1;
+  let position = '';
+  if (groupLength <= 1) {
+    position = 'only';
+  } else if (index === 0) {
+    position = 'first';
+  } else if (index === lastIndex) {
+    position = 'last';
+  }
 
   return {
     showAuthorName: index === 0 && !isOwner && !isOneOnOne,
     showTimestamp: index === lastIndex,
+    position,
   };
 }

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -268,37 +268,10 @@ $scrollbar-width: 5px;
       display: flex;
       clear: both;
       margin: 4px 16px;
-      --border-radius: 2px 8px 8px 2px;
 
       &--owner {
         justify-content: flex-end;
-        --border-owner-radius: 8px 2px 2px 8px;
       }
-
-      &--owner:first-child {
-        --border-owner-radius: 8px 8px 2px 8px;
-      }
-
-      &--owner:last-child {
-        --border-owner-radius: 8px 2px 0px 8px;
-      }
-
-      &--owner:only-child {
-        --border-owner-radius: 8px 8px 2px 8px;
-      }
-    }
-
-    &__message-row:first-child {
-      --border-radius: 8px 8px 8px 2px;
-    }
-
-    &__message-row:last-child {
-      margin-bottom: 16px;
-      --border-radius: 2px 8px 8px 0px;
-    }
-
-    &__message-row:only-child {
-      --border-radius: 8px 8px 8px 0px;
     }
   }
 }


### PR DESCRIPTION
### What does this do?

Removes the message group wrapper node in the conversation view. This was previously used to style the messages based on their position in the group. Replaced it with specific classes on the nodes.

### Why are we making this change?

Having larger wrapping nodes gets in the way of the browser maintaining scroll position when content changes.

### How do I test this?

Scroll up on a long conversation and note that most situations load new data without the view "jumping"
