### PR TITLE
Update `userByMatrixId` to fetch user from API, if it doesn't exist in redux store

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -438,10 +438,10 @@ export function* otherUserJoinedChannel(roomId: string, user: User) {
   }
 
   if (user.userId === user.matrixId) {
-    user = yield select(userByMatrixId, user.matrixId);
+    user = yield call(userByMatrixId, user.matrixId) || user;
   }
 
-  if (!channel.otherMembers.includes(user.userId)) {
+  if (!channel?.otherMembers.includes(user.userId)) {
     const otherMembers = [...channel.otherMembers, user];
     yield put(
       receiveChannel({
@@ -459,7 +459,7 @@ export function* otherUserLeftChannel(roomId: string, user: User) {
     return;
   }
 
-  const existingUser = yield select(userByMatrixId, user.matrixId);
+  const existingUser = yield call(userByMatrixId, user.matrixId);
   if (!existingUser) {
     return;
   }

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -85,7 +85,7 @@ export function* mapReceivedMessage(message) {
       profileImage: currentUser.profileSummary?.profileImage,
     };
   } else {
-    const user = yield select(userByMatrixId, matrixId);
+    const user = yield call(userByMatrixId, matrixId);
     message.sender = user || message.sender;
   }
 

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -21,7 +21,7 @@ export function* receiveSearchResults(searchResults) {
 }
 
 export function* userPresenceChanged(matrixId: string, isOnline: boolean, lastSeenAt: string) {
-  const user = yield select(userByMatrixId, matrixId);
+  const user = yield call(userByMatrixId, matrixId);
 
   if (!user) {
     return;

--- a/src/store/users/selectors.ts
+++ b/src/store/users/selectors.ts
@@ -1,5 +1,11 @@
-import { RootState } from '../reducer';
+import { call, select } from 'redux-saga/effects';
+import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
 
-export function userByMatrixId(state: RootState, matrixId: string) {
-  return Object.values(state.normalized['users'] || {}).find((u: any) => u.matrixId === matrixId);
+export function* userByMatrixId(matrixId: string) {
+  const usersFromState = (yield select((state) => state.normalized.users)) ?? {};
+  let user = Object.values(usersFromState).find((u: any) => u.matrixId === matrixId);
+  if (!user) {
+    user = (yield call(getZEROUsersAPI, [matrixId]) ?? [])[0];
+  }
+  return user;
 }


### PR DESCRIPTION
### What does this do?

Updates the `userByMatrixId` function to fetch the ZERO user using the API, if it doesn't exist in store locally. This is particularly helpful on the other end of the "create conversation" (i.e the user who the conversation was started with).
