### PR TITLE
Mark messages read instantaneously for a channel/conversation

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -14,6 +14,7 @@ describe('ConversationListPanel', () => {
       onConversationClick: () => null,
       startConversation: () => null,
       onCreateConversation: () => null,
+      markConversationAsRead: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -27,6 +27,7 @@ export interface Properties {
   startConversation: () => void;
   onCreateConversation: (userId: string) => void;
   onConversationClick: (conversationId: string) => void;
+  markConversationAsRead: (payload: { channelId: string }) => void;
 }
 
 interface State {
@@ -116,6 +117,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
 
   openExistingConversation = (id: string) => {
     this.props.onConversationClick(id);
+    this.props.markConversationAsRead({ channelId: id });
     this.setState({ filter: '' });
   };
 

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -46,6 +46,7 @@ describe('messenger-list', () => {
       openConversation: jest.fn(),
       fetchConversations: jest.fn(),
       createConversation: jest.fn(),
+      markConversationAsRead: jest.fn(),
       startCreateConversation: () => null,
       membersSelected: () => null,
       startGroup: () => null,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -3,6 +3,7 @@ import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store/reducer';
 import { Channel } from '../../../store/channels';
 import { setactiveConversationId } from '../../../store/chat';
+import { markAllMessagesAsReadInConversation } from '../../../store/channels';
 import { denormalizeConversations, fetchConversations } from '../../../store/channels-list';
 import { compareDatesDesc } from '../../../lib/date';
 import { MemberNetworks } from '../../../store/users/types';
@@ -72,6 +73,7 @@ export interface Properties extends PublicProperties {
   fetchConversations: () => void;
   membersSelected: (payload: MembersSelectedPayload) => void;
   createConversation: (payload: CreateMessengerConversation) => void;
+  markConversationAsRead: (payload: { channelId: string }) => void;
   enterFullScreenMessenger: () => void;
   fetchRewards: (_obj: any) => void;
   rewardsPopupClosed: () => void;
@@ -125,6 +127,7 @@ export class Container extends React.Component<Properties, State> {
   static mapActions(_props: Properties): Partial<Properties> {
     return {
       openConversation: setactiveConversationId,
+      markConversationAsRead: markAllMessagesAsReadInConversation,
       fetchConversations,
       createConversation,
       startCreateConversation,
@@ -252,6 +255,7 @@ export class Container extends React.Component<Properties, State> {
               conversations={this.props.conversations}
               onCreateConversation={this.createOneOnOneConversation}
               onConversationClick={this.props.openConversation}
+              markConversationAsRead={this.props.markConversationAsRead}
               startConversation={this.props.startCreateConversation}
               myUserId={this.props.myUserId}
               activeConversationId={this.props.activeConversationId}

--- a/src/platform-apps/channels/container.test.tsx
+++ b/src/platform-apps/channels/container.test.tsx
@@ -26,6 +26,7 @@ describe('ChannelsContainer', () => {
       fetchChannels: () => undefined,
       stopSyncChannels: () => undefined,
       setActiveChannelId: () => undefined,
+      markAllMessagesAsReadInChannel: () => undefined,
       channelId: '',
       match: { url: '' },
       user: {

--- a/src/platform-apps/channels/container.tsx
+++ b/src/platform-apps/channels/container.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import getDeepProperty from 'lodash.get';
 import { setActiveChannelId } from '../../store/chat';
+import { markAllMessagesAsReadInChannel } from '../../store/channels';
 
 import { RootState } from '../../store/reducer';
 import { Store } from 'redux';
@@ -31,6 +32,7 @@ interface PublicProperties {
 
 export interface Properties extends PublicProperties {
   setActiveChannelId: (channelId: string) => void;
+  markAllMessagesAsReadInChannel: (payload: { channelId: string }) => void;
 
   domainId: string;
   channels: Channel[];
@@ -57,12 +59,14 @@ export class Container extends React.Component<Properties> {
     return {
       fetchChannels,
       setActiveChannelId,
+      markAllMessagesAsReadInChannel,
     };
   }
 
   setActiveChannelId() {
     if (this.props.channelId) {
       this.props.setActiveChannelId(this.props.channelId);
+      this.props.markAllMessagesAsReadInChannel({ channelId: this.props.channelId });
     }
   }
 

--- a/src/store/channels-list/channels.ts
+++ b/src/store/channels-list/channels.ts
@@ -1,12 +1,6 @@
 import { multicastChannel } from 'redux-saga';
 import { call } from 'redux-saga/effects';
 
-// create 2 events: message loaded for channel, messages loaded for conversation
-export enum ChannelEvents {
-  MessagesLoadedForChannel = 'channel/messages/loaded',
-  MessagesLoadedForConversation = 'conversation/messages/loaded',
-}
-
 let theConversationsChannel;
 export function* conversationsChannel() {
   if (!theConversationsChannel) {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -57,9 +57,13 @@ export interface Channel {
 export enum SagaActionTypes {
   JoinChannel = 'channels/saga/joinChannel',
   UnreadCountUpdated = 'channels/saga/unreadCountUpdated',
+  MarkAllMessagesAsReadInChannel = 'channels/saga/markAllMessagesAsReadInChannel',
+  MarkAllMessagesAsReadInConversation = 'channels/saga/markAllMessagesAsReadInConversation',
 }
 
 const joinChannel = createAction<Payload>(SagaActionTypes.JoinChannel);
+const markAllMessagesAsReadInChannel = createAction<Payload>(SagaActionTypes.MarkAllMessagesAsReadInChannel);
+const markAllMessagesAsReadInConversation = createAction<Payload>(SagaActionTypes.MarkAllMessagesAsReadInConversation);
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
 
 const slice = createNormalizedSlice({
@@ -72,4 +76,10 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { joinChannel, unreadCountUpdated, removeAll };
+export {
+  joinChannel,
+  unreadCountUpdated,
+  removeAll,
+  markAllMessagesAsReadInChannel,
+  markAllMessagesAsReadInConversation,
+};

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -66,7 +66,7 @@ describe('channels list saga', () => {
         .withActiveChannel({ id: channelId, unreadCount: 3 })
         .build();
 
-      await expectSaga(markChannelAsReadIfActive, channelId)
+      await expectSaga(markChannelAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .call(markAllMessagesAsRead, channelId, userId)
@@ -82,7 +82,7 @@ describe('channels list saga', () => {
         .withActiveChannel({ id: 'some-other-channel-id' })
         .build();
 
-      await expectSaga(markChannelAsReadIfActive, channelId)
+      await expectSaga(markChannelAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .not.call(markAllMessagesAsRead, channelId, userId)
@@ -97,7 +97,7 @@ describe('channels list saga', () => {
         .withActiveChannel({ id: channelId, unreadCount: 3 })
         .build();
 
-      await expectSaga(markChannelAsReadIfActive, channelId)
+      await expectSaga(markChannelAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .not.call(markAllMessagesAsRead, channelId, userId)
@@ -112,7 +112,7 @@ describe('channels list saga', () => {
         .withActiveChannel({ id: channelId, unreadCount: 0 })
         .build();
 
-      await expectSaga(markChannelAsReadIfActive, channelId)
+      await expectSaga(markChannelAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .not.call(markAllMessagesAsRead, channelId, userId)
@@ -128,7 +128,7 @@ describe('channels list saga', () => {
         .withActiveConversation({ id: channelId, unreadCount: 3 })
         .build();
 
-      await expectSaga(markConversationAsReadIfActive, channelId)
+      await expectSaga(markConversationAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .call(markAllMessagesAsRead, channelId, userId)
@@ -143,7 +143,7 @@ describe('channels list saga', () => {
         .withActiveConversation({ id: 'some-other-channel-id' })
         .build();
 
-      await expectSaga(markConversationAsReadIfActive, channelId)
+      await expectSaga(markConversationAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .not.call(markAllMessagesAsRead, channelId, userId)
@@ -157,7 +157,7 @@ describe('channels list saga', () => {
         .withActiveConversation({ id: channelId, unreadCount: 0 })
         .build();
 
-      await expectSaga(markConversationAsReadIfActive, channelId)
+      await expectSaga(markConversationAsReadIfActive, { payload: { channelId } })
         .provide([stubResponse(matchers.call.fn(markAllMessagesAsReadInChannelAPI), 200)])
         .withReducer(rootReducer, state)
         .not.call(markAllMessagesAsRead, channelId, userId)

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -19,6 +19,7 @@ import { Web3Events, getWeb3Channel } from '../web3/channels';
 import { conversationsChannel } from '../channels-list/channels';
 import { rawConversationsList } from '../channels-list/saga';
 import { setactiveConversationId } from '../chat';
+import { markConversationAsReadIfActive } from '../channels/saga';
 
 export function* emailLogin(action) {
   const { email, password } = action.payload;
@@ -157,6 +158,7 @@ export function* openFirstConversation() {
   const existingConversationsList = yield select(rawConversationsList());
   if (existingConversationsList.length > 0) {
     yield put(setactiveConversationId(existingConversationsList[0]));
+    yield call(markConversationAsReadIfActive, { payload: { channelId: existingConversationsList[0] } });
   }
 }
 

--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -3,8 +3,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { fetch } from './saga';
 import { rootReducer } from '../reducer';
 import { ConversationStatus, denormalize } from '../channels';
-import { ChannelEvents, conversationsChannel } from '../channels-list/channels';
-import { multicastChannel } from 'redux-saga';
 import { chat } from '../../lib/chat';
 import { StoreBuilder } from '../test/store';
 import { call } from 'redux-saga/effects';
@@ -57,25 +55,6 @@ describe(fetch, () => {
       .run();
 
     expect(denormalize(channel.id, storeState).hasMore).toBe(false);
-  });
-
-  it('emits markAsRead event on the conversations channel for a channel OR conversation', async () => {
-    const channel = { id: 'channel-id' };
-    const conversationsChannelStub = multicastChannel();
-
-    // channel
-    await subject(fetch, { payload: { channelId: channel.id } })
-      .provide([[matchers.call.fn(conversationsChannel), conversationsChannelStub]])
-      .withReducer(rootReducer, initialChannelState({ ...channel, isChannel: true }))
-      .put(conversationsChannelStub, { type: ChannelEvents.MessagesLoadedForChannel, channelId: channel.id })
-      .run();
-
-    // conversation
-    await subject(fetch, { payload: { channelId: channel.id } })
-      .provide([[matchers.call.fn(conversationsChannel), conversationsChannelStub]])
-      .withReducer(rootReducer, initialChannelState({ ...channel, isChannel: false }))
-      .put(conversationsChannelStub, { type: ChannelEvents.MessagesLoadedForConversation, channelId: channel.id })
-      .run();
   });
 
   it('sets hasLoadedMessages on channel', async () => {

--- a/src/store/messages/saga.receiveNewMessage.test.ts
+++ b/src/store/messages/saga.receiveNewMessage.test.ts
@@ -90,14 +90,14 @@ describe(receiveNewMessage, () => {
     await expectSaga(receiveNewMessage, { payload: { channelId: 'channel-id', message } })
       .provide(successResponses())
       .withReducer(rootReducer, channelState.build())
-      .call(markChannelAsReadIfActive, 'channel-id')
+      .call(markChannelAsReadIfActive, { payload: { channelId: 'channel-id' } })
       .run();
 
     const conversationState = new StoreBuilder().withConversationList({ id: 'channel-id' });
     await expectSaga(receiveNewMessage, { payload: { channelId: 'channel-id', message } })
       .provide(successResponses())
       .withReducer(rootReducer, conversationState.build())
-      .call(markConversationAsReadIfActive, 'channel-id')
+      .call(markConversationAsReadIfActive, { payload: { channelId: 'channel-id' } })
       .run();
   });
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -22,7 +22,6 @@ import { ParentMessage } from '../../lib/chat/types';
 import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
-import { ChannelEvents, conversationsChannel } from '../channels-list/channels';
 import { Uploadable, createUploadableFile } from './uploadable';
 import { chat } from '../../lib/chat';
 import { activeChannelIdSelector } from '../chat/selectors';
@@ -122,14 +121,6 @@ export function* fetch(action) {
         messagesFetchStatus: MessagesFetchState.SUCCESS,
       })
     );
-
-    // Publish a system message across the channel
-    const channel = yield call(conversationsChannel);
-    const isChannel = yield select(_isChannel(channelId));
-    yield put(channel, {
-      type: isChannel ? ChannelEvents.MessagesLoadedForChannel : ChannelEvents.MessagesLoadedForConversation,
-      channelId,
-    });
   } catch (error) {
     yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.FAILED }));
   }
@@ -407,7 +398,7 @@ export function* receiveNewMessage(action) {
   const isChannel = yield select(_isChannel(channelId));
   const markAllAsReadAction = isChannel ? markChannelAsReadIfActive : markConversationAsReadIfActive;
 
-  yield call(markAllAsReadAction, channelId);
+  yield call(markAllAsReadAction, { payload: { channelId } });
 }
 
 export function* replaceOptimisticMessage(currentMessages, message) {


### PR DESCRIPTION
### What does this do?

Marks all messages as read instantly when you select a channel or conversation. 
<img width="732" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/7582d199-03fd-464b-af5e-520b767d622c">


### Why are we making this change?

Earlier marking messages as read felt slow/unresponsive, since we were only marking as read when you load all the messages (including background fetching). 


I thought about just "hiding" the unread count marker on the UI, but i guess if the user quickly switches b/w loading conversations/channels, then the unread count marker would dissappear and popup again & again, which won't be much ideal i think.


https://github.com/zer0-os/zOS/assets/33264364/d2156f80-9204-4fc1-a211-88f25bda123f


