### PR TITLE
Auto accept invites to rooms

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -172,10 +172,10 @@ export class MatrixClient implements IChatClient {
         this.events.receiveNewMessage(event.room_id, this.mapMessage(event));
       }
     });
-    this.matrix.on(RoomMemberEvent.Membership, async (event, member) => {
+    this.matrix.on(RoomMemberEvent.Membership, async (_event, member) => {
       if (member.membership === 'invite' && member.userId === this.userId) {
         await this.matrix.joinRoom(member.roomId);
-        this.events.onUserReceivedInvitation((event as any).room_id);
+        this.events.onUserReceivedInvitation(member.roomId);
       }
     });
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -6,6 +6,7 @@ import {
   ICreateRoomOpts,
   Preset,
   Room,
+  RoomMemberEvent,
   MatrixClient as SDKMatrixClient,
   Visibility,
 } from 'matrix-js-sdk';
@@ -48,8 +49,9 @@ export class MatrixClient implements IChatClient {
   }
 
   async connect(userId: string, accessToken: string) {
+    this.userId = userId;
     this.setConnectionStatus(ConnectionStatus.Connecting);
-    await this.initializeClient(this.userId || userId, this.accessToken || accessToken);
+    await this.initializeClient(this.userId, this.accessToken || accessToken);
     await this.initializeEventHandlers();
 
     this.setConnectionStatus(ConnectionStatus.Connected);
@@ -168,6 +170,12 @@ export class MatrixClient implements IChatClient {
 
       if (event.type === 'm.room.message') {
         this.events.receiveNewMessage(event.room_id, this.mapMessage(event));
+      }
+    });
+    this.matrix.on(RoomMemberEvent.Membership, async (event, member) => {
+      if (member.membership === 'invite' && member.userId === this.userId) {
+        await this.matrix.joinRoom(member.roomId);
+        this.events.onUserReceivedInvitation((event as any).room_id);
       }
     });
   }


### PR DESCRIPTION
### What does this do?

Auto accepts invites when we receive an invite event for the current user

### Why are we making this change?

So the user sees the conversation/channel immediately upon creation.

### How do I test this?

Create a conversation with someone. In that other user's browser, verify that the conversation appears and you can see/send messages

