### PR TITLE
Fix: Save new messages to state during `fetch`

### DIFF
--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -38,7 +38,7 @@ describe(fetch, () => {
       .withReducer(rootReducer, initialChannelState(channel) as any)
       .run();
 
-    expect(denormalize(channel.id, storeState).messages).toStrictEqual([
+    expect(denormalize(channel.id, storeState).messages).toIncludeSameMembers([
       { id: 'second-page', message: 'old' },
       { id: 'first-page', message: 'fresh' },
       { id: 'brand-new', message: 'new' },


### PR DESCRIPTION
### What does this do?

Saves any new message fetched, OR if a an existing message has an updated property (eg. `parentMessage`) to the redux state. 