### PR TITLE
Configure zOS to a home server and save user creds in local storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,4 @@ REACT_APP_ASSETS_PATH="https://res.cloudinary.com/fact0ry/image/upload/v16817455
 
 REACT_APP_ANDROID_STORE_PATH="https://play.google.com/store/apps/details?id=com.zero.android"
 
-##
-# Matrix settings. For now, uncommenting/providing a value for these acts
-# as a feature flag, enabling Matrix instead of Sendbird.
-##
-# REACT_APP_MATRIX_USER_ID='@your-name:zos-dev.zer0.io'
-# REACT_APP_MATRIX_ACCESS_TOKEN='syt_0000000000000000000000000000000000'
+REACT_APP_MATRIX_HOME_SERVER_URL='https://zero-synapse-development-db365bf96189.herokuapp.com'

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export const config = {
   matrix: {
     userId: process.env.REACT_APP_MATRIX_USER_ID,
     accessToken: process.env.REACT_APP_MATRIX_ACCESS_TOKEN,
+    homeServerUrl: process.env.REACT_APP_MATRIX_HOME_SERVER_URL,
   },
   androidStorePath: process.env.REACT_APP_ANDROID_STORE_PATH,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,8 +36,6 @@ export const config = {
   inviteUrl: process.env.REACT_APP_MESSENGER_INVITE_PATH,
   assetsPath: process.env.REACT_APP_ASSETS_PATH,
   matrix: {
-    userId: process.env.REACT_APP_MATRIX_USER_ID,
-    accessToken: process.env.REACT_APP_MATRIX_ACCESS_TOKEN,
     homeServerUrl: process.env.REACT_APP_MATRIX_HOME_SERVER_URL,
   },
   androidStorePath: process.env.REACT_APP_ANDROID_STORE_PATH,

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -5,6 +5,7 @@ import { SendbirdClient } from './sendbird-client';
 import { config } from '../../config';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage } from './types';
+import { featureFlags } from '../feature-flags';
 
 export interface RealtimeChatEvents {
   reconnectStart: () => void;
@@ -84,8 +85,7 @@ export class Chat {
 
 const ClientFactory = {
   get() {
-    const matrix = config.matrix;
-    if (matrix.userId && matrix.accessToken) {
+    if (featureFlags.enableMatrix) {
       return new MatrixClient();
     }
 

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -2,7 +2,6 @@ import { Message, MessagesResponse } from '../../store/messages';
 import { Channel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { SendbirdClient } from './sendbird-client';
-import { config } from '../../config';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage } from './types';
 import { featureFlags } from '../feature-flags';

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -15,19 +15,13 @@ const getSdkClient = (sdkClient = {}) => ({
   ...sdkClient,
 });
 
-const subject = (props = {}, config = {}) => {
+const subject = (props = {}) => {
   const allProps: any = {
     createClient: (_opts: any) => getSdkClient(),
     ...props,
   };
 
-  const allConfig = {
-    userId: undefined,
-    accessToken: undefined,
-    ...config,
-  };
-
-  return new MatrixClient(allProps, allConfig);
+  return new MatrixClient(allProps);
 };
 
 describe('matrix client', () => {
@@ -44,24 +38,6 @@ describe('matrix client', () => {
         expect.objectContaining({
           userId: 'username',
           accessToken: 'token',
-        })
-      );
-    });
-
-    it('uses default credentials if they are provided', () => {
-      const sdkClient = getSdkClient();
-      const createClient = jest.fn(() => sdkClient);
-
-      const userId = 'the-default-user-id';
-      const accessToken = 'the-default-access-token';
-      const client = subject({ createClient }, { userId, accessToken });
-
-      client.connect('username', 'token');
-
-      expect(createClient).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userId,
-          accessToken,
         })
       );
     });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -4,18 +4,13 @@ import { mapMatrixMessage } from './chat-message';
 import { ConversationStatus, GroupChannelType, Channel } from '../../store/channels';
 import { MessagesResponse } from '../../store/messages';
 import { FileUploadResult } from '../../store/messages/saga';
-import { config as appConfig } from '../../config';
 import { ParentMessage } from './types';
+import { config } from '../../config';
 
 enum ConnectionStatus {
   Connected = 'connected',
   Connecting = 'connecting',
   Disconnected = 'disconnected',
-}
-
-class MatrixConfig {
-  userId: string;
-  accessToken: string;
 }
 
 export class MatrixClient implements IChatClient {
@@ -29,12 +24,7 @@ export class MatrixClient implements IChatClient {
   private connectionResolver: () => void;
   private connectionAwaiter: Promise<void>;
 
-  constructor(private sdk = { createClient }, config: MatrixConfig = appConfig.matrix) {
-    if (config.userId && config.accessToken) {
-      this.accessToken = config.accessToken;
-      this.userId = config.userId;
-    }
-  }
+  constructor(private sdk = { createClient }) {}
 
   init(events: RealtimeChatEvents) {
     this.events = events;
@@ -130,7 +120,7 @@ export class MatrixClient implements IChatClient {
   private async initializeClient(userId: string, accessToken: string) {
     if (!this.matrix) {
       this.matrix = this.sdk.createClient({
-        baseUrl: 'http://localhost:8008',
+        baseUrl: config.matrix.homeServerUrl,
         accessToken,
         userId,
       });

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -35,6 +35,12 @@ export function* setAuthentication({ chatAccessToken } = { chatAccessToken: '' }
   yield put(setChatAccessToken({ value: chatAccessToken, isLoading: false }));
 }
 
+function getMatrixCredentialsInLocalStorage() {
+  const matrixId = localStorage.getItem('matrixId') ?? '';
+  const matrixAccessToken = localStorage.getItem('matrixAccessToken') ?? '';
+  return { matrixId, matrixAccessToken };
+}
+
 export function* nonceOrAuthorize(action) {
   const { signedWeb3Token } = action.payload;
   const { nonceToken: nonce = undefined, chatAccessToken } = yield call(nonceOrAuthorizeApi, signedWeb3Token);
@@ -57,7 +63,9 @@ export function* completeUserLogin(user = null) {
     yield call(completePendingUserProfile, user);
     return;
   }
-  yield put(setUser({ data: user }));
+  // Temporary until the credentials come back with the user record
+  const matrixCredentials = getMatrixCredentialsInLocalStorage();
+  yield put(setUser({ data: { ...user, ...matrixCredentials } }));
   yield call(initializeUserState, user);
   yield call(publishUserLogin, user);
 }

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -36,6 +36,8 @@ export interface User {
   updatedAt: string;
   profileSummary: ProfileSummary;
   wallets: Wallet[];
+  matrixId?: string;
+  matrixAccessToken?: string;
 }
 
 export interface AuthenticationState {

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -7,7 +7,7 @@ import { startChannelsAndConversationsAutoRefresh } from '../channels-list';
 import { Events, createChatConnection, getChatBus } from './bus';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
 import { featureFlags } from '../../lib/feature-flags';
-import { config } from '../../config';
+import { currentUserSelector } from '../authentication/saga';
 
 function* listenForReconnectStart(_action) {
   yield put(setReconnecting(true));
@@ -35,10 +35,10 @@ function* convertToBusEvents(action) {
 function* connectOnLogin() {
   yield take(yield call(getAuthChannel), AuthEvents.UserLogin);
   let userId, chatAccessToken;
-  // Might want this higher up and just set the state to better values?
   if (featureFlags.enableMatrix) {
-    userId = config.matrix.userId;
-    chatAccessToken = config.matrix.accessToken;
+    const user = yield select(currentUserSelector());
+    userId = user.matrixId;
+    chatAccessToken = user.matrixAccessToken;
   } else {
     userId = yield select((state) => getDeepProperty(state, 'authentication.user.data.id', null));
     chatAccessToken = yield select((state) => getDeepProperty(state, 'chat.chatAccessToken.value', null));

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -6,6 +6,8 @@ import { setActiveChannelId, setReconnecting, setactiveConversationId } from '.'
 import { startChannelsAndConversationsAutoRefresh } from '../channels-list';
 import { Events, createChatConnection, getChatBus } from './bus';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
+import { featureFlags } from '../../lib/feature-flags';
+import { config } from '../../config';
 
 function* listenForReconnectStart(_action) {
   yield put(setReconnecting(true));
@@ -32,8 +34,15 @@ function* convertToBusEvents(action) {
 
 function* connectOnLogin() {
   yield take(yield call(getAuthChannel), AuthEvents.UserLogin);
-  const userId = yield select((state) => getDeepProperty(state, 'authentication.user.data.id', null));
-  const chatAccessToken = yield select((state) => getDeepProperty(state, 'chat.chatAccessToken.value', null));
+  let userId, chatAccessToken;
+  // Might want this higher up and just set the state to better values?
+  if (featureFlags.enableMatrix) {
+    userId = config.matrix.userId;
+    chatAccessToken = config.matrix.accessToken;
+  } else {
+    userId = yield select((state) => getDeepProperty(state, 'authentication.user.data.id', null));
+    chatAccessToken = yield select((state) => getDeepProperty(state, 'chat.chatAccessToken.value', null));
+  }
 
   yield initChat(userId, chatAccessToken);
 }

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -1,9 +1,6 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects';
 import { SagaActionTypes, State, setErrors, setState } from '.';
-import {
-  editUserProfile as apiEditUserProfile,
-  saveUserMatrixCredentials as apiSaveUserMatrixCredentials,
-} from './api';
+import { editUserProfile as apiEditUserProfile } from './api';
 import { ProfileDetailsErrors } from '../registration';
 import { uploadImage } from '../registration/api';
 import cloneDeep from 'lodash/cloneDeep';
@@ -51,10 +48,13 @@ export function* editProfile(action) {
 
 export function* saveUserMatrixCredentials(payload) {
   const { matrixId, matrixAccessToken } = payload;
-  const response = yield call(apiSaveUserMatrixCredentials, {
-    matrixId,
-    matrixAccessToken,
-  });
+  // const response = yield call(apiSaveUserMatrixCredentials, {
+  //   matrixId,
+  //   matrixAccessToken,
+  // });
+
+  // Temporarily store in localStorage
+  const response = saveMatrixCredentialsInLocalStorage({ matrixId, matrixAccessToken });
 
   if (response.success) {
     let currentUser = cloneDeep(yield select(currentUserSelector()));
@@ -62,6 +62,12 @@ export function* saveUserMatrixCredentials(payload) {
     yield put(setUser({ data: currentUser }));
     return;
   }
+}
+
+function saveMatrixCredentialsInLocalStorage({ matrixId, matrixAccessToken }) {
+  localStorage.setItem('matrixId', matrixId);
+  localStorage.setItem('matrixAccessToken', matrixAccessToken);
+  return { success: true };
 }
 
 export function* updateUserProfile(payload) {


### PR DESCRIPTION
### What does this do?

Adds an env var for the default home server and saves the user credentials in local storage

### Why are we making this change?

* To allow defining the default home server per environment (currently just development or local)
* To allow testers to quickly set up a user to test with

