### PR TITLE
Change conversation creation updates to event based

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -15,6 +15,7 @@ export interface RealtimeChatEvents {
   onMessageUpdated: (channelId: string, message: Message) => void;
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
   onUserReceivedInvitation: (channel) => void;
+  onUserJoinedChannel: (conversation) => void;
   invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;
 }
@@ -35,7 +36,7 @@ export interface IChatClient {
     name: string,
     image: File,
     optimisticId: string
-  ) => Promise<Partial<Channel> | null>;
+  ) => Promise<Partial<Channel> | void>;
   sendMessagesByChannelId: (
     channelId: string,
     message: string,

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -18,6 +18,7 @@ export interface RealtimeChatEvents {
   onUserJoinedChannel: (conversation) => void;
   invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;
+  onConversationListChanged: (conversationIds: string[]) => void;
 }
 
 export interface IChatClient {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1,6 +1,5 @@
 import { EventType, GuestAccess, Preset, Visibility } from 'matrix-js-sdk';
 import { MatrixClient } from './matrix-client';
-import { when } from 'jest-when';
 import { setAsDM } from './matrix/utils';
 
 jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
@@ -362,20 +361,6 @@ describe('matrix client', () => {
       await client.createConversation(users, null, null, null);
 
       expect(createRoom).toHaveBeenCalledWith(expect.objectContaining({ invite: ['@first.user', '@second.user'] }));
-    });
-
-    it('returns the created conversation', async () => {
-      const createRoom = jest.fn().mockResolvedValue({ room_id: 'a-new-room' });
-      const getRoom = jest.fn();
-      when(getRoom)
-        .calledWith('a-new-room')
-        .mockReturnValue(stubRoom({ roomId: 'a-new-room' }));
-      const users = [{ userId: 'id-1', matrixId: '@first.user' }];
-      const client = await subject({ createRoom, getRoom });
-
-      const conversation = await client.createConversation(users, null, null, null);
-
-      expect(conversation.id).toEqual('a-new-room');
     });
 
     it('sets the conversation as a Matrix direct message', async () => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -127,7 +127,6 @@ export class MatrixClient implements IChatClient {
     const result = await this.matrix.createRoom(options);
     // Any room is only set as a DM based on a single user. We'll use the first one.
     await setAsDM(this.matrix, result.room_id, users[0].matrixId);
-    return this.mapConversation(this.matrix.getRoom(result.room_id));
   }
 
   async sendMessagesByChannelId(
@@ -188,6 +187,10 @@ export class MatrixClient implements IChatClient {
 
       if (event.type === 'm.room.message') {
         this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix)) as any);
+      }
+
+      if (event.type === 'm.room.create') {
+        this.roomCreated(event);
       }
     });
     this.matrix.on(RoomMemberEvent.Membership, async (_event, member) => {
@@ -254,6 +257,10 @@ export class MatrixClient implements IChatClient {
     });
   }
 
