### PR TITLE
fix: edit action icon sizes and padding

### DIFF
--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -56,7 +56,7 @@ export default class EditMessageActions extends React.Component<Properties> {
     return (
       <div {...cn()} ref={this.editMessageActionRef}>
         <Tooltip content={this.props.secondaryTooltipText}>
-          <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size={24} />
+          <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size='small' />
         </Tooltip>
         <Tooltip
           content={this.props.primaryTooltipText}
@@ -69,7 +69,7 @@ export default class EditMessageActions extends React.Component<Properties> {
             Icon={IconCheck}
             isDisabled={isDisabled}
             isFilled
-            size={24}
+            size='small'
           />
         </Tooltip>
       </div>

--- a/src/components/message/edit-message-actions/styles.scss
+++ b/src/components/message/edit-message-actions/styles.scss
@@ -4,13 +4,9 @@
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+  padding: 8px 0px;
 
   &__icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 32px;
-    width: 32px;
     color: theme.$color-greyscale-12;
 
     &--disabled {

--- a/src/components/message/edit-message-actions/styles.scss
+++ b/src/components/message/edit-message-actions/styles.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  padding: 8px 0px;
+  padding: 8px 0px 0px;
 
   &__icon {
     color: theme.$color-greyscale-12;


### PR DESCRIPTION
### What does this do?
- fixes edit action icon sizes 

### Why are we making this change?
- broken ui since latest zUI version bump

Figma
<img width="432" alt="Screenshot 2023-09-14 at 10 46 57" src="https://github.com/zer0-os/zOS/assets/39112648/fb9b5a7a-2775-4fb5-abee-cf5b78ee6489">

BEFORE

<img width="432" alt="Screenshot 2023-09-14 at 10 52 50" src="https://github.com/zer0-os/zOS/assets/39112648/7a69a291-b1fa-4ec8-ba36-484c68ce0062">

AFTER


<img width="432" alt="Screenshot 2023-09-14 at 10 56 49" src="https://github.com/zer0-os/zOS/assets/39112648/494c4ab6-2ca9-47ed-8a9d-7986ff53e243">
