### PR TITLE
Matrix: set `parentMessage` while mapping messages which are replies

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -38,7 +38,7 @@ export interface IChatClient {
   searchMyNetworksByName: (filter: string) => Promise<MemberNetworks[] | any>;
   searchMentionableUsersForChannel: (channelId: string, search: string, channelMembers?: UserModel[]) => Promise<any[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
-  getMessageByChannelId: (channelId: string, messageId: string) => Promise<any>;
+  getMessageByRoomId: (channelId: string, messageId: string) => Promise<any>;
   createConversation: (
     users: User[],
     name: string,
@@ -81,8 +81,8 @@ export class Chat {
     return this.client.getMessagesByChannelId(channelId, lastCreatedAt);
   }
 
-  async getMessageByChannelId(channelId: string, messageId: string) {
-    return this.client.getMessageByChannelId(channelId, messageId);
+  async getMessageByRoomId(channelId: string, messageId: string) {
+    return this.client.getMessageByRoomId(channelId, messageId);
   }
 
   async createConversation(users: User[], name: string, image: File, optimisticId: string) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -38,6 +38,7 @@ export interface IChatClient {
   searchMyNetworksByName: (filter: string) => Promise<MemberNetworks[] | any>;
   searchMentionableUsersForChannel: (channelId: string, search: string, channelMembers?: UserModel[]) => Promise<any[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
+  getMessageByChannelId: (channelId: string, messageId: string) => Promise<any>;
   createConversation: (
     users: User[],
     name: string,
@@ -78,6 +79,10 @@ export class Chat {
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
     return this.client.getMessagesByChannelId(channelId, lastCreatedAt);
+  }
+
+  async getMessageByChannelId(channelId: string, messageId: string) {
+    return this.client.getMessageByChannelId(channelId, messageId);
   }
 
   async createConversation(users: User[], name: string, image: File, optimisticId: string) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -154,7 +154,7 @@ export class MatrixClient implements IChatClient {
     return { messages: mappedMessages as any, hasMore: false };
   }
 
-  async getMessageByChannelId(channelId: string, messageId: string) {
+  async getMessageByRoomId(channelId: string, messageId: string) {
     await this.waitForConnection();
     const newMessage = await this.matrix.fetchRoomEvent(channelId, messageId);
     return await mapMatrixMessage(newMessage, this.matrix);
@@ -210,7 +210,7 @@ export class MatrixClient implements IChatClient {
     }
 
     const messageResult = await this.matrix.sendMessage(channelId, content);
-    const newMessage = await this.getMessageByChannelId(channelId, messageResult.event_id);
+    const newMessage = await this.getMessageByRoomId(channelId, messageResult.event_id);
     return {
       ...newMessage,
       optimisticId,

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -154,6 +154,12 @@ export class MatrixClient implements IChatClient {
     return { messages: mappedMessages as any, hasMore: false };
   }
 
+  async getMessageByChannelId(channelId: string, messageId: string) {
+    await this.waitForConnection();
+    const newMessage = await this.matrix.fetchRoomEvent(channelId, messageId);
+    return await mapMatrixMessage(newMessage, this.matrix);
+  }
+
   async createConversation(users: User[], name: string = null, image: File = null, _optimisticId: string) {
     await this.waitForConnection();
     const coverUrl = await this.uploadCoverImage(image);
@@ -204,9 +210,9 @@ export class MatrixClient implements IChatClient {
     }
 
     const messageResult = await this.matrix.sendMessage(channelId, content);
-    const newMessage = await this.matrix.fetchRoomEvent(channelId, messageResult.event_id);
+    const newMessage = await this.getMessageByChannelId(channelId, messageResult.event_id);
     return {
-      ...(await mapMatrixMessage(newMessage, this.matrix)),
+      ...newMessage,
       optimisticId,
     };
   }

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -111,6 +111,10 @@ export class SendbirdClient implements IChatClient {
     return response.body;
   }
 
+  async getMessageByChannelId(_channelId: string, _messageId: string) {
+    return [];
+  }
+
   async createConversation(users: User[], name: string = null, image: File = null, optimisticId: string) {
     let coverUrl = '';
     if (image) {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -111,8 +111,8 @@ export class SendbirdClient implements IChatClient {
     return response.body;
   }
 
-  async getMessageByChannelId(_channelId: string, _messageId: string) {
-    return [];
+  async getMessageByRoomId(_channelId: string, _messageId: string) {
+    return {};
   }
 
   async createConversation(users: User[], name: string = null, image: File = null, optimisticId: string) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -127,13 +127,13 @@ export function* fetch(action) {
     if (referenceTimestamp) {
       yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.MORE_IN_PROGRESS }));
       messagesResponse = yield call([chatClient, chatClient.getMessagesByChannelId], channelId, referenceTimestamp);
-      yield call(mapMessageSenders, messagesResponse.messages);
+      yield call(mapMessageSenders, messagesResponse.messages, channelId);
       const existingMessages = yield select(rawMessagesSelector(channelId));
       messages = [...messagesResponse.messages, ...existingMessages];
     } else {
       yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.IN_PROGRESS }));
       messagesResponse = yield call([chatClient, chatClient.getMessagesByChannelId], channelId);
-      yield call(mapMessageSenders, messagesResponse.messages);
+      yield call(mapMessageSenders, messagesResponse.messages, channelId);
       const existingMessages = yield select(rawMessagesSelector(channelId));
       messages = [...existingMessages, ...messagesResponse.messages];
     }
@@ -333,7 +333,7 @@ export function* fetchNewMessages(channelId: string) {
       ],
       channelId
     );
-    yield call(mapMessageSenders, messagesResponse.messages);
+    yield call(mapMessageSenders, messagesResponse.messages, channelId);
 
     yield put(
       receive({
@@ -449,7 +449,7 @@ export function* receiveDelete(action) {
 
 export function* receiveNewMessage(action) {
   let { channelId, message } = action.payload;
-  yield call(mapMessageSenders, [message]);
+  yield call(mapMessageSenders, [message], channelId);
 
   const channel = yield select(rawChannelSelector(channelId));
   const currentMessages = channel?.messages || [];

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -20,7 +20,7 @@ function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
       } else {
         // if we don't have the parent message in our list, we need to fetch it
         // this can happen when a message is a reply to a message which is not in the current page/list
-        parentMessage = yield call([chatClient, chatClient.getMessageByChannelId], channelId, message.parentMessageId);
+        parentMessage = yield call([chatClient, chatClient.getMessageByRoomId], channelId, message.parentMessageId);
         parentMessage.sender = zeroUsersMap[parentMessage.sender?.userId] || parentMessage.sender;
         message.parentMessage = parentMessage;
       }

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -2,10 +2,35 @@ import { call } from 'redux-saga/effects';
 import { featureFlags } from '../../lib/feature-flags';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
 import { getZeroUsersMap } from './saga';
+import { chat } from '../../lib/chat';
+
+function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
+  const chatClient = yield call(chat.get);
+
+  const messagesById = {};
+  messages.forEach((m) => {
+    messagesById[m.id] = m;
+  });
+
+  for (const message of messages) {
+    if (message.parentMessageId) {
+      let parentMessage = messagesById[message.parentMessageId];
+      if (parentMessage) {
+        message.parentMessage = parentMessage;
+      } else {
+        // if we don't have the parent message in our list, we need to fetch it
+        // this can happen when a message is a reply to a message which is not in the current page/list
+        parentMessage = yield call([chatClient, chatClient.getMessageByChannelId], channelId, message.parentMessageId);
+        parentMessage.sender = zeroUsersMap[parentMessage.sender?.userId] || parentMessage.sender;
+        message.parentMessage = parentMessage;
+      }
+    }
+  }
+}
 
 // takes in a list of messages, and maps the sender to a ZERO user for each message
 // this is used to display the sender's name and profile image
-export function* mapMessageSenders(messages) {
+export function* mapMessageSenders(messages, channelId) {
   if (!featureFlags.enableMatrix) {
     return;
   }
@@ -37,4 +62,6 @@ export function* mapMessageSenders(messages) {
   messages.forEach((message) => {
     message.sender = zeroUsersMap[message.sender?.userId] || message.sender; // note: message.sender.userId is the matrixId
   });
+
+  yield call(mapParentForMessages, messages, channelId, zeroUsersMap);
 }


### PR DESCRIPTION
### What does this do?

Fetches/maps the parentMessage data correctly while parsing all messages fetched after loading a channels/conversation. 
- We first try to fetch the parent message from the list of "already loaded messages"
- if message is not found (i.e it could be an older message), in that case we call the matrix API to fetch the message.

Before:
<img width="538" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/f90d2d6b-5fc2-4d56-9c4b-c1d3f224abd6">

<img width="336" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/82ae8f4f-3c1f-4dfd-b9c8-c71998288c4d">


After:
<img width="462" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/7b9377d5-ab42-4502-8fbc-7b420081751a">

<img width="242" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/16cd5d78-27a8-4fb5-aed0-2a8cb60a3254">


**NOTE**: This does not currently work for when replying to messages in real-time.