### PR TITLE
Remove updatedAt timestamp from Matrix message mapping

### DIFF
--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -128,7 +128,7 @@ export function mapMatrixMessage(matrixMessage) {
     parentMessageText: '',
     parentMessageId: parent ? parent['m.in_reply_to'].event_id : null,
     createdAt: matrixMessage.origin_server_ts,
-    updatedAt: matrixMessage.origin_server_ts,
+    updatedAt: null,
     sender: {},
     isAdmin: false,
     ...{ mentionedUsers: [], hidePreview: false, media: null, image: null, admin: {} },


### PR DESCRIPTION
### What does this do?

Removes the updatedAt timestamp from the original matrix message mapping. We use that to determine if we've edited the message and since we don't do that yet we might as well have it cleared

