### PR TITLE
Filter conversation list properly when account data event is received

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -527,10 +527,10 @@ export class MatrixClient implements IChatClient {
     this.events.receiveNewMessage(event.room_id, mapMatrixMessage(event, this.matrix) as any);
   }
 
-  private publishConversationListChange = (event: MatrixEvent) => {
+  private publishConversationListChange = async (event: MatrixEvent) => {
     if (event.getType() === EventType.Direct) {
-      const content = event.getContent();
-      this.events.onConversationListChanged(Object.values(content ?? {}).flat());
+      const rooms = await this.getFilteredRooms(this.isConversation);
+      this.events.onConversationListChanged(rooms.map((r) => r.roomId));
     }
   };
 


### PR DESCRIPTION
### What does this do?

The AccountData is only one way in which a room is identified as a conversations. The other is that the room has a DMInviter.

