### PR TITLE
Set truly optimistic link preview

### DIFF
--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -62,7 +62,7 @@ export function createOptimisticMessageObject(
 }
 
 export function extractLink(messageText: string): linkifyType[] {
-  return linkifyjs.find(messageText);
+  return linkifyjs.find(messageText || '');
 }
 
 export const enum FileType {


### PR DESCRIPTION
### What does this do?

Sets a thin link preview on the optimistic message so it's rendered immediately

### Why are we making this change?

More feedback for the user

### How do I test this?

Send a message with a url. You'll see the link preview briefly while the true preview is being fetched.

