### PR TITLE
Remove `''` while selecting messages in `rawMessagesSelector`

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -76,7 +76,7 @@ interface MediaInfo {
 }
 
 export const rawMessagesSelector = (channelId) => (state) => {
-  return getDeepProperty(state, `normalized.channels['${channelId}'].messages`, []);
+  return getDeepProperty(state, `normalized.channels[${channelId}].messages`, []);
 };
 
 export const messageSelector = (messageId) => (state) => {
@@ -84,7 +84,7 @@ export const messageSelector = (messageId) => (state) => {
 };
 
 export const _isChannel = (channelId) => (state) =>
-  getDeepProperty(state, `normalized.channels['${channelId}'].isChannel`, null);
+  getDeepProperty(state, `normalized.channels[${channelId}].isChannel`, null);
 
 const _isActive = (channelId) => (state) => {
   return channelId === state.chat.activeChannelId || channelId === state.chat.activeConversationId;


### PR DESCRIPTION
### What does this do?

Reverts [this](https://github.com/zer0-os/zOS/pull/1074/files#diff-e407e648c98001ae7df5920d97c03f7c4d30f5ca8ddc6ee3c553cd244aa331d3R87) change. This is causing the messages to not render the parent message.

Before:
<img width="498" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/79dbec93-84ce-42ef-a3b7-dadbc49e6666">

<img width="480" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/d8330be9-774a-465b-983d-f861ffb020d6">

After reverting:
<img width="527" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/96d845d5-18fb-49f0-89b8-fd8b4d2dc49d">

<img width="479" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/de316c39-99f3-4749-8da3-03b23712be7c">
