### PR TITLE
Fix opening a one on one from matrix

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -114,7 +114,7 @@ export class Container extends React.Component<Properties, State> {
       return '';
     }
 
-    if (this.isOneOnOne()) {
+    if (this.isOneOnOne() && this.props.directMessage.otherMembers[0]) {
       return this.props.directMessage.otherMembers[0].profileImage;
     }
 


### PR DESCRIPTION
### What does this do?

Missed a spot where we're assuming an "other member" exists but for Matrix convos we don't have that mapped yet.

