### PR TITLE
CreateConversation: Only send the name field if it is not null

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -170,13 +170,15 @@ export class MatrixClient implements IChatClient {
     }
 
     const options: ICreateRoomOpts = {
-      name,
       preset: Preset.TrustedPrivateChat,
       visibility: Visibility.Private,
       invite: users.map((u) => u.matrixId),
       is_direct: true,
       initial_state,
     };
+    if (name) {
+      options.name = name;
+    }
 
     const result = await this.matrix.createRoom(options);
     // Any room is only set as a DM based on a single user. We'll use the first one.


### PR DESCRIPTION
### What does this do?

Only sends the name field when creating a conversation if it is set.

### Why are we making this change?

Matrix rejects fields with `null` based on some type checking (i.e., it is not a string) so just don't send it.

### How do I test this?

Ensure creating 1 on 1 conversations and group conversations without a name work.

