### PR TITLE
Force decrypt the events before we start processing the rooms

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -18,6 +18,7 @@ const stubRoom = (attrs = {}) => ({
   getMembers: () => [],
   getDMInviter: () => undefined,
   loadMembersIfNeeded: () => undefined,
+  decryptAllEvents: () => undefined,
   getLiveTimeline: () => stubTimeline(),
   getMyMembership: () => 'join',
   getEvents: () => stubTimeline(),

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -96,6 +96,7 @@ export class MatrixClient implements IChatClient {
     await this.waitForConnection();
     const rooms = await this.getFilteredRooms(this.isChannel);
     for (const room of rooms) {
+      await room.decryptAllEvents();
       await room.loadMembersIfNeeded();
     }
 
@@ -108,6 +109,7 @@ export class MatrixClient implements IChatClient {
 
     const failedToJoin = [];
     for (const room of rooms) {
+      await room.decryptAllEvents();
       await room.loadMembersIfNeeded();
       const membership = room.getMyMembership();
       if (membership === MembershipStateType.Invite) {


### PR DESCRIPTION
### What does this do?

Adds a forced decryption on rooms when loading the channels and conversations to ensure messages are all decrypted before we process the data

### Why are we making this change?

There was a timing issue when loading channels the first time which caused messages to not get loaded.

### How do I test this?

Open the app with some Channels and verify that the messages load

