### PR TITLE
feat: implement unread message count functionality with matrix client

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -155,7 +155,7 @@ export class Chat {
   async markRoomAsRead(roomId: string, userId?: string): Promise<void> {
     return this.client.markRoomAsRead(roomId, userId);
   }
-  
+
   async getSecureBackup(): Promise<any> {
     return this.client.getSecureBackup();
   }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -62,7 +62,7 @@ export interface IChatClient {
     mentionedUserIds: string[],
     data?: Partial<EditMessageOptions>
   ): Promise<any>;
-  markRoomAsRead: (roomId: string) => Promise<void>;
+  markRoomAsRead: (roomId: string, userId?: string) => Promise<void>;
 }
 
 export class Chat {
@@ -139,8 +139,8 @@ export class Chat {
     return this.client.fetchConversationsWithUsers(users);
   }
 
-  async markRoomAsRead(roomId: string): Promise<void> {
-    return this.client.markRoomAsRead(roomId);
+  async markRoomAsRead(roomId: string, userId?: string): Promise<void> {
+    return this.client.markRoomAsRead(roomId, userId);
   }
 
   initChat(events: RealtimeChatEvents): void {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -62,6 +62,7 @@ export interface IChatClient {
     mentionedUserIds: string[],
     data?: Partial<EditMessageOptions>
   ): Promise<any>;
+  markRoomAsRead: (roomId: string) => Promise<void>;
 }
 
 export class Chat {
@@ -136,6 +137,10 @@ export class Chat {
 
   async fetchConversationsWithUsers(users: User[]): Promise<any[]> {
     return this.client.fetchConversationsWithUsers(users);
+  }
+
+  async markRoomAsRead(roomId: string): Promise<void> {
+    return this.client.markRoomAsRead(roomId);
   }
 
   initChat(events: RealtimeChatEvents): void {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -22,6 +22,7 @@ const stubRoom = (attrs = {}) => ({
   getLiveTimeline: () => stubTimeline(),
   getMyMembership: () => 'join',
   getEvents: () => stubTimeline(),
+  getUnreadNotificationCount: () => 0,
   ...attrs,
 });
 

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -742,4 +742,33 @@ describe('matrix client', () => {
       });
     });
   });
+
+  describe('markRoomAsRead', () => {
+    it('marks room as read successfully', async () => {
+      const roomId = '!testRoomId';
+      const latestEventId = 'latest-event-id';
+      const latestEvent = {
+        event: { event_id: latestEventId },
+      };
+
+      const sendReadReceipt = jest.fn().mockResolvedValue(undefined);
+      const setRoomReadMarkers = jest.fn().mockResolvedValue(undefined);
+      const getLiveTimelineEvents = jest.fn().mockReturnValue([latestEvent]);
+      const getRoom = jest.fn().mockReturnValue(
+        stubRoom({
+          getLiveTimeline: jest.fn().mockReturnValue(stubTimeline({ getEvents: getLiveTimelineEvents })),
+        })
+      );
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ sendReadReceipt, setRoomReadMarkers, getRoom })),
+      });
+
+      await client.connect(null, 'token');
+      await client.markRoomAsRead(roomId);
+
+      expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent);
+      expect(setRoomReadMarkers).toHaveBeenCalledWith(roomId, latestEventId);
+    });
+  });
 });

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -24,6 +24,7 @@ const stubRoom = (attrs = {}) => ({
   getEvents: () => stubTimeline(),
   getUnreadNotificationCount: () => 0,
   on: () => undefined,
+  off: () => undefined,
   ...attrs,
 });
 
