### PR TITLE
Handle membership events to ensure correct room members

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -1,5 +1,5 @@
 import { Message, MessagesResponse } from '../../store/messages';
-import { Channel } from '../../store/channels/index';
+import { Channel, User as UserModel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { SendbirdClient } from './sendbird-client';
 import { FileUploadResult } from '../../store/messages/saga';
@@ -21,6 +21,8 @@ export interface RealtimeChatEvents {
   onConversationListChanged: (conversationIds: string[]) => void;
   onUserPresenceChanged: (matrixId: string, isOnline: boolean, lastSeenAt: string) => void;
   onRoomNameChanged: (channelId: string, name: string) => void;
+  onOtherUserJoinedChannel: (channelId: string, user: UserModel) => void;
+  onOtherUserLeftChannel: (channelId: string, user: UserModel) => void;
 }
 
 export interface IChatClient {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -9,6 +9,7 @@ const stubRoom = (attrs = {}) => ({
   getAvatarUrl: () => '',
   getMembers: () => [],
   getDMInviter: () => undefined,
+  loadMembersIfNeeded: () => undefined,
   ...attrs,
 });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -371,10 +371,9 @@ export class MatrixClient implements IChatClient {
   }
 
   private getOtherMembersFromRoom(room: Room): string[] {
-    // This is actually wrong...we need the current active list
-    console.log('XXX room: ', room.getMembers());
     return room
       .getMembers()
+      .filter((member) => member.membership === 'join' || member.membership === 'invite')
       .filter((member) => member.userId !== this.userId)
       .map((member) => member.userId);
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -87,11 +87,17 @@ export class MatrixClient implements IChatClient {
 
   async getChannels(_id: string) {
     const rooms = await this.getFilteredRooms(this.isChannel);
+    for (const room of rooms) {
+      await room.loadMembersIfNeeded();
+    }
     return rooms.map(this.mapChannel);
   }
 
   async getConversations() {
     const rooms = await this.getFilteredRooms(this.isConversation);
+    for (const room of rooms) {
+      await room.loadMembersIfNeeded();
+    }
     return rooms.map(this.mapConversation);
   }
 
@@ -215,6 +221,7 @@ export class MatrixClient implements IChatClient {
     this.matrix.on(ClientEvent.AccountData, this.publishConversationListChange);
     this.matrix.on(ClientEvent.Event, this.publishUserPresenceChange);
     this.matrix.on(RoomEvent.Name, this.publishRoomNameChange);
+    this.matrix.on(RoomStateEvent.Members, this.publishMembershipChange);
 
     // Log events during development to help with understanding which events are happening
     Object.keys(ClientEvent).forEach((key) => {
@@ -304,13 +311,26 @@ export class MatrixClient implements IChatClient {
     }
   };
 
+  private publishMembershipChange = (event: MatrixEvent) => {
+    if (event.getType() === EventType.RoomMember) {
+      const user = this.mapUser(event.getStateKey());
+      if (event.getStateKey() !== this.userId) {
+        if (event.getContent().membership === 'leave') {
+          this.events.onOtherUserLeftChannel(event.getRoomId(), user);
+        } else {
+          this.events.onOtherUserJoinedChannel(event.getRoomId(), user);
+        }
+      }
+    }
+  };
+
   private mapToGeneralChannel(room: Room) {
     const otherMembersList = this.getOtherMembersFromRoom(room);
     const otherMembers = otherMembersList.map((userId) => this.mapUser(userId));
 
     return {
       id: room.roomId,
-      name: room.name,
+      name: '',
       icon: null,
       isChannel: true,
       // Even if a member leaves they stay in the member list so this will still be correct
@@ -339,9 +359,9 @@ export class MatrixClient implements IChatClient {
   private mapUser(userId: string): UserModel {
     const user = this.matrix.getUser(userId);
     return {
-      userId: user?.userId,
-      matrixId: user?.userId,
-      firstName: '',
+      userId: userId,
+      matrixId: userId,
+      firstName: user?.displayName,
       lastName: '',
       profileId: '',
       isOnline: user?.presence === 'online',
@@ -351,6 +371,8 @@ export class MatrixClient implements IChatClient {
   }
 
   private getOtherMembersFromRoom(room: Room): string[] {
+    // This is actually wrong...we need the current active list
+    console.log('XXX room: ', room.getMembers());
     return room
       .getMembers()
       .filter((member) => member.userId !== this.userId)

--- a/src/store/channels/selectors.ts
+++ b/src/store/channels/selectors.ts
@@ -1,0 +1,6 @@
+import { RootState } from '../reducer';
+import getDeepProperty from 'lodash.get';
+
+export const rawChannel = (state: RootState, channelId: string) => {
+  return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
+};

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -16,6 +16,8 @@ export enum Events {
   ConversationListChanged = 'chat/conversationListChanged',
   UserPresenceChanged = 'chat/user/presenceChanged',
   RoomNameChanged = 'chat/roomNameChanged',
+  OtherUserJoinedChannel = 'chat/channel/otherUserJoined',
+  OtherUserLeftChannel = 'chat/channel/otherUserLeft',
 }
 
 let theBus;
@@ -50,6 +52,10 @@ export function createChatConnection(userId, chatAccessToken) {
     const onUserPresenceChanged = (matrixId, isOnline, lastSeenAt) =>
       emit({ type: Events.UserPresenceChanged, payload: { matrixId, isOnline, lastSeenAt } });
     const onRoomNameChanged = (roomId, name) => emit({ type: Events.RoomNameChanged, payload: { id: roomId, name } });
+    const onOtherUserJoinedChannel = (channelId, user) =>
+      emit({ type: Events.OtherUserJoinedChannel, payload: { channelId, user } });
+    const onOtherUserLeftChannel = (channelId, user) =>
+      emit({ type: Events.OtherUserLeftChannel, payload: { channelId, user } });
 
     chatClient.initChat({
       reconnectStart,
@@ -65,6 +71,8 @@ export function createChatConnection(userId, chatAccessToken) {
       onConversationListChanged,
       onUserPresenceChanged,
       onRoomNameChanged,
+      onOtherUserJoinedChannel,
+      onOtherUserLeftChannel,
     });
     chatClient.connect(userId, chatAccessToken);
 

--- a/src/store/test/store.ts
+++ b/src/store/test/store.ts
@@ -86,7 +86,10 @@ export class StoreBuilder {
       channelsList: { value: channelsList },
       normalized: {
         ...channelEntitities,
-        users: normalizedUsers,
+        users: {
+          ...channelEntitities.users,
+          ...normalizedUsers,
+        },
       } as any,
       chat: {
         activeChannelId: this.activeChannel.id || null,

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -2,6 +2,7 @@ import { call, put, select, takeEvery } from 'redux-saga/effects';
 import { schema, removeAll, receive, SagaActionTypes } from '.';
 import { Events, getChatBus } from '../chat/bus';
 import { takeEveryFromBus } from '../../lib/saga';
+import { userByMatrixId } from './selectors';
 
 export function* clearUsers() {
   yield put(removeAll({ schema: schema.key }));
@@ -20,7 +21,7 @@ export function* receiveSearchResults(searchResults) {
 }
 
 export function* userPresenceChanged(matrixId: string, isOnline: boolean, lastSeenAt: string) {
-  const user = yield select((state) => Object.values(state.normalized.users).find((u: any) => u.matrixId === matrixId));
+  const user = yield select(userByMatrixId, matrixId);
 
   if (!user) {
     return;

--- a/src/store/users/selectors.ts
+++ b/src/store/users/selectors.ts
@@ -1,0 +1,5 @@
+import { RootState } from '../reducer';
+
+export function userByMatrixId(state: RootState, matrixId: string) {
+  return Object.values(state.normalized['users']).find((u: any) => u.matrixId === matrixId);
+}


### PR DESCRIPTION
### What does this do?

Adds event listeners for when users are added to / removed from rooms and fixes up the initial determination of room members.

### Why are we making this change?

Handle membership based on events so that we can replay the events and get into the correct state as well as handle the real time updates.