+  private async roomCreated(event) {
+    this.events.onUserJoinedChannel(this.mapChannel(this.matrix.getRoom(event.room_id)));
+  }
+
   private mapToGeneralChannel(room: Room) {
     return {
       id: room.roomId,
@@ -291,12 +298,15 @@ export class MatrixClient implements IChatClient {
       await this.waitForConnection();
     }
 
+    const dmConversationIds = await this.getConversationIds();
+    const rooms = this.matrix.getRooms() || [];
+    return rooms.filter((r) => filterFunc(r, dmConversationIds));
+  }
+
+  private async getConversationIds() {
     const accountData = await this.getAccountData(EventType.Direct);
     const content = accountData?.getContent();
 
-    const dmConversationIds = content ? (Object.values(content).flat() as string[]) : [];
-
-    const rooms = this.matrix.getRooms() || [];
-    return rooms.filter((r) => filterFunc(r, dmConversationIds));
+    return Object.values(content ?? {}).flat();
   }
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -264,12 +264,12 @@ export class MatrixClient implements IChatClient {
     this.events.onUserJoinedChannel(this.mapChannel(this.matrix.getRoom(event.room_id)));
   }
 
-  private async publishConversationListChange(event: MatrixEvent) {
+  private publishConversationListChange = (event: MatrixEvent) => {
     if (event.getType() === EventType.Direct) {
       const content = event.getContent();
       this.events.onConversationListChanged(Object.values(content ?? {}).flat());
     }
-  }
+  };
 
   private mapToGeneralChannel(room: Room) {
     return {

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -12,6 +12,7 @@ import {
   clearChannelsAndConversations,
   userLeftChannel,
   addChannel,
+  setConversations,
 } from './saga';
 
 import { SagaActionTypes, setStatus } from '.';
@@ -339,6 +340,48 @@ describe('channels list saga', () => {
         .run();
 
       expect(storeState.channelsList.value).toIncludeSameMembers(['existing-conversation-id']);
+    });
+  });
+
+  describe(setConversations, () => {
+    it('changes channels to conversation', async () => {
+      const initialState = new StoreBuilder().withChannelList(
+        { id: 'channel-1', isChannel: true },
+        { id: 'channel-2', isChannel: true },
+        { id: 'channel-3', isChannel: true }
+      );
+
+      const { storeState } = await expectSaga(setConversations, ['channel-1', 'channel-3'])
+        .withReducer(rootReducer, initialState.build())
+        .run();
+
+      const channel1 = denormalizeChannel('channel-1', storeState);
+      expect(channel1.isChannel).toEqual(false);
+      const channel3 = denormalizeChannel('channel-3', storeState);
+      expect(channel3.isChannel).toEqual(false);
+
+      const channel2 = denormalizeChannel('channel-2', storeState);
+      expect(channel2.isChannel).toEqual(true);
+    });
+
+    it('changes conversations to channels', async () => {
+      const initialState = new StoreBuilder().withChannelList(
+        { id: 'channel-1', isChannel: false },
+        { id: 'channel-2', isChannel: false },
+        { id: 'channel-3', isChannel: false }
+      );
+
+      const { storeState } = await expectSaga(setConversations, ['channel-2'])
+        .withReducer(rootReducer, initialState.build())
+        .run();
+
+      const channel1 = denormalizeChannel('channel-1', storeState);
+      expect(channel1.isChannel).toEqual(true);
+      const channel3 = denormalizeChannel('channel-3', storeState);
+      expect(channel3.isChannel).toEqual(true);
+
+      const channel2 = denormalizeChannel('channel-2', storeState);
+      expect(channel2.isChannel).toEqual(false);
     });
   });
 });

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -11,6 +11,7 @@ import {
   startChannelsAndConversationsRefresh,
   clearChannelsAndConversations,
   userLeftChannel,
+  addChannel,
 } from './saga';
 
 import { SagaActionTypes, setStatus } from '.';
@@ -315,5 +316,29 @@ describe('channels list saga', () => {
     });
 
     expect(channelsListResult).toEqual({ value: [] });
