### PR TITLE
[Matrix] Implement user mentions

### DIFF
--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -343,7 +343,7 @@ describe('ChatView', () => {
 
     await input.prop('getUsersForMentions')('bob');
 
-    expect(mockSearchMentionableUsersForChannel).toHaveBeenCalledWith('5', 'bob');
+    expect(mockSearchMentionableUsersForChannel).toHaveBeenCalledWith('5', 'bob', []);
   });
 
   describe('formatDayHeader', () => {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -218,7 +218,7 @@ export class ChatView extends React.Component<Properties, State> {
   }
 
   searchMentionableUsers = async (search: string) => {
-    return await searchMentionableUsersForChannel(this.props.id, search);
+    return await searchMentionableUsersForChannel(this.props.id, search, this.props.otherMembers);
   };
 
   get failureMessage() {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -35,7 +35,7 @@ export interface IChatClient {
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
   getConversations: () => Promise<Partial<Channel>[]>;
   searchMyNetworksByName: (filter: string) => Promise<MemberNetworks[] | any>;
-  searchMentionableUsersForChannel: (channelId: string, search: string) => Promise<any[]>;
+  searchMentionableUsersForChannel: (channelId: string, search: string, channelMembers?: UserModel[]) => Promise<any[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
   createConversation: (
     users: User[],
@@ -86,8 +86,8 @@ export class Chat {
     return this.client.searchMyNetworksByName(filter);
   }
 
-  async searchMentionableUsersForChannel(channelId: string, search: string) {
-    return this.client.searchMentionableUsersForChannel(channelId, search);
+  async searchMentionableUsersForChannel(channelId: string, search: string, channelMembers: UserModel[]) {
+    return this.client.searchMentionableUsersForChannel(channelId, search, channelMembers);
   }
 
   async sendMessagesByChannelId(

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -27,7 +27,7 @@ import { ParentMessage, User } from './types';
 import { config } from '../../config';
 import { get } from '../api/rest';
 import { MemberNetworks } from '../../store/users/types';
-import { setAsDM } from './matrix/utils';
+import { getFilteredMembersForAutoComplete, setAsDM } from './matrix/utils';
 
 enum ConnectionStatus {
   Connected = 'connected',
@@ -119,8 +119,10 @@ export class MatrixClient implements IChatClient {
       .then((response) => response?.body || []);
   }
 
-  async searchMentionableUsersForChannel(_channelId: string, _search: string) {
-    return [];
+  async searchMentionableUsersForChannel(channelId: string, search: string) {
+    const roomMembers = await this.matrix.getJoinedRoomMembers(channelId);
+    const searchResults = await getFilteredMembersForAutoComplete(roomMembers.joined, search);
+    return searchResults.map((u) => ({ id: u.matrixId, display: u.displayName, profileImage: u.avatar_url }));
   }
 
   async getMessagesByChannelId(channelId: string, _lastCreatedAt?: number): Promise<MessagesResponse> {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -119,9 +119,8 @@ export class MatrixClient implements IChatClient {
       .then((response) => response?.body || []);
   }
 
-  async searchMentionableUsersForChannel(channelId: string, search: string) {
-    const roomMembers = await this.matrix.getJoinedRoomMembers(channelId);
-    const searchResults = await getFilteredMembersForAutoComplete(roomMembers.joined, search);
+  async searchMentionableUsersForChannel(channelId: string, search: string, channelMembers: UserModel[]) {
+    const searchResults = await getFilteredMembersForAutoComplete(channelMembers, search);
     return searchResults.map((u) => ({ id: u.matrixId, display: u.displayName, profileImage: u.avatar_url }));
   }
 

--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -2,16 +2,28 @@
 import { getFilteredMembersForAutoComplete } from './utils';
 
 // Example room members data
-const roomMembers = {
-  '@ratik21:zero-synapse-development.zer0.io': {
-    avatar_url: null,
-    display_name: 'ratik21',
+const roomMembers = [
+  {
+    userId: '@domw:zero-synapse-development.zer0.io',
+    matrixId: '@domw:zero-synapse-development.zer0.io',
+    firstName: 'domw',
+    lastName: '',
+    profileId: '',
+    isOnline: false,
+    profileImage: '',
+    lastSeenAt: '',
   },
-  '@dale.fukami:zero-synapse-development.zer0.io': {
-    avatar_url: null,
-    display_name: 'dale.fukami',
+  {
+    userId: '@dale.fukami:zero-synapse-development.zer0.io',
+    matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
+    firstName: 'dale.fukami',
+    lastName: '',
+    profileId: '',
+    isOnline: false,
+    profileImage: '',
+    lastSeenAt: '',
   },
-};
+];
 
 describe('getFilteredMembersForAutoComplete', () => {
   it('should return empty array if no matching members', async () => {
@@ -33,37 +45,14 @@ describe('getFilteredMembersForAutoComplete', () => {
     ]);
   });
 
-  it('should return filtered members based on matrix ID if display name is NOT set', async () => {
-    const filter = 'ratik21';
-    const result = await getFilteredMembersForAutoComplete(
-      {
-        ...roomMembers,
-        '@ratik21:zero-synapse-development.zer0.io': {
-          avatar_url: null,
-          display_name: '',
-        },
-      },
-      filter
-    );
-
-    // Expect members with 'ratik21' in matrix ID
-    expect(result).toEqual([
-      {
-        matrixId: '@ratik21:zero-synapse-development.zer0.io',
-        displayName: 'ratik21',
-        avatar_url: '',
-      },
-    ]);
-  });
-
   it('should return case-insensitive results', async () => {
-    const filter = 'RaTiK21'; // Case-insensitive filter
+    const filter = 'dOmW'; // Case-insensitive filter
     const result = await getFilteredMembersForAutoComplete(roomMembers, filter);
     // Expect members with 'ratik21' in display name
     expect(result).toEqual([
       {
-        matrixId: '@ratik21:zero-synapse-development.zer0.io',
-        displayName: 'ratik21',
+        matrixId: '@domw:zero-synapse-development.zer0.io',
+        displayName: 'domw',
         avatar_url: '',
       },
     ]);
@@ -75,8 +64,8 @@ describe('getFilteredMembersForAutoComplete', () => {
     // Expect all members
     expect(result).toEqual([
       {
-        matrixId: '@ratik21:zero-synapse-development.zer0.io',
-        displayName: 'ratik21',
+        matrixId: '@domw:zero-synapse-development.zer0.io',
+        displayName: 'domw',
         avatar_url: '',
       },
       {

--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -1,0 +1,89 @@
+// Import your function and any necessary dependencies
+import { getFilteredMembersForAutoComplete } from './utils';
+
+// Example room members data
+const roomMembers = {
+  '@ratik21:zero-synapse-development.zer0.io': {
+    avatar_url: null,
+    display_name: 'ratik21',
+  },
+  '@dale.fukami:zero-synapse-development.zer0.io': {
+    avatar_url: null,
+    display_name: 'dale.fukami',
+  },
+};
+
+describe('getFilteredMembersForAutoComplete', () => {
+  it('should return empty array if no matching members', async () => {
+    const filter = 'xyz'; // No matching members
+    const result = await getFilteredMembersForAutoComplete(roomMembers, filter);
+    expect(result).toEqual([]);
+  });
+
+  it('should return filtered members based on display name', async () => {
+    const filter = 'da';
+    const result = await getFilteredMembersForAutoComplete(roomMembers, filter);
+    // Expect members with 'da' in display name
+    expect(result).toEqual([
+      {
+        matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
+        displayName: 'dale.fukami',
+        avatar_url: '',
+      },
+    ]);
+  });
+
+  it('should return filtered members based on matrix ID if display name is NOT set', async () => {
+    const filter = 'ratik21';
+    const result = await getFilteredMembersForAutoComplete(
+      {
+        ...roomMembers,
+        '@ratik21:zero-synapse-development.zer0.io': {
+          avatar_url: null,
+          display_name: '',
+        },
+      },
+      filter
+    );
+
+    // Expect members with 'ratik21' in matrix ID
+    expect(result).toEqual([
+      {
+        matrixId: '@ratik21:zero-synapse-development.zer0.io',
+        displayName: 'ratik21',
+        avatar_url: '',
+      },
+    ]);
+  });
+
+  it('should return case-insensitive results', async () => {
+    const filter = 'RaTiK21'; // Case-insensitive filter
+    const result = await getFilteredMembersForAutoComplete(roomMembers, filter);
+    // Expect members with 'ratik21' in display name
+    expect(result).toEqual([
+      {
+        matrixId: '@ratik21:zero-synapse-development.zer0.io',
+        displayName: 'ratik21',
+        avatar_url: '',
+      },
+    ]);
+  });
+
+  it('should return all members if filter is empty', async () => {
+    const filter = ''; // Empty filter
+    const result = await getFilteredMembersForAutoComplete(roomMembers, filter);
+    // Expect all members
+    expect(result).toEqual([
+      {
+        matrixId: '@ratik21:zero-synapse-development.zer0.io',
+        displayName: 'ratik21',
+        avatar_url: '',
+      },
+      {
+        matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
+        displayName: 'dale.fukami',
+        avatar_url: '',
+      },
+    ]);
+  });
+});

--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -2,26 +2,16 @@
 import { getFilteredMembersForAutoComplete } from './utils';
 
 // Example room members data
-const roomMembers = [
+const roomMembers: any[] = [
   {
     userId: '@domw:zero-synapse-development.zer0.io',
     matrixId: '@domw:zero-synapse-development.zer0.io',
     firstName: 'domw',
-    lastName: '',
-    profileId: '',
-    isOnline: false,
-    profileImage: '',
-    lastSeenAt: '',
   },
   {
     userId: '@dale.fukami:zero-synapse-development.zer0.io',
     matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
     firstName: 'dale.fukami',
-    lastName: '',
-    profileId: '',
-    isOnline: false,
-    profileImage: '',
-    lastSeenAt: '',
   },
 ];
 

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -1,4 +1,5 @@
 import { EventType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
+import { User as ChannelMember } from '../../../store/channels';
 
 // Copied from the matrix-react-sdk
 export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: string): Promise<void> {
@@ -38,21 +39,18 @@ export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: s
   await matrix.setAccountData(EventType.Direct, Object.fromEntries(dmRoomMap));
 }
 
-export async function getFilteredMembersForAutoComplete(
-  roomMembers: { [userId: string]: { avatar_url?: string; display_name?: string } },
-  filter: string
-) {
+// TODO: follow up to use zOS user instead of matrix user
+export async function getFilteredMembersForAutoComplete(roomMembers: ChannelMember[] = [], filter: string = '') {
   const normalizedFilter = filter.toLowerCase(); // Case-insensitive search
 
   const filteredResults = [];
-  for (let matrixId of Object.keys(roomMembers)) {
-    let displayName = roomMembers[matrixId]['display_name'] || matrixId.match(/@([^:]+)/)[1] || '';
+  for (const member of roomMembers) {
+    let displayName = member.matrixId?.match(/@([^:]+)/)[1] || '';
     if (displayName.includes(normalizedFilter)) {
       filteredResults.push({
-        matrixId,
-        // should we prioritize the display_name, avatar_url from matrix OR our own db?
+        matrixId: member.matrixId,
         displayName,
-        avatar_url: roomMembers[matrixId]['avatar_url'] || '', // this will likely be '' for now
+        avatar_url: '',
       });
     }
   }

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -37,3 +37,25 @@ export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: s
 
   await matrix.setAccountData(EventType.Direct, Object.fromEntries(dmRoomMap));
 }
+
+export async function getFilteredMembersForAutoComplete(
+  roomMembers: { [userId: string]: { avatar_url?: string; display_name?: string } },
+  filter: string
+) {
+  const normalizedFilter = filter.toLowerCase(); // Case-insensitive search
+
+  const filteredResults = [];
+  for (let matrixId of Object.keys(roomMembers)) {
+    let displayName = roomMembers[matrixId]['display_name'] || matrixId.match(/@([^:]+)/)[1] || '';
+    if (displayName.includes(normalizedFilter)) {
+      filteredResults.push({
+        matrixId,
+        // should we prioritize the display_name, avatar_url from matrix OR our own db?
+        displayName,
+        avatar_url: roomMembers[matrixId]['avatar_url'] || '', // this will likely be '' for now
+      });
+    }
+  }
+
+  return filteredResults;
+}

--- a/src/platform-apps/channels/util/api.ts
+++ b/src/platform-apps/channels/util/api.ts
@@ -1,8 +1,13 @@
 import { chat } from '../../../lib/chat';
+import { User as ChannelMember } from '../../../store/channels';
 
-export async function searchMentionableUsersForChannel(channelId: string, search: string) {
+export async function searchMentionableUsersForChannel(
+  channelId: string,
+  search: string,
+  channelMembers: ChannelMember[]
+) {
   const chatClient = chat.get();
-  return await chatClient.searchMentionableUsersForChannel(channelId, search);
+  return await chatClient.searchMentionableUsersForChannel(channelId, search, channelMembers);
 }
 
 export async function searchMyNetworksByName(search: string) {


### PR DESCRIPTION
### What does this do?

Implements user mentions using matrix

![image](https://github.com/zer0-os/zOS/assets/33264364/549f0ced-39ca-4ef1-a6a3-fdeaef7da961)
![image](https://github.com/zer0-os/zOS/assets/33264364/c619a8f9-9905-44a5-b0eb-219ed06b4bd7)


*NOTE*:
+ This implements a simple approach - we use channel.otherMembers as cache, and then filter the results based on the search string. 

**Follow ups**:
- map the `otherMembers` in the channelInfo to the zOS users.
- update the sendbird implementation for "conversations" to use otherMembers as cache as well.