### PR TITLE
refactor: remove unused get user method

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -325,43 +325,6 @@ describe('matrix client', () => {
     });
   });
 
-  describe('getUser', () => {
-    it('returns user data for given userId', async () => {
-      const matrixUser = {
-        userId: '@john:matrix.org',
-        displayName: 'John Doe',
-        avatarUrl: 'https://example.com/avatar.jpg',
-        presence: 'online',
-        currentlyActive: true,
-        lastPresenceTs: 123456789,
-      };
-
-      const getUser = jest.fn().mockReturnValue(matrixUser);
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getUser })),
-      });
-
-      await client.connect('username', 'token');
-      const user = await client.getUser('@john:matrix.org');
-
-      expect(getUser).toHaveBeenCalledWith('@john:matrix.org');
-      expect(user).toEqual(matrixUser);
-    });
-
-    it('returns null if user does not exist', async () => {
-      const getUser = jest.fn().mockReturnValue(null);
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getUser })),
-      });
-
-      await client.connect('username', 'token');
-      const user = await client.getUser('@unknown:matrix.org');
-
-      expect(getUser).toHaveBeenCalledWith('@unknown:matrix.org');
-      expect(user).toBeNull();
-    });
-  });
-
   describe('createConversation', () => {
     const subject = async (stubs = {}) => {
       const allStubs = {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -9,7 +9,6 @@ import {
   RoomMemberEvent,
   MatrixClient as SDKMatrixClient,
   MsgType,
-  User as SDKMatrixUser,
   Visibility,
   RoomEvent,
   ClientEvent,
@@ -65,12 +64,6 @@ export class MatrixClient implements IChatClient {
 
   disconnect: () => void;
   reconnect: () => void;
-
-  async getUser(userId: string): Promise<SDKMatrixUser> {
-    await this.waitForConnection();
-    const user = this.matrix.getUser(userId);
-    return user;
-  }
 
   async getAccountData(eventType: string) {
     await this.waitForConnection();


### PR DESCRIPTION
### What does this do?
- removes unused `getUser`. 

### Why are we making this change?
- noticed we are not actually using this `getUser` method. Instead we use `this.matrix.getUser`, this is likely due to `getUser` being async.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
