### PR TITLE
refactor: silence user presence retrieval errors

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -91,7 +91,6 @@ export class MatrixClient implements IChatClient {
 
       return { lastSeenAt, isOnline };
     } catch (error) {
-      console.error(error);
       return { lastSeenAt: null, isOnline: false };
     }
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -74,23 +74,8 @@ export class MatrixClient implements IChatClient {
     return this.matrix.getAccountData(eventType);
   }
 
-  private hasSharedJoinedRoom(userId: string): boolean {
-    const rooms = this.matrix.getRooms();
-
-    return !!rooms.find((room) => {
-      const myMember = room.getMember(this.matrix.getUserId());
-      const targetMember = room.getMember(userId);
-
-      return myMember && myMember.membership === 'join' && targetMember && targetMember.membership === 'join';
-    });
-  }
-
   async getUserPresence(userId: string) {
     await this.waitForConnection();
-
-    if (!this.hasSharedJoinedRoom(userId)) {
-      return { lastSeenAt: null, isOnline: false };
-    }
 
     try {
       const userPresenceData = await this.matrix.getPresence(userId);
@@ -104,7 +89,11 @@ export class MatrixClient implements IChatClient {
       const lastSeenAt = last_active_ago ? new Date(Date.now() - last_active_ago).toISOString() : null;
 
       return { lastSeenAt, isOnline };
-    } catch (error) {
+    } catch (error: any) {
+      if (error && typeof error === 'object' && error.errcode !== 'M_FORBIDDEN') {
+        console.error(error);
+      }
+
       return { lastSeenAt: null, isOnline: false };
     }
   }


### PR DESCRIPTION
### What does this do?
- Error handling in `getUserPresence` to silently handle errors without logging them to the console.

### Why are we making this change?
- To reduce console noise and ensure graceful degradation in scenarios where user presence data is unavailable or erroneous.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="736" alt="Screenshot 2023-10-18 at 21 43 08" src="https://github.com/zer0-os/zOS/assets/39112648/3ed20db3-5b3e-41f9-81f5-1f97d2a205f6">




