### PR TITLE
feat: set status badge using matrix presence

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -305,6 +305,43 @@ describe('matrix client', () => {
     });
   });
 
+  describe('getUser', () => {
+    it('returns user data for given userId', async () => {
+      const matrixUser = {
+        userId: '@john:matrix.org',
+        displayName: 'John Doe',
+        avatarUrl: 'https://example.com/avatar.jpg',
+        presence: 'online',
+        currentlyActive: true,
+        lastPresenceTs: 123456789,
+      };
+
+      const getUser = jest.fn().mockReturnValue(matrixUser);
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getUser })),
+      });
+
+      await client.connect('username', 'token');
+      const user = await client.getUser('@john:matrix.org');
+
+      expect(getUser).toHaveBeenCalledWith('@john:matrix.org');
+      expect(user).toEqual(matrixUser);
+    });
+
+    it('returns null if user does not exist', async () => {
+      const getUser = jest.fn().mockReturnValue(null);
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getUser })),
+      });
+
+      await client.connect('username', 'token');
+      const user = await client.getUser('@unknown:matrix.org');
+
+      expect(getUser).toHaveBeenCalledWith('@unknown:matrix.org');
+      expect(user).toBeNull();
+    });
+  });
+
   describe('createConversation', () => {
     const subject = async (stubs = {}) => {
       const allStubs = {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -71,10 +71,6 @@ export class MatrixClient implements IChatClient {
     return user;
   }
 
-  async getUserPresence(userId: string) {
-    return this.matrix.getPresence(userId);
-  }
-
   async getAccountData(eventType: string) {
     if (this.isDisconnected) {
       throw new Error('Matrix client is disconnected');
@@ -175,10 +171,6 @@ export class MatrixClient implements IChatClient {
 
   get isConnecting() {
     return this.connectionStatus === ConnectionStatus.Connecting;
-  }
-
-  get currentUserId() {
-    return this.userId;
   }
 
   private setConnectionStatus(connectionStatus: ConnectionStatus) {
@@ -289,6 +281,7 @@ export class MatrixClient implements IChatClient {
   }
 
   private mapChannel = (room: Room): Partial<Channel> => this.mapToGeneralChannel(room);
+
   private mapConversation = (room: Room): Partial<Channel> => {
     const otherMembersList = this.getOtherMembersFromRoom(room);
     const otherMembers = otherMembersList.map((userId) => this.mapUser(userId));


### PR DESCRIPTION
### What does this do?
- sets the user status using the presence data provided from getUser.

### Why are we making this change?
- to be able to see if a user is online or offline.

### How do I test this?
- open the messenger and check the user status. You can console.log the user data and check is user.presence is equal to online.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
<img width="1040" alt="Screenshot 2023-09-25 at 20 42 15" src="https://github.com/zer0-os/zOS/assets/39112648/41c137e8-1087-46b0-824b-5351e988e007">
