### PR TITLE
refactor: (delete message modal) replace local icon button component

### DIFF
--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -95,12 +95,7 @@ export class MessageMenu extends React.Component<Properties, State> {
       <Modal className='delete-message-modal' open={this.showDeleteModal} onOpenChange={this.toggleDeleteDialog}>
         <div className='delete-message-modal__header'>
           <h2>Delete message</h2>
-          <IconButton
-            className='delete-message-modal__icon-button'
-            Icon={IconXClose}
-            size={32}
-            onClick={this.toggleDeleteDialog}
-          />
+          <IconButton Icon={IconXClose} size='large' onClick={this.toggleDeleteDialog} />
         </div>
         <div className='delete-message-text-content'>
           Are you sure you want to delete this message? This cannot be undone.

--- a/src/platform-apps/channels/messages-menu/styles.scss
+++ b/src/platform-apps/channels/messages-menu/styles.scss
@@ -64,10 +64,6 @@
     }
   }
 
-  &__icon-button {
-    outline: none;
-  }
-
   &__text-content {
     line-height: 24px;
   }


### PR DESCRIPTION
### What does this do?
- replaces local icon button component with zUI icon button component for delete message modal close icon

### Why are we making this change?
- in order to delete/remove IconButton (zOS local) and IconButton (zos-component-library) from the code base, we need to replace all uses of IconButton with the component from zUI.

How it looks in PROD
<img width="958" alt="Screenshot 2023-09-14 at 18 04 09" src="https://github.com/zer0-os/zOS/assets/39112648/bf65dbbc-e361-4a8e-b0c3-fa523a9c3293">


How it looks after LOCAL change
<img width="958" alt="Screenshot 2023-09-14 at 18 04 36" src="https://github.com/zer0-os/zOS/assets/39112648/e06728c9-883d-42ea-99e4-3fa13c8953f4">
