### PR TITLE
Don't fetch conversations when the list is rendered

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -45,7 +45,6 @@ describe('messenger-list', () => {
       showRewardsInTooltip: false,
       showRewardsInPopup: false,
       onConversationClick: jest.fn(),
-      fetchConversations: jest.fn(),
       createConversation: jest.fn(),
       startCreateConversation: () => null,
       membersSelected: () => null,
@@ -68,14 +67,6 @@ describe('messenger-list', () => {
     const wrapper = subject({});
 
     expect(wrapper.find('.direct-message-members').exists()).toBe(true);
-  });
-
-  it('start sync direct messages', function () {
-    const fetchConversations = jest.fn();
-
-    subject({ fetchConversations });
-
-    expect(fetchConversations).toHaveBeenCalledOnce();
   });
 
   it('publishes close event when titlebar X clicked', function () {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -3,7 +3,7 @@ import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store/reducer';
 import { Channel } from '../../../store/channels';
 import { openConversation } from '../../../store/channels';
-import { denormalizeConversations, fetchConversations } from '../../../store/channels-list';
+import { denormalizeConversations } from '../../../store/channels-list';
 import { compareDatesDesc } from '../../../lib/date';
 import { MemberNetworks } from '../../../store/users/types';
 import { searchMyNetworksByName } from '../../../platform-apps/channels/util/api';
@@ -70,7 +70,6 @@ export interface Properties extends PublicProperties {
   startCreateConversation: () => void;
   startGroup: () => void;
   back: () => void;
-  fetchConversations: () => void;
   membersSelected: (payload: MembersSelectedPayload) => void;
   createConversation: (payload: CreateMessengerConversation) => void;
   onConversationClick: (payload: { conversationId: string }) => void;
@@ -127,7 +126,6 @@ export class Container extends React.Component<Properties, State> {
   static mapActions(_props: Properties): Partial<Properties> {
     return {
       onConversationClick: openConversation,
-      fetchConversations,
       createConversation,
       startCreateConversation,
       back,
@@ -147,7 +145,6 @@ export class Container extends React.Component<Properties, State> {
   };
 
   componentDidMount(): void {
-    this.props.fetchConversations();
     this.props.fetchRewards({});
   }
 

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -5,13 +5,11 @@ import { schema } from '../channels';
 
 export enum SagaActionTypes {
   FetchChannels = 'channelsList/saga/fetchChannels',
-  FetchConversations = 'channelsList/saga/fetchConversations',
   StartChannelsAndConversationsAutoRefresh = 'channelsList/saga/startChannelsAndConversationsAutoRefresh',
   StopChannelsAndConversationsAutoRefresh = 'channelsList/saga/stopChannelsAndConversationsAutoRefresh',
 }
 
 const fetchChannels = createAction<string>(SagaActionTypes.FetchChannels);
-const fetchConversations = createAction<string>(SagaActionTypes.FetchConversations);
 const startChannelsAndConversationsAutoRefresh = createAction(SagaActionTypes.StartChannelsAndConversationsAutoRefresh);
 
 const slice = createNormalizedListSlice({
@@ -21,7 +19,7 @@ const slice = createNormalizedListSlice({
 
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
-export { fetchChannels, fetchConversations, startChannelsAndConversationsAutoRefresh };
+export { fetchChannels, startChannelsAndConversationsAutoRefresh };
 
 export function denormalizeChannels(state) {
   return denormalizeChannelsAndConversations(state).filter((c) => c.isChannel);

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -303,7 +303,6 @@ export function* saga() {
   yield spawn(listenForUserLogout);
   yield takeLatest(SagaActionTypes.FetchChannels, fetchChannels);
   yield takeLatest(SagaActionTypes.StartChannelsAndConversationsAutoRefresh, startChannelsAndConversationsRefresh);
-  yield takeLatest(SagaActionTypes.FetchConversations, fetchConversations);
 
   const chatBus = yield call(getChatBus);
   yield takeEveryFromBus(chatBus, ChatEvents.ChannelInvitationReceived, currentUserAddedToChannel);


### PR DESCRIPTION
### What does this do?

This removes the component triggered conversation list fetch.

### Why are we making this change?

When we load the app we are already loading the conversations in the background. There's no need to use the component to trigger it and it was just causing duplicate requests.

### How do I test this?

Open the app and verify that conversations load on render.