@@ -59,6 +60,7 @@ const getSdkClient = (sdkClient = {}) => ({
   on: jest.fn((topic, callback) => {
     if (topic === 'sync') callback('PREPARED');
   }),
+  off: jest.fn(),
   getRooms: jest.fn(),
   getRoom: jest.fn().mockReturnValue(stubRoom()),
   getAccountData: jest.fn(),

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -23,6 +23,7 @@ const stubRoom = (attrs = {}) => ({
   getMyMembership: () => 'join',
   getEvents: () => stubTimeline(),
   getUnreadNotificationCount: () => 0,
+  on: () => undefined,
   ...attrs,
 });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -513,19 +513,6 @@ export class MatrixClient implements IChatClient {
 
       await this.waitForSync();
 
-      this.matrix.once('sync' as any, (state) => {
-        if (state === 'PREPARED' || state === 'SYNCING') {
-          let rooms = this.matrix.getRooms();
-          rooms.forEach((room) => {
-            room.on(RoomEvent.UnreadNotifications, (unreadNotifications) => {
-              console.log('Unread notifications for room:', room.roomId, 'UNREAD:', unreadNotifications);
-
-              this.events.receiveUnreadCount(room.roomId, unreadNotifications?.total || 0);
-            });
-          });
-        }
-      });
-
       return opts.userId;
     }
   }
@@ -605,7 +592,7 @@ export class MatrixClient implements IChatClient {
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
     const messages = this.getAllMessagesFromRoom(room);
-    const unreadCount = room.getRoomUnreadNotificationCount(NotificationCountType.Total);
+    const unreadCount = room.getUnreadNotificationCount(NotificationCountType.Total);
 
     return {
       id: room.roomId,

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -267,7 +267,9 @@ export class MatrixClient implements IChatClient {
     // Any room is only set as a DM based on a single user. We'll use the first one.
     await setAsDM(this.matrix, result.room_id, users[0].matrixId);
 
-    return await this.mapConversation(this.matrix.getRoom(result.room_id));
+    const room = this.matrix.getRoom(result.room_id);
+    this.initializeRoomEventHandlers(room);
+    return await this.mapConversation(room);
   }
 
   async sendMessagesByChannelId(

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -543,6 +543,10 @@ export class MatrixClient implements IChatClient {
   private publishMessageEvent(event) {
     const room = this.matrix.getRoom(event.room_id);
 
+    if (!room) {
+      return;
+    }
+
     if (event.sender !== this.userId) {
       this.events.receiveUnreadCount(event.room_id, room.getUnreadNotificationCount(NotificationCountType.Total));
     }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -597,8 +597,6 @@ export class MatrixClient implements IChatClient {
     const messages = this.getAllMessagesFromRoom(room);
     const unreadCount = room.getUnreadNotificationCount(NotificationCountType.Total);
 
-    console.log('unreadCount: ', unreadCount);
-
     return {
       id: room.roomId,
       name,

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -668,7 +668,6 @@ export class MatrixClient implements IChatClient {
     const messages = this.getAllMessagesFromRoom(room);
     console.log('GENERALCHANNEL_ROOM', room);
     const unreadCount = room.getRoomUnreadNotificationCount(NotificationCountType.Total);
-    console.log('NEWCOMP', unreadCount);
 
     return {
       id: room.roomId,

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -617,7 +617,9 @@ export class MatrixClient implements IChatClient {
   }
 
   private async roomCreated(event) {
-    this.events.onUserJoinedChannel(await this.mapConversation(this.matrix.getRoom(event.room_id)));
+    const room = this.matrix.getRoom(event.room_id);
+    this.initializeRoomEventHandlers(room);
+    this.events.onUserJoinedChannel(await this.mapConversation(room));
   }
 
   private receiveDeleteMessage = (event) => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -334,12 +334,8 @@ export class MatrixClient implements IChatClient {
       return;
     }
 
-    try {
-      await this.matrix.sendReadReceipt(latestEvent);
-      await this.matrix.setRoomReadMarkers(roomId, latestEvent.event.event_id);
-    } catch (error) {
-      console.error(`Failed to mark room with ID: ${roomId} as read. Error:`, error);
-    }
+    await this.matrix.sendReadReceipt(latestEvent);
+    await this.matrix.setRoomReadMarkers(roomId, latestEvent.event.event_id);
   }
 
   private async onMessageUpdated(event): Promise<void> {
@@ -440,13 +436,6 @@ export class MatrixClient implements IChatClient {
     });
 
     this.matrix.on(MatrixEventEvent.Decrypted, async (decryptedEvent: MatrixEvent) => {
-      const event = decryptedEvent.getEffectiveEvent();
-      if (event.type === EventType.RoomMessage) {
-        this.processMessageEvent(event);
-      }
-    });
-
-    this.matrix.on(RoomEvent.Timeline, async (decryptedEvent: MatrixEvent) => {
       const event = decryptedEvent.getEffectiveEvent();
       if (event.type === EventType.RoomMessage) {
         this.processMessageEvent(event);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -450,10 +450,15 @@ export class MatrixClient implements IChatClient {
     }
   }
 
-  private initializeRoomEventHandlers(room) {
-    room.on(RoomEvent.UnreadNotifications, (unreadNotifications) => {
+  private initializeRoomEventHandlers(room: Room) {
+    const handleUnreadNotifications = (unreadNotifications) => {
       this.events.receiveUnreadCount(room.roomId, unreadNotifications?.total || 0);
-    });
+    };
+
+    // Removing the event handler if it already exists to prevent duplicates.
+    room.off(RoomEvent.UnreadNotifications, handleUnreadNotifications);
+
+    room.on(RoomEvent.UnreadNotifications, handleUnreadNotifications);
   }
 
   private async initializeEventHandlers() {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -92,8 +92,14 @@ export class SendbirdClient implements IChatClient {
     return null;
   }
 
-  async markRoomAsRead() {
-    return null;
+  async markRoomAsRead(roomId: string, userId: string): Promise<void> {
+    try {
+      const response = await put<any>(`/chatChannels/${roomId}/messages/mark-as-read`).send({ id: userId });
+      return response.status;
+    } catch (error: any) {
+      console.log('Error occurred while marking room as read: ', error?.response ?? error);
+      return null;
+    }
   }
 
   async searchMyNetworksByName(filter: string): Promise<MemberNetworks[]> {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -92,6 +92,10 @@ export class SendbirdClient implements IChatClient {
     return null;
   }
 
+  async markRoomAsRead() {
+    return null;
+  }
+
   async searchMyNetworksByName(filter: string): Promise<MemberNetworks[]> {
     return await get('/api/v2/users/searchInNetworksByName', { filter, limit: 50 })
       .catch((_error) => null)

--- a/src/store/channels/api.ts
+++ b/src/store/channels/api.ts
@@ -1,13 +1,7 @@
-import { post, put } from '../../lib/api/rest';
+import { post } from '../../lib/api/rest';
 
 export async function joinChannel(channelId: string): Promise<number> {
   const response = await post<any>(`/chatChannels/${channelId}/join`);
-
-  return response.status;
-}
-
-export async function markAllMessagesAsReadInChannel(channelId: string, userId: string): Promise<number> {
-  const response = await put<any>(`/chatChannels/${channelId}/messages/mark-as-read`).send({ id: userId });
 
   return response.status;
 }

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -100,9 +100,9 @@ export function* unreadCountUpdated(action) {
     })
   );
 
-  if (!channel.hasLoadedMessages && unreadCount > 0) {
-    yield spawn(fetchMessages, { payload: { channelId } });
-  }
+  // if (!channel.hasLoadedMessages && unreadCount > 0) {
+  //   yield spawn(fetchMessages, { payload: { channelId } });
+  // }
 }
 
 export function* clearChannels() {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -6,7 +6,6 @@ import { joinChannel as joinChannelAPI } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
-import { fetch as fetchMessages } from '../messages/saga';
 import { setActiveChannelId, setactiveConversationId } from '../chat';
 import { chat } from '../../lib/chat';
 
@@ -33,14 +32,16 @@ export function* markAllMessagesAsRead(channelId, userId) {
   }
 
   const chatClient = yield call(chat.get);
-  yield call([chatClient, chatClient.markRoomAsRead], channelId, userId);
+  try {
+    yield call([chatClient, chatClient.markRoomAsRead], channelId, userId);
 
-  yield put(
-    receive({
-      id: channelId,
-      unreadCount: 0,
-    })
-  );
+    yield put(
+      receive({
+        id: channelId,
+        unreadCount: 0,
+      })
+    );
+  } catch (error) {}
 }
 
 // mark all messages as read in current active channel (only if you're not in full screen mode)
@@ -97,10 +98,6 @@ export function* unreadCountUpdated(action) {
       unreadCount: unreadCount,
     })
   );
-
-  if (!channel.hasLoadedMessages && unreadCount > 0) {
-    yield spawn(fetchMessages, { payload: { channelId } });
-  }
 }
 
 export function* clearChannels() {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -2,7 +2,7 @@ import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, select, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, receive, schema, removeAll } from '.';
 
-import { joinChannel as joinChannelAPI, markAllMessagesAsReadInChannel as markAllMessagesAsReadAPI } from './api';
+import { joinChannel as joinChannelAPI } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
@@ -32,7 +32,8 @@ export function* markAllMessagesAsRead(channelId, userId) {
     return;
   }
 
-  const status = yield call(markAllMessagesAsReadAPI, channelId, userId);
+  const chatClient = yield call(chat.get);
+  const status = yield call([chatClient, chatClient.markRoomAsRead], channelId, userId);
 
   if (status === 200) {
     yield put(
@@ -62,8 +63,6 @@ export function* markConversationAsRead(conversationId) {
   const conversationInfo = yield select(rawChannelSelector(conversationId));
   if (conversationInfo?.unreadCount > 0) {
     yield call(markAllMessagesAsRead, conversationId, currentUser.id);
-    const chatClient = yield call(chat.get);
-    yield call([chatClient, chatClient.markRoomAsRead], conversationId);
   }
 }
 

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -100,9 +100,9 @@ export function* unreadCountUpdated(action) {
     })
   );
 
-  // if (!channel.hasLoadedMessages && unreadCount > 0) {
-  //   yield spawn(fetchMessages, { payload: { channelId } });
-  // }
+  if (!channel.hasLoadedMessages && unreadCount > 0) {
+    yield spawn(fetchMessages, { payload: { channelId } });
+  }
 }
 
 export function* clearChannels() {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -8,6 +8,7 @@ import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
 import { fetch as fetchMessages } from '../messages/saga';
 import { setActiveChannelId, setactiveConversationId } from '../chat';
+import { chat } from '../../lib/chat';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -61,6 +62,8 @@ export function* markConversationAsRead(conversationId) {
   const conversationInfo = yield select(rawChannelSelector(conversationId));
   if (conversationInfo?.unreadCount > 0) {
     yield call(markAllMessagesAsRead, conversationId, currentUser.id);
+    const chatClient = yield call(chat.get);
+    yield call([chatClient, chatClient.markRoomAsRead], conversationId);
   }
 }
 

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -33,16 +33,14 @@ export function* markAllMessagesAsRead(channelId, userId) {
   }
 
   const chatClient = yield call(chat.get);
-  const status = yield call([chatClient, chatClient.markRoomAsRead], channelId, userId);
+  yield call([chatClient, chatClient.markRoomAsRead], channelId, userId);
 
-  if (status === 200) {
-    yield put(
-      receive({
-        id: channelId,
-        unreadCount: 0,
-      })
-    );
-  }
+  yield put(
+    receive({
+      id: channelId,
+      unreadCount: 0,
+    })
+  );
 }
 
 // mark all messages as read in current active channel (only if you're not in full screen mode)
@@ -99,10 +97,6 @@ export function* unreadCountUpdated(action) {
       unreadCount: unreadCount,
     })
   );
-
-  if (!channel.hasLoadedMessages && unreadCount > 0) {
-    yield spawn(fetchMessages, { payload: { channelId } });
-  }
 }
 
 export function* clearChannels() {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -97,6 +97,10 @@ export function* unreadCountUpdated(action) {
       unreadCount: unreadCount,
     })
   );
+
+  if (!channel.hasLoadedMessages && unreadCount > 0) {
+    yield spawn(fetchMessages, { payload: { channelId } });
+  }
 }
 
 export function* clearChannels() {


### PR DESCRIPTION
### What does this do?
- This PR implements functionality to track and update unread message counts in the application using the Matrix client. It refactors the existing event handling logic to streamline the process of receiving new messages and updates the unread count accordingly. 

### Why are we making this change?
- To ensure conversations are highlighted when there are unread messages, and the unread count is updated and reflected in the UI. 

### How do I test this?
- Send messages to a zOS user you are logged in with and check the conversation list item is highlighted, and, the unread counter in the conversation list item increments for every unread message. Once the conversation has been `read` the conversation list item should no longer be highlighted and a send receipt will be sent to the server which should set the unread count back to 0, in turn the UI should reflect this by no longer highlighting the conversation list item as `unread`.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO

https://github.com/zer0-os/zOS/assets/39112648/1402902a-4ae5-40c7-a89e-a2400cb8e37f

