### PR TITLE
chore: bump version (`0.63.0`) -> (`0.64.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "zOS",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "zOS",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "dependencies": {
         "@craco/craco": "^6.4.3",
         "@giphy/js-fetch-api": "^4.7.1",
@@ -35437,7 +35436,7 @@
         "@radix-ui/react-focus-guards": "0.1.0",
         "@radix-ui/react-focus-scope": "0.1.4",
         "@radix-ui/react-id": "0.1.5",
-        "@radix-ui/react-popper": "1.0.0",
+        "@radix-ui/react-popper": "0.1.4",
         "@radix-ui/react-portal": "0.1.4",
         "@radix-ui/react-presence": "0.1.2",
         "@radix-ui/react-primitive": "0.1.4",
@@ -36695,7 +36694,7 @@
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
-        "@types/react": "^16.14.21"
+        "@types/react": "*"
       }
     },
     "@types/eslint": {
@@ -36752,7 +36751,7 @@
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "requires": {
-        "@types/react": "^16.14.21",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -36924,21 +36923,21 @@
     "@types/react-dom": {
       "version": "16.9.14",
       "requires": {
-        "@types/react": "^16.14.21"
+        "@types/react": "^16"
       }
     },
     "@types/react-portal": {
       "version": "4.0.4",
       "dev": true,
       "requires": {
-        "@types/react": "^16.14.21"
+        "@types/react": "*"
       }
     },
     "@types/react-redux": {
       "version": "7.1.20",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "^16.14.21",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zOS",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "private": true,
   "main": "./public/electron.js",
   "engines": {


### PR DESCRIPTION
- chore: bump version (`0.63.0`) -> (`0.64.0`)
