### PR TITLE
Remove editing of Matrix credentials from Edit Profile modal

### DIFF
--- a/src/components/edit-profile/container.test.tsx
+++ b/src/components/edit-profile/container.test.tsx
@@ -12,8 +12,6 @@ describe('Container', () => {
       editProfileState: 0, // Set the initial editProfileState to State.NONE
       currentDisplayName: 'John Doe',
       currentProfileImage: 'profile.jpg',
-      currentMatrixId: '',
-      currentMatrixAccessToken: '',
       editProfile: () => null,
       startProfileEdit: () => null,
       ...props,

--- a/src/components/edit-profile/container.tsx
+++ b/src/components/edit-profile/container.tsx
@@ -17,9 +17,7 @@ export interface Properties extends PublicProperties {
   editProfileState: State;
   currentDisplayName: string;
   currentProfileImage: string;
-  currentMatrixId: string;
-  currentMatrixAccessToken: string;
-  editProfile: (data: { name: string; image: File; matrixId: string; matrixAccessToken: string }) => void;
+  editProfile: (data: { name: string; image: File }) => void;
   startProfileEdit: () => void;
 }
 
@@ -33,8 +31,6 @@ export class Container extends React.Component<Properties> {
       errors: RegistrationContainer.mapErrors(editProfile.errors),
       currentDisplayName: user?.data?.profileSummary.firstName,
       currentProfileImage: user?.data?.profileSummary.profileImage,
-      currentMatrixId: user?.data?.matrixId,
-      currentMatrixAccessToken: user?.data?.matrixAccessToken,
       editProfileState: editProfile.state,
     };
   }
@@ -56,8 +52,6 @@ export class Container extends React.Component<Properties> {
         editProfileState={this.props.editProfileState}
         currentDisplayName={this.props.currentDisplayName}
         currentProfileImage={this.props.currentProfileImage}
-        currentMatrixId={this.props.currentMatrixId}
-        currentMatrixAccessToken={this.props.currentMatrixAccessToken}
       />
     );
   }

--- a/src/components/edit-profile/index.test.tsx
+++ b/src/components/edit-profile/index.test.tsx
@@ -13,8 +13,6 @@ describe('EditProfile', () => {
       errors: {},
       currentDisplayName: 'John Doe',
       currentProfileImage: 'profile.jpg',
-      currentMatrixId: '',
-      currentMatrixAccessToken: '',
       onEdit: () => null,
       onClose: () => null,
       ...props,
@@ -53,8 +51,6 @@ describe('EditProfile', () => {
     expect(onEditMock).toHaveBeenCalledWith({
       name: 'John Doe',
       image: null,
-      matrixId: '',
-      matrixAccessToken: '',
     });
   });
 
@@ -90,8 +86,6 @@ describe('EditProfile', () => {
     const formData = {
       name: 'Jane Smith',
       image: 'new-image.jpg', // note: this is actually supposed to be a nodejs FILE object
-      matrixId: '',
-      matrixAccessToken: '',
     };
 
     wrapper.find('Input[name="name"]').simulate('change', formData.name);

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -7,7 +7,6 @@ import { bem } from '../../lib/bem';
 import { ImageUpload } from '../../components/image-upload';
 import { IconUpload2, IconXClose } from '@zero-tech/zui/icons';
 import { State as EditProfileState } from '../../store/edit-profile';
-import { FeatureFlag } from '../feature-flag';
 
 const c = bem('edit-profile');
 
@@ -20,40 +19,30 @@ export interface Properties {
   };
   currentDisplayName: string;
   currentProfileImage: string;
-  currentMatrixId: string;
-  currentMatrixAccessToken: string;
-  onEdit: (data: { name: string; image: File; matrixId: string; matrixAccessToken: string }) => void;
+  onEdit: (data: { name: string; image: File }) => void;
   onClose?: () => void;
 }
 
 interface State {
   name: string;
   image: File | null;
-  matrixId: string;
-  matrixAccessToken: string;
 }
 
 export class EditProfile extends React.Component<Properties, State> {
   state = {
     name: this.props.currentDisplayName,
     image: null,
-    matrixId: this.props.currentMatrixId,
-    matrixAccessToken: this.props.currentMatrixAccessToken,
   };
 
   handleEdit = () => {
     this.props.onEdit({
       name: this.state.name,
       image: this.state.image,
-      matrixId: this.state.matrixId,
-      matrixAccessToken: this.state.matrixAccessToken,
     });
   };
 
   trackName = (value) => this.setState({ name: value });
   trackImage = (image) => this.setState({ image });
-  trackMatrixId = (matrixId) => this.setState({ matrixId });
-  trackMatrixAccessToken = (matrixAccessToken) => this.setState({ matrixAccessToken });
 
   get isValid() {
     return this.state.name.trim().length > 0;
@@ -83,10 +72,6 @@ export class EditProfile extends React.Component<Properties, State> {
   }
 
   get isDisabled() {
-    if (this.state.matrixId !== '' && this.state.matrixAccessToken !== '') {
-      return false;
-    }
-
     return (
       !!this.nameError ||
       this.isLoading ||
@@ -123,23 +108,6 @@ export class EditProfile extends React.Component<Properties, State> {
             alert={this.nameError}
             className={c('body-input')}
           />
-
-          <FeatureFlag featureFlag='enableMatrix'>
-            <Input
-              label='Matrix ID'
-              name='matrix_id'
-              value={this.state.matrixId}
-              onChange={this.trackMatrixId}
-              className={c('body-input')}
-            />
-            <Input
-              label='Matrix Access Token'
-              name='access_token'
-              value={this.state.matrixAccessToken}
-              onChange={this.trackMatrixAccessToken}
-              className={c('body-input')}
-            />
-          </FeatureFlag>
         </div>
         {this.imageError && (
           <Alert className={c('alert-large')} variant='error'>

--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -24,8 +24,6 @@ export const initialState: EditProfileState = {
 export const editProfile = createAction<{
   name: string;
   image: File | null;
-  matrixId: string;
-  matrixAccessToken: string;
 }>(SagaActionTypes.EditProfile);
 
 const slice = createSlice({

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -11,7 +11,7 @@ import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
 
 export function* editProfile(action) {
-  const { name, image, matrixId, matrixAccessToken } = action.payload;
+  const { name, image } = action.payload;
 
   yield put(setState(State.INPROGRESS));
   try {
@@ -24,10 +24,6 @@ export function* editProfile(action) {
         yield put(setErrors([ProfileDetailsErrors.FILE_UPLOAD_ERROR]));
         return;
       }
-    }
-
-    if (matrixId) {
-      yield call(saveUserMatrixCredentials, matrixId, matrixAccessToken);
     }
 
     const { profileId } = yield select((state) => state.authentication.user.data);


### PR DESCRIPTION
### What does this do?

Removes the temporary scaffolding for manually setting the Matrix credentials.

### Why are we making this change?

No longer needed as this is all hidden from the user now.

### How do I test this?

Open the Edit Profile modal and verify you can still edit things but the Matrix related fields are no longer visible.

