### PR TITLE
refactor: (rewards popup close icon) replace local icon button component

### DIFF
--- a/src/components/rewards-popup/index.tsx
+++ b/src/components/rewards-popup/index.tsx
@@ -61,7 +61,7 @@ export class RewardsPopup extends React.Component<Properties, State> {
               Icon={IconXClose}
               className={c('close-button')}
               variant='tertiary'
-              size={32}
+              size='large'
               onClick={this.abort}
             />
             <ZeroSymbol height={32} width={32} />

--- a/src/components/rewards-popup/styles.scss
+++ b/src/components/rewards-popup/styles.scss
@@ -80,12 +80,6 @@ $content-padding-y: 40px;
     position: absolute;
     top: 18px;
     right: 18px;
-
-    svg {
-      path {
-        color: theme.$color-greyscale-12;
-      }
-    }
   }
 
   &__heading {


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for rewards pop up close icon

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD

<img width="828" alt="Screenshot 2023-09-14 at 17 38 27" src="https://github.com/zer0-os/zOS/assets/39112648/57f436e7-79d0-49b1-88ac-dc730ebee99b">


How it looks after LOCAL change

<img width="828" alt="Screenshot 2023-09-14 at 17 38 33" src="https://github.com/zer0-os/zOS/assets/39112648/10d23934-8de7-4fe5-ac48-7fe21db6ded9">





FIGMA (providing screenshot because of size change)
<img width="828" alt="Screenshot 2023-09-14 at 17 38 41" src="https://github.com/zer0-os/zOS/assets/39112648/de64fb7a-e0c1-4198-b615-8e2216627644">