+  });
+
+  describe(addChannel, () => {
+    it('adds channel to list', async () => {
+      const initialState = new StoreBuilder()
+        .withConversationList({ id: 'conversation-id' })
+        .withChannelList({ id: 'channel-id' });
+
+      const { storeState } = await expectSaga(addChannel, { id: 'new-convo' })
+        .withReducer(rootReducer, initialState.build())
+        .run();
+
+      expect(storeState.channelsList.value).toIncludeSameMembers(['conversation-id', 'channel-id', 'new-convo']);
+    });
+
+    it('does not duplicate the conversation', async () => {
+      const initialState = new StoreBuilder().withConversationList({ id: 'existing-conversation-id' });
+
+      const { storeState } = await expectSaga(addChannel, { id: 'existing-conversation-id' })
+        .withReducer(rootReducer, initialState.build())
+        .run();
+
+      expect(storeState.channelsList.value).toIncludeSameMembers(['existing-conversation-id']);
+    });
   });
 });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -308,4 +308,20 @@ export function* saga() {
   yield takeEveryFromBus(chatBus, ChatEvents.UserLeftChannel, ({ payload }) =>
     userLeftChannel(payload.channelId, payload.userId)
   );
+  yield takeEveryFromBus(chatBus, ChatEvents.UserJoinedChannel, userJoinedChannelAction);
+}
+
+function* userJoinedChannelAction({ payload }) {
+  yield addChannel(payload.channel);
+}
+
+export function* addChannel(channel) {
+  const conversationsList = yield select(rawConversationsList());
+  const channelsList = yield select(rawChannelsList());
+
+  yield put(receive(uniqNormalizedList([...channelsList, ...conversationsList, channel])));
+}
+
+function uniqNormalizedList(objectsAndIds: ({ id: string } | string)[]): any {
+  return uniqBy(objectsAndIds, (c) => c.id ?? c);
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -309,10 +309,15 @@ export function* saga() {
     userLeftChannel(payload.channelId, payload.userId)
   );
   yield takeEveryFromBus(chatBus, ChatEvents.UserJoinedChannel, userJoinedChannelAction);
+  yield takeEveryFromBus(chatBus, ChatEvents.ConversationListChanged, conversationListChangedAction);
 }
 
 function* userJoinedChannelAction({ payload }) {
   yield addChannel(payload.channel);
+}
+
+function* conversationListChangedAction({ payload }) {
+  yield setConversations(payload.conversationIds);
 }
 
 export function* addChannel(channel) {
@@ -320,6 +325,14 @@ export function* addChannel(channel) {
   const channelsList = yield select(rawChannelsList());
 
   yield put(receive(uniqNormalizedList([...channelsList, ...conversationsList, channel])));
+}
+
+export function* setConversations(conversationIds: string[]) {
+  const allChannelIds = yield select((state) => getDeepProperty(state, 'channelsList.value', []));
+  for (const id of allChannelIds) {
+    const isChannel = !conversationIds.includes(id);
+    yield put(receiveChannel({ id, isChannel }));
+  }
 }
 
 function uniqNormalizedList(objectsAndIds: ({ id: string } | string)[]): any {

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -13,6 +13,7 @@ export enum Events {
   ChannelInvitationReceived = 'chat/channel/invitationReceived',
   UserLeftChannel = 'chat/channel/userLeft',
   UserJoinedChannel = 'chat/channel/userJoined',
+  ConversationListChanged = 'chat/conversationListChanged',
 }
 
 let theBus;
@@ -42,6 +43,8 @@ export function createChatConnection(userId, chatAccessToken) {
       emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
+    const onConversationListChanged = (conversationIds) =>
+      emit({ type: Events.ConversationListChanged, payload: { conversationIds } });
 
     chatClient.initChat({
       reconnectStart,
@@ -54,6 +57,7 @@ export function createChatConnection(userId, chatAccessToken) {
       onUserReceivedInvitation,
       onUserLeft,
       onUserJoinedChannel,
+      onConversationListChanged,
     });
     chatClient.connect(userId, chatAccessToken);
 

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -12,6 +12,7 @@ export enum Events {
   InvalidToken = 'chat/invalidToken',
   ChannelInvitationReceived = 'chat/channel/invitationReceived',
   UserLeftChannel = 'chat/channel/userLeft',
+  UserJoinedChannel = 'chat/channel/userJoined',
 }
 
 let theBus;
@@ -40,6 +41,7 @@ export function createChatConnection(userId, chatAccessToken) {
     const onUserReceivedInvitation = (channelId) =>
       emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
+    const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
 
     chatClient.initChat({
       reconnectStart,
@@ -51,6 +53,7 @@ export function createChatConnection(userId, chatAccessToken) {
       invalidChatAccessToken,
       onUserReceivedInvitation,
       onUserLeft,
+      onUserJoinedChannel,
     });
     chatClient.connect(userId, chatAccessToken);
 


### PR DESCRIPTION
### What does this do?

This changes the rendering of created conversations to be event based.

### Why are we making this change?

When you refresh the browser the Matrix SDK provides an old data state and then replays events. By rendering this way we ensure that both the initial creation works and the rendering upon refresh.

### How do I test this?

Create a conversation and verify that it renders. Refresh the browser and verify that it also shows up then.

