### PR TITLE
fix: prevent TypeError in mapToZeroUsers by ensuring non-null values

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -43,7 +43,7 @@ export function* mapToZeroUsers(channels: any[]) {
 
   let allMatrixIds = [];
   for (const channel of channels) {
-    const matrixIds = channel.otherMembers.map((u) => u.matrixId);
+    const matrixIds = (channel.otherMembers || []).filter((u) => u).map((u) => u.matrixId);
     allMatrixIds = union(allMatrixIds, matrixIds);
   }
 
@@ -52,8 +52,12 @@ export function* mapToZeroUsers(channels: any[]) {
   for (const user of zeroUsers) {
     zeroUsersMap[user.matrixId] = user;
   }
+
   const currentUser = yield select(currentUserSelector());
-  zeroUsersMap[currentUser.matrixId] = currentUser;
+
+  if (currentUser && currentUser.matrixId) {
+    zeroUsersMap[currentUser.matrixId] = currentUser;
+  }
 
   mapOtherMembersOfChannel(channels, zeroUsersMap);
   mapChannelMessages(channels, zeroUsersMap);


### PR DESCRIPTION
### What does this do?
This PR introduces safety checks within the mapToZeroUsers saga. By ensuring that only non-null members are mapped and by verifying the existence of the currentUser.matrixId, potential TypeErrors related to accessing properties on null values are prevented.

### Why are we making this change?
Making this change to enhance the robustness of the code. With these adjustments, the saga can handle cases where the otherMembers array might contain null entries or when the currentUser doesn't have a matrixId, thus preventing unexpected application failures and improving the user experience.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
 Error logged when logging out
<img width="970" alt="Screenshot 2023-10-11 at 11 43 21" src="https://github.com/zer0-os/zOS/assets/39112648/345315c5-ba02-4db1-be83-36055bc1bdf4">

