### PR TITLE
Return the explicit room name when rendering conversations

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -10,8 +10,17 @@ const stubRoom = (attrs = {}) => ({
   getMembers: () => [],
   getDMInviter: () => undefined,
   loadMembersIfNeeded: () => undefined,
+  getLiveTimeline: () => stubTimeline(),
   ...attrs,
 });
+
+function stubTimeline() {
+  return {
+    getState: () => ({
+      getStateEvents: () => null,
+    }),
+  };
+}
 
 const getMockAccountData = (data = {}) => {
   return jest.fn((eventType) => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -328,9 +328,18 @@ export class MatrixClient implements IChatClient {
     const otherMembersList = this.getOtherMembersFromRoom(room);
     const otherMembers = otherMembersList.map((userId) => this.mapUser(userId));
 
+    let name = '';
+    const roomNameEvent = room
+      .getLiveTimeline()
+      .getState(EventTimeline.FORWARDS)
+      .getStateEvents(EventType.RoomName, '');
+    if (roomNameEvent && roomNameEvent.getType() === EventType.RoomName) {
+      name = roomNameEvent.getContent().name;
+    }
+
     return {
       id: room.roomId,
-      name: '',
+      name,
       icon: null,
       isChannel: true,
       // Even if a member leaves they stay in the member list so this will still be correct


### PR DESCRIPTION
### What does this do?

For initial render of Rooms we return the explicitly set room name if exists.

### Why are we making this change?

To perform the initial render correctly

