### PR TITLE
fix: handle when a user has no conversations or channels

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -155,6 +155,35 @@ describe('matrix client', () => {
       expect(channels).toHaveLength(1);
       expect(channels[0].id).toEqual('channel-id');
     });
+
+    it('returns empty array if no rooms exist', async () => {
+      const getRooms = jest.fn(() => []);
+      const getAccountData = getMockAccountData();
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
+      });
+
+      await client.connect('username', 'token');
+      const channels = await client.getChannels('network-id');
+
+      expect(channels).toHaveLength(0);
+    });
+
+    it('returns all rooms as channels if no direct room data exists', async () => {
+      const rooms = [getRoom({ roomId: 'channel-id' }), getRoom({ roomId: 'dm-id' })];
+      const getRooms = jest.fn(() => rooms);
+      const getAccountData = getMockAccountData();
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
+      });
+
+      await client.connect('username', 'token');
+      const channels = await client.getChannels('network-id');
+
+      expect(channels).toHaveLength(2);
+    });
   });
 
   describe('getConversations', () => {
@@ -173,6 +202,20 @@ describe('matrix client', () => {
 
       expect(conversations).toHaveLength(1);
       expect(conversations[0].id).toEqual('dm-id');
+    });
+
+    it('returns empty array if no direct rooms exist', async () => {
+      const getRooms = jest.fn(() => []);
+      const getAccountData = getMockAccountData();
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
+      });
+
+      await client.connect('username', 'token');
+      const conversations = await client.getConversations();
+
+      expect(conversations).toHaveLength(0);
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -205,8 +205,11 @@ export class MatrixClient implements IChatClient {
     }
 
     const accountData = await this.getAccountData(EventType.Direct);
+    const content = accountData?.getContent();
+
+    const dmConversationIds = content ? (Object.values(content).flat() as string[]) : [];
+
     const rooms = this.matrix.getRooms() || [];
-    const dmConversationIds = Object.values(accountData?.getContent()).flat() as string[];
     return rooms.filter((r) => filterFunc(r.roomId, dmConversationIds));
   }
 }


### PR DESCRIPTION
### What does this do?
- handles when a user has no conversations or channels yet.
- adds test coverage.

### Why are we making this change?
- Fixes the following console error: TypeError: Cannot convert undefined or null to object 

### How do I test this?
- create a new account on Element and go through the steps to add this user in zOS with the matrix id and token. Open the console and check if the error is thrown.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before
<img width="1903" alt="Screenshot 2023-09-20 at 11 38 33" src="https://github.com/zer0-os/zOS/assets/39112648/e50186cd-e7fe-4ff1-94db-fc4dcfd2eb58">

After
<img width="1903" alt="Screenshot 2023-09-20 at 11 43 22" src="https://github.com/zer0-os/zOS/assets/39112648/5ebb9023-f8ce-4ad8-919d-62562c563eb2">
