### PR TITLE
Map message senders in matrix mode

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -468,6 +468,7 @@ export function* receiveDelete(action) {
 
 export function* receiveNewMessage(action) {
   let { channelId, message } = action.payload;
+  yield call(mapMessageSenders, [message]);
 
   const channel = yield select(rawChannelSelector(channelId));
   const currentMessages = channel?.messages || [];

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -353,6 +353,7 @@ export function* fetchNewMessages(channelId: string) {
       ],
       channelId
     );
+    yield call(mapMessageSenders, messagesResponse.messages);
 
     yield put(
       receive({


### PR DESCRIPTION
### What does this do?

Maps the message senders to ZERO users when we load messages for a channel/conversation. Messages are being rendered more properly now.


<img width="876" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/ee4ffbe7-f285-4b33-8cb6-5553bb16d5de">
<img width="1014" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/c993464b-4cf4-4e8e-bd41-22e4119d11a2">


Also, the names on the conversation list are also of ZERO users:
<img width="307" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/688c2af3-5407-4cf0-8455-1eb9b545bbb7">
