### PR TITLE
Do not render link preview if message has some other components

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -342,6 +342,26 @@ describe('message', () => {
     expect(onEdit).toHaveBeenCalledWith(id, message, [], { hidePreview: true });
   });
 
+  it('does not render link preview if there is a file', () => {
+    const wrapper = subject({
+      preview: { url: 'example.com' },
+      hidePreview: false,
+      media: { url: 'https://image.com/image.png', type: MediaType.Image },
+    });
+
+    expect(wrapper).not.toHaveElement(LinkPreview);
+  });
+
+  it('does not render link preview if message is a reply', () => {
+    const wrapper = subject({
+      preview: { url: 'example.com' },
+      hidePreview: false,
+      parentMessageText: 'quoted message',
+    });
+
+    expect(wrapper).not.toHaveElement(LinkPreview);
+  });
+
   it('renders message with mention', () => {
     const wrapper = subject({ message: '@[HamzaKH ](user:aec3c346-a34c-4440-a9e6-d476c2671dd1)' });
 

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -265,15 +265,14 @@ export class Message extends React.Component<Properties, State> {
   }
 
   renderLinkPreview() {
-    const { preview, isOwner, hidePreview } = this.props;
-    return (
-      <>
-        {preview && !hidePreview && (
-          <LinkPreview url={preview.url} {...preview} allowRemove={isOwner} onRemove={this.onRemovePreview} />
-        )}
-      </>
-    );
+    const { preview, isOwner, hidePreview, media, parentMessageText } = this.props;
+    if (!preview || hidePreview || media || parentMessageText) {
+      return;
+    }
+
+    return <LinkPreview url={preview.url} {...preview} allowRemove={isOwner} onRemove={this.onRemovePreview} />;
   }
+
   renderBody() {
     const { message } = this.props;
 


### PR DESCRIPTION
### What does this do?

Only want to render the link preview if it's a purely text message and not a reply.

