### PR TITLE
feat: fetch the users presence asynchronously (isOnline)

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -80,10 +80,15 @@ export class MatrixClient implements IChatClient {
 
     try {
       const userPresenceData = await this.matrix.getPresence(userId);
-      const isOnline = userPresenceData?.presence === 'online';
-      const lastSeenAt = userPresenceData?.last_active_ago
-        ? new Date(Date.now() - userPresenceData.last_active_ago).toISOString()
-        : null;
+
+      if (!userPresenceData) {
+        return { lastSeenAt: null, isOnline: false };
+      }
+
+      const { presence, last_active_ago } = userPresenceData;
+
+      const isOnline = presence === 'online';
+      const lastSeenAt = last_active_ago ? new Date(Date.now() - last_active_ago).toISOString() : null;
 
       return { lastSeenAt, isOnline };
     } catch (error) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -508,7 +508,7 @@ export class MatrixClient implements IChatClient {
       firstName: user?.displayName,
       lastName: '',
       profileId: '',
-      isOnline: user?.presence === 'online',
+      isOnline: false,
       profileImage: user?.avatarUrl,
       lastSeenAt: '',
     };

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -670,5 +670,63 @@ describe('channels list saga', () => {
 
       await subject(conversationsWithMissingMatrixId).call(chat.get).not.call(chatClient.getUserPresence).run();
     });
+
+    it('should set lastSeenAt, and isOnline to true if user is online', () => {
+      const mockConversations = [
+        {
+          id: 'conversation_0001',
+          otherMembers: [
+            {
+              userId: 'user_1',
+              matrixId: 'matrix_1',
+              lastSeenAt: '',
+              isOnline: false,
+            },
+          ],
+        },
+      ];
+
+      const mockPresenceData1 = { lastSeenAt: '2023-10-17T10:00:00.000Z', isOnline: true };
+
+      testSaga(updateUserPresence, mockConversations)
+        .next()
+        .call(chat.get)
+        .next(chatClient)
+        .call([chatClient, chatClient.getUserPresence], 'matrix_1')
+        .next(mockPresenceData1)
+        .isDone();
+
+      expect(mockConversations[0].otherMembers[0].lastSeenAt).toBe(mockPresenceData1.lastSeenAt);
+      expect(mockConversations[0].otherMembers[0].isOnline).toBe(mockPresenceData1.isOnline);
+    });
+
+    it('should set lastSeenAt to null and isOnline to false if user is offline', () => {
+      const mockConversations = [
+        {
+          id: 'conversation_0001',
+          otherMembers: [
+            {
+              userId: 'user_1',
+              matrixId: 'matrix_1',
+              lastSeenAt: '',
+              isOnline: false,
+            },
+          ],
+        },
+      ];
+
+      const mockPresenceData1 = { lastSeenAt: null, isOnline: false };
+
+      testSaga(updateUserPresence, mockConversations)
+        .next()
+        .call(chat.get)
+        .next(chatClient)
+        .call([chatClient, chatClient.getUserPresence], 'matrix_1')
+        .next(mockPresenceData1)
+        .isDone();
+
+      expect(mockConversations[0].otherMembers[0].lastSeenAt).toBe(mockPresenceData1.lastSeenAt);
+      expect(mockConversations[0].otherMembers[0].isOnline).toBe(mockPresenceData1.isOnline);
+    });
   });
 });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -80,13 +80,8 @@ export function* updateUserPresence(conversations) {
       if (!presenceData) continue;
 
       const { lastSeenAt, isOnline } = presenceData;
-
-      if (lastSeenAt) {
-        member.lastSeenAt = lastSeenAt;
-      }
-      if (isOnline) {
-        member.isOnline = isOnline;
-      }
+      member.lastSeenAt = lastSeenAt;
+      member.isOnline = isOnline;
     }
   }
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -70,19 +70,22 @@ export function* updateUserPresence(conversations) {
 
   const chatClient = yield call(chat.get);
   for (let conversation of conversations) {
-    const { isOneOnOne, otherMembers } = conversation;
-    const matrixId = otherMembers?.[0]?.matrixId;
+    const { otherMembers } = conversation;
 
-    if (isOneOnOne && matrixId) {
+    for (let member of otherMembers) {
+      const matrixId = member?.matrixId;
+      if (!matrixId) continue;
+
       const presenceData = yield call([chatClient, chatClient.getUserPresence], matrixId);
+      if (!presenceData) continue;
 
-      if (presenceData) {
-        if (presenceData.lastSeenAt) {
-          conversation.otherMembers[0].lastSeenAt = presenceData.lastSeenAt;
-        }
-        if (presenceData.isOnline) {
-          conversation.otherMembers[0].isOnline = presenceData.isOnline;
-        }
+      const { lastSeenAt, isOnline } = presenceData;
+
+      if (lastSeenAt) {
+        member.lastSeenAt = lastSeenAt;
+      }
+      if (isOnline) {
+        member.isOnline = isOnline;
       }
     }
   }


### PR DESCRIPTION
### What does this do?
- replaces how we're currently setting the users `isOnline` status by fetching the correct data using matrixs `getPresence` method.

### Why are we making this change?
- currently using `getUser`, to set the users online status, this accidentally works as the user will be defaulted to `offline`. Using `getPresence` asynchronously will return the users correct online status. Similar to how we are getting the last seen at data.

### How do I test this?
- open messenger and check users online status in the conversation list.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
