### PR TITLE
Maintain existing cached messages when loading the first page of a conversation

### DIFF
--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -22,13 +22,16 @@ describe(fetch, () => {
     ]);
   }
 
-  it('adds messages to channel', async () => {
-    const channel = { id: 'channel-id', messages: ['old-message-id'] };
+  it('adds newly fetched messages to channel', async () => {
+    const existingMessages = [
+      { id: 'second-page', message: 'old' },
+      { id: 'first-page', message: 'fresh' },
+    ];
+    const channel = { id: 'channel-id', messages: existingMessages };
     const messageResponse = {
       messages: [
-        { id: 'the-first-message-id', message: 'the first message' },
-        { id: 'the-second-message-id', message: 'the second message' },
-        { id: 'the-third-message-id', message: 'the third message' },
+        { id: 'first-page', message: 'fresh' },
+        { id: 'brand-new', message: 'new' },
       ],
     };
 
@@ -38,15 +41,15 @@ describe(fetch, () => {
       .run();
 
     expect(denormalize(channel.id, storeState).messages).toStrictEqual([
-      { id: 'the-first-message-id', message: 'the first message' },
-      { id: 'the-second-message-id', message: 'the second message' },
-      { id: 'the-third-message-id', message: 'the third message' },
+      { id: 'second-page', message: 'old' },
+      { id: 'first-page', message: 'fresh' },
+      { id: 'brand-new', message: 'new' },
     ]);
   });
 
   it('sets hasMore on channel', async () => {
-    const channel = { id: 'channel-id', hasMore: true };
-    const messageResponse = { hasMore: false };
+    const channel = { id: 'channel-id', hasMore: true, messages: [] };
+    const messageResponse = { hasMore: false, messages: [] };
 
     const { storeState } = await subject(fetch, { payload: { channelId: channel.id } })
       .provide([[matchers.call.fn(chatClient.getMessagesByChannelId), messageResponse]])


### PR DESCRIPTION
### What does this do?

This ensures we maintain the message cache that we already have when fetching messages upon opening a conversation.

### Why are we making this change?

Previously if you scrolled up and loaded a few pages of a conversation then switched away, when you came back we would fetch the first page again but then wipe out the later pages that hade been loaded. This ensures we don't wipe out all that data we've already gathered.

