### PR TITLE
feat: update rewards route and response properties from zero to meow

### DIFF
--- a/src/store/rewards/api.ts
+++ b/src/store/rewards/api.ts
@@ -3,8 +3,8 @@ import { get } from '../../lib/api/rest';
 export interface RewardsResp {
   success: boolean;
   response: {
-    zero: string;
-    zeroPreviousDay: string;
+    meow: string;
+    meowPreviousDay: string;
     decimals: number;
   };
 }
@@ -18,7 +18,7 @@ export async function fetchRewards(_obj: any): Promise<RewardsResp> {
 }
 
 export async function fetchCurrentMeowPriceInUSD() {
-  const response = await get('/api/tokens/zero');
+  const response = await get('/api/tokens/meow');
   return {
     success: true,
     response: response.body,

--- a/src/store/rewards/saga.test.ts
+++ b/src/store/rewards/saga.test.ts
@@ -13,7 +13,7 @@ describe('fetch', () => {
       .provide([
         [
           call(fetchRewards, {}),
-          { success: true, response: { zero: '517' } },
+          { success: true, response: { meow: '517' } },
         ],
       ])
       .withReducer(rootReducer, initialState({}))

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -35,8 +35,8 @@ export function* fetch(_action) {
   try {
     const result: RewardsResp = yield call(fetchRewards, {});
     if (result.success) {
-      yield put(setMeow(result.response.zero.toString()));
-      yield put(setMeowPreviousDay(result.response.zeroPreviousDay.toString()));
+      yield put(setMeow(result.response.meow.toString()));
+      yield put(setMeowPreviousDay(result.response.meowPreviousDay.toString()));
 
       yield call(checkNewRewardsLoaded);
     } else {


### PR DESCRIPTION
### What does this do?
- updates rewards route `/zero` to `/meow`
- updates response properties: `zero` -> `meow` & `zeroPreviousDay` -> `meowPreviousDay`

### Why are we making this change?
- token name change.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
<img width="1934" alt="Screenshot 2023-10-27 at 12 28 49" src="https://github.com/zer0-os/zOS/assets/39112648/7dcaacf6-2476-49ea-b486-0616adb585fd">

