### PR TITLE
fix: remove edited flag on unedited messages

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -466,7 +466,7 @@ export class MatrixClient implements IChatClient {
       message,
       isAdmin: false,
       createdAt: timestamp,
-      updatedAt: timestamp,
+      updatedAt: null,
       sender: {
         userId: senderId,
         firstName: matrixEvent.sender?.name,


### PR DESCRIPTION
### What does this do?
- removes timestamp set for `updatedAt` in `mapMatrixEventToMessage`.

### Why are we making this change?
- to remove the edited flag on unedited messages.

### How do I test this?
- send a message and ensure the edited flag does not appear on the message footer.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE

<img width="740" alt="Screenshot 2023-10-06 at 10 47 59" src="https://github.com/zer0-os/zOS/assets/39112648/f7d79f27-26f1-4423-931a-f8c598e8b197">

AFTER

<img width="740" alt="Screenshot 2023-10-06 at 10 50 28" src="https://github.com/zer0-os/zOS/assets/39112648/317917da-63b3-46d3-af0b-1d6e94793bb9">
