### PR TITLE
Map ZERO users to matrix users

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -415,7 +415,6 @@ export class MatrixClient implements IChatClient {
   }
 
   private mapChannel = (room: Room): Partial<Channel> => {
-    console.log('i was called!');
     return this.mapToGeneralChannel(room);
   };
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -88,7 +88,7 @@ export class MatrixClient implements IChatClient {
     for (const room of rooms) {
       await room.loadMembersIfNeeded();
     }
-    return rooms.map(this.mapChannel);
+    const channels = rooms.map(this.mapChannel);
   }
 
   async getConversations() {

--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -7,11 +7,15 @@ const roomMembers: any[] = [
     userId: '@domw:zero-synapse-development.zer0.io',
     matrixId: '@domw:zero-synapse-development.zer0.io',
     firstName: 'domw',
+    profileImage: '',
   },
   {
-    userId: '@dale.fukami:zero-synapse-development.zer0.io',
+    userId: '6fec1869-4608-4f7e-ab32-e50376b58e30',
     matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
     firstName: 'dale.fukami',
+    lastName: '',
+    profileId: 'a9d1b1a5-dc43-4860-93b6-fb63ee3ca911',
+    profileImage: '',
   },
 ];
 
@@ -28,9 +32,9 @@ describe('getFilteredMembersForAutoComplete', () => {
     // Expect members with 'da' in display name
     expect(result).toEqual([
       {
-        matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
-        displayName: 'dale.fukami',
-        avatar_url: '',
+        id: '6fec1869-4608-4f7e-ab32-e50376b58e30',
+        displayName: 'dale.fukami ',
+        profileImage: '',
       },
     ]);
   });
@@ -41,9 +45,9 @@ describe('getFilteredMembersForAutoComplete', () => {
     // Expect members with 'ratik21' in display name
     expect(result).toEqual([
       {
-        matrixId: '@domw:zero-synapse-development.zer0.io',
-        displayName: 'domw',
-        avatar_url: '',
+        id: '@domw:zero-synapse-development.zer0.io',
+        displayName: 'domw ',
+        profileImage: '',
       },
     ]);
   });
@@ -54,14 +58,14 @@ describe('getFilteredMembersForAutoComplete', () => {
     // Expect all members
     expect(result).toEqual([
       {
-        matrixId: '@domw:zero-synapse-development.zer0.io',
-        displayName: 'domw',
-        avatar_url: '',
+        id: '@domw:zero-synapse-development.zer0.io',
+        displayName: 'domw ',
+        profileImage: '',
       },
       {
-        matrixId: '@dale.fukami:zero-synapse-development.zer0.io',
-        displayName: 'dale.fukami',
-        avatar_url: '',
+        id: '6fec1869-4608-4f7e-ab32-e50376b58e30',
+        displayName: 'dale.fukami ',
+        profileImage: '',
       },
     ]);
   });

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -45,12 +45,12 @@ export async function getFilteredMembersForAutoComplete(roomMembers: ChannelMemb
 
   const filteredResults = [];
   for (const member of roomMembers) {
-    let displayName = member.matrixId?.match(/@([^:]+)/)[1] || '';
+    let displayName = `${member.firstName || ''} ${member.lastName || ''}`;
     if (displayName.includes(normalizedFilter)) {
       filteredResults.push({
-        matrixId: member.matrixId,
+        id: member.userId || member.matrixId,
         displayName,
-        avatar_url: '',
+        profileImage: member.profileImage,
       });
     }
   }


### PR DESCRIPTION
### What does this do?

Fetches and maps ZERO users <-> matrix users, when we fetch all channels + conversations. This also fixes the user mention display (if the matrix account is linked with ZERO).

<img width="279" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/0b0e18d2-d61f-494b-b85b-d072a87d3373">

 
Follow Up
- check on realtime events (messages, join/leave a room etc)