### PR TITLE
Fix reply rendering

### DIFF
--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -15,6 +15,8 @@
   }
 
   &__group-message {
+    max-width: 100%;
+
     --border-radius: 2px 8px 8px 2px;
   }
 

--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -17,7 +17,6 @@
   &__content {
     padding-left: 8px;
     flex-grow: 1;
-    width: 1px; // Force an initial width to allow flex-grow to work properly
     overflow: hidden;
     white-space: nowrap;
   }


### PR DESCRIPTION
### What does this do?

Fixes rendering of replies to shorter messages. Previous fix for long messages didn't take this into account.

Before:
![image](https://github.com/zer0-os/zOS/assets/43770/928f5b8c-3fb9-4366-b68f-460faf0392d2)

After:
![image](https://github.com/zer0-os/zOS/assets/43770/4da682bd-cec3-4173-9941-eb9cf2f421fc)

