### PR TITLE
Change array wrap to more than 3 elements in prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "plugins": ["./node_modules/prettier-plugin-multiline-arrays"],
+  "multilineArraysWrapThreshold": 3,
   "singleQuote": true,
   "trailingComma": "es5",
   "jsxSingleQuote": true,

--- a/src/components/address-bar/container.tsx
+++ b/src/components/address-bar/container.tsx
@@ -55,10 +55,7 @@ export class Container extends React.Component<Properties> {
   }
 
   getNextRoute() {
-    let [
-      nextRoute,
-      ...segments
-    ] = this.props.deepestVisitedRoute.split('.');
+    let [nextRoute, ...segments] = this.props.deepestVisitedRoute.split('.');
 
     for (const segment of segments) {
       const workingRoute = `${nextRoute}.${segment}`;


### PR DESCRIPTION
### What does this do?

Update the prettier config to allow single line arrays up to 3 elements.

### Why are we making this change?

Forcing arrays to multiple lines makes a lot of code very hard to scan due to the extended vertical height.

Before:
![image](https://github.com/zer0-os/zOS/assets/43770/d2408b05-8324-4bfd-b0f5-9cf6233050a7)

After:
![image](https://github.com/zer0-os/zOS/assets/43770/83cec1e6-7eef-4ed8-9340-a9cb6d78dce4)
