### PR TITLE
Sort messages by created timestamp

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -23,6 +23,7 @@ import { Payload as PayloadJoinChannel } from '../../store/channels/types';
 import { withContext as withAuthenticationContext } from '../authentication/context';
 import { Media } from '../message-input/utils';
 import { ParentMessage } from '../../lib/chat/types';
+import { compareDatesAsc } from '../../lib/date';
 
 export interface Properties extends PublicProperties {
   channel: Channel;
@@ -214,7 +215,7 @@ export class Container extends React.Component<Properties, State> {
       }
     });
 
-    return messages;
+    return messages.sort((a, b) => compareDatesAsc(a.createdAt, b.createdAt));
   }
 
   get sendDisabledMessage() {


### PR DESCRIPTION
### What does this do?

Sorts messages by created time prior to rendering rather than relying on the data store to be exactly correct all the time.

### Why are we making this change?

To ensure we render in the correct order

