### PR TITLE
Fix optimistic preview replacement

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -411,26 +411,23 @@ export function* receiveNewMessage(action) {
 }
 
 export function* replaceOptimisticMessage(currentMessages, message) {
-  if (!message.optimisticId) {
-    return null;
-  }
   const messageIndex = currentMessages.findIndex((id) => id === message.optimisticId);
   if (messageIndex < 0) {
     return null;
   }
 
   const optimisticMessage = yield select(messageSelector(message.optimisticId));
-  if (optimisticMessage) {
-    const messages = [...currentMessages];
-    messages[messageIndex] = {
-      ...message,
-      preview: message.preview || optimisticMessage.preview,
-      sendStatus: MessageSendStatus.SUCCESS,
-    };
-    return messages;
+  if (!optimisticMessage) {
+    return null; // This shouldn't happen because we'd have bailed above, but just in case.
   }
 
-  return null;
+  const messages = [...currentMessages];
+  messages[messageIndex] = {
+    ...message,
+    preview: message.preview || optimisticMessage.preview,
+    sendStatus: MessageSendStatus.SUCCESS,
+  };
+  return messages;
 }
 
 export function* receiveUpdateMessage(action) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -422,7 +422,11 @@ export function* replaceOptimisticMessage(currentMessages, message) {
   const optimisticMessage = yield select(messageSelector(message.optimisticId));
   if (optimisticMessage) {
     const messages = [...currentMessages];
-    messages[messageIndex] = { ...message, sendStatus: MessageSendStatus.SUCCESS };
+    messages[messageIndex] = {
+      ...message,
+      preview: message.preview || optimisticMessage.preview,
+      sendStatus: MessageSendStatus.SUCCESS,
+    };
     return messages;
   }
 


### PR DESCRIPTION
### What does this do?

This fixes a scenario where we receive the result of the api send call _before_ receiving the real time message notification. Previously, we were wiping out the fetched preview which would cause it to disappear from rendering.

