### PR TITLE
feat: [matrix] delete a message 

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -11,7 +11,7 @@ export interface RealtimeChatEvents {
   reconnectStart: () => void;
   reconnectStop: () => void;
   receiveNewMessage: (channelId: string, message: Message) => void;
-  receiveDeleteMessage: (channelId: string, messageId: number) => void;
+  receiveDeleteMessage: (roomId: string, messageId: string) => void;
   onMessageUpdated: (channelId: string, message: Message) => void;
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
   onUserReceivedInvitation: (channel) => void;
@@ -54,7 +54,7 @@ export interface IChatClient {
     optimisticId?: string
   ) => Promise<MessagesResponse>;
   fetchConversationsWithUsers: (users: User[]) => Promise<Partial<Channel>[]>;
-  deleteMessageByRoomId: (channelId: string, messageId: number) => Promise<any>;
+  deleteMessageByRoomId: (roomId: string, messageId: string) => Promise<void>;
 }
 
 export class Chat {
@@ -90,8 +90,8 @@ export class Chat {
     return this.client.createConversation(users, name, image, optimisticId);
   }
 
-  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
-    return this.client.deleteMessageByRoomId(channelId, messageId);
+  async deleteMessageByRoomId(roomId: string, messageId: string): Promise<void> {
+    return this.client.deleteMessageByRoomId(roomId, messageId);
   }
 
   async searchMyNetworksByName(filter: string) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -54,6 +54,7 @@ export interface IChatClient {
     optimisticId?: string
   ) => Promise<MessagesResponse>;
   fetchConversationsWithUsers: (users: User[]) => Promise<Partial<Channel>[]>;
+  deleteMessageByRoomId: (channelId: string, messageId: number) => Promise<void>;
 }
 
 export class Chat {
@@ -87,6 +88,10 @@ export class Chat {
 
   async createConversation(users: User[], name: string, image: File, optimisticId: string) {
     return this.client.createConversation(users, name, image, optimisticId);
+  }
+
+  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<void> {
+    return this.client.deleteMessageByRoomId(channelId, messageId);
   }
 
   async searchMyNetworksByName(filter: string) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -54,7 +54,7 @@ export interface IChatClient {
     optimisticId?: string
   ) => Promise<MessagesResponse>;
   fetchConversationsWithUsers: (users: User[]) => Promise<Partial<Channel>[]>;
-  deleteMessageByRoomId: (channelId: string, messageId: number) => Promise<void>;
+  deleteMessageByRoomId: (channelId: string, messageId: number) => Promise<any>;
 }
 
 export class Chat {
@@ -90,7 +90,7 @@ export class Chat {
     return this.client.createConversation(users, name, image, optimisticId);
   }
 
-  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<void> {
+  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
     return this.client.deleteMessageByRoomId(channelId, messageId);
   }
 

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -513,7 +513,7 @@ describe('matrix client', () => {
 
   describe('deleteMessageByRoomId', () => {
     it('deletes a message by room ID and message ID', async () => {
-      const messageId = 123456;
+      const messageId = '123456';
       const channelId = '!abcdefg';
       const redactEvent = jest.fn().mockResolvedValue({});
 
@@ -524,7 +524,7 @@ describe('matrix client', () => {
       await client.connect(null, 'token');
       await client.deleteMessageByRoomId(channelId, messageId);
 
-      expect(redactEvent).toHaveBeenCalledWith(channelId, messageId.toString());
+      expect(redactEvent).toHaveBeenCalledWith(channelId, messageId);
     });
   });
 

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -510,4 +510,98 @@ describe('matrix client', () => {
       });
     });
   });
+
+  describe('deleteMessageByRoomId', () => {
+    it('deletes a message by room ID and message ID', async () => {
+      const messageId = 123456;
+      const channelId = '!abcdefg';
+      const redactEvent = jest.fn().mockResolvedValue({});
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ redactEvent })),
+      });
+
+      await client.connect(null, 'token');
+      await client.deleteMessageByRoomId(channelId, messageId);
+
+      expect(redactEvent).toHaveBeenCalledWith(channelId, messageId.toString());
+    });
+  });
+
+  describe('getMessagesByChannelId', () => {
+    it('filters out redacted messages', async () => {
+      const getUser = jest.fn().mockReturnValue({ displayName: 'Mock User' });
+      const createMessagesRequest = jest.fn().mockResolvedValue({
+        chunk: [
+          {
+            type: 'm.room.message',
+            content: { body: 'message 1', msgtype: 'm.text' },
+            event_id: 'message-id-1',
+            unsigned: { redacted_because: {} }, // Indicates the message has been redacted.
+          },
+          {
+            type: 'm.room.message',
+            content: { body: 'message 2', msgtype: 'm.text' },
+            event_id: 'message-id-2',
+          },
+        ],
+      });
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ createMessagesRequest, getUser })),
+      });
+
+      await client.connect(null, 'token');
+      const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
+
+      expect(fetchedMessages).toHaveLength(1);
+      expect(fetchedMessages[0].message).toEqual('message 2');
+    });
+
+    it('fetches messages successfully', async () => {
+      const getUser = jest.fn().mockReturnValue({ displayName: 'Mock User' });
+      const createMessagesRequest = jest.fn().mockResolvedValue({
+        chunk: [
+          {
+            type: 'm.room.message',
+            content: { body: 'message 1', msgtype: 'm.text' },
+            event_id: 'message-id-1',
+          },
+          {
+            type: 'm.room.message',
+            content: { body: 'message 2', msgtype: 'm.text' },
+            event_id: 'message-id-2',
+          },
+          {
+            type: 'm.room.message',
+            content: { body: 'message 3', msgtype: 'm.text' },
+            event_id: 'message-id-3',
+          },
+        ],
+      });
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ createMessagesRequest, getUser })),
+      });
+
+      await client.connect(null, 'token');
+      const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
+
+      expect(fetchedMessages).toHaveLength(3);
+    });
+
+    it('returns an empty array if no messages are found', async () => {
+      const getUser = jest.fn().mockReturnValue({ displayName: 'Mock User' });
+      const createMessagesRequest = jest.fn().mockResolvedValue({ chunk: [] });
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ createMessagesRequest, getUser })),
+      });
+
+      await client.connect(null, 'token');
+      const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
+
+      expect(fetchedMessages).toHaveLength(0);
+    });
+  });
 });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -124,8 +124,8 @@ export class MatrixClient implements IChatClient {
     return dmConversationIds.includes(room.roomId) || !!room.getDMInviter();
   };
 
