### PR TITLE
Matrix: Handle real time replies, update mapping for `receiveNewMessage`

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -57,7 +57,7 @@ export interface IChatClient {
 }
 
 export class Chat {
-  constructor(private client: IChatClient = null) { }
+  constructor(private client: IChatClient = null) {}
 
   supportsOptimisticCreateConversation = () => this.client.supportsOptimisticCreateConversation();
 

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -57,7 +57,7 @@ export interface IChatClient {
 }
 
 export class Chat {
-  constructor(private client: IChatClient = null) {}
+  constructor(private client: IChatClient = null) { }
 
   supportsOptimisticCreateConversation = () => this.client.supportsOptimisticCreateConversation();
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -26,7 +26,7 @@ import { Uploadable, createUploadableFile } from './uploadable';
 import { chat } from '../../lib/chat';
 import { activeChannelIdSelector } from '../chat/selectors';
 import { User } from '../channels';
-import { mapMessageSenders } from './utils.matrix';
+import { mapMessageSenders, mapReceivedMessage } from './utils.matrix';
 
 export interface Payload {
   channelId: string;
@@ -79,7 +79,7 @@ export const rawMessagesSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}'].messages`, []);
 };
 
-const messageSelector = (messageId) => (state) => {
+export const messageSelector = (messageId) => (state) => {
   return getDeepProperty(state, `normalized.messages[${messageId}]`, null);
 };
 
@@ -418,7 +418,7 @@ export function* receiveDelete(action) {
 
 export function* receiveNewMessage(action) {
   let { channelId, message } = action.payload;
-  yield call(mapMessageSenders, [message], channelId);
+  yield call(mapReceivedMessage, message);
 
   const channel = yield select(rawChannelSelector(channelId));
   const currentMessages = channel?.messages || [];


### PR DESCRIPTION
### What does this do?

- Handles the parentMessage mapping, when sending a message in real time. In this case we should always have the "parentMessage" in our local redux state. 
- Also added a new function for mapping message.sender for a single new message, since we don't need to create a whole new map in this case.


https://github.com/zer0-os/zOS/assets/33264364/38fbe58f-a92f-4251-b97e-aad4be47b03e

