### PR TITLE
Create conversation via Matrix

### DIFF
--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -1,0 +1,41 @@
+import { EventType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
+
+// Copied from the matrix-react-sdk
+export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: string): Promise<void> {
+  const mDirectEvent = matrix.getAccountData(EventType.Direct);
+  const currentContent = mDirectEvent?.getContent() || {};
+
+  const dmRoomMap = new Map(Object.entries(currentContent));
+  let modified = false;
+
+  // remove it from the lists of any others users
+  // (it can only be a DM room for one person)
+  for (const thisUserId of dmRoomMap.keys()) {
+    const roomList = dmRoomMap.get(thisUserId) || [];
+
+    if (thisUserId !== userId) {
+      const indexOfRoom = roomList.indexOf(roomId);
+      if (indexOfRoom > -1) {
+        roomList.splice(indexOfRoom, 1);
+        modified = true;
+      }
+    }
+  }
+
+  // now add it, if it's not already there
+  if (userId) {
+    const roomList = dmRoomMap.get(userId) || [];
+    if (roomList.indexOf(roomId) === -1) {
+      roomList.push(roomId);
+      modified = true;
+    }
+    dmRoomMap.set(userId, roomList);
+  }
+
+  // prevent unnecessary calls to setAccountData
+  if (!modified) return;
+
+  console.log('setting account data for room', roomId);
+  console.log('setting account data', dmRoomMap);
+  await matrix.setAccountData(EventType.Direct, Object.fromEntries(dmRoomMap));
+}

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -35,7 +35,5 @@ export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: s
   // prevent unnecessary calls to setAccountData
   if (!modified) return;
 
-  console.log('setting account data for room', roomId);
-  console.log('setting account data', dmRoomMap);
   await matrix.setAccountData(EventType.Direct, Object.fromEntries(dmRoomMap));
 }

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -28,4 +28,5 @@ export interface ParentMessage {
 
 export interface User {
   userId: string;
+  matrixId: string;
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -83,7 +83,7 @@ export function userSelector(state, userIds) {
 export function* createConversation(userIds: string[], name: string = null, image: File = null) {
   const chatClient = yield call(chat.get);
 
-  let optimisticConversation = null;
+  let optimisticConversation = { id: '', optimisticId: '' };
   if (yield call(chatClient.supportsOptimisticSend)) {
     optimisticConversation = yield call(createOptimisticConversation, userIds, name, image);
     yield put(setactiveConversationId(optimisticConversation.id));
@@ -106,7 +106,9 @@ export function* createConversation(userIds: string[], name: string = null, imag
 }
 
 export function* handleCreateConversationError(optimisticConversation) {
-  yield put(receiveChannel({ id: optimisticConversation.id, conversationStatus: ConversationStatus.ERROR }));
+  if (optimisticConversation) {
+    yield put(receiveChannel({ id: optimisticConversation.id, conversationStatus: ConversationStatus.ERROR }));
+  }
 }
 
 export function* createOptimisticConversation(userIds: string[], name: string = null, _image: File = null) {

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -11,7 +11,9 @@ export function* receiveSearchResults(searchResults) {
 
   const mappedUsers = searchResults
     .filter((r) => !existingUserIds.includes(r.id))
-    .map((r) => ({ userId: r.id, firstName: r.name, profileImage: r.profileImage }));
+    .map((r) => {
+      return { userId: r.id, firstName: r.name, profileImage: r.profileImage, matrixId: r.matrixId };
+    });
   yield put(receive(mappedUsers));
 }
 


### PR DESCRIPTION
### What does this do?

Adds the Matrix specific functionality to create a Conversation (in Matrix this is a room that "is_direct" and is in the user's account list of `m.direct` events)

Notes:
* This functionality works for group Conversations too but the process of creating a group conversation has other checks that need to be switched to Matrix first.
* Currently the receiving user still has to manually accept the invitation in Element. Future work will do this automatically on behalf of the user.

### How do I test this?

In zOS search for a user that has a matrix id set and start a conversation with them. You will see the conversation created and can send a message. Verify the other user received the invite by going to Element.

