### PR TITLE
Zos 708 matrix reply to text only message

### DIFF
--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -4,6 +4,7 @@ import { ChatMember } from './types';
 import { denormalize as denormalizeUser } from '../../store/users';
 import { currentUserSelector } from '../../store/authentication/saga';
 import moment from 'moment';
+import { MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 
 const DEFAULT_MEDIA_TYPE = 'image';
 
@@ -119,19 +120,38 @@ function extractMessageData(jsonData, isMediaMessage) {
   };
 }
 
-export function mapMatrixMessage(matrixMessage) {
-  const parent = matrixMessage.content['m.relates_to'];
+async function extractParentMessageData(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
+  const parentMessageData = {
+    parentMessageId: null,
+    parentMessageText: '',
+  };
 
+  const parent = matrixMessage.content['m.relates_to'];
+  if (parent && parent['m.in_reply_to']) {
+    parentMessageData.parentMessageId = parent['m.in_reply_to'].event_id;
+
+    const parentMessage = await sdkMatrixClient.fetchRoomEvent(
+      matrixMessage.room_id,
+      parentMessageData.parentMessageId
+    );
+    if (parentMessage) {
+      parentMessageData.parentMessageText = parentMessage.content.body;
+    }
+  }
+
+  return parentMessageData;
+}
+
+export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
   return {
     id: matrixMessage.event_id,
     message: matrixMessage.content.body,
-    parentMessageText: '',
-    parentMessageId: parent ? parent['m.in_reply_to'].event_id : null,
     createdAt: matrixMessage.origin_server_ts,
     updatedAt: null,
     sender: {},
     isAdmin: false,
     ...{ mentionedUsers: [], hidePreview: false, media: null, image: null, admin: {} },
+    ...(await extractParentMessageData(matrixMessage, sdkMatrixClient)),
   };
 }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -39,7 +39,7 @@ export class MatrixClient implements IChatClient {
   private connectionResolver: () => void;
   private connectionAwaiter: Promise<void>;
 
-  constructor(private sdk = { createClient }) { }
+  constructor(private sdk = { createClient }) {}
 
   init(events: RealtimeChatEvents) {
     this.events = events;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -97,11 +97,14 @@ export class MatrixClient implements IChatClient {
   }
 
   async getMessagesByChannelId(channelId: string, _lastCreatedAt?: number): Promise<MessagesResponse> {
-    const { chunk } = await this.matrix.createMessagesRequest(channelId, null, 30, Direction.Forward);
+    const { chunk } = await this.matrix.createMessagesRequest(channelId, null, 50, Direction.Backward);
+    const messages = chunk.filter((m) => m.type === 'm.room.message');
+    const mappedMessages = [];
+    for (const message of messages) {
+      mappedMessages.push(await mapMatrixMessage(message, this.matrix));
+    }
 
-    const messages = chunk.filter((m) => m.type === 'm.room.message').map(mapMatrixMessage);
-
-    return { messages: messages as any, hasMore: false };
+    return { messages: mappedMessages as any, hasMore: false };
   }
 
   async createConversation(users: User[], _name: string = null, _image: File = null, _optimisticId: string) {
@@ -126,17 +129,27 @@ export class MatrixClient implements IChatClient {
     channelId: string,
     message: string,
     _mentionedUserIds: string[],
-    _parentMessage?: ParentMessage,
+    parentMessage?: ParentMessage,
     _file?: FileUploadResult,
     optimisticId?: string
   ): Promise<any> {
-    const messageResult = await this.matrix.sendTextMessage(channelId, message);
+    let content = {
+      body: message,
+      msgtype: 'm.text',
+    };
+
+    if (parentMessage) {
+      content['m.relates_to'] = {
+        'm.in_reply_to': {
+          event_id: parentMessage.messageId,
+        },
+      };
+    }
+
+    const messageResult = await this.matrix.sendMessage(channelId, content);
     const newMessage = await this.matrix.fetchRoomEvent(channelId, messageResult.event_id);
-
-    console.log('message: ', newMessage);
-
     return {
-      ...mapMatrixMessage(newMessage),
+      ...(await mapMatrixMessage(newMessage, this.matrix)),
       optimisticId,
     };
   }
@@ -162,14 +175,14 @@ export class MatrixClient implements IChatClient {
   }
 
   private async initializeEventHandlers() {
-    this.matrix.on('event' as any, ({ event }) => {
+    this.matrix.on('event' as any, async ({ event }) => {
       console.log('event: ', event);
       if (event.type === 'm.room.encrypted') {
         console.log('encryped message: ', event);
       }
 
       if (event.type === 'm.room.message') {
-        this.events.receiveNewMessage(event.room_id, this.mapMessage(event));
+        this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix)) as any);
       }
     });
     this.matrix.on(RoomMemberEvent.Membership, async (_event, member) => {
@@ -215,7 +228,6 @@ export class MatrixClient implements IChatClient {
     });
   }
 
-  private mapMessage = (message): any => mapMatrixMessage(message);
   private mapChannel = (channel): Partial<Channel> => ({
     id: channel.roomId,
     name: channel.name,

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -8,6 +8,7 @@ import {
   Room,
   RoomMemberEvent,
   MatrixClient as SDKMatrixClient,
+  MsgType,
   Visibility,
 } from 'matrix-js-sdk';
 import { RealtimeChatEvents, IChatClient } from './';
@@ -38,7 +39,7 @@ export class MatrixClient implements IChatClient {
   private connectionResolver: () => void;
   private connectionAwaiter: Promise<void>;
 
-  constructor(private sdk = { createClient }) {}
+  constructor(private sdk = { createClient }) { }
 
   init(events: RealtimeChatEvents) {
     this.events = events;
@@ -135,7 +136,7 @@ export class MatrixClient implements IChatClient {
   ): Promise<any> {
     let content = {
       body: message,
-      msgtype: 'm.text',
+      msgtype: MsgType.Text,
     };
 
     if (parentMessage) {


### PR DESCRIPTION
- Implements "reply to text messages" using the matrix API.

**NOTE**: this creates a reply to a message, and NOT a thread. 

<img width="532" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/a12b351e-643a-4214-913d-1d858696613f">

Also, we're having `undefined` as the user's `firstName` & `lastName` (aka the `message sender`). This is because the matrix message does NOT return the sender metadata. It just returns it's user_id. Will discuss more about this.