### PR TITLE
feat: add matrix user avatar to mapped user

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -305,6 +305,43 @@ describe('matrix client', () => {
     });
   });
 
+  describe('getUser', () => {
+    it('returns user data for given userId', async () => {
+      const matrixUser = {
+        userId: '@john:matrix.org',
+        displayName: 'John Doe',
+        avatarUrl: 'https://example.com/avatar.jpg',
+        presence: 'online',
+        currentlyActive: true,
+        lastPresenceTs: 123456789,
+      };
+
+      const getUser = jest.fn().mockReturnValue(matrixUser);
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getUser })),
+      });
+
+      await client.connect('username', 'token');
+      const user = await client.getUser('@john:matrix.org');
+
+      expect(getUser).toHaveBeenCalledWith('@john:matrix.org');
+      expect(user).toEqual(matrixUser);
+    });
+
+    it('returns null if user does not exist', async () => {
+      const getUser = jest.fn().mockReturnValue(null);
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getUser })),
+      });
+
+      await client.connect('username', 'token');
+      const user = await client.getUser('@unknown:matrix.org');
+
+      expect(getUser).toHaveBeenCalledWith('@unknown:matrix.org');
+      expect(user).toBeNull();
+    });
+  });
+
   describe('createConversation', () => {
     const subject = async (stubs = {}) => {
       const allStubs = {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -294,13 +294,16 @@ export class MatrixClient implements IChatClient {
 
   private mapUser(userId: string): ChannelUser {
     const user = this.matrix.getUser(userId);
+    const avatarMxc = user?.avatarUrl;
+    const httpAvatarUrl = this.matrix.mxcUrlToHttp(avatarMxc);
+
     return {
       userId: user?.userId,
       firstName: '',
       lastName: '',
       profileId: '',
       isOnline: user?.presence === 'online',
-      profileImage: '',
+      profileImage: httpAvatarUrl,
       lastSeenAt: '',
     };
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -71,10 +71,6 @@ export class MatrixClient implements IChatClient {
     return user;
   }
 
-  async getUserPresence(userId: string) {
-    return this.matrix.getPresence(userId);
-  }
-
   async getAccountData(eventType: string) {
     if (this.isDisconnected) {
       throw new Error('Matrix client is disconnected');
@@ -175,10 +171,6 @@ export class MatrixClient implements IChatClient {
 
   get isConnecting() {
     return this.connectionStatus === ConnectionStatus.Connecting;
-  }
-
-  get currentUserId() {
-    return this.userId;
   }
 
   private setConnectionStatus(connectionStatus: ConnectionStatus) {
@@ -289,6 +281,7 @@ export class MatrixClient implements IChatClient {
   }
 
   private mapChannel = (room: Room): Partial<Channel> => this.mapToGeneralChannel(room);
+
   private mapConversation = (room: Room): Partial<Channel> => {
     const otherMembersList = this.getOtherMembersFromRoom(room);
     const otherMembers = otherMembersList.map((userId) => this.mapUser(userId));


### PR DESCRIPTION
### What does this do?
- adds matrix user avatar if an avatar url is available

### Why are we making this change?
- to display the users avatar that is set with matrix

### How do I test this?
- log the user data and check if the user has data for avatarUrl. If the user has this data, the matrix URI should be converted to a http URL and rendered in the UI as shown below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

ZOS
<img width="920" alt="Screenshot 2023-09-26 at 11 38 40" src="https://github.com/zer0-os/zOS/assets/39112648/5edd2806-481b-4863-b1b2-f891883c64b3">


ELEMENT
<img width="520" alt="Screenshot 2023-09-26 at 11 38 08" src="https://github.com/zer0-os/zOS/assets/39112648/5c79f59e-135c-479b-837f-35826e8cb1d2">
