### PR TITLE
fix: only return changed data when editing a message

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -699,6 +699,7 @@ describe('matrix client', () => {
       const originalMessageId = 'orig-message-id';
       const roomId = '!testRoomId';
       const editedMessage = 'edited message content';
+      const updatedAtTimestamp = Date.now();
 
       const sendMessage = jest.fn(() =>
         Promise.resolve({
@@ -719,6 +720,7 @@ describe('matrix client', () => {
           },
           event_id: 'edited-message-id',
           user_id: '@testUser:zero-synapse-development.zer0.io',
+          origin_server_ts: updatedAtTimestamp,
         })
       );
 
@@ -738,6 +740,7 @@ describe('matrix client', () => {
       expect(result).toMatchObject({
         id: 'edited-message-id',
         message: editedMessage,
+        updatedAt: updatedAtTimestamp,
       });
     });
   });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -311,6 +311,7 @@ export class MatrixClient implements IChatClient {
     const newMessage = await this.matrix.fetchRoomEvent(roomId, editResult.event_id);
 
     return {
+      id: editResult.event_id,
       message: newMessage.content.body,
       updatedAt: newMessage.origin_server_ts,
     };

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -308,7 +308,12 @@ export class MatrixClient implements IChatClient {
     };
 
     const editResult = await this.matrix.sendMessage(roomId, content);
-    return await this.getMessageByRoomId(roomId, editResult.event_id);
+    const newMessage = await this.matrix.fetchRoomEvent(roomId, editResult.event_id);
+
+    return {
+      message: newMessage.content.body,
+      updatedAt: newMessage.origin_server_ts,
+    };
   }
 
   private async onMessageUpdated(event): Promise<void> {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -489,6 +489,8 @@ export function* receiveUpdateMessage(action) {
   const preview = yield call(getPreview, message.message);
   message.preview = preview;
 
+  yield call(mapReceivedMessage, message);
+
   yield put(receiveMessage(message));
 }
 


### PR DESCRIPTION
### What does this do?
- only returns changed data when editing or receiving an updated message
- maps to zero user when receiving an updated message.

### Why are we making this change?
- we only need to return the message data that has changed when editing a message, i.e. message and updatedAt.
- to prevent the UI inconsistency as shown in the before demo below.
- to correctly map the sender data to ensure the UI renders correctly.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE:

https://github.com/zer0-os/zOS/assets/39112648/de69cda6-bc81-4e60-9a4e-d957225964e5


AFTER:



https://github.com/zer0-os/zOS/assets/39112648/0f70ea29-bcca-4fae-9f6a-87ccac96f298

