### PR TITLE
Cursor should be active by default in input field when you EDIT a message

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -75,6 +75,10 @@ export class MessageInput extends React.Component<Properties, State> {
   }
 
   componentDidMount() {
+    if (this.props.isEditing) {
+      this.focusInput();
+    }
+
     if (this.props.onMessageInputRendered) {
       this.props.onMessageInputRendered(this.textareaRef);
     }
@@ -127,7 +131,14 @@ export class MessageInput extends React.Component<Properties, State> {
 
   focusInput() {
     if (this.textareaRef && this.textareaRef.current) {
-      this.textareaRef.current.focus();
+      const input = this.textareaRef.current;
+
+      // Set focus on the input
+      input.focus();
+
+      // Move the cursor to the end of the text
+      const textLength = input.value.length;
+      input.setSelectionRange(textLength, textLength);
     }
   }
 


### PR DESCRIPTION
Before (focus not active by default):

https://github.com/zer0-os/zOS/assets/33264364/7700058f-9c56-4e6f-b1bd-b5bc31ae68f2

After:


https://github.com/zer0-os/zOS/assets/33264364/0b5092ba-ec5e-4042-afa1-b62313a949cb

