### PR TITLE
feat: send a message with Matrix implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ REACT_APP_MESSENGER_INVITE_PATH="http://localhost:3000/get-access"
 REACT_APP_ASSETS_PATH="https://res.cloudinary.com/fact0ry/image/upload/v1681745540/zero-assets/zos"
 
 REACT_APP_ANDROID_STORE_PATH="https://play.google.com/store/apps/details?id=com.zero.android"
+
+##
+# Matrix settings. For now, uncommenting/providing a value for these acts
+# as a feature flag, enabling Matrix instead of Sendbird.
+##
+# REACT_APP_MATRIX_USER_ID='@your-name:zos-dev.zer0.io'
+# REACT_APP_MATRIX_ACCESS_TOKEN='syt_0000000000000000000000000000000000'

--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ A high level overview of the Component, Connected Component, Redux Saga, Normali
 1. View https://github.com/zer0-os/zOS/releases, find your new release and edit it, ensure that `Set as the latest release` is checked, and click the `Publish Release` button
 1. View https://github.com/zer0-os/zOS/actions, watch for your release deployment to complete
 1. View https://zos.zer0.io, open the Developer Tools Console, verify that your version number is correct (matches your version increment in package.json from the first step)
+
+#### Matrix
+
+To enable Matrix for chat instead of Sendbird, all you need to do is provide values for two ENV vars: `REACT_APP_MATRIX_USER_ID`, `REACT_APP_MATRIX_ACCESS_TOKEN`
+Currently this is what allows you to connect as a user. To create a user, you'll need to use an external app. For local development, it is easiest to run our matrix server locally, and use the instance of Element provided in that repo: [https://github.com/zer0-os/zOS-chat-server](https://github.com/zer0-os/zOS-chat-server).
+Once you've got the server and client running, you can retrieve your user id from the menu in the upper left corner menu of Element. To get your access token, from the same menu go to All Settings -> Help & About -> Advanced (Expand the Access Token drawer).
+Add those two ENV vars, restart zOS, and you should be connected to your local Matrix server.
+
+For testing at this point, you can use the local Element instance to provide any functionality that we haven't yet enabled in zOS. Ideally, we will maintain full interoperability between clients, unless we intentionally decide to deviate.

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,6 +23,7 @@ export interface IChatClient {
   connect: (userId: string, accessToken: string) => Promise<void>;
   disconnect: () => void;
   reconnect: () => void;
+  supportsOptimisticSend: () => boolean;
 
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
@@ -38,6 +39,8 @@ export interface IChatClient {
 
 export class Chat {
   constructor(private client: IChatClient = null) {}
+
+  supportsOptimisticSend = () => this.client.supportsOptimisticSend();
 
   async connect(userId: string, accessToken: string) {
     if (!accessToken || !userId) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -3,7 +3,7 @@ import { Channel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { SendbirdClient } from './sendbird-client';
 import { config } from '../../config';
-import { FileUploadResult, SendPayload } from '../../store/messages/saga';
+import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage } from './types';
 
 export interface RealtimeChatEvents {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -3,6 +3,8 @@ import { Channel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { SendbirdClient } from './sendbird-client';
 import { config } from '../../config';
+import { FileUploadResult, SendPayload } from '../../store/messages/saga';
+import { ParentMessage } from './types';
 
 export interface RealtimeChatEvents {
   reconnectStart: () => void;
@@ -24,6 +26,14 @@ export interface IChatClient {
 
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
+  sendMessagesByChannelId: (
+    channelId: string,
+    message: string,
+    mentionedUserIds: string[],
+    parentMessage?: ParentMessage,
+    file?: FileUploadResult,
+    optimisticId?: string
+  ) => Promise<MessagesResponse>;
 }
 
 export class Chat {
@@ -43,6 +53,17 @@ export class Chat {
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
     return this.client.getMessagesByChannelId(channelId, lastCreatedAt);
+  }
+
+  async sendMessagesByChannelId(
+    channelId: string,
+    message: string,
+    mentionedUserIds: string[],
+    parentMessage?: ParentMessage,
+    file?: FileUploadResult,
+    optimisticId?: string
+  ): Promise<any> {
+    return this.client.sendMessagesByChannelId(channelId, message, mentionedUserIds, parentMessage, file, optimisticId);
   }
 
   initChat(events: RealtimeChatEvents): void {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -40,6 +40,10 @@ export class MatrixClient implements IChatClient {
     this.events = events;
   }
 
+  supportsOptimisticSend() {
+    return false;
+  }
+
   async connect(userId: string, accessToken: string) {
     this.setConnectionStatus(ConnectionStatus.Connecting);
     await this.initializeClient(this.userId || userId, this.accessToken || accessToken);

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -31,6 +31,10 @@ export class SendbirdClient implements IChatClient {
     }, 10 * 1000);
   }
 
+  supportsOptimisticSend() {
+    return true;
+  }
+
   async connect(userId: string, accessToken: string) {
     if (!accessToken || !userId) {
       return;

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -2,9 +2,12 @@ import { GroupChannelHandler, GroupChannelModule, SendbirdGroupChat } from '@sen
 import SendbirdChat, { ConnectionHandler, ConnectionState, SessionHandler } from '@sendbird/chat';
 import { map as mapMessage } from './chat-message';
 import { Message, MessagesResponse } from '../../store/messages';
+import { sendMessagesByChannelId } from '../../store/messages/api';
+import { FileUploadResult } from '../../store/messages/saga';
 import { config } from '../../config';
 import { get } from '../../lib/api/rest';
 import { toLocalChannel } from '../../store/channels-list/utils';
+import { ParentMessage } from './types';
 
 import { RealtimeChatEvents, IChatClient } from './';
 
@@ -73,6 +76,17 @@ export class SendbirdClient implements IChatClient {
 
     const response = await get<any>(`/chatChannels/${channelId}/messages`, filter);
     return response.body;
+  }
+
+  async sendMessagesByChannelId(
+    channelId: string,
+    message: string,
+    mentionedUserIds: string[],
+    parentMessage?: ParentMessage,
+    file?: FileUploadResult,
+    optimisticId?: string
+  ): Promise<any> {
+    return sendMessagesByChannelId(channelId, message, mentionedUserIds, parentMessage, file, optimisticId);
   }
 
   private initSessionHandler(events: RealtimeChatEvents) {

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -52,9 +52,11 @@ describe(send, () => {
     const uploadableFile = { file: { nativeFile: {} } };
     const files = [{ id: 'file-id' }];
 
+    mockCreateUploadableFile.mockReturnValue(uploadableFile);
+
     testSaga(send, { payload: { channelId, files } })
       .next()
-      .call(createOptimisticMessages, channelId, undefined, undefined, files)
+      .call(createOptimisticMessages, channelId, undefined, undefined, [uploadableFile])
       .next({ uploadableFiles: [uploadableFile] })
       .call(uploadFileMessages, channelId, '', [uploadableFile])
       .next()
@@ -118,12 +120,10 @@ describe(createOptimisticMessages, () => {
   it('creates the uploadable files with optimistic message', async () => {
     const channelId = 'channel-id';
     const message = 'test message';
-    const file = { nativeFile: {} };
     const uploadableFile = { file: { name: 'media-file' } };
-    mockCreateUploadableFile.mockReturnValue(uploadableFile);
 
     const { returnValue, storeState } = await expectSaga(createOptimisticMessages, channelId, message, undefined, [
-      file,
+      uploadableFile,
     ])
       .withReducer(rootReducer, new StoreBuilder().build())
       .run();

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -10,6 +10,8 @@ import {
   messageSendFailed,
   performSend,
   send,
+  sendOptimistically,
+  sendPessimistically,
   uploadFileMessages,
 } from './saga';
 import { rootReducer } from '../reducer';
@@ -26,6 +28,157 @@ jest.mock('./uploadable', () => ({
 }));
 
 describe(send, () => {
+  it('sends optimistically when lib supports it', async () => {
+    const channelId = 'channel-id';
+    const message = 'hello';
+    const mentionedUserIds = [
+      'user-id1',
+      'user-id2',
+    ];
+    const parentMessage = { messageId: 999, userId: 'user' };
+
+    const chatClient = {
+      supportsOptimisticSend: () => undefined,
+    };
+
+    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+      .next()
+      .call(chat.get)
+      .next(chatClient)
+      .call(chatClient.supportsOptimisticSend)
+      .next(true)
+      .call(sendOptimistically, { channelId, message, mentionedUserIds, parentMessage })
+      .next()
+      .isDone();
+  });
+
+  it('sends pessimistically when lib does not support optimistic sending', async () => {
+    const channelId = 'channel-id';
+    const message = 'hello';
+    const mentionedUserIds = [
+      'user-id1',
+      'user-id2',
+    ];
+    const parentMessage = { messageId: 999, userId: 'user' };
+
+    const chatClient = {
+      supportsOptimisticSend: () => undefined,
+    };
+
+    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+      .next()
+      .call(chat.get)
+      .next(chatClient)
+      .call(chatClient.supportsOptimisticSend)
+      .next(false)
+      .call(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage })
+      .next()
+      .isDone();
+  });
+});
+
+describe(sendPessimistically, () => {
+  it('performs the message sending', async () => {
+    const channelId = 'channel-id';
+    const message = 'test message';
+    const mentionedUserIds = [
+      'user-id1',
+      'user-id2',
+    ];
+    const parentMessage = { id: 'parent' };
+
+    await expectSaga(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage })
+      .provide([
+        ...successResponses(),
+        stubResponse(matchers.call.fn(performSend), { id: 'message-id' }),
+        // stubResponse(matchers.call(performSend, channelId, message, mentionedUserIds, parentMessage, 0), { id: 'message-id' }),
+      ])
+      .call.like({
+        fn: performSend,
+        args: [
+          channelId,
+          message,
+          mentionedUserIds,
+          parentMessage,
+          '0',
+        ],
+      })
+      .run();
+  });
+
+  it('sends the files', async () => {
+    const channelId = 'channel-id';
+    const uploadableFile = { file: { nativeFile: {} } };
+    const files = [{ id: 'file-id' }];
+
+    mockCreateUploadableFile.mockReturnValue(uploadableFile);
+
+    await expectSaga(sendPessimistically, { channelId, files })
+      .provide([
+        ...successResponses(),
+        stubResponse(matchers.call.fn(performSend), { id: 'message-id' }),
+        [matchers.call.fn(uploadFileMessages)],
+        // stubResponse(matchers.call(performSend, channelId, message, mentionedUserIds, parentMessage, 0), { id: 'message-id' }),
+      ])
+      .not.call.fn(performSend)
+      .call(uploadFileMessages, channelId, '', [uploadableFile])
+      .run();
+  });
+
+  it('sends text, and files with rootMessageId', async () => {
+    const channelId = 'channel-id';
+    const uploadableFile = { file: { nativeFile: {} } };
+    const files = [{ id: 'file-id' }];
+    const message = 'test message';
+    const mentionedUserIds = [
+      'user-id1',
+      'user-id2',
+    ];
+    const parentMessage = { id: 'parent' };
+
+    mockCreateUploadableFile.mockReturnValue(uploadableFile);
+
+    await expectSaga(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage, files })
+      .provide([
+        ...successResponses(),
+        stubResponse(matchers.call.fn(performSend), { id: 'message-id' }),
+        [matchers.call.fn(uploadFileMessages)],
+      ])
+      .call(performSend, channelId, message, mentionedUserIds, parentMessage, '0')
+      .call(uploadFileMessages, channelId, 'message-id', [uploadableFile])
+      .run();
+  });
+
+  it('sends all but the first file if the text message fails', async () => {
+    const channelId = 'channel-id';
+    const uploadableFile1 = { file: { nativeFile: { what: '1' } } };
+    const uploadableFile2 = { file: { nativeFile: { what: '2' } } };
+    const files = [
+      { id: 'file-id-1' },
+      { id: 'file-id-2' },
+    ];
+    const message = 'test message';
+    const mentionedUserIds = [
+      'user-id1',
+      'user-id2',
+    ];
+    const parentMessage = { id: 'parent' };
+
+    mockCreateUploadableFile.mockReturnValueOnce(uploadableFile1).mockReturnValueOnce(uploadableFile2);
+
+    await expectSaga(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage, files })
+      .provide([
+        ...successResponses(),
+        stubResponse(matchers.call.fn(performSend), null),
+        [matchers.call.fn(uploadFileMessages)],
+      ])
+      .call(performSend, channelId, message, mentionedUserIds, parentMessage, '0')
+      .call(uploadFileMessages, channelId, '', [uploadableFile2])
+      .run();
+  });
+});
+
+describe(sendOptimistically, () => {
   it('creates optimistic messages then fetches preview and sends the message in parallel', async () => {
     const channelId = 'channel-id';
     const message = 'hello';
@@ -35,7 +188,7 @@ describe(send, () => {
     ];
     const parentMessage = { messageId: 999, userId: 'user' };
 
-    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
+    testSaga(sendOptimistically, { channelId, message, mentionedUserIds, parentMessage })
       .next()
       .call(createOptimisticMessages, channelId, message, parentMessage, [])
       .next({ optimisticRootMessage: { id: 'optimistic-message-id' } })
@@ -54,7 +207,7 @@ describe(send, () => {
 
     mockCreateUploadableFile.mockReturnValue(uploadableFile);
 
-    testSaga(send, { payload: { channelId, files } })
+    testSaga(sendOptimistically, { channelId, files })
       .next()
       .call(createOptimisticMessages, channelId, undefined, undefined, [uploadableFile])
       .next({ uploadableFiles: [uploadableFile] })
@@ -68,7 +221,7 @@ describe(send, () => {
     const uploadableFile = { nativeFile: {} };
     const files = [{ id: 'file-id' }];
 
-    testSaga(send, { payload: { channelId, files } })
+    testSaga(sendOptimistically, { channelId, files })
       .next()
       .next({ optimisticRootMessage: { id: 'root-id' }, uploadableFiles: [uploadableFile] })
       .next()
@@ -84,7 +237,7 @@ describe(send, () => {
     const uploadableFile2 = { nativeFile: {} };
     const files = [{ id: 'file-id' }];
 
-    testSaga(send, { payload: { channelId, files } })
+    testSaga(sendOptimistically, { channelId, files })
       .next()
       .next({
         optimisticRootMessage: { id: 'root-id' },

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -16,7 +16,7 @@ import { ConversationStatus, MessagesFetchState, receive } from '../channels';
 import { markChannelAsReadIfActive, markConversationAsReadIfActive, rawChannelSelector } from '../channels/saga';
 import uniqBy from 'lodash.uniqby';
 
-import { deleteMessageApi, sendMessagesByChannelId, editMessageApi, getLinkPreviews } from './api';
+import { deleteMessageApi, editMessageApi, getLinkPreviews } from './api';
 import { extractLink, linkifyType, createOptimisticMessageObject } from './utils';
 import { ParentMessage } from '../../lib/chat/types';
 import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
@@ -217,8 +217,13 @@ export function* createOptimisticPreview(channelId: string, optimisticMessage) {
 }
 
 export function* performSend(channelId, message, mentionedUserIds, parentMessage, optimisticId) {
+  const chatClient = yield call(chat.get);
+
   const messageCall = call(
-    sendMessagesByChannelId,
+    [
+      chatClient,
+      chatClient.sendMessagesByChannelId,
+    ],
     channelId,
     message,
     mentionedUserIds,

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -138,12 +138,14 @@ export function* fetch(action) {
 export function* send(action) {
   const { channelId, message, mentionedUserIds, parentMessage, files = [] } = action.payload;
 
+  const processedFiles: Uploadable[] = files.map(createUploadableFile);
+
   const { optimisticRootMessage, uploadableFiles } = yield call(
     createOptimisticMessages,
     channelId,
     message,
     parentMessage,
-    files
+    processedFiles
   );
 
   let rootMessageId = '';
@@ -169,15 +171,13 @@ export function* send(action) {
   yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
 }
 
-export function* createOptimisticMessages(channelId, message, parentMessage, files?) {
+export function* createOptimisticMessages(channelId, message, parentMessage, uploadableFiles?) {
   let optimisticRootMessage = null;
   if (message?.trim()) {
     const { optimisticMessage } = yield call(createOptimisticMessage, channelId, message, parentMessage);
     optimisticRootMessage = optimisticMessage;
   }
 
-  const uploadableFiles: Uploadable[] = [];
-  files.forEach((f) => uploadableFiles.push(createUploadableFile(f)));
   for (const index in uploadableFiles) {
     const file = uploadableFiles[index].file;
     // only the first file should connect to the root message for now.


### PR DESCRIPTION
### What does this do?
- implements ability to send a message with Matrix.

### Why are we making this change?
- deprecate sendbird.

### How do I test this?
- follow the instructions in the README to get an instance of Element and Matrix set up to send messages using Matrix.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
