### PR TITLE
refactor: (tooltip popup) replace local icon button component

### DIFF
--- a/src/components/tooltip-popup/styles.scss
+++ b/src/components/tooltip-popup/styles.scss
@@ -48,9 +48,6 @@
   }
 
   &__close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     margin-left: 8px;
   }
 }

--- a/src/components/tooltip-popup/tooltip-popup.tsx
+++ b/src/components/tooltip-popup/tooltip-popup.tsx
@@ -3,8 +3,8 @@ import './styles.scss';
 import { bem } from '../../lib/bem';
 import type { ReactNode } from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-import { IconButton } from '../icon-button';
 import { IconXClose } from '@zero-tech/zui/icons';
+import { IconButton } from '@zero-tech/zui/components';
 
 const c = bem('tooltip-popup');
 
@@ -31,7 +31,7 @@ export class TooltipPopup extends React.Component<Properties> {
             <TooltipPrimitive.Content side={this.props.side} align={this.props.align} className={c('content')}>
               {this.props.content}
               <TooltipPrimitive.Arrow className={c('arrow')} width={32} height={16} />
-              <IconButton className={c('close')} Icon={IconXClose} size={16} onClick={this.props.onClose} />
+              <IconButton className={c('close')} Icon={IconXClose} size='x-small' onClick={this.props.onClose} />
             </TooltipPrimitive.Content>
           </TooltipPrimitive.Root>
         </TooltipPrimitive.Provider>


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for tooltip pop up close icon

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD
<img width="598" alt="Screenshot 2023-09-14 at 17 45 01" src="https://github.com/zer0-os/zOS/assets/39112648/13f164cf-7ecc-4dc7-9f91-e55458afffa2">


How it looks after LOCAL change
<img width="598" alt="Screenshot 2023-09-14 at 17 45 05" src="https://github.com/zer0-os/zOS/assets/39112648/4d36eae2-cbad-4251-97af-8e3b2ccf159f">





