### PR TITLE
refactor: extract settings menu and refactor rewards bar

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -15,6 +15,7 @@ import { LayoutState } from '../../../store/layout/types';
 import { RewardsState } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
 import { previewDisplayDate } from '../../../lib/chat/chat-message';
+import { SettingsMenu } from '../../settings-menu';
 
 const mockSearchMyNetworksByName = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -106,6 +107,24 @@ describe('messenger-list', () => {
     const wrapper = subject({ stage: Stage.CreateOneOnOne });
 
     expect(wrapper).not.toHaveElement(RewardsBar);
+  });
+
+  it('renders SettingsMenu when stage is equal to none and messenger is fullscreen', function () {
+    const wrapper = subject({ stage: Stage.None, includeRewardsAvatar: true, isMessengerFullScreen: true });
+
+    expect(wrapper).toHaveElement(SettingsMenu);
+  });
+
+  it('does not render SettingsMenu when stage is equal to none and messenger is not fullscreen', function () {
+    const wrapper = subject({ stage: Stage.None, isMessengerFullScreen: false });
+
+    expect(wrapper).not.toHaveElement(SettingsMenu);
+  });
+
+  it('does not render SettingsMenu when stage is not equal to none', function () {
+    const wrapper = subject({ stage: Stage.CreateOneOnOne });
+
+    expect(wrapper).not.toHaveElement(SettingsMenu);
   });
 
   it('renders CreateConversationPanel', function () {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -32,6 +32,8 @@ import { InviteDialogContainer } from '../../invite-dialog/container';
 import { fetch as fetchRewards, rewardsPopupClosed, rewardsTooltipClosed } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
 import { receiveSearchResults } from '../../../store/users';
+import { SettingsMenu } from '../../settings-menu';
+import { FeatureFlag } from '../../feature-flag';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -221,28 +223,44 @@ export class Container extends React.Component<Properties, State> {
     );
   }
 
+  renderSettingsMenu() {
+    return (
+      <SettingsMenu
+        onLogout={this.props.logout}
+        userName={this.props.userName}
+        userHandle={this.props.userHandle}
+        userAvatarUrl={this.props.userAvatarUrl}
+      />
+    );
+  }
+
   render() {
     return (
       <>
         {this.props.includeTitleBar && this.renderTitleBar()}
 
         {this.props.stage === SagaStage.None && (
-          <RewardsBar
-            zeroPreviousDay={this.props.zeroPreviousDay}
-            isRewardsLoading={this.props.isRewardsLoading}
-            isMessengerFullScreen={this.props.isMessengerFullScreen}
-            showRewardsInTooltip={this.props.showRewardsInTooltip}
-            showRewardsInPopup={this.props.showRewardsInPopup}
-            isFirstTimeLogin={this.props.isFirstTimeLogin}
-            includeRewardsAvatar={this.props.includeRewardsAvatar}
-            userName={this.props.userName}
-            userHandle={this.props.userHandle}
-            userAvatarUrl={this.props.userAvatarUrl}
-            onRewardsPopupClose={this.props.rewardsPopupClosed}
-            onRewardsTooltipClose={this.props.rewardsTooltipClosed}
-            onLogout={this.props.logout}
-            hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
-          />
+          <div {...cnMessageList('profile-bar')}>
+            {this.props.includeRewardsAvatar && (
+              <div {...cnMessageList('avatar-container')}>{this.renderSettingsMenu()}</div>
+            )}
+
+            <FeatureFlag featureFlag='enableRewards'>
+              <div {...cnMessageList('rewards-container', this.props.includeRewardsAvatar && 'with-avatar')}>
+                <RewardsBar
+                  zeroPreviousDay={this.props.zeroPreviousDay}
+                  isRewardsLoading={this.props.isRewardsLoading}
+                  isMessengerFullScreen={this.props.isMessengerFullScreen}
+                  showRewardsInTooltip={this.props.showRewardsInTooltip}
+                  showRewardsInPopup={this.props.showRewardsInPopup}
+                  isFirstTimeLogin={this.props.isFirstTimeLogin}
+                  onRewardsPopupClose={this.props.rewardsPopupClosed}
+                  onRewardsTooltipClose={this.props.rewardsTooltipClosed}
+                  hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
+                />
+              </div>
+            </FeatureFlag>
+          </div>
         )}
 
         <div {...cn('')}>

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -33,7 +33,6 @@ import { fetch as fetchRewards, rewardsPopupClosed, rewardsTooltipClosed } from 
 import { RewardsBar } from '../../rewards-bar';
 import { receiveSearchResults } from '../../../store/users';
 import { SettingsMenu } from '../../settings-menu';
-import { FeatureFlag } from '../../feature-flag';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -245,21 +244,19 @@ export class Container extends React.Component<Properties, State> {
               <div {...cnMessageList('avatar-container')}>{this.renderSettingsMenu()}</div>
             )}
 
-            <FeatureFlag featureFlag='enableRewards'>
-              <div {...cnMessageList('rewards-container', this.props.includeRewardsAvatar && 'with-avatar')}>
-                <RewardsBar
-                  zeroPreviousDay={this.props.zeroPreviousDay}
-                  isRewardsLoading={this.props.isRewardsLoading}
-                  isMessengerFullScreen={this.props.isMessengerFullScreen}
-                  showRewardsInTooltip={this.props.showRewardsInTooltip}
-                  showRewardsInPopup={this.props.showRewardsInPopup}
-                  isFirstTimeLogin={this.props.isFirstTimeLogin}
-                  onRewardsPopupClose={this.props.rewardsPopupClosed}
-                  onRewardsTooltipClose={this.props.rewardsTooltipClosed}
-                  hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
-                />
-              </div>
-            </FeatureFlag>
+            <div {...cnMessageList('rewards-container', this.props.includeRewardsAvatar && 'with-avatar')}>
+              <RewardsBar
+                zeroPreviousDay={this.props.zeroPreviousDay}
+                isRewardsLoading={this.props.isRewardsLoading}
+                isMessengerFullScreen={this.props.isMessengerFullScreen}
+                showRewardsInTooltip={this.props.showRewardsInTooltip}
+                showRewardsInPopup={this.props.showRewardsInPopup}
+                isFirstTimeLogin={this.props.isFirstTimeLogin}
+                onRewardsPopupClose={this.props.rewardsPopupClosed}
+                onRewardsTooltipClose={this.props.rewardsTooltipClosed}
+                hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
+              />
+            </div>
           </div>
         )}
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -32,6 +32,7 @@ import { InviteDialogContainer } from '../../invite-dialog/container';
 import { fetch as fetchRewards, rewardsPopupClosed, rewardsTooltipClosed } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
 import { receiveSearchResults } from '../../../store/users';