-  private isDeleted(m) {
-    return m?.unsigned?.redacted_because;
+  private isDeleted(event) {
+    return event?.unsigned?.redacted_because;
   }
 
   async searchMyNetworksByName(filter: string): Promise<MemberNetworks[]> {
@@ -142,7 +142,7 @@ export class MatrixClient implements IChatClient {
   async getMessagesByChannelId(channelId: string, _lastCreatedAt?: number): Promise<MessagesResponse> {
     await this.waitForConnection();
     const { chunk } = await this.matrix.createMessagesRequest(channelId, null, 50, Direction.Backward);
-    const messages = chunk.filter((m) => m.type === EventType.RoomMessage && !this.isDeleted(m));
+    const messages = chunk.filter((event) => event.type === EventType.RoomMessage && !this.isDeleted(event));
     const mappedMessages = [];
     for (const message of messages) {
       mappedMessages.push(mapMatrixMessage(message, this.matrix));

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -133,7 +133,8 @@ export class MatrixClient implements IChatClient {
   async getMessagesByChannelId(channelId: string, _lastCreatedAt?: number): Promise<MessagesResponse> {
     await this.waitForConnection();
     const { chunk } = await this.matrix.createMessagesRequest(channelId, null, 50, Direction.Backward);
-    const messages = chunk.filter((m) => m.type === EventType.RoomMessage);
+    const messages = chunk.filter((m) => m.type === EventType.RoomMessage && !m?.unsigned?.redacted_because);
+
     const mappedMessages = [];
     for (const message of messages) {
       mappedMessages.push(mapMatrixMessage(message, this.matrix));
@@ -491,7 +492,7 @@ export class MatrixClient implements IChatClient {
   private getAllMessagesFromRoom(room: Room) {
     const timeline = room.getLiveTimeline().getEvents();
     const messages = timeline
-      .filter((event) => event.getType() === EventType.RoomMessage)
+      .filter((event) => event.getType() === EventType.RoomMessage && !event.isRedacted())
       .map(this.mapMatrixEventToMessage);
     return messages;
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -271,6 +271,9 @@ export class MatrixClient implements IChatClient {
       if (event.type === EventType.RoomAvatar) {
         this.publishRoomAvatarChange(event);
       }
+      if (event.type === EventType.RoomRedaction) {
+        this.receiveDeleteMessage(event);
+      }
     });
     this.matrix.on(RoomMemberEvent.Membership, async (_event, member) => {
       if (member.membership === MembershipStateType.Invite && member.userId === this.userId) {
@@ -346,6 +349,10 @@ export class MatrixClient implements IChatClient {
   private async roomCreated(event) {
     this.events.onUserJoinedChannel(this.mapChannel(this.matrix.getRoom(event.room_id)));
   }
+
+  private receiveDeleteMessage = (event) => {
+    this.events.receiveDeleteMessage(event.room_id, event.redacts);
+  };
 
   private publishConversationListChange = (event: MatrixEvent) => {
     if (event.getType() === EventType.Direct) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -209,7 +209,7 @@ export class MatrixClient implements IChatClient {
     };
   }
 
-  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<void> {
+  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
     await this.matrix.redactEvent(channelId, messageId.toString(), null);
   }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -208,6 +208,10 @@ export class MatrixClient implements IChatClient {
     };
   }
 
+  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<void> {
+    await this.matrix.redactEvent(channelId, messageId.toString(), null);
+  }
+
   async fetchConversationsWithUsers(users: User[]) {
     const userMatrixIds = users.map((u) => u.matrixId);
     const rooms = await this.getFilteredRooms(this.isConversation);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -134,7 +134,6 @@ export class MatrixClient implements IChatClient {
     await this.waitForConnection();
     const { chunk } = await this.matrix.createMessagesRequest(channelId, null, 50, Direction.Backward);
     const messages = chunk.filter((m) => m.type === EventType.RoomMessage && !m?.unsigned?.redacted_because);
-
     const mappedMessages = [];
     for (const message of messages) {
       mappedMessages.push(mapMatrixMessage(message, this.matrix));
@@ -210,7 +209,7 @@ export class MatrixClient implements IChatClient {
   }
 
   async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
-    await this.matrix.redactEvent(channelId, messageId.toString(), null);
+    await this.matrix.redactEvent(channelId, messageId.toString());
   }
 
   async fetchConversationsWithUsers(users: User[]) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -208,8 +208,8 @@ export class MatrixClient implements IChatClient {
     };
   }
 
-  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
-    await this.matrix.redactEvent(channelId, messageId.toString());
+  async deleteMessageByRoomId(roomId: string, messageId: string): Promise<void> {
+    await this.matrix.redactEvent(roomId, messageId);
   }
 
   async fetchConversationsWithUsers(users: User[]) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -119,6 +119,10 @@ export class MatrixClient implements IChatClient {
     return dmConversationIds.includes(room.roomId) || !!room.getDMInviter();
   };
 
+  private isDeleted(m) {
+    return m?.unsigned?.redacted_because;
+  }
+
   async searchMyNetworksByName(filter: string): Promise<MemberNetworks[]> {
     return await get('/api/v2/users/searchInNetworksByName', { filter, limit: 50, isMatrixEnabled: true })
       .catch((_error) => null)
@@ -133,7 +137,7 @@ export class MatrixClient implements IChatClient {
   async getMessagesByChannelId(channelId: string, _lastCreatedAt?: number): Promise<MessagesResponse> {
     await this.waitForConnection();
     const { chunk } = await this.matrix.createMessagesRequest(channelId, null, 50, Direction.Backward);
-    const messages = chunk.filter((m) => m.type === EventType.RoomMessage && !m?.unsigned?.redacted_because);
+    const messages = chunk.filter((m) => m.type === EventType.RoomMessage && !this.isDeleted(m));
     const mappedMessages = [];
     for (const message of messages) {
       mappedMessages.push(mapMatrixMessage(message, this.matrix));

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -5,7 +5,7 @@ import { Message, MessagesResponse } from '../../store/messages';
 import { sendMessagesByChannelId } from '../../store/messages/api';
 import { FileUploadResult } from '../../store/messages/saga';
 import { config } from '../../config';
-import { get } from '../../lib/api/rest';
+import { del, get } from '../../lib/api/rest';
 import { toLocalChannel } from '../../store/channels-list/utils';
 import { ParentMessage, User } from './types';
 
@@ -99,6 +99,14 @@ export class SendbirdClient implements IChatClient {
       .then((response) => response?.body || []);
 
     return results.map((u) => ({ id: u.id, display: u.name, profileImage: u.profileImage }));
+  }
+
+  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<void> {
+    try {
+      await del<any>(`/chatChannels/${channelId}/message`).send({ message: { id: messageId } });
+    } catch (error: any) {
+      console.log('Error occurred while deleting message', error?.response ?? error);
+    }
   }
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number): Promise<MessagesResponse> {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -101,7 +101,7 @@ export class SendbirdClient implements IChatClient {
     return results.map((u) => ({ id: u.id, display: u.name, profileImage: u.profileImage }));
   }
 
-  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<void> {
+  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
     try {
       await del<any>(`/chatChannels/${channelId}/message`).send({ message: { id: messageId } });
     } catch (error: any) {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -101,9 +101,9 @@ export class SendbirdClient implements IChatClient {
     return results.map((u) => ({ id: u.id, display: u.name, profileImage: u.profileImage }));
   }
 
-  async deleteMessageByRoomId(channelId: string, messageId: number): Promise<any> {
+  async deleteMessageByRoomId(roomId: string, messageId: string): Promise<void> {
     try {
-      await del<any>(`/chatChannels/${channelId}/message`).send({ message: { id: messageId } });
+      await del<any>(`/chatChannels/${roomId}/message`).send({ message: { id: messageId } });
     } catch (error: any) {
       console.log('Error occurred while deleting message', error?.response ?? error);
     }
@@ -219,7 +219,7 @@ export class SendbirdClient implements IChatClient {
       onMessageDeleted: (channel, messageId) => {
         const channelId = this.getChannelId(channel);
 
-        events.receiveDeleteMessage(channelId, messageId);
+        events.receiveDeleteMessage(channelId, messageId.toString());
       },
       onChannelChanged: (channel) => {
         const channelId = this.getChannelId(channel);

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -102,11 +102,7 @@ export class SendbirdClient implements IChatClient {
   }
 
   async deleteMessageByRoomId(roomId: string, messageId: string): Promise<void> {
-    try {
-      await del<any>(`/chatChannels/${roomId}/message`).send({ message: { id: messageId } });
-    } catch (error: any) {
-      console.log('Error occurred while deleting message', error?.response ?? error);
-    }
+    await del<any>(`/chatChannels/${roomId}/message`).send({ message: { id: messageId } });
   }
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number): Promise<MessagesResponse> {

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -1,5 +1,5 @@
 import { AttachmentResponse } from '../../lib/api/attachment';
-import { del, get, post, put } from '../../lib/api/rest';
+import { get, post, put } from '../../lib/api/rest';
 import { ParentMessage } from '../../lib/chat/types';
 import { LinkPreview } from '../../lib/link-preview';
 import { AttachmentUploadResult, EditMessageOptions } from './index';
@@ -33,12 +33,6 @@ export async function sendMessagesByChannelId(
   const response = await post<any>(`/chatChannels/${channelId}/message`).send(data);
 
   return response.body;
-}
-
-export async function deleteMessageApi(channelId: string, messageId: number): Promise<number> {
-  const response = await del<any>(`/chatChannels/${channelId}/message`).send({ message: { id: messageId } });
-
-  return response.status;
 }
 
 export async function editMessageApi(

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -326,7 +326,8 @@ export function* deleteMessage(action) {
   const existingMessageIds = yield select(rawMessagesSelector(channelId));
   const fullMessages = yield select((state) => denormalize(existingMessageIds, state));
 
-  const messageIdsToDelete = fullMessages.filter((m) => m.rootMessageId === messageId).map((m) => m.id);
+  const messageIdsToDelete = fullMessages.filter((m) => m.rootMessageId === messageId.toString()).map((m) => m.id); // toString() because message ids are currently a number
+
   messageIdsToDelete.unshift(messageId);
 
   yield put(

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -326,7 +326,7 @@ export function* deleteMessage(action) {
   const existingMessageIds = yield select(rawMessagesSelector(channelId));
   const fullMessages = yield select((state) => denormalize(existingMessageIds, state));
 
-  const messageIdsToDelete = fullMessages.filter((m) => m.rootMessageId === messageId.toString()).map((m) => m.id); // toString() because message ids are currently a number
+  const messageIdsToDelete = fullMessages.filter((m) => m.rootMessageId === messageId).map((m) => m.id);
   messageIdsToDelete.unshift(messageId);
 
   yield put(

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -326,7 +326,7 @@ export function* deleteMessage(action) {
   const existingMessageIds = yield select(rawMessagesSelector(channelId));
   const fullMessages = yield select((state) => denormalize(existingMessageIds, state));
 
-  const messageIdsToDelete = fullMessages.filter((m) => m.rootMessageId === messageId.toString()).map((m) => m.id);
+  const messageIdsToDelete = fullMessages.filter((m) => m.rootMessageId === messageId.toString()).map((m) => m.id); // toString() because message ids are currently a number
   messageIdsToDelete.unshift(messageId);
 
   yield put(


### PR DESCRIPTION
### What does this do?
This PR introduces an update to the chat functionality of our application to support the deletion of messages across two different chat clients: Matrix and Sendbird. It achieves the following:

- updated IChatClient interface by abstracting out the deletion method so that irrespective of the underlying chat client, the application can delete messages in a consistent manner.

- implemented the deleteMessageByRoomId method for the Matrix client, utilizing the redactEvent method from the Matrix JS SDK.

- direct implementation within the Sendbird client of the deleteMessage api. This approach ensures that the deletion logic is encapsulated within the chat client itself.

- updated messages/saga.ts function deleteMessage to fetch the active chat client and delegate the delete operation to it.

- filters out redacted messages from the matrix chat fetch results.

- adds test coverage.

### Why are we making this change?
- to ensure delete message works with matrix client as it does with sendbird.

### How do I test this?
- open messenger > send a message in a conversation > hover over the sent message and select the three dots menu > click delete message.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

**Delete A Message**

https://github.com/zer0-os/zOS/assets/39112648/bb5e46c7-2cc3-406c-b0e8-424075ec3756

