### PR TITLE
Remove messages wrapper node

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -191,12 +191,12 @@ export class ChatView extends React.Component<Properties, State> {
     const groups = createMessageGroups(messagesByDay[day]);
 
     return (
-      <div className='messages' key={day}>
+      <Fragment key={day}>
         <div className='message__header'>
           <div className='message__header-date'>{this.formatDayHeader(day)}</div>
         </div>
         {groups.map((group) => this.renderMessageGroup(group)).flat()}
-      </div>
+      </Fragment>
     );
   }
 

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -240,38 +240,28 @@ $scrollbar-width: 5px;
 .messages__container {
   animation: fadein 200ms ease-out forwards;
 
-  .messages {
+  .message__header {
+    display: flex;
+    align-items: center;
     position: relative;
-    overflow: inherit;
-    transition: opacity 0.9s ease-out;
-    opacity: 1;
-    clear: both;
+    margin: 8px 16px;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
 
-    .message__header {
-      display: flex;
-      align-items: center;
-      position: relative;
-      margin: 8px 16px;
-      font-weight: 400;
-      font-size: 12px;
-      line-height: 15px;
-      clear: both;
-
-      &-date {
-        color: theme.$color-greyscale-transparency-11;
-        width: 100%;
-        text-align: center;
-      }
+    &-date {
+      color: theme.$color-greyscale-transparency-11;
+      width: 100%;
+      text-align: center;
     }
+  }
 
-    &__message-row {
-      display: flex;
-      clear: both;
-      margin: 4px 16px;
+  .messages__message-row {
+    display: flex;
+    margin: 4px 16px;
 
-      &--owner {
-        justify-content: flex-end;
-      }
+    &--owner {
+      justify-content: flex-end;
     }
   }
 }
@@ -285,7 +275,7 @@ $scrollbar-width: 5px;
   }
 }
 
-.messages__container .messages .messages__message-row:hover {
+.messages__container .messages__message-row:hover {
   .message__menu {
     transform: translateX(0);
     transition: transform 0.1s ease-in-out, opacity 0s ease-in-out;


### PR DESCRIPTION
### What does this do?

Removes the `messages` wrapper node in the conversation view. It's unclear why this existed in the first place but it seems to not be required.

### Why are we making this change?

Having larger wrapping nodes gets in the way of the browser maintaining scroll position when content changes.

### How do I test this?

Scroll up on a long conversation and note that most situations load new data without the view "jumping"
