### PR TITLE
refactor: (messagenger/chat) replace local icon button component 

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -5,7 +5,6 @@ import { setactiveConversationId } from '../../../store/chat';
 import { RootState } from '../../../store/reducer';
 import { connectContainer } from '../../../store/redux-container';
 import Tooltip from '../../tooltip';
-import { IconButton } from '../../icon-button';
 import { Channel, denormalize } from '../../../store/channels';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
 import { getProvider } from '../../../lib/cloudinary/provider';
@@ -14,6 +13,7 @@ import { otherMembersToString } from '../../../platform-apps/channels/util';
 import './styles.scss';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
 import { isCustomIcon } from '../list/utils/utils';
+import { IconButton } from '@zero-tech/zui/components';
 
 export interface PublicProperties {}
 
@@ -157,9 +157,9 @@ export class Container extends React.Component<Properties, State> {
         <div className='direct-message-chat__content'>
           {!this.props.isFullScreen && (
             <div className='direct-message-chat__title-bar'>
-              <IconButton onClick={this.handleMaximize} Icon={IconExpand1} size={12} />
-              <IconButton onClick={this.handleMinimizeClick} Icon={IconMinus} size={12} />
-              <IconButton onClick={this.handleClose} Icon={IconXClose} size={12} />
+              <IconButton onClick={this.handleMaximize} Icon={IconExpand1} size='x-small' />
+              <IconButton onClick={this.handleMinimizeClick} Icon={IconMinus} size='x-small' />
+              <IconButton onClick={this.handleClose} Icon={IconXClose} size='x-small' />
             </div>
           )}
 
@@ -184,12 +184,7 @@ export class Container extends React.Component<Properties, State> {
 
             {this.props.allowCollapse && (
               <div>
-                <IconButton
-                  className='direct-message-chat__icon-collapse'
-                  onClick={this.handleDockRight}
-                  Icon={IconCollapse1}
-                  size={24}
-                />
+                <IconButton onClick={this.handleDockRight} Icon={IconCollapse1} size='small' />
               </div>
             )}
           </div>

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -157,14 +157,6 @@ $recent-indicator-size: 8px;
     color: theme.$color-greyscale-11;
   }
 
-  &__icon-collapse {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-  }
-
   &--transition {
     transition: all animation.$animation-duration-half ease-out;
 


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for messenger chat

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD
<img width="459" alt="Screenshot 2023-09-14 at 17 11 35" src="https://github.com/zer0-os/zOS/assets/39112648/8d344170-0a1a-4c47-b9d2-daf7309adb18">

<img width="1547" alt="Screenshot 2023-09-14 at 17 12 42" src="https://github.com/zer0-os/zOS/assets/39112648/1b0a0506-4f98-44e5-a2f2-ee66f4015e72">
----


How it looks after LOCAL change

<img width="459" alt="Screenshot 2023-09-14 at 17 11 39" src="https://github.com/zer0-os/zOS/assets/39112648/003c94a0-9c57-40db-9405-5b5ace9e93f9">

Lol ignore the title for one of my bookmarks there
<img width="1547" alt="Screenshot 2023-09-14 at 17 12 46" src="https://github.com/zer0-os/zOS/assets/39112648/14db961b-6066-42d3-bb51-464d9de7e441">





FIGMA (providing screenshot because of size change)
<img width="459" alt="Screenshot 2023-09-14 at 17 12 16" src="https://github.com/zer0-os/zOS/assets/39112648/23f0df93-2a1d-47d0-aa29-caf1ffd500ed">
