### PR TITLE
Refactor: remove `await` from `mapMatrixMessage`

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -136,7 +136,7 @@ export class MatrixClient implements IChatClient {
     const messages = chunk.filter((m) => m.type === EventType.RoomMessage);
     const mappedMessages = [];
     for (const message of messages) {
-      mappedMessages.push(await mapMatrixMessage(message, this.matrix));
+      mappedMessages.push(mapMatrixMessage(message, this.matrix));
     }
 
     return { messages: mappedMessages as any, hasMore: false };
@@ -145,7 +145,7 @@ export class MatrixClient implements IChatClient {
   async getMessageByRoomId(channelId: string, messageId: string) {
     await this.waitForConnection();
     const newMessage = await this.matrix.fetchRoomEvent(channelId, messageId);
-    return await mapMatrixMessage(newMessage, this.matrix);
+    return mapMatrixMessage(newMessage, this.matrix);
   }
 
   async createConversation(users: User[], name: string = null, image: File = null, _optimisticId: string) {
@@ -257,7 +257,7 @@ export class MatrixClient implements IChatClient {
       }
 
       if (event.type === EventType.RoomMessage) {
-        this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix)) as any);
+        this.events.receiveNewMessage(event.room_id, mapMatrixMessage(event, this.matrix) as any);
       }
 
       if (event.type === EventType.RoomCreate) {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,29 +1,8 @@
 import { MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 
-async function extractParentMessageData(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
-  const parentMessageData = {
-    parentMessageId: null,
-    parentMessageText: '',
-  };
-
-  const parent = matrixMessage.content['m.relates_to'];
-  if (parent && parent['m.in_reply_to']) {
-    parentMessageData.parentMessageId = parent['m.in_reply_to'].event_id;
-
-    const parentMessage = await sdkMatrixClient.fetchRoomEvent(
-      matrixMessage.room_id,
-      parentMessageData.parentMessageId
-    );
-    if (parentMessage) {
-      parentMessageData.parentMessageText = parentMessage.content.body;
-    }
-  }
-
-  return parentMessageData;
-}
-
-export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
+export function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
   const { event_id, content, origin_server_ts, sender: senderId } = matrixMessage;
+  const parent = matrixMessage.content['m.relates_to'];
   const senderData = sdkMatrixClient.getUser(senderId);
 
   return {
@@ -41,6 +20,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     isAdmin: false,
     optimisticId: content.optimisticId,
     ...{ mentionedUsers: [], hidePreview: false, media: null, image: null, admin: {} },
-    ...(await extractParentMessageData(matrixMessage, sdkMatrixClient)),
+    parentMessageText: '',
+    parentMessageId: parent ? parent['m.in_reply_to'].event_id : null,
   };
 }

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -17,15 +17,15 @@ function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
   for (const message of messages) {
     if (message.parentMessageId) {
       let parentMessage = messagesById[message.parentMessageId];
-      if (parentMessage) {
-        message.parentMessage = parentMessage;
-      } else {
+      if (!parentMessage) {
         // if we don't have the parent message in our list, we need to fetch it
         // this can happen when a message is a reply to a message which is not in the current page/list
         parentMessage = yield call([chatClient, chatClient.getMessageByRoomId], channelId, message.parentMessageId);
         parentMessage.sender = zeroUsersMap[parentMessage.sender?.userId] || parentMessage.sender;
-        message.parentMessage = parentMessage;
       }
+
+      message.parentMessage = parentMessage;
+      message.parentMessageText = parentMessage.message;
     }
   }
 }
@@ -92,5 +92,6 @@ export function* mapReceivedMessage(message) {
   if (message.parentMessageId) {
     const parentMessage = yield select(messageSelector(message.parentMessageId));
     message.parentMessage = parentMessage || {};
+    message.parentMessageText = parentMessage.message;
   }
 }


### PR DESCRIPTION
### What does this do?

We don't need to fetch the parent message data during `mapMatrixMessage`, since we already do that while loading new messages. 
