### PR TITLE
refactor: (conversation list/new icon) replace local icon button component

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -40,14 +40,6 @@ $side-padding: 16px;
         width: 0;
       }
     }
-
-    &-conversations-new-icon {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 32px;
-      height: 32px;
-    }
   }
 
   &__item-list {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -3,10 +3,9 @@ import * as React from 'react';
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import { Channel } from '../../../../store/channels';
 import { IconPlus, IconUserPlus1 } from '@zero-tech/zui/icons';
-import { IconButton } from '../../../icon-button';
 import { ConversationItem } from '../conversation-item';
 import { InviteDialogContainer } from '../../../invite-dialog/container';
-import { Button, Input, Modal } from '@zero-tech/zui/components';
+import { Button, IconButton, Input, Modal } from '@zero-tech/zui/components';
 import { Item, Option } from '../../lib/types';
 import { UserSearchResults } from '../user-search-results';
 import { itemToOption } from '../../lib/utils';
@@ -139,12 +138,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             />
 
             <div>
-              <IconButton
-                {...cn('items-conversations-new-icon')}
-                Icon={IconPlus}
-                onClick={this.props.startConversation}
-                size={24}
-              />
+              <IconButton Icon={IconPlus} onClick={this.props.startConversation} size='small' />
             </div>
           </div>
 


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for conversation list new icon

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD
<img width="354" alt="Screenshot 2023-09-14 at 17 21 12" src="https://github.com/zer0-os/zOS/assets/39112648/32606d6a-90eb-485b-bae5-cb8623609c20">


How it looks after LOCAL change (not sure why screenshot is blurry but it looks fine in browser)
<img width="354" alt="Screenshot 2023-09-14 at 17 22 38" src="https://github.com/zer0-os/zOS/assets/39112648/260e5031-6c4a-4623-8746-173ba60038aa">
