### PR TITLE
Set the conversation name if provided

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -423,6 +423,15 @@ describe('matrix client', () => {
 
       expect(setAsDM).toHaveBeenCalledWith(expect.anything(), 'test-room', '@first.user');
     });
+
+    it('sets the conversatio name', async () => {
+      const createRoom = jest.fn().mockResolvedValue({ room_id: 'new-room-id' });
+      const client = await subject({ createRoom });
+
+      await client.createConversation([{ userId: 'id', matrixId: '@somebody.else' }], 'room-name', null, null);
+
+      expect(createRoom).toHaveBeenCalledWith(expect.objectContaining({ name: 'room-name' }));
+    });
   });
 
   describe('sendMessagesByChannelId', () => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -151,12 +151,13 @@ export class MatrixClient implements IChatClient {
     return { messages: mappedMessages as any, hasMore: false };
   }
 
-  async createConversation(users: User[], _name: string = null, _image: File = null, _optimisticId: string) {
+  async createConversation(users: User[], name: string = null, _image: File = null, _optimisticId: string) {
     await this.waitForConnection();
     const initial_state = [
       { type: 'm.room.guest_access', state_key: '', content: { guest_access: GuestAccess.Forbidden } },
     ];
     const options: ICreateRoomOpts = {
+      name,
       preset: Preset.TrustedPrivateChat,
       visibility: Visibility.Private,
       invite: users.map((u) => u.matrixId),


### PR DESCRIPTION
### What does this do?

Sets the Matrix room name if provided when creating a conversation

