### PR TITLE
refactor: (message input) replace local icon button component 

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -9,7 +9,6 @@ import { emojiMentionsConfig, userMentionsConfig } from './mentions-config';
 import { UserForMention, Media, dropzoneToMedia, addImagePreview, windowClipboard } from './utils';
 
 import Menu from './menu/menu';
-import { IconButton } from '../icon-button';
 import { EmojiPicker } from './emoji-picker/emoji-picker';
 import ReplyCard from '../reply-card/reply-card';
 import MessageAudioRecorder from '../message-audio-recorder';
@@ -20,7 +19,7 @@ import ImageCards from '../../platform-apps/channels/image-cards';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
 import { PublicProperties as PublicPropertiesContainer } from './container';
 import { IconFaceSmile, IconSend3, IconMicrophone2, IconStickerCircle } from '@zero-tech/zui/icons';
-import { Avatar, Tooltip } from '@zero-tech/zui/components';
+import { Avatar, IconButton, Tooltip } from '@zero-tech/zui/components';
 
 import classNames from 'classnames';
 import './styles.scss';
@@ -377,8 +376,9 @@ export class MessageInput extends React.Component<Properties, State> {
                   className={classNames('message-input__icon', 'message-input__icon--giphy')}
                   onClick={this.openGiphy}
                   Icon={IconStickerCircle}
-                  size={24}
+                  size='small'
                 />
+
                 <Menu
                   onSelected={this.mediaSelected}
                   mimeTypes={this.mimeTypes}
@@ -457,7 +457,7 @@ export class MessageInput extends React.Component<Properties, State> {
                         className={classNames('message-input__icon', ' message-input__icon--emoji')}
                         onClick={this.openEmojis}
                         Icon={IconFaceSmile}
-                        size={24}
+                        size='small'
                       />
                     )}
                   </div>
@@ -476,7 +476,7 @@ export class MessageInput extends React.Component<Properties, State> {
                     })}
                     onClick={hasInputValue ? this.onSend : this.startMic}
                     Icon={hasInputValue ? IconSend3 : IconMicrophone2}
-                    size={24}
+                    size='small'
                   />
                 </Tooltip>
               </div>

--- a/src/components/message-input/menu/menu.tsx
+++ b/src/components/message-input/menu/menu.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import { bytesToMB, dropzoneToMedia, Media } from '../utils';
 import { IconPaperclip } from '@zero-tech/zui/icons';
-import { IconButton } from '../../icon-button';
 
 import './styles.scss';
-import { ToastNotification } from '@zero-tech/zui/components';
+import { IconButton, ToastNotification } from '@zero-tech/zui/components';
 import { config } from '../../../config';
 
 export interface Properties {
@@ -66,7 +65,7 @@ export default class Menu extends React.Component<Properties, State> {
             <div className='image-send'>
               <div {...getRootProps({ className: 'image-send__dropzone' })}>
                 <input {...getInputProps()} />
-                <IconButton onClick={open} Icon={IconPaperclip} size={24} className='image-send__icon' />
+                <IconButton onClick={open} Icon={IconPaperclip} size='small' />
               </div>
             </div>
           )}

--- a/src/components/message-input/menu/styles.scss
+++ b/src/components/message-input/menu/styles.scss
@@ -1,14 +1,3 @@
-.image-send {
-  &__icon {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 32px;
-    width: 32px;
-  }
-}
-
 .invite-toast-notification {
   padding: 64px;
 }

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -86,11 +86,6 @@
   }
 
   &__icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 32px;
-    width: 32px;
     color: theme.$color-greyscale-12;
 
     &--highlighted {


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for message input

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD
<img width="1568" alt="Screenshot 2023-09-14 at 16 56 35" src="https://github.com/zer0-os/zOS/assets/39112648/552c46c3-0a59-4d41-bcd0-bc820acf390e">

How it looks after LOCAL change
<img width="1568" alt="Screenshot 2023-09-14 at 16 56 38" src="https://github.com/zer0-os/zOS/assets/39112648/cdd22583-ed98-4ec0-94c4-c5003a65b2ad">
