### PR TITLE
Remove existing channels from list When fetching full conversation list

### DIFF
--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -170,6 +170,19 @@ describe('channels list saga', () => {
         'conversation-id',
       ]);
     });
+
+    it('removes channels that are duplicates of the newly fetched conversations', async () => {
+      const fetchedConversations = [{ id: 'previously-a-channel' }];
+
+      const initialState = new StoreBuilder().withChannelList({ id: 'previously-a-channel' });
+
+      const { storeState } = await subject(fetchConversations, undefined)
+        .provide([[matchers.call([chatClient, chatClient.getConversations]), fetchedConversations]])
+        .withReducer(rootReducer, initialState.build())
+        .run();
+
+      expect(storeState.channelsList.value).toIncludeSameMembers(['previously-a-channel']);
+    });
   });
 
   describe(fetchChannelsAndConversations, () => {

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -66,9 +66,12 @@ export function* fetchConversations() {
     .map((c) => c.id);
 
   const channelsList = yield select(rawChannelsList());
+  const conversationIds = conversations.map((c) => c.id);
+  // Channels can change to conversations (due to the nature of Matrix)
+  const filteredChannelsList = channelsList.filter((id) => !conversationIds.includes(id));
   yield put(
     receive([
-      ...channelsList,
+      ...filteredChannelsList,
       ...optimisticConversationIds,
       ...conversations,
     ])


### PR DESCRIPTION
### What does this do?

Fixes a bug where the receiving users of a new conversation were seeing the conversation in the list twice.

### Why are we making this change?

Because of the evented nature of the data changes the room is first noted as a Channel and then eventually gets found to be a Conversation. When we were refetching the whole conversation list this would cause the room id to be in the channel (room) list twice which caused the double rendering.

