### PR TITLE
feat: show last message in conversation list and preview details

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -99,6 +99,7 @@ export class Container extends React.Component<Properties, State> {
     const hasWallet = user?.data?.wallets?.length > 0;
 
     const conversations = denormalizeConversations(state).map(addLastMessageMeta(state)).sort(byLastMessageOrCreation);
+    console.log('CONVERSATIONS', conversations);
 
     return {
       conversations,
@@ -306,6 +307,7 @@ export class Container extends React.Component<Properties, State> {
 function addLastMessageMeta(state: RootState): any {
   return (conversation) => {
     const sortedMessages = conversation.messages?.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
+    console.log('SORTED MESSAGES', sortedMessages);
     let mostRecentMessage = sortedMessages[0] || conversation.lastMessage;
     return {
       ...conversation,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -99,7 +99,6 @@ export class Container extends React.Component<Properties, State> {
     const hasWallet = user?.data?.wallets?.length > 0;
 
     const conversations = denormalizeConversations(state).map(addLastMessageMeta(state)).sort(byLastMessageOrCreation);
-    console.log('CONVERSATIONS', conversations);
 
     return {
       conversations,
@@ -307,7 +306,7 @@ export class Container extends React.Component<Properties, State> {
 function addLastMessageMeta(state: RootState): any {
   return (conversation) => {
     const sortedMessages = conversation.messages?.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
-    console.log('SORTED MESSAGES', sortedMessages);
+
     let mostRecentMessage = sortedMessages[0] || conversation.lastMessage;
     return {
       ...conversation,

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -44,6 +44,7 @@ const getSdkClient = (sdkClient = {}) => ({
   }),
   getRooms: jest.fn(),
   getAccountData: jest.fn(),
+  getUser: jest.fn(),
   ...sdkClient,
 });
 
@@ -443,8 +444,14 @@ describe('matrix client', () => {
         })
       );
 
+      const getSenderData = jest.fn(() =>
+        Promise.resolve({
+          displayName: 'Joe Bloggs',
+        })
+      );
+
       const client = subject({
-        createClient: jest.fn(() => getSdkClient({ sendMessage, fetchRoomEvent })),
+        createClient: jest.fn(() => getSdkClient({ sendMessage, fetchRoomEvent, getUser: getSenderData })),
       });
 
       await client.connect('username', 'token');
@@ -482,8 +489,14 @@ describe('matrix client', () => {
         })
       );
 
+      const getSenderData = jest.fn(() =>
+        Promise.resolve({
+          displayName: 'Joe Bloggs',
+        })
+      );
+
       const client = subject({
-        createClient: jest.fn(() => getSdkClient({ sendMessage, fetchRoomEvent })),
+        createClient: jest.fn(() => getSdkClient({ sendMessage, fetchRoomEvent, getUser: getSenderData })),
       });
 
       await client.connect('username', 'token');

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -12,6 +12,7 @@ const stubRoom = (attrs = {}) => ({
   loadMembersIfNeeded: () => undefined,
   getLiveTimeline: () => stubTimeline(),
   getMyMembership: () => 'join',
+  getEvents: () => stubTimeline(),
   ...attrs,
 });
 
@@ -20,6 +21,7 @@ function stubTimeline() {
     getState: () => ({
       getStateEvents: () => null,
     }),
+    getEvents: () => [],
   };
 }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -128,7 +128,7 @@ export class MatrixClient implements IChatClient {
     const messages = chunk.filter((m) => m.type === 'm.room.message');
     const mappedMessages = [];
     for (const message of messages) {
-      mappedMessages.push(await mapMatrixMessage(message, this.matrix));
+      mappedMessages.push(await mapMatrixMessage(message, this.matrix, this.userId));
     }
 
     return { messages: mappedMessages as any, hasMore: false };
@@ -175,7 +175,7 @@ export class MatrixClient implements IChatClient {
     const messageResult = await this.matrix.sendMessage(channelId, content);
     const newMessage = await this.matrix.fetchRoomEvent(channelId, messageResult.event_id);
     return {
-      ...(await mapMatrixMessage(newMessage, this.matrix)),
+      ...(await mapMatrixMessage(newMessage, this.matrix, this.userId)),
       optimisticId,
     };
   }
@@ -208,7 +208,7 @@ export class MatrixClient implements IChatClient {
       }
 
       if (event.type === 'm.room.message') {
-        this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix)) as any);
+        this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix, this.userId)) as any);
       }
 
       if (event.type === 'm.room.create') {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -23,8 +23,8 @@ async function extractParentMessageData(matrixMessage, sdkMatrixClient: SDKMatri
 }
 
 export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient, currentMatrixUserId: string) {
-  const { event_id, content, origin_server_ts, sender } = matrixMessage;
-  const senderData = sdkMatrixClient.getUser(sender);
+  const { event_id, content, origin_server_ts, sender: senderId } = matrixMessage;
+  const senderData = sdkMatrixClient.getUser(senderId);
 
   return {
     id: event_id,
@@ -32,8 +32,9 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     createdAt: origin_server_ts,
     updatedAt: null,
     sender: {
-      userId: sender,
-      firstName: sender === currentMatrixUserId ? 'You' : senderData.displayName,
+      userId: senderId,
+      // remove condition when matrix maps to zos user
+      firstName: senderId === currentMatrixUserId ? 'You' : senderData.displayName,
       lastName: '',
       profileImage: '',
       profileId: '',

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -22,13 +22,22 @@ async function extractParentMessageData(matrixMessage, sdkMatrixClient: SDKMatri
   return parentMessageData;
 }
 
-export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
+export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient, currentMatrixUserId: string) {
+  const { event_id, content, origin_server_ts, sender } = matrixMessage;
+  const senderData = sdkMatrixClient.getUser(sender);
+
   return {
-    id: matrixMessage.event_id,
-    message: matrixMessage.content.body,
-    createdAt: matrixMessage.origin_server_ts,
+    id: event_id,
+    message: content.body,
+    createdAt: origin_server_ts,
     updatedAt: null,
-    sender: {},
+    sender: {
+      userId: sender,
+      firstName: sender === currentMatrixUserId ? 'You' : senderData.displayName,
+      lastName: '',
+      profileImage: '',
+      profileId: '',
+    },
     isAdmin: false,
     ...{ mentionedUsers: [], hidePreview: false, media: null, image: null, admin: {} },
     ...(await extractParentMessageData(matrixMessage, sdkMatrixClient)),


### PR DESCRIPTION
### What does this do?
- enhances the mapMatrixMessage to include sender details

### Why are we making this change?
- to have defined sender details data in the message preview (conversation list item)

### How do I test this?
- open messenger > click on a user in the conversation list that has message history > when conversation renders to top of the list you should see the senders name or 'you'. If the senders name is visible and they sent the last message, this means the sender data is being fetched correctly.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE
<img width="663" alt="Screenshot 2023-09-28 at 11 48 21" src="https://github.com/zer0-os/zOS/assets/39112648/7e405669-5607-44c9-8fcb-f7e49e3760d2">

AFTER
<img width="663" alt="Screenshot 2023-09-28 at 11 47 36" src="https://github.com/zer0-os/zOS/assets/39112648/b083c8dc-371d-49ab-bf1e-6d4b66edfaa7">


DEMO - SORT ORDER

https://github.com/zer0-os/zOS/assets/39112648/279f913e-f2c5-495d-ac71-7855c357e17a

