### PR TITLE
Only overwrite changed data when sending a new message

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -574,89 +574,25 @@ describe('matrix client', () => {
 
   describe('sendMessagesByChannelId', () => {
     it('sends a message successfully', async () => {
-      const sendMessage = jest.fn(() =>
-        Promise.resolve({
-          event_id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU',
-        })
-      );
-      const fetchRoomEvent = jest.fn(() =>
-        Promise.resolve({
-          type: 'm.room.message',
-          room_id: '!wqnBBSmtCokmfmPlbK:zero-synapse-development.zer0.io',
-          sender: '@ratik21:zero-synapse-development.zer0.io',
-          content: {
-            body: 'test',
-            msgtype: 'm.text',
-          },
-          event_id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU',
-          user_id: '@ratik21:zero-synapse-development.zer0.io',
-        })
-      );
+      const sendMessage = jest.fn().mockResolvedValue({ event_id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU' });
 
-      const getSenderData = jest.fn(() =>
-        Promise.resolve({
-          displayName: 'Joe Bloggs',
-        })
-      );
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ sendMessage, fetchRoomEvent, getUser: getSenderData })),
-      });
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ sendMessage })) });
 
       await client.connect(null, 'token');
 
       const result = await client.sendMessagesByChannelId('channel-id', 'message', []);
-      expect(result).toMatchObject({
-        id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU',
-        message: 'test',
-        parentMessageId: null,
-        parentMessageText: '',
-      });
+      expect(result).toMatchObject({ id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU' });
     });
 
     it('sends a reply message successfully', async () => {
-      const sendMessage = jest.fn(() =>
-        Promise.resolve({
-          event_id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c',
-        })
-      );
-
-      const fetchRoomEvent = jest.fn(() =>
-        Promise.resolve({
-          type: 'm.room.message',
-          content: {
-            body: 'reply',
-            msgtype: 'm.text',
-            'm.relates_to': {
-              'm.in_reply_to': {
-                event_id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU',
-              },
-            },
-          },
-          event_id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c',
-          user_id: '@ratik21:zero-synapse-development.zer0.io',
-        })
-      );
-
-      const getSenderData = jest.fn(() =>
-        Promise.resolve({
-          displayName: 'Joe Bloggs',
-        })
-      );
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ sendMessage, fetchRoomEvent, getUser: getSenderData })),
-      });
+      const sendMessage = jest.fn().mockResolvedValue({ event_id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c' });
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ sendMessage })) });
 
       await client.connect(null, 'token');
 
       const result = await client.sendMessagesByChannelId('channel-id', 'message', []);
 
-      expect(result).toMatchObject({
-        id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c',
-        message: 'reply',
-        parentMessageId: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU',
-      });
+      expect(result).toMatchObject({ id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c' });
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -267,8 +267,7 @@ export class MatrixClient implements IChatClient {
     }
 
     const messageResult = await this.matrix.sendMessage(channelId, content);
-    const newMessage = await this.getMessageByRoomId(channelId, messageResult.event_id);
-    this.recordMessageSent(channelId, newMessage.createdAt);
+    this.recordMessageSent(channelId);
 
     // Don't return a full message, only the pertinent attributes that changed.
     return {
@@ -277,8 +276,8 @@ export class MatrixClient implements IChatClient {
     };
   }
 
-  async recordMessageSent(roomId: string, sentAt: number): Promise<void> {
-    const data = { roomId, sentAt };
+  async recordMessageSent(roomId: string): Promise<void> {
+    const data = { roomId, sentAt: new Date().valueOf() };
 
     await post<any>('/matrix/message')
       .send(data)

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -269,8 +269,10 @@ export class MatrixClient implements IChatClient {
     const messageResult = await this.matrix.sendMessage(channelId, content);
     const newMessage = await this.getMessageByRoomId(channelId, messageResult.event_id);
     this.recordMessageSent(channelId, newMessage.createdAt);
+
+    // Don't return a full message, only the pertinent attributes that changed.
     return {
-      ...newMessage,
+      id: messageResult.event_id,
       optimisticId,
     };
   }

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -476,8 +476,8 @@ export function* replaceOptimisticMessage(currentMessages, message) {
 
   const messages = [...currentMessages];
   messages[messageIndex] = {
+    ...optimisticMessage,
     ...message,
-    preview: message.preview || optimisticMessage.preview,
     sendStatus: MessageSendStatus.SUCCESS,
   };
   return messages;


### PR DESCRIPTION
### What does this do?

When sending a new Matrix message we were not returning the proper Message data. This fixes the send and also changes the `replaceOptimisticMessage` to not overwrite the entire object and only the fields that were provided.

### Why are we making this change?

Depending on the order of events arriving this was causing the optimistic message to be overwritten with mostly empty data.

### How do I test this?

Send messages. Disable the new message event handler and send messages again. Verify that, without the event handler, sending still works as expected.

