### PR TITLE
Remove Waypoint while fetching messages

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -265,7 +265,7 @@ export class ChatView extends React.Component<Properties, State> {
                 <ChatSkeleton conversationId={this.props.id} short />
               </div>
             )}
-            {this.props.messages.length > 0 && (
+            {this.props.messages.length > 0 && this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && (
               <div {...cn('infinite-scroll-waypoint')}>
                 <Waypoint onEnter={this.props.onFetchMore} />
               </div>


### PR DESCRIPTION
### What does this do?

Hide the waypoint when we fetch more messages for a conversation.

### Why are we making this change?

When fetching new messages a user may scroll around which triggers more leave/enter events on the waypoint but we don't really want to trigger more fetches.
