### PR TITLE
feat: remove matrix feature flag check from syncRewardsAndTokenPrice

### DIFF
--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -64,7 +64,7 @@ export function* syncZEROPrice() {
 }
 
 export function* syncRewardsAndTokenPrice() {
-  if (!featureFlags.enableRewards || featureFlags.enableMatrix) {
+  if (!featureFlags.enableRewards) {
     return;
   }
 


### PR DESCRIPTION
### What does this do?
- Removes the condition that checks the enableMatrix feature flag within the syncRewardsAndTokenPrice function.

### Why are we making this change?
- To enable the syncing of rewards when using matrix, ensuring it only depends on the enableRewards flag.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
