### PR TITLE
refactor: remove includesRewardsAvatar (duplicate prop)

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -34,7 +34,7 @@ describe('messenger-list', () => {
       allowClose: true,
       allowExpand: true,
       isMessengerFullScreen: false,
-      includesUserSettings: false,
+      includeUserSettings: false,
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
@@ -110,7 +110,7 @@ describe('messenger-list', () => {
   });
 
   it('renders SettingsMenu when stage is equal to none and messenger is fullscreen', function () {
-    const wrapper = subject({ stage: Stage.None, includesUserSettings: true, isMessengerFullScreen: true });
+    const wrapper = subject({ stage: Stage.None, includeUserSettings: true, isMessengerFullScreen: true });
 
     expect(wrapper).toHaveElement(SettingsMenu);
   });
@@ -508,18 +508,18 @@ describe('messenger-list', () => {
       expect(state.allowExpand).toEqual(true);
     });
 
-    test('includesUserSettings', async () => {
+    test('includeUserSettings', async () => {
       let state = DirectMessageChat.mapState({
         ...getState([]),
         layout: { value: { isMessengerFullScreen: true } } as LayoutState,
       });
-      expect(state.includesUserSettings).toEqual(true);
+      expect(state.includeUserSettings).toEqual(true);
 
       state = DirectMessageChat.mapState({
         ...getState([]),
         layout: { value: { isMessengerFullScreen: false } } as LayoutState,
       });
-      expect(state.includesUserSettings).toEqual(false);
+      expect(state.includeUserSettings).toEqual(false);
     });
   });
 });

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -33,7 +33,6 @@ describe('messenger-list', () => {
       includeTitleBar: true,
       allowClose: true,
       allowExpand: true,
-      includeRewardsAvatar: false,
       isMessengerFullScreen: false,
       userName: '',
       userHandle: '',
@@ -110,7 +109,7 @@ describe('messenger-list', () => {
   });
 
   it('renders SettingsMenu when stage is equal to none and messenger is fullscreen', function () {
-    const wrapper = subject({ stage: Stage.None, includeRewardsAvatar: true, isMessengerFullScreen: true });
+    const wrapper = subject({ stage: Stage.None, isMessengerFullScreen: true });
 
     expect(wrapper).toHaveElement(SettingsMenu);
   });
@@ -506,20 +505,6 @@ describe('messenger-list', () => {
         layout: { value: { isMessengerFullScreen: false } } as LayoutState,
       });
       expect(state.allowExpand).toEqual(true);
-    });
-
-    test('includeRewardsAvatar', async () => {
-      let state = DirectMessageChat.mapState({
-        ...getState([]),
-        layout: { value: { isMessengerFullScreen: true } } as LayoutState,
-      });
-      expect(state.includeRewardsAvatar).toEqual(true);
-
-      state = DirectMessageChat.mapState({
-        ...getState([]),
-        layout: { value: { isMessengerFullScreen: false } } as LayoutState,
-      });
-      expect(state.includeRewardsAvatar).toEqual(false);
     });
   });
 });

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -34,6 +34,7 @@ describe('messenger-list', () => {
       allowClose: true,
       allowExpand: true,
       isMessengerFullScreen: false,
+      includesUserSettings: false,
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
@@ -109,7 +110,7 @@ describe('messenger-list', () => {
   });
 
   it('renders SettingsMenu when stage is equal to none and messenger is fullscreen', function () {
-    const wrapper = subject({ stage: Stage.None, isMessengerFullScreen: true });
+    const wrapper = subject({ stage: Stage.None, includesUserSettings: true, isMessengerFullScreen: true });
 
     expect(wrapper).toHaveElement(SettingsMenu);
   });
@@ -505,6 +506,20 @@ describe('messenger-list', () => {
         layout: { value: { isMessengerFullScreen: false } } as LayoutState,
       });
       expect(state.allowExpand).toEqual(true);
+    });
+
+    test('includesUserSettings', async () => {
+      let state = DirectMessageChat.mapState({
+        ...getState([]),
+        layout: { value: { isMessengerFullScreen: true } } as LayoutState,
+      });
+      expect(state.includesUserSettings).toEqual(true);
+
+      state = DirectMessageChat.mapState({
+        ...getState([]),
+        layout: { value: { isMessengerFullScreen: false } } as LayoutState,
+      });
+      expect(state.includesUserSettings).toEqual(false);
     });
   });
 });

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -54,7 +54,6 @@ export interface Properties extends PublicProperties {
   includeTitleBar: boolean;
   allowClose: boolean;
   allowExpand: boolean;
-  includeRewardsAvatar: boolean;
   userName: string;
   userHandle: string;
   userAvatarUrl: string;
@@ -111,7 +110,6 @@ export class Container extends React.Component<Properties, State> {
       includeTitleBar: !layout?.value?.isMessengerFullScreen,
       allowClose: !layout?.value?.isMessengerFullScreen,
       allowExpand: !layout?.value?.isMessengerFullScreen,
-      includeRewardsAvatar: layout?.value?.isMessengerFullScreen,
       isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
       userName: user?.data?.profileSummary?.firstName || '',
       userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
@@ -241,12 +239,14 @@ export class Container extends React.Component<Properties, State> {
 
         {this.props.stage === SagaStage.None && (
           <div {...cnMessageList('profile-bar')}>
-            {this.props.includeRewardsAvatar && (
+            {this.props.isMessengerFullScreen && (
               <div {...cnMessageList('avatar-container')}>{this.renderSettingsMenu()}</div>
             )}
 
             <FeatureFlag featureFlag='enableRewards'>
-              <div {...cnMessageList('rewards-container', this.props.includeRewardsAvatar && 'with-avatar')}>
+              <div
+                {...cnMessageList('rewards-container', this.props.isMessengerFullScreen && 'with-full-screen-modifier')}
+              >
                 <RewardsBar
                   zeroPreviousDay={this.props.zeroPreviousDay}
                   isRewardsLoading={this.props.isRewardsLoading}

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -58,7 +58,7 @@ export interface Properties extends PublicProperties {
   userHandle: string;
   userAvatarUrl: string;
   zeroPreviousDay: string;
-  includesUserSettings: boolean;
+  includeUserSettings: boolean;
   isMessengerFullScreen: boolean;
   isRewardsLoading: boolean;
   isInviteNotificationOpen: boolean;
@@ -111,7 +111,7 @@ export class Container extends React.Component<Properties, State> {
       includeTitleBar: !layout?.value?.isMessengerFullScreen,
       allowClose: !layout?.value?.isMessengerFullScreen,
       allowExpand: !layout?.value?.isMessengerFullScreen,
-      includesUserSettings: layout?.value?.isMessengerFullScreen,
+      includeUserSettings: layout?.value?.isMessengerFullScreen,
       isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
       userName: user?.data?.profileSummary?.firstName || '',
       userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
@@ -241,12 +241,12 @@ export class Container extends React.Component<Properties, State> {
 
         {this.props.stage === SagaStage.None && (
           <div {...cnMessageList('profile-bar')}>
-            {this.props.includesUserSettings && (
+            {this.props.includeUserSettings && (
               <div {...cnMessageList('avatar-container')}>{this.renderSettingsMenu()}</div>
             )}
 
             <FeatureFlag featureFlag='enableRewards'>
-              <div {...cnMessageList('rewards-container', this.props.includesUserSettings && 'center')}>
+              <div {...cnMessageList('rewards-container', this.props.includeUserSettings && 'center')}>
                 <RewardsBar
                   zeroPreviousDay={this.props.zeroPreviousDay}
                   isRewardsLoading={this.props.isRewardsLoading}

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -58,6 +58,7 @@ export interface Properties extends PublicProperties {
   userHandle: string;
   userAvatarUrl: string;
   zeroPreviousDay: string;
+  includesUserSettings: boolean;
   isMessengerFullScreen: boolean;
   isRewardsLoading: boolean;
   isInviteNotificationOpen: boolean;
@@ -110,6 +111,7 @@ export class Container extends React.Component<Properties, State> {
       includeTitleBar: !layout?.value?.isMessengerFullScreen,
       allowClose: !layout?.value?.isMessengerFullScreen,
       allowExpand: !layout?.value?.isMessengerFullScreen,
+      includesUserSettings: layout?.value?.isMessengerFullScreen,
       isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
       userName: user?.data?.profileSummary?.firstName || '',
       userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
@@ -239,14 +241,12 @@ export class Container extends React.Component<Properties, State> {
 
         {this.props.stage === SagaStage.None && (
           <div {...cnMessageList('profile-bar')}>
-            {this.props.isMessengerFullScreen && (
+            {this.props.includesUserSettings && (
               <div {...cnMessageList('avatar-container')}>{this.renderSettingsMenu()}</div>
             )}
 
             <FeatureFlag featureFlag='enableRewards'>
-              <div
-                {...cnMessageList('rewards-container', this.props.isMessengerFullScreen && 'with-full-screen-modifier')}
-              >
+              <div {...cnMessageList('rewards-container', this.props.includesUserSettings && 'center')}>
                 <RewardsBar
                   zeroPreviousDay={this.props.zeroPreviousDay}
                   isRewardsLoading={this.props.isRewardsLoading}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -50,7 +50,7 @@ $side-padding: 16px;
     height: 64px;
     background-color: theme.$color-primary-3;
 
-    &--with-avatar {
+    &--with-full-screen-modifier {
       width: unset;
     }
   }

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -50,7 +50,7 @@ $side-padding: 16px;
     height: 64px;
     background-color: theme.$color-primary-3;
 
-    &--with-full-screen-modifier {
+    &--center {
       width: unset;
     }
   }


### PR DESCRIPTION
### What does this do?
- removes `includesRewardsAvatar` prop.
- replaces conditions using `includesRewardsAvatar` prop with `isMessengerFullScreen`.

### Why are we making this change?
- `includesRewardsAvatar` is used in the same way `isMessengerFullScreen`. Made sense to me to remove and replace.

```
includeRewardsAvatar: layout?.value?.isMessengerFullScreen,
isMessengerFullScreen: layout?.value?.isMessengerFullScreen,
```

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
