### PR TITLE
feat: (matrix) differentiate between 1-on-1 and group conversations

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -5,6 +5,7 @@ import { SendbirdClient } from './sendbird-client';
 import { config } from '../../config';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage } from './types';
+import { MatrixEvent } from 'matrix-js-sdk';
 
 export interface RealtimeChatEvents {
   reconnectStart: () => void;
@@ -26,6 +27,7 @@ export interface IChatClient {
   supportsOptimisticSend: () => boolean;
 
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
+  getConversations?: () => Promise<Partial<Channel>[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
   sendMessagesByChannelId: (
     channelId: string,
@@ -35,6 +37,7 @@ export interface IChatClient {
     file?: FileUploadResult,
     optimisticId?: string
   ) => Promise<MessagesResponse>;
+  getAccountData?: (eventType: string) => Promise<MatrixEvent | undefined>;
 }
 
 export class Chat {
@@ -54,8 +57,16 @@ export class Chat {
     return this.client.getChannels(id);
   }
 
+  async getConversations() {
+    return this.client.getConversations();
+  }
+
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
     return this.client.getMessagesByChannelId(channelId, lastCreatedAt);
+  }
+
+  async getAccountData(eventType: string) {
+    return this.client.getAccountData(eventType);
   }
 
   async sendMessagesByChannelId(

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -4,7 +4,6 @@ import { MatrixClient } from './matrix-client';
 import { SendbirdClient } from './sendbird-client';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage } from './types';
-import { MatrixEvent } from 'matrix-js-sdk';
 import { featureFlags } from '../feature-flags';
 
 export interface RealtimeChatEvents {
@@ -28,7 +27,7 @@ export interface IChatClient {
 
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
   getConversations: () => Promise<Partial<Channel>[]>;
-  getAccountData?: (eventType: string) => Promise<MatrixEvent | undefined>;
+
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
   sendMessagesByChannelId: (
     channelId: string,
@@ -59,10 +58,6 @@ export class Chat {
 
   async getConversations() {
     return this.client.getConversations();
-  }
-
-  async getAccountData(eventType: string) {
-    return this.client.getAccountData(eventType);
   }
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -27,7 +27,8 @@ export interface IChatClient {
   supportsOptimisticSend: () => boolean;
 
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
-  getConversations?: () => Promise<Partial<Channel>[]>;
+  getConversations: () => Promise<Partial<Channel>[]>;
+  getAccountData?: (eventType: string) => Promise<MatrixEvent | undefined>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
   sendMessagesByChannelId: (
     channelId: string,
@@ -37,7 +38,6 @@ export interface IChatClient {
     file?: FileUploadResult,
     optimisticId?: string
   ) => Promise<MessagesResponse>;
-  getAccountData?: (eventType: string) => Promise<MatrixEvent | undefined>;
 }
 
 export class Chat {
@@ -61,12 +61,12 @@ export class Chat {
     return this.client.getConversations();
   }
 
-  async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
-    return this.client.getMessagesByChannelId(channelId, lastCreatedAt);
-  }
-
   async getAccountData(eventType: string) {
     return this.client.getAccountData(eventType);
+  }
+
+  async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
+    return this.client.getMessagesByChannelId(channelId, lastCreatedAt);
   }
 
   async sendMessagesByChannelId(

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -10,9 +10,7 @@ const getMockAccountData = (data = {}) => {
   return jest.fn((eventType) => {
     if (eventType === 'm.direct') {
       return {
-        event: {
-          content: data,
-        },
+        event: { content: data },
       };
     }
     return {};
@@ -176,7 +174,10 @@ describe('matrix client', () => {
 
   describe('getAccountData', () => {
     it('get account data', async () => {
-      const getAccountData = getMockAccountData([{ id: '!abcdefg' }, { id: '!hijklmn' }]);
+      const getAccountData = getMockAccountData({
+        '@mockuser1': ['!abcdefg'],
+        '@mockuser2:': ['!hijklmn', '!opqrstuv'],
+      });
 
       const client = subject({
         createClient: jest.fn(() => getSdkClient({ getAccountData })),
@@ -207,7 +208,11 @@ describe('matrix client', () => {
     });
 
     it('fetches and returns correct account data when type is "m.direct"', async () => {
-      const getAccountData = getMockAccountData([{ id: '!abcdefg' }, { id: '!hijklmn' }]);
+      const getAccountData = getMockAccountData({
+        '@mockuser1': ['!abcdefg'],
+        '@mockuser2:': ['!hijklmn', '!opqrstuv'],
+      });
+
       const client = subject({
         createClient: jest.fn(() => getSdkClient({ getAccountData })),
       });
@@ -215,7 +220,14 @@ describe('matrix client', () => {
       await client.connect('username', 'token');
 
       const result = await client.getAccountData('m.direct');
-      expect(result).toEqual({ event: { content: [{ id: '!abcdefg' }, { id: '!hijklmn' }] } });
+      expect(result).toEqual({
+        event: {
+          content: {
+            '@mockuser1': ['!abcdefg'],
+            '@mockuser2:': ['!hijklmn', '!opqrstuv'],
+          },
+        },
+      });
     });
   });
 });

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -12,9 +12,12 @@ const getMockAccountData = (data = {}) => {
     if (eventType === EventType.Direct) {
       return {
         event: { content: data },
+        getContent: () => data,
       };
     }
-    return {};
+    return {
+      getContent: () => ({}),
+    };
   });
 };
 
@@ -221,7 +224,7 @@ describe('matrix client', () => {
       await client.connect('username', 'token');
 
       const result = await client.getAccountData(EventType.Direct);
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         event: {
           content: {
             '@mockuser1': ['!abcdefg'],

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1,3 +1,4 @@
+import { EventType } from 'matrix-js-sdk';
 import { MatrixClient } from './matrix-client';
 
 const getRoom = (props: any = {}) => ({
@@ -8,7 +9,7 @@ const getRoom = (props: any = {}) => ({
 
 const getMockAccountData = (data = {}) => {
   return jest.fn((eventType) => {
-    if (eventType === 'm.direct') {
+    if (eventType === EventType.Direct) {
       return {
         event: { content: data },
       };
@@ -187,7 +188,7 @@ describe('matrix client', () => {
 
       await client.getConversations();
 
-      expect(getAccountData).toHaveBeenCalledWith('m.direct');
+      expect(getAccountData).toHaveBeenCalledWith(EventType.Direct);
     });
 
     it('waits for connection if matrix client is connecting to get account data', async () => {
@@ -197,14 +198,14 @@ describe('matrix client', () => {
       const client = subject({ createClient });
       client.connect('username', 'token');
 
-      const accountDataFetch = client.getAccountData('m.direct');
+      const accountDataFetch = client.getAccountData(EventType.Direct);
       expect(sdkClient.getAccountData).not.toHaveBeenCalled();
 
       await new Promise((resolve) => setImmediate(resolve));
 
       await accountDataFetch;
 
-      expect(sdkClient.getAccountData).toHaveBeenCalledWith('m.direct');
+      expect(sdkClient.getAccountData).toHaveBeenCalledWith(EventType.Direct);
     });
 
     it('fetches and returns correct account data when type is "m.direct"', async () => {
@@ -219,7 +220,7 @@ describe('matrix client', () => {
 
       await client.connect('username', 'token');
 
-      const result = await client.getAccountData('m.direct');
+      const result = await client.getAccountData(EventType.Direct);
       expect(result).toEqual({
         event: {
           content: {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -12,6 +12,7 @@ const getSdkClient = (sdkClient = {}) => ({
     if (topic === 'sync') callback('PREPARED');
   }),
   getRooms: jest.fn(),
+  getAccountData: jest.fn(),
   ...sdkClient,
 });
 
@@ -83,7 +84,7 @@ describe('matrix client', () => {
 
       await client.connect('username', 'token');
 
-      client.getChannels('network-id');
+      await client.getChannels('network-id');
 
       expect(getRooms).toHaveBeenCalledOnce();
     });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -205,9 +205,8 @@ export class MatrixClient implements IChatClient {
     }
 
     const accountData = await this.getAccountData('m.direct');
-    const rooms = this.matrix.getRooms();
-    const dmConversationIds = Object.values(accountData.event.content).flat();
-
+    const rooms = this.matrix.getRooms() || [];
+    const dmConversationIds = Object.values(accountData?.event?.content).flat();
     return rooms.filter((r) => filterFunc(r.roomId, dmConversationIds));
   }
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1,4 +1,4 @@
-import { createClient, Direction, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
+import { createClient, Direction, EventType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { RealtimeChatEvents, IChatClient } from './';
 import { mapMatrixMessage } from './chat-message';
 import { ConversationStatus, GroupChannelType, Channel } from '../../store/channels';
@@ -204,7 +204,7 @@ export class MatrixClient implements IChatClient {
       await this.waitForConnection();
     }
 
-    const accountData = await this.getAccountData('m.direct');
+    const accountData = await this.getAccountData(EventType.Direct);
     const rooms = this.matrix.getRooms() || [];
     const dmConversationIds = Object.values(accountData?.event?.content).flat();
     return rooms.filter((r) => filterFunc(r.roomId, dmConversationIds));

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -206,7 +206,7 @@ export class MatrixClient implements IChatClient {
 
     const accountData = await this.getAccountData(EventType.Direct);
     const rooms = this.matrix.getRooms() || [];
-    const dmConversationIds = Object.values(accountData?.event?.content).flat();
+    const dmConversationIds = Object.values(accountData?.getContent()).flat() as string[];
     return rooms.filter((r) => filterFunc(r.roomId, dmConversationIds));
   }
 }

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -74,7 +74,7 @@ export class SendbirdClient implements IChatClient {
   async getConversations() {
     try {
       const conversations = await get<any>('/directMessages/mine');
-      return (conversations.body || []).map((currentChannel) => toLocalChannel(currentChannel));
+      return (conversations.body || []).map(toLocalChannel);
     } catch (error: any) {
       console.log('Error occured while fetching conversations ', error?.response ?? error); // eg. error.code = ENOTFOUND
       return [];

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -72,7 +72,13 @@ export class SendbirdClient implements IChatClient {
   }
 
   async getConversations() {
-    return [];
+    try {
+      const conversations = await get<any>('/directMessages/mine');
+      return (conversations.body || []).map((currentChannel) => toLocalChannel(currentChannel));
+    } catch (error: any) {
+      console.log('Error occured while fetching conversations ', error?.response ?? error); // eg. error.code = ENOTFOUND
+      return [];
+    }
   }
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number): Promise<MessagesResponse> {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -71,6 +71,10 @@ export class SendbirdClient implements IChatClient {
     }
   }
 
+  async getConversations() {
+    return [];
+  }
+
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number): Promise<MessagesResponse> {
     const filter: any = {};
 

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -12,16 +12,6 @@ export async function fetchChannels(id: string) {
   }
 }
 
-export async function fetchConversations(): Promise<Channel[]> {
-  try {
-    const directMessages = await get<Channel[]>('/directMessages/mine');
-    return directMessages.body;
-  } catch (error: any) {
-    console.log('Error occured while fetching conversations ', error?.response ?? error);
-    return [];
-  }
-}
-
 export async function createConversation(
   userIds: string[],
   name: string = '',

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -1,7 +1,6 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import { call, race, take } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { fetchConversations as fetchConversationsApi } from './api';
 import { chat } from '../../lib/chat';
 
 import {
@@ -20,7 +19,6 @@ import { AsyncListStatus } from '../normalized';
 import { conversationsChannel } from './channels';
 import { multicastChannel } from 'redux-saga';
 import { ConversationStatus, denormalize as denormalizeChannel } from '../channels';
-import { stubResponse } from '../../test/saga';
 import { StoreBuilder } from '../test/store';
 
 const MOCK_CHANNELS = [
@@ -29,8 +27,28 @@ const MOCK_CHANNELS = [
   { name: 'channel 3', id: 'channel_0003', url: 'channel_0003', icon: 'channel-icon', hasJoined: false },
 ];
 
+const MOCK_CONVERSATIONS = [
+  {
+    name: 'conversation 1',
+    id: 'conversation_0001',
+    url: 'conversation_0001',
+    icon: 'conversation-icon',
+    hasJoined: true,
+    isChannel: false,
+  },
+  {
+    name: 'conversation 2',
+    id: 'conversation_0002',
+    url: 'conversation_0002',
+    icon: 'conversation-icon',
+    hasJoined: true,
+    isChannel: false,
+  },
+];
+
 const chatClient = {
   getChannels: () => MOCK_CHANNELS,
+  getConversations: () => MOCK_CONVERSATIONS,
 };
 
 describe('channels list saga', () => {
@@ -191,7 +209,10 @@ describe('channels list saga', () => {
           [channel],
         ],
         [
-          matchers.call.fn(fetchConversationsApi),
+          matchers.call([
+            chatClient,
+            chatClient.getConversations,
+          ]),
           [conversation],
         ],
         [
@@ -307,12 +328,20 @@ describe(fetchConversations, () => {
     await expectSaga(fetchConversations)
       .provide([
         [
-          matchers.call.fn(fetchConversationsApi),
-          MOCK_CHANNELS,
+          matchers.call(chat.get),
+          chatClient,
+        ],
+        [
+          matchers.call([
+            chatClient,
+            chatClient.getConversations,
+          ]),
+          MOCK_CONVERSATIONS,
         ],
       ])
       .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
-      .call(fetchConversationsApi)
+      .call(chat.get)
+      .call([chatClient, chatClient.getConversations])
       .run();
   });
 
@@ -322,8 +351,15 @@ describe(fetchConversations, () => {
     await expectSaga(fetchConversations)
       .provide([
         [
-          matchers.call.fn(fetchConversationsApi),
-          MOCK_CHANNELS,
+          matchers.call(chat.get),
+          chatClient,
+        ],
+        [
+          matchers.call([
+            chatClient,
+            chatClient.getConversations,
+          ]),
+          MOCK_CONVERSATIONS,
         ],
         [
           matchers.call.fn(conversationsChannel),
@@ -343,7 +379,10 @@ describe(fetchConversations, () => {
     const initialState = new StoreBuilder().withConversationList(optimisticChannel1, optimisticChannel2).build();
 
     const { storeState } = await expectSaga(fetchConversations)
-      .provide([stubResponse(matchers.call.fn(fetchConversationsApi), [fetchedChannel])])
+      .provide([
+        [matchers.call.fn(chat.get), chatClient],
+        [matchers.call([chatClient, chatClient.getConversations]), [fetchedChannel]],
+      ])
       .withReducer(rootReducer, initialState)
       .run();
 

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -26,6 +26,7 @@ const mockChannel = (id: string) => ({
   name: `channel ${id}`,
   icon: 'channel-icon',
   hasJoined: false,
+  isChannel: true,
 });
 
 const mockConversation = (id: string) => ({

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -21,30 +21,23 @@ import { multicastChannel } from 'redux-saga';
 import { ConversationStatus, denormalize as denormalizeChannel } from '../channels';
 import { StoreBuilder } from '../test/store';
 
-const MOCK_CHANNELS = [
-  { name: 'channel 1', id: 'channel_0001', url: 'channel_0001', icon: 'channel-icon', hasJoined: false },
-  { name: 'channel 2', id: 'channel_0002', url: 'channel_0002', icon: 'channel-icon', hasJoined: false },
-  { name: 'channel 3', id: 'channel_0003', url: 'channel_0003', icon: 'channel-icon', hasJoined: false },
-];
+const mockChannel = (id: string) => ({
+  id: `channel_${id}`,
+  name: `channel ${id}`,
+  icon: 'channel-icon',
+  hasJoined: false,
+});
 
-const MOCK_CONVERSATIONS = [
-  {
-    name: 'conversation 1',
-    id: 'conversation_0001',
-    url: 'conversation_0001',
-    icon: 'conversation-icon',
-    hasJoined: true,
-    isChannel: false,
-  },
-  {
-    name: 'conversation 2',
-    id: 'conversation_0002',
-    url: 'conversation_0002',
-    icon: 'conversation-icon',
-    hasJoined: true,
-    isChannel: false,
-  },
-];
+const mockConversation = (id: string) => ({
+  id: `conversation_${id}`,
+  name: `conversation ${id}`,
+  icon: 'conversation-icon',
+  hasJoined: true,
+  isChannel: false,
+});
+
+const MOCK_CHANNELS = [mockChannel('0001'), mockChannel('0002'), mockChannel('0003')];
+const MOCK_CONVERSATIONS = [mockConversation('0001'), mockConversation('0002')];
 
 const chatClient = {
   getChannels: () => MOCK_CHANNELS,

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -56,8 +56,14 @@ export function* fetchChannels(action) {
 }
 
 export function* fetchConversations() {
-  const conversations = yield call(fetchConversationsMessagesApi);
-  const conversationsList = conversations.map((currentChannel) => toLocalChannel(currentChannel));
+  const chatClient = yield call(chat.get);
+  const conversations = yield call([
+    chatClient,
+    chatClient.getConversations,
+  ]);
+
+  // const conversations = yield call(fetchConversationsMessagesApi);
+  // const conversationsList = conversations.map((currentChannel) => toLocalChannel(currentChannel));
 
   const existingConversationList = yield select(denormalizeConversations);
   const optimisticConversationIds = existingConversationList
@@ -69,7 +75,7 @@ export function* fetchConversations() {
     receive([
       ...channelsList,
       ...optimisticConversationIds,
-      ...conversationsList,
+      ...conversations,
     ])
   );
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -6,11 +6,7 @@ import { takeLatest, put, call, take, race, all, select, spawn } from 'redux-sag
 import { SagaActionTypes, setStatus, receive, denormalizeConversations } from '.';
 import { chat } from '../../lib/chat';
 
-import {
-  fetchConversations as fetchConversationsMessagesApi,
-  createConversation as createConversationMessageApi,
-  uploadImage as uploadImageApi,
-} from './api';
+import { createConversation as createConversationMessageApi, uploadImage as uploadImageApi } from './api';
 import { AsyncListStatus } from '../normalized';
 import { toLocalChannel, filterChannelsList } from './utils';
 import { setactiveConversationId } from '../chat';
@@ -61,9 +57,6 @@ export function* fetchConversations() {
     chatClient,
     chatClient.getConversations,
   ]);
-
-  // const conversations = yield call(fetchConversationsMessagesApi);
-  // const conversationsList = conversations.map((currentChannel) => toLocalChannel(currentChannel));
 
   const existingConversationList = yield select(denormalizeConversations);
   const optimisticConversationIds = existingConversationList


### PR DESCRIPTION
### What does this do?
- Updates the Matrix Client to differentiate between 1-on-1 and group conversations.
- Updates the Channels List saga to call client.
- Updates the Sendbird Client.
- Adds test coverage / fixes failing tests.

### Why are we making this change?
- to differentiate between 1-on-1 and group conversations.
- to ensure Sendbird Client also still fetches conversations.

### How do I test this?
- run Matrix/Element and check one on one conversations appear in the conversation list, and channels appear in the channel list.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Screenshot of 1-on-1 & channels lists
<img width="1404" alt="Screenshot 2023-09-18 at 20 47 31" src="https://github.com/zer0-os/zOS/assets/39112648/059f97b3-0db3-4493-b520-f118c43c8aa0">
