### PR TITLE
refactor: (audio card delete icon) replace local icon button component

### DIFF
--- a/src/platform-apps/channels/audio-cards/audio-card.tsx
+++ b/src/platform-apps/channels/audio-cards/audio-card.tsx
@@ -1,6 +1,6 @@
 import { IconTrash4 } from '@zero-tech/zui/icons';
 import React from 'react';
-import { IconButton } from '../../../components/icon-button';
+import { IconButton } from '@zero-tech/zui/components';
 import { AudioModel } from './types';
 
 export interface Properties {
@@ -15,7 +15,7 @@ export default class AudioCard extends React.Component<Properties> {
     if (onRemove) {
       return (
         <div className='audio__cards-card__actions'>
-          <IconButton onClick={onRemove} Icon={IconTrash4} size={20} className='audio__cards-card__actions-delete' />
+          <IconButton onClick={onRemove} Icon={IconTrash4} size={28} className='audio__cards-card__actions-delete' />
         </div>
       );
     }


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for audio card delete icon

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD (this is from design as audio is currently broken - refer to image card delete icon for the same icon)
<img width="122" alt="Screenshot 2023-09-14 at 18 01 00" src="https://github.com/zer0-os/zOS/assets/39112648/d7c7c633-bc10-4167-b427-fd9b73a978d4">

How it looks after LOCAL change
<img width="122" alt="Screenshot 2023-09-14 at 18 02 13" src="https://github.com/zer0-os/zOS/assets/39112648/c76d5167-aba1-4ec1-ad8d-93293b885776">

