### PR TITLE
Set the active conversation as the newly created one

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -240,6 +240,8 @@ export class MatrixClient implements IChatClient {
     const result = await this.matrix.createRoom(options);
     // Any room is only set as a DM based on a single user. We'll use the first one.
     await setAsDM(this.matrix, result.room_id, users[0].matrixId);
+
+    return this.mapConversation(this.matrix.getRoom(result.room_id));
   }
 
   async sendMessagesByChannelId(


### PR DESCRIPTION
### What does this do?

- returns the created conversation data "after" creating the conversation
- this also sets the default conversation as the newly created one. 

https://github.com/zer0-os/zOS/assets/33264364/bddeff28-87ad-402c-835b-399b22baef0c


