### PR TITLE
remove `ConversationListChanged` event (fired when the `AccountData` is updated)

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -18,7 +18,6 @@ export interface RealtimeChatEvents {
   onUserJoinedChannel: (conversation) => void;
   invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;
-  onConversationListChanged: (conversationIds: string[]) => void;
   onUserPresenceChanged: (matrixId: string, isOnline: boolean, lastSeenAt: string) => void;
   onRoomNameChanged: (channelId: string, name: string) => void;
   onRoomAvatarChanged: (roomId: string, url: string) => void;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -417,7 +417,6 @@ export class MatrixClient implements IChatClient {
       }
     });
 
-    this.matrix.on(ClientEvent.AccountData, this.publishConversationListChange);
     this.matrix.on(ClientEvent.Event, this.publishUserPresenceChange);
     this.matrix.on(RoomEvent.Name, this.publishRoomNameChange);
     this.matrix.on(RoomStateEvent.Members, this.publishMembershipChange);
@@ -520,13 +519,6 @@ export class MatrixClient implements IChatClient {
   private publishMessageEvent(event) {
     this.events.receiveNewMessage(event.room_id, mapMatrixMessage(event, this.matrix) as any);
   }
-
-  private publishConversationListChange = (event: MatrixEvent) => {
-    if (event.getType() === EventType.Direct) {
-      const content = event.getContent();
-      this.events.onConversationListChanged(Object.values(content ?? {}).flat());
-    }
-  };
 
   private publishUserPresenceChange = (event: MatrixEvent) => {
     if (event.getType() === EventType.Presence) {

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -12,7 +12,6 @@ import {
   clearChannelsAndConversations,
   userLeftChannel,
   addChannel,
-  setConversations,
   otherUserJoinedChannel,
   otherUserLeftChannel,
   mapToZeroUsers,
@@ -384,48 +383,6 @@ describe('channels list saga', () => {
         .run();
 
       expect(storeState.channelsList.value).toIncludeSameMembers(['existing-conversation-id']);
-    });
-  });
-
-  describe(setConversations, () => {
-    it('changes channels to conversation', async () => {
-      const initialState = new StoreBuilder().withChannelList(
-        { id: 'channel-1', isChannel: true },
-        { id: 'channel-2', isChannel: true },
-        { id: 'channel-3', isChannel: true }
-      );
-
-      const { storeState } = await expectSaga(setConversations, ['channel-1', 'channel-3'])
-        .withReducer(rootReducer, initialState.build())
-        .run();
-
-      const channel1 = denormalizeChannel('channel-1', storeState);
-      expect(channel1.isChannel).toEqual(false);
-      const channel3 = denormalizeChannel('channel-3', storeState);
-      expect(channel3.isChannel).toEqual(false);
-
-      const channel2 = denormalizeChannel('channel-2', storeState);
-      expect(channel2.isChannel).toEqual(true);
-    });
-
-    it('changes conversations to channels', async () => {
-      const initialState = new StoreBuilder().withChannelList(
-        { id: 'channel-1', isChannel: false },
-        { id: 'channel-2', isChannel: false },
-        { id: 'channel-3', isChannel: false }
-      );
-
-      const { storeState } = await expectSaga(setConversations, ['channel-2'])
-        .withReducer(rootReducer, initialState.build())
-        .run();
-
-      const channel1 = denormalizeChannel('channel-1', storeState);
-      expect(channel1.isChannel).toEqual(true);
-      const channel3 = denormalizeChannel('channel-3', storeState);
-      expect(channel3.isChannel).toEqual(true);
-
-      const channel2 = denormalizeChannel('channel-2', storeState);
-      expect(channel2.isChannel).toEqual(false);
     });
   });
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -377,7 +377,6 @@ export function* saga() {
     userLeftChannel(payload.channelId, payload.userId)
   );
   yield takeEveryFromBus(chatBus, ChatEvents.UserJoinedChannel, userJoinedChannelAction);
-  yield takeEveryFromBus(chatBus, ChatEvents.ConversationListChanged, conversationListChangedAction);
   yield takeEveryFromBus(chatBus, ChatEvents.RoomNameChanged, roomNameChangedAction);
   yield takeEveryFromBus(chatBus, ChatEvents.RoomAvatarChanged, roomAvatarChangedAction);
   yield takeEveryFromBus(chatBus, ChatEvents.OtherUserJoinedChannel, otherUserJoinedChannelAction);
@@ -386,10 +385,6 @@ export function* saga() {
 
 function* userJoinedChannelAction({ payload }) {
   yield addChannel(payload.channel);
-}
-
-function* conversationListChangedAction({ payload }) {
-  yield setConversations(payload.conversationIds);
 }
 
 function* roomNameChangedAction(action) {
@@ -413,14 +408,6 @@ export function* addChannel(channel) {
   const channelsList = yield select(rawChannelsList());
 
   yield put(receive(uniqNormalizedList([...channelsList, ...conversationsList, channel])));
-}
-
-export function* setConversations(conversationIds: string[]) {
-  const allChannelIds = yield select((state) => getDeepProperty(state, 'channelsList.value', []));
-  for (const id of allChannelIds) {
-    const isChannel = !conversationIds.includes(id);
-    yield put(receiveChannel({ id, isChannel }));
-  }
 }
 
 export function* roomNameChanged(id: string, name: string) {

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -49,8 +49,6 @@ export function createChatConnection(userId, chatAccessToken) {
       emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
-    const onConversationListChanged = (conversationIds) =>
-      emit({ type: Events.ConversationListChanged, payload: { conversationIds } });
     const onUserPresenceChanged = (matrixId, isOnline, lastSeenAt) =>
       emit({ type: Events.UserPresenceChanged, payload: { matrixId, isOnline, lastSeenAt } });
     const onRoomNameChanged = (roomId, name) => emit({ type: Events.RoomNameChanged, payload: { id: roomId, name } });
@@ -71,7 +69,6 @@ export function createChatConnection(userId, chatAccessToken) {
       onUserReceivedInvitation,
       onUserLeft,
       onUserJoinedChannel,
-      onConversationListChanged,
       onUserPresenceChanged,
       onRoomNameChanged,
       onRoomAvatarChanged,


### PR DESCRIPTION
### What does this do?

Removes `conversationListChanged` event, which fires up when `AccountData` event is emitted from matrix.

### Why are we making this change?

There are some conversations which aren't getting set in the `accountData` while creating a new conversation. So when we get the "conversationListChanged" event at the end of the create conversation flow ([here](https://github.com/zer0-os/zOS/blob/main/src/lib/chat/matrix-client.ts#L524)), it is missing one (or maybe more) conversationId's from the list. So that conversation which is missed, is being marked as a channel ([here](https://github.com/zer0-os/zOS/blob/main/src/store/channels-list/saga.ts#L422)), due to which it disappears from the list.

Before:

https://github.com/zer0-os/zOS/assets/33264364/e7851523-19d1-432e-a2cd-fe6aae9e75ab


After:

https://github.com/zer0-os/zOS/assets/33264364/cca12624-470f-443a-bdc5-4a967ef52c60



