### PR TITLE
refactor: (rewards faq modal close icon) replace local icon button component

### DIFF
--- a/src/components/rewards-faq-modal/index.test.tsx
+++ b/src/components/rewards-faq-modal/index.test.tsx
@@ -27,7 +27,7 @@ describe('RewardsPopup', () => {
     const closeRewardsFAQModal = jest.fn();
     const wrapper = subject({ isRewardsFAQModalOpen: true, closeRewardsFAQModal });
 
-    wrapper.find('.rewards-faq-modal__close').simulate('click');
+    wrapper.find('IconButton').simulate('click');
     expect(closeRewardsFAQModal).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/rewards-faq-modal/index.tsx
+++ b/src/components/rewards-faq-modal/index.tsx
@@ -25,7 +25,7 @@ export class RewardsFAQModal extends React.Component<Properties> {
         <Modal open={this.props.isRewardsFAQModalOpen} onOpenChange={this.closeRewardsFAQModal} className={c('')}>
           <div className={c('title-bar')}>
             <h3 className={c('title')}>Zero Rewards</h3>
-            <IconButton size={32} className={c('close')} Icon={IconXClose} onClick={this.closeRewardsFAQModal} />
+            <IconButton size='large' Icon={IconXClose} onClick={this.closeRewardsFAQModal} />
           </div>
           <Accordion contrast='low' items={rewardsFaq} />
         </Modal>

--- a/src/components/rewards-faq-modal/styles.scss
+++ b/src/components/rewards-faq-modal/styles.scss
@@ -28,16 +28,4 @@
     line-height: 29px;
     margin: 0px;
   }
-
-  &__close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 40px;
-    width: 40px;
-
-    &:focus-visible {
-      outline: none;
-    }
-  }
 }


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for rewards faq modal

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD
<img width="828" alt="Screenshot 2023-09-14 at 17 32 22" src="https://github.com/zer0-os/zOS/assets/39112648/b150b772-41d6-4024-b354-f7ace737e842">


How it looks after LOCAL change
<img width="828" alt="Screenshot 2023-09-14 at 17 32 25" src="https://github.com/zer0-os/zOS/assets/39112648/54abafd7-1e4f-442a-9d2a-b61e2bd504d6">


FIGMA (providing screenshot because of size change)
<img width="534" alt="Screenshot 2023-09-14 at 17 31 35" src="https://github.com/zer0-os/zOS/assets/39112648/67a52c62-7730-4569-847f-4d70da2ce03b">
