### PR TITLE
Fix scenario when rendering a reply for a message that hasn't been loaded yet

### DIFF
--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -92,6 +92,6 @@ export function* mapReceivedMessage(message) {
   if (message.parentMessageId) {
     const parentMessage = yield select(messageSelector(message.parentMessageId));
     message.parentMessage = parentMessage || {};
-    message.parentMessageText = parentMessage.message;
+    message.parentMessageText = parentMessage?.message;
   }
 }


### PR DESCRIPTION
### What does this do?

We're making the assumption that the parent message of a reply is already in state but that's not always the case. This provides null handling

