### PR TITLE
feat: implement and handle online status and last seen real-time events

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -19,6 +19,7 @@ export interface RealtimeChatEvents {
   invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;
   onConversationListChanged: (conversationIds: string[]) => void;
+  onUserPresenceChanged: (matrixId: string, isOnline: boolean, lastSeenAt: string) => void;
 }
 
 export interface IChatClient {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -7,6 +7,7 @@ import { Payload, UnreadCountUpdatedPayload } from './types';
 
 export interface User {
   userId: string;
+  matrixId: string;
   firstName: string;
   lastName: string;
   profileId: string;

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -14,6 +14,7 @@ export enum Events {
   UserLeftChannel = 'chat/channel/userLeft',
   UserJoinedChannel = 'chat/channel/userJoined',
   ConversationListChanged = 'chat/conversationListChanged',
+  UserPresenceChanged = 'chat/user/presenceChanged',
 }
 
 let theBus;
@@ -45,6 +46,8 @@ export function createChatConnection(userId, chatAccessToken) {
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
     const onConversationListChanged = (conversationIds) =>
       emit({ type: Events.ConversationListChanged, payload: { conversationIds } });
+    const onUserPresenceChanged = (matrixId, isOnline, lastSeenAt) =>
+      emit({ type: Events.UserPresenceChanged, payload: { matrixId, isOnline, lastSeenAt } });
 
     chatClient.initChat({
       reconnectStart,
@@ -58,6 +61,7 @@ export function createChatConnection(userId, chatAccessToken) {
       onUserLeft,
       onUserJoinedChannel,
       onConversationListChanged,
+      onUserPresenceChanged,
     });
     chatClient.connect(userId, chatAccessToken);
 

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -1,5 +1,7 @@
-import { put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select, takeEvery } from 'redux-saga/effects';
 import { schema, removeAll, receive, SagaActionTypes } from '.';
+import { Events, getChatBus } from '../chat/bus';
+import { takeEveryFromBus } from '../../lib/saga';
 
 export function* clearUsers() {
   yield put(removeAll({ schema: schema.key }));
@@ -17,8 +19,25 @@ export function* receiveSearchResults(searchResults) {
   yield put(receive(mappedUsers));
 }
 
+export function* userPresenceChanged(matrixId: string, isOnline: boolean, lastSeenAt: string) {
+  const user = yield select((state) => Object.values(state.normalized.users).find((u: any) => u.matrixId === matrixId));
+
+  if (!user) {
+    return;
+  }
+
+  yield put(receive({ userId: user.userId, isOnline, lastSeenAt }));
+}
+
 export function* saga() {
   yield takeEvery(SagaActionTypes.SearchResults, receiveSearchResultsAction);
+
+  const chatBus = yield call(getChatBus);
+  yield takeEveryFromBus(chatBus, Events.UserPresenceChanged, userPresenceChangedAction);
+}
+
+function* userPresenceChangedAction(action) {
+  yield userPresenceChanged(action.payload.matrixId, action.payload.isOnline, action.payload.lastSeenAt);
 }
 
 export function* receiveSearchResultsAction(action) {


### PR DESCRIPTION
### What does this do?
- sets online status in real time using matrix presence event
- sets last seen status in real time using matrix presence events

### Why are we making this change?
- to ensure real time updates of the users online status and last seen data.

### How do I test this?
- have two elements running where both users are in your people list, and sign in/sign out to follow the presence events fired and check if the online status badge and last seen are updated.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Last Seen and Online Status Badge
<img width="920" alt="Screenshot 2023-09-26 at 16 05 04" src="https://github.com/zer0-os/zOS/assets/39112648/4c37b7bb-f6c6-4bcf-9df8-5bce2e959a94">
