### PR TITLE
fix: icon button ui breaks with latest zui version bump 

### DIFF
--- a/src/components/image-upload/index.tsx
+++ b/src/components/image-upload/index.tsx
@@ -62,6 +62,7 @@ export class ImageUpload extends Component<Properties, State> {
         />
         <IconButton
           className={'image-upload__edit-button'}
+          size='small'
           type='button'
           color='primary'
           variant='primary'

--- a/src/components/image-upload/styles.scss
+++ b/src/components/image-upload/styles.scss
@@ -58,14 +58,7 @@
     }
 
     &__edit-button {
-      display: flex;
-      flex-direction: row;
-      justify-content: center;
-      align-items: center;
       position: absolute;
-
-      width: 32px;
-      height: 32px;
     }
 
     &__error-message {

--- a/src/platform-apps/channels/attachment-cards/attachment-card.tsx
+++ b/src/platform-apps/channels/attachment-cards/attachment-card.tsx
@@ -82,7 +82,7 @@ export default class AttachmentCard extends React.Component<Properties, undefine
       <div className={className}>
         {this.file()}
         {this.props.onRemove && (
-          <IconButton Icon={IconXClose} onClick={this.onRemove} size={17} className='attachment-card__delete' />
+          <IconButton Icon={IconXClose} onClick={this.onRemove} size={24} className='attachment-card__delete' />
         )}
       </div>
     );


### PR DESCRIPTION
### What does this do?
- fixes attachment card close icon button size
- fixes image upload icon button size / over riding styles.

### Why are we making this change?
- since the latest zUI version bump, some icon buttons required tweaking due to the changes

Examples of fixes from bumping latest zUI version. The attachment card and the image upload required some manual tweaks to their sizes.

BEFORE
<img width="432" alt="Screenshot 2023-09-14 at 10 07 29" src="https://github.com/zer0-os/zOS/assets/39112648/1015987c-a564-440b-bee6-e64e9bab3052">

<img width="392" alt="Screenshot 2023-09-14 at 10 03 21" src="https://github.com/zer0-os/zOS/assets/39112648/847baeb0-f753-4c47-97a5-dfff3ee0353c">

<img width="410" alt="Screenshot 2023-09-14 at 10 00 39" src="https://github.com/zer0-os/zOS/assets/39112648/b5baac32-5807-454d-8a13-e8bbde1b87c1">

AFTER

<img width="432" alt="Screenshot 2023-09-14 at 10 07 22" src="https://github.com/zer0-os/zOS/assets/39112648/b3fb7e5f-0366-4aa9-98d2-dce71d174e7a">

<img width="392" alt="Screenshot 2023-09-14 at 10 02 59" src="https://github.com/zer0-os/zOS/assets/39112648/cd719ff9-88d6-4ee7-a820-18b0cf0911f0">

<img width="410" alt="Screenshot 2023-09-14 at 10 01 32" src="https://github.com/zer0-os/zOS/assets/39112648/f7b307ea-cf7e-4853-b867-3a9a168bd775">

