### PR TITLE
Add a status when fetching more messages for a conversation

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -260,7 +260,7 @@ export class ChatView extends React.Component<Properties, State> {
                 <span>This is the start of the channel.</span>
               </div>
             )}
-            {this.props.hasLoadedMessages && this.props.messagesFetchStatus === MessagesFetchState.IN_PROGRESS && (
+            {this.props.hasLoadedMessages && this.props.messagesFetchStatus === MessagesFetchState.MORE_IN_PROGRESS && (
               <div {...cn('scroll-skeleton')}>
                 <ChatSkeleton conversationId={this.props.id} short />
               </div>

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -23,6 +23,7 @@ export enum GroupChannelType {
 export enum MessagesFetchState {
   SUCCESS,
   IN_PROGRESS,
+  MORE_IN_PROGRESS,
   FAILED,
 }
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -96,12 +96,11 @@ export function* fetch(action) {
   let messagesResponse: any;
   let messages: any[];
 
-  yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.IN_PROGRESS }));
-
   try {
     const chatClient = yield call(chat.get);
 
     if (referenceTimestamp) {
+      yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.MORE_IN_PROGRESS }));
       const existingMessages = yield select(rawMessagesSelector(channelId));
       messagesResponse = yield call(
         [
@@ -117,6 +116,7 @@ export function* fetch(action) {
         ...existingMessages,
       ];
     } else {
+      yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.IN_PROGRESS }));
       messagesResponse = yield call(
         [
           chatClient,


### PR DESCRIPTION
### What does this do?

Adds a separate progress state for loading more messages in a conversation/channel.

### Why are we making this change?

Having them connected causes the fetch more skeleton to render at inappropriate times.

### How do I test this?

Open a conversation and scroll up to trigger loading more messages. Verify the small skeleton renders appropriately.