+import { FeatureFlag } from '../../feature-flag';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -226,24 +227,26 @@ export class Container extends React.Component<Properties, State> {
       <>
         {this.props.includeTitleBar && this.renderTitleBar()}
 
-        {this.props.stage === SagaStage.None && (
-          <RewardsBar
-            zeroPreviousDay={this.props.zeroPreviousDay}
-            isRewardsLoading={this.props.isRewardsLoading}
-            isMessengerFullScreen={this.props.isMessengerFullScreen}
-            showRewardsInTooltip={this.props.showRewardsInTooltip}
-            showRewardsInPopup={this.props.showRewardsInPopup}
-            isFirstTimeLogin={this.props.isFirstTimeLogin}
-            includeRewardsAvatar={this.props.includeRewardsAvatar}
-            userName={this.props.userName}
-            userHandle={this.props.userHandle}
-            userAvatarUrl={this.props.userAvatarUrl}
-            onRewardsPopupClose={this.props.rewardsPopupClosed}
-            onRewardsTooltipClose={this.props.rewardsTooltipClosed}
-            onLogout={this.props.logout}
-            hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
-          />
-        )}
+        <FeatureFlag featureFlag={'enableRewards'}>
+          {this.props.stage === SagaStage.None && (
+            <RewardsBar
+              zeroPreviousDay={this.props.zeroPreviousDay}
+              isRewardsLoading={this.props.isRewardsLoading}
+              isMessengerFullScreen={this.props.isMessengerFullScreen}
+              showRewardsInTooltip={this.props.showRewardsInTooltip}
+              showRewardsInPopup={this.props.showRewardsInPopup}
+              isFirstTimeLogin={this.props.isFirstTimeLogin}
+              includeRewardsAvatar={this.props.includeRewardsAvatar}
+              userName={this.props.userName}
+              userHandle={this.props.userHandle}
+              userAvatarUrl={this.props.userAvatarUrl}
+              onRewardsPopupClose={this.props.rewardsPopupClosed}
+              onRewardsTooltipClose={this.props.rewardsTooltipClosed}
+              onLogout={this.props.logout}
+              hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
+            />
+          )}
+        </FeatureFlag>
 
         <div {...cn('')}>
           {this.props.stage === SagaStage.None && (

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -32,7 +32,6 @@ import { InviteDialogContainer } from '../../invite-dialog/container';
 import { fetch as fetchRewards, rewardsPopupClosed, rewardsTooltipClosed } from '../../../store/rewards';
 import { RewardsBar } from '../../rewards-bar';
 import { receiveSearchResults } from '../../../store/users';
-import { FeatureFlag } from '../../feature-flag';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -227,26 +226,24 @@ export class Container extends React.Component<Properties, State> {
       <>
         {this.props.includeTitleBar && this.renderTitleBar()}
 
-        <FeatureFlag featureFlag={'enableRewards'}>
-          {this.props.stage === SagaStage.None && (
-            <RewardsBar
-              zeroPreviousDay={this.props.zeroPreviousDay}
-              isRewardsLoading={this.props.isRewardsLoading}
-              isMessengerFullScreen={this.props.isMessengerFullScreen}
-              showRewardsInTooltip={this.props.showRewardsInTooltip}
-              showRewardsInPopup={this.props.showRewardsInPopup}
-              isFirstTimeLogin={this.props.isFirstTimeLogin}
-              includeRewardsAvatar={this.props.includeRewardsAvatar}
-              userName={this.props.userName}
-              userHandle={this.props.userHandle}
-              userAvatarUrl={this.props.userAvatarUrl}
-              onRewardsPopupClose={this.props.rewardsPopupClosed}
-              onRewardsTooltipClose={this.props.rewardsTooltipClosed}
-              onLogout={this.props.logout}
-              hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
-            />
-          )}
-        </FeatureFlag>
+        {this.props.stage === SagaStage.None && (
+          <RewardsBar
+            zeroPreviousDay={this.props.zeroPreviousDay}
+            isRewardsLoading={this.props.isRewardsLoading}
+            isMessengerFullScreen={this.props.isMessengerFullScreen}
+            showRewardsInTooltip={this.props.showRewardsInTooltip}
+            showRewardsInPopup={this.props.showRewardsInPopup}
+            isFirstTimeLogin={this.props.isFirstTimeLogin}
+            includeRewardsAvatar={this.props.includeRewardsAvatar}
+            userName={this.props.userName}
+            userHandle={this.props.userHandle}
+            userAvatarUrl={this.props.userAvatarUrl}
+            onRewardsPopupClose={this.props.rewardsPopupClosed}
+            onRewardsTooltipClose={this.props.rewardsTooltipClosed}
+            onLogout={this.props.logout}
+            hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
+          />
+        )}
 
         <div {...cn('')}>
           {this.props.stage === SagaStage.None && (

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -28,6 +28,33 @@ $side-padding: 16px;
     padding-right: 13px;
   }
 
+  &__profile-bar {
+    display: flex;
+    align-items: center;
+  }
+
+  &__avatar-container {
+    display: flex;
+    padding-left: 16px;
+    width: 100%;
+    height: 64px;
+    background-color: theme.$color-primary-3;
+  }
+
+  &__rewards-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-right: 8px;
+    width: 100%;
+    height: 64px;
+    background-color: theme.$color-primary-3;
+
+    &--with-avatar {
+      width: unset;
+    }
+  }
+
   &__icon-button {
     border-radius: 50%;
     padding: 2px;

--- a/src/components/rewards-bar/index.test.tsx
+++ b/src/components/rewards-bar/index.test.tsx
@@ -8,11 +8,7 @@ describe('rewards-bar', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
       isFirstTimeLogin: false,
-      includeRewardsAvatar: false,
       isMessengerFullScreen: false,
-      userName: '',
-      userHandle: '',
-      userAvatarUrl: '',
       zeroPreviousDay: '',
       isRewardsLoading: false,
       showRewardsInTooltip: false,
@@ -20,7 +16,6 @@ describe('rewards-bar', () => {
       hasLoadedConversation: false,
       onRewardsPopupClose: () => {},
       onRewardsTooltipClose: () => {},
-      onLogout: () => {},
       ...props,
     };
 
@@ -51,7 +46,8 @@ describe('rewards-bar', () => {
 
   it('rewards tooltip popup is not rendered if messenger not fullscreen', async function () {
     const wrapper = subject({ zeroPreviousDay: '9000000000000000000' });
-    expect(wrapper).not.toHaveElement(TooltipPopup);
+    const tooltipPopup = wrapper.find(TooltipPopup);
+    expect(tooltipPopup.prop('open')).toBe(false);
   });
 
   it('rewards tooltip popup is not rendered if first time log in', async function () {
@@ -60,7 +56,8 @@ describe('rewards-bar', () => {
       isRewardsLoading: false,
       isFirstTimeLogin: true,
     });
-    expect(wrapper).not.toHaveElement(TooltipPopup);
+    const tooltipPopup = wrapper.find(TooltipPopup);
+    expect(tooltipPopup.prop('open')).toBe(false);
   });
 
   it('does not render rewards tooltip popup if not in full screen', async function () {
@@ -70,7 +67,8 @@ describe('rewards-bar', () => {
       showRewardsInTooltip: true,
       isMessengerFullScreen: false,
     });
-    expect(wrapper).not.toHaveElement(TooltipPopup);
+    const tooltipPopup = wrapper.find(TooltipPopup);
+    expect(tooltipPopup.prop('open')).toBe(false);
   });
 
   it('rewards tooltip popup is rendered upon load', async function () {
@@ -121,13 +119,5 @@ describe('rewards-bar', () => {
     wrapper.find('.rewards-bar__rewards-button').simulate('click');
 
     expect(wrapper.find('.rewards-bar__rewards-icon__status')).toHaveLength(0);
-  });
-
-  it('renders the SettingsMenu as necessary', function () {
-    let wrapper = subject({ includeRewardsAvatar: true });
-    expect(wrapper).toHaveElement('SettingsMenu');
-
-    wrapper.setProps({ includeRewardsAvatar: false });
-    expect(wrapper).not.toHaveElement('SettingsMenu');
   });
 });

--- a/src/components/rewards-bar/index.tsx
+++ b/src/components/rewards-bar/index.tsx
@@ -1,34 +1,30 @@
+import * as React from 'react';
+
+import { RewardsFAQModal } from '../rewards-faq-modal';
+import { TooltipPopup } from '../tooltip-popup/tooltip-popup';
+import { RewardsPopupContainer } from '../rewards-popup/container';
+
 import { Status } from '@zero-tech/zui/components';
 import { IconCurrencyDollar } from '@zero-tech/zui/icons';
-import classnames from 'classnames';
-import * as React from 'react';
-import { RewardsFAQModal } from '../rewards-faq-modal';
-import { RewardsPopupContainer } from '../rewards-popup/container';
-import { TooltipPopup } from '../tooltip-popup/tooltip-popup';
-import { SettingsMenu } from '../settings-menu';
+
 import { bem } from '../../lib/bem';
 import { formatWeiAmount } from '../../lib/number';
 
+import classnames from 'classnames';
 import './styles.scss';
 
 const c = bem('rewards-bar');
 
 export interface Properties {
   isFirstTimeLogin: boolean;
-  includeRewardsAvatar: boolean;
   isMessengerFullScreen: boolean;
   hasLoadedConversation: boolean;
-
-  userName: string;
-  userHandle: string;
-  userAvatarUrl: string;
 
   zeroPreviousDay: string;
   isRewardsLoading: boolean;
   showRewardsInTooltip: boolean;
   showRewardsInPopup: boolean;
 
-  onLogout: () => void;
   onRewardsPopupClose: () => void;
   onRewardsTooltipClose: () => void;
 }
@@ -64,21 +60,15 @@ export class RewardsBar extends React.Component<Properties, State> {
   closeRewardsFAQModal = () => this.setState({ isRewardsFAQModalOpen: false });
   closeRewardsTooltip = () => this.props.onRewardsTooltipClose();
 
-  renderRewardsBar() {
+  renderRewardsButton() {
     return (
-      <div
-        className={classnames(c('rewards-bar'), {
-          [c('rewards-bar', 'with-avatar')]: this.props.includeRewardsAvatar,
-        })}
+      <TooltipPopup
+        open={!this.props.isRewardsLoading && this.props.showRewardsInTooltip && this.props.isMessengerFullScreen}
+        align='center'
+        side='right'
+        content={`You’ve earned ${formatWeiAmount(this.props.zeroPreviousDay)} ZERO today`}
+        onClose={this.closeRewardsTooltip}
       >
-        {this.props.includeRewardsAvatar && (
-          <SettingsMenu
-            onLogout={this.props.onLogout}
-            userName={this.props.userName}
-            userHandle={this.props.userHandle}
-            userAvatarUrl={this.props.userAvatarUrl}
-          />
-        )}
         <div className={c('rewards-button-container')}>
           <button
             onClick={this.openRewards}
@@ -101,26 +91,14 @@ export class RewardsBar extends React.Component<Properties, State> {
             </div>
           </button>
         </div>
-      </div>
+      </TooltipPopup>
     );
   }
 
   render() {
     return (
-      <div>
-        {this.props.showRewardsInTooltip && this.props.isMessengerFullScreen ? (
-          <TooltipPopup
-            open={!this.props.isRewardsLoading}
-            align='center'
-            side='left'
-            content={`You’ve earned ${formatWeiAmount(this.props.zeroPreviousDay)} ZERO today`}
-            onClose={this.closeRewardsTooltip}
-          >
-            {this.renderRewardsBar()}
-          </TooltipPopup>
-        ) : (
-          this.renderRewardsBar()
-        )}
+      <div className={c('')}>
+        {this.renderRewardsButton()}
 
         {this.state.isRewardsPopupOpen && (this.props.hasLoadedConversation || !this.props.isFirstTimeLogin) && (
           <RewardsPopupContainer

--- a/src/components/rewards-bar/styles.scss
+++ b/src/components/rewards-bar/styles.scss
@@ -1,22 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .rewards-bar {
-  &__rewards-bar {
-    background-color: theme.$color-primary-3;
-
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    padding: 0px 8px 0 16px;
-
-    height: 64px;
-
-    &--with-avatar {
-      justify-content: space-between;
-    }
-  }
-
   &__rewards-button-container {
     padding: 8px;
 
@@ -71,8 +55,8 @@
 
     &__status {
       position: absolute;
-      top: 16px;
-      right: 16px;
+      top: 8px;
+      right: 8px;
     }
   }
 }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -40,6 +40,14 @@ export class FeatureFlags {
   set resetPasswordPage(value: boolean) {
     this._setBoolean('resetPasswordPage', value);
   }
+
+  get enableRewards() {
+    return this._getBoolean('enableRewards');
+  }
+
+  set enableRewards(value: boolean) {
+    this._setBoolean('enableRewards', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -40,14 +40,6 @@ export class FeatureFlags {
   set resetPasswordPage(value: boolean) {
     this._setBoolean('resetPasswordPage', value);
   }
-
-  get enableRewards() {
-    return this._getBoolean('enableRewards');
-  }
-
-  set enableRewards(value: boolean) {
-    this._setBoolean('enableRewards', value);
-  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?
- refactors the rewards feature
- extracts settings menu from rewards
- tidies up the styles for rewards and settings menu

NOTE : Feature flag to be added in a separate PR.

### Why are we making this change?
- In order to easily feature flag rewards.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1439" alt="Screenshot 2023-09-12 at 11 13 26" src="https://github.com/zer0-os/zOS/assets/39112648/41a2905a-8e35-493e-8fdd-b4918d498d56">


<img width="1439" alt="Screenshot 2023-09-12 at 11 13 19" src="https://github.com/zer0-os/zOS/assets/39112648/31a1ab17-57bb-44ed-a0e5-5c248d2d3e84">
