### PR TITLE
feat: display error if any message fails to send

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -31,7 +31,6 @@ export interface IChatClient {
   connect: (userId: string, accessToken: string) => Promise<void>;
   disconnect: () => void;
   reconnect: () => void;
-  supportsOptimisticSend: () => boolean;
 
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
   getConversations: () => Promise<Partial<Channel>[]>;
@@ -57,8 +56,6 @@ export interface IChatClient {
 
 export class Chat {
   constructor(private client: IChatClient = null) {}
-
-  supportsOptimisticSend = () => this.client.supportsOptimisticSend();
 
   async connect(userId: string, accessToken: string) {
     if (!accessToken || !userId) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -56,10 +56,6 @@ export class MatrixClient implements IChatClient {
     this.events = events;
   }
 
-  supportsOptimisticSend() {
-    return false;
-  }
-
   async connect(userId: string, accessToken: string) {
     this.userId = userId;
     this.setConnectionStatus(ConnectionStatus.Connecting);
@@ -191,6 +187,7 @@ export class MatrixClient implements IChatClient {
     _file?: FileUploadResult,
     optimisticId?: string
   ): Promise<any> {
+    // throw new Error('Method not implemented.');
     await this.waitForConnection();
     let content = {
       body: message,
@@ -205,6 +202,8 @@ export class MatrixClient implements IChatClient {
       };
     }
 
+    // set custom metadata (optimisticId)
+    // send message docs
     const messageResult = await this.matrix.sendMessage(channelId, content);
     const newMessage = await this.matrix.fetchRoomEvent(channelId, messageResult.event_id);
     return {
@@ -263,6 +262,7 @@ export class MatrixClient implements IChatClient {
       }
 
       if (event.type === 'm.room.message') {
+        // rendering two messages
         this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix)) as any);
       }
 

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -10,8 +10,6 @@ import {
   messageSendFailed,
   performSend,
   send,
-  sendOptimistically,
-  sendPessimistically,
   uploadFileMessages,
 } from './saga';
 import { rootReducer } from '../reducer';
@@ -28,157 +26,6 @@ jest.mock('./uploadable', () => ({
 }));
 
 describe(send, () => {
-  it('sends optimistically when lib supports it', async () => {
-    const channelId = 'channel-id';
-    const message = 'hello';
-    const mentionedUserIds = [
-      'user-id1',
-      'user-id2',
-    ];
-    const parentMessage = { messageId: 999, userId: 'user' };
-
-    const chatClient = {
-      supportsOptimisticSend: () => undefined,
-    };
-
-    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
-      .next()
-      .call(chat.get)
-      .next(chatClient)
-      .call(chatClient.supportsOptimisticSend)
-      .next(true)
-      .call(sendOptimistically, { channelId, message, mentionedUserIds, parentMessage })
-      .next()
-      .isDone();
-  });
-
-  it('sends pessimistically when lib does not support optimistic sending', async () => {
-    const channelId = 'channel-id';
-    const message = 'hello';
-    const mentionedUserIds = [
-      'user-id1',
-      'user-id2',
-    ];
-    const parentMessage = { messageId: 999, userId: 'user' };
-
-    const chatClient = {
-      supportsOptimisticSend: () => undefined,
-    };
-
-    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
-      .next()
-      .call(chat.get)
-      .next(chatClient)
-      .call(chatClient.supportsOptimisticSend)
-      .next(false)
-      .call(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage })
-      .next()
-      .isDone();
-  });
-});
-
-describe(sendPessimistically, () => {
-  it('performs the message sending', async () => {
-    const channelId = 'channel-id';
-    const message = 'test message';
-    const mentionedUserIds = [
-      'user-id1',
-      'user-id2',
-    ];
-    const parentMessage = { id: 'parent' };
-
-    await expectSaga(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage })
-      .provide([
-        ...successResponses(),
-        stubResponse(matchers.call.fn(performSend), { id: 'message-id' }),
-        // stubResponse(matchers.call(performSend, channelId, message, mentionedUserIds, parentMessage, 0), { id: 'message-id' }),
-      ])
-      .call.like({
-        fn: performSend,
-        args: [
-          channelId,
-          message,
-          mentionedUserIds,
-          parentMessage,
-          '0',
-        ],
-      })
-      .run();
-  });
-
-  it('sends the files', async () => {
-    const channelId = 'channel-id';
-    const uploadableFile = { file: { nativeFile: {} } };
-    const files = [{ id: 'file-id' }];
-
-    mockCreateUploadableFile.mockReturnValue(uploadableFile);
-
-    await expectSaga(sendPessimistically, { channelId, files })
-      .provide([
-        ...successResponses(),
-        stubResponse(matchers.call.fn(performSend), { id: 'message-id' }),
-        [matchers.call.fn(uploadFileMessages)],
-        // stubResponse(matchers.call(performSend, channelId, message, mentionedUserIds, parentMessage, 0), { id: 'message-id' }),
-      ])
-      .not.call.fn(performSend)
-      .call(uploadFileMessages, channelId, '', [uploadableFile])
-      .run();
-  });
-
-  it('sends text, and files with rootMessageId', async () => {
-    const channelId = 'channel-id';
-    const uploadableFile = { file: { nativeFile: {} } };
-    const files = [{ id: 'file-id' }];
-    const message = 'test message';
-    const mentionedUserIds = [
-      'user-id1',
-      'user-id2',
-    ];
-    const parentMessage = { id: 'parent' };
-
-    mockCreateUploadableFile.mockReturnValue(uploadableFile);
-
-    await expectSaga(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage, files })
-      .provide([
-        ...successResponses(),
-        stubResponse(matchers.call.fn(performSend), { id: 'message-id' }),
-        [matchers.call.fn(uploadFileMessages)],
-      ])
-      .call(performSend, channelId, message, mentionedUserIds, parentMessage, '0')
-      .call(uploadFileMessages, channelId, 'message-id', [uploadableFile])
-      .run();
-  });
-
-  it('sends all but the first file if the text message fails', async () => {
-    const channelId = 'channel-id';
-    const uploadableFile1 = { file: { nativeFile: { what: '1' } } };
-    const uploadableFile2 = { file: { nativeFile: { what: '2' } } };
-    const files = [
-      { id: 'file-id-1' },
-      { id: 'file-id-2' },
-    ];
-    const message = 'test message';
-    const mentionedUserIds = [
-      'user-id1',
-      'user-id2',
-    ];
-    const parentMessage = { id: 'parent' };
-
-    mockCreateUploadableFile.mockReturnValueOnce(uploadableFile1).mockReturnValueOnce(uploadableFile2);
-
-    await expectSaga(sendPessimistically, { channelId, message, mentionedUserIds, parentMessage, files })
-      .provide([
-        ...successResponses(),
-        stubResponse(matchers.call.fn(performSend), null),
-        [matchers.call.fn(uploadFileMessages)],
-      ])
-      .call(performSend, channelId, message, mentionedUserIds, parentMessage, '0')
-      .call(uploadFileMessages, channelId, '', [uploadableFile2])
-      .run();
-  });
-});
-
-describe(sendOptimistically, () => {
   it('creates optimistic messages then fetches preview and sends the message in parallel', async () => {
     const channelId = 'channel-id';
     const message = 'hello';
@@ -188,7 +35,7 @@ describe(sendOptimistically, () => {
     ];
     const parentMessage = { messageId: 999, userId: 'user' };
 
-    testSaga(sendOptimistically, { channelId, message, mentionedUserIds, parentMessage })
+    testSaga(send, { payload: { channelId, message, mentionedUserIds, parentMessage } })
       .next()
       .call(createOptimisticMessages, channelId, message, parentMessage, [])
       .next({ optimisticRootMessage: { id: 'optimistic-message-id' } })
@@ -207,7 +54,7 @@ describe(sendOptimistically, () => {
 
     mockCreateUploadableFile.mockReturnValue(uploadableFile);
 
-    testSaga(sendOptimistically, { channelId, files })
+    testSaga(send, { payload: { channelId, files } })
       .next()
       .call(createOptimisticMessages, channelId, undefined, undefined, [uploadableFile])
       .next({ uploadableFiles: [uploadableFile] })
@@ -221,7 +68,7 @@ describe(sendOptimistically, () => {
     const uploadableFile = { nativeFile: {} };
     const files = [{ id: 'file-id' }];
 
-    testSaga(sendOptimistically, { channelId, files })
+    testSaga(send, { payload: { channelId, files } })
       .next()
       .next({ optimisticRootMessage: { id: 'root-id' }, uploadableFiles: [uploadableFile] })
       .next()
@@ -237,7 +84,7 @@ describe(sendOptimistically, () => {
     const uploadableFile2 = { nativeFile: {} };
     const files = [{ id: 'file-id' }];
 
-    testSaga(sendOptimistically, { channelId, files })
+    testSaga(send, { payload: { channelId, files } })
       .next()
       .next({
         optimisticRootMessage: { id: 'root-id' },

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -74,7 +74,7 @@ interface MediaInfo {
 }
 
 export const rawMessagesSelector = (channelId) => (state) => {
-  return getDeepProperty(state, `normalized.channels[${channelId}].messages`, []);
+  return getDeepProperty(state, `normalized.channels['${channelId}'].messages`, []);
 };
 
 const messageSelector = (messageId) => (state) => {
@@ -82,7 +82,7 @@ const messageSelector = (messageId) => (state) => {
 };
 
 export const _isChannel = (channelId) => (state) =>
-  getDeepProperty(state, `normalized.channels[${channelId}].isChannel`, null);
+  getDeepProperty(state, `normalized.channels['${channelId}'].isChannel`, null);
 
 const _isActive = (channelId) => (state) => {
   return channelId === state.chat.activeChannelId || channelId === state.chat.activeConversationId;
@@ -131,38 +131,7 @@ export function* fetch(action) {
 }
 
 export function* send(action) {
-  const chatClient = yield call(chat.get);
-
-  if (yield call(chatClient.supportsOptimisticSend)) {
-    yield call(sendOptimistically, action.payload);
-    return;
-  }
-
-  yield call(sendPessimistically, action.payload);
-}
-
-export function* sendPessimistically(payload) {
-  const { channelId, message, mentionedUserIds, parentMessage, files = [] } = payload;
-
-  const uploadableFiles: Uploadable[] = files.map(createUploadableFile);
-
-  let rootMessageId = '';
-  if (message?.trim()) {
-    const textMessage = yield call(performSend, channelId, message, mentionedUserIds, parentMessage, '0');
-
-    if (textMessage) {
-      rootMessageId = textMessage.id;
-    } else {
-      // If the text message failed, we'll leave the first file as unsent
-      uploadableFiles.shift();
-    }
-  }
-
-  yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
-}
-
-export function* sendOptimistically(payload) {
-  const { channelId, message, mentionedUserIds, parentMessage, files = [] } = payload;
+  const { channelId, message, mentionedUserIds, parentMessage, files = [] } = action.payload;
 
   const processedFiles: Uploadable[] = files.map(createUploadableFile);
 


### PR DESCRIPTION
### What does this do?
- updates the messages/saga.ts: removes `sendPessimistically` and replaces `sendOptimistically` with `send`.
- removes need for `supportsOptimisticSend`.
- resolves failing tests due to above changes.

### Why are we making this change?
- to ensure matrix has the same behaviour as sendbird when a message fails to send.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
