### PR TITLE
Batch the processing of new message received events

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -440,6 +440,10 @@ export function* receiveNewMessage(action) {
   // Clone and empty so follow up events can debounce again
   const batchedPayloads = [...savedMessages];
   savedMessages = [];
+  return yield call(batchedReceiveNewMessage, batchedPayloads);
+}
+
+export function* batchedReceiveNewMessage(batchedPayloads) {
   const byChannelId = {};
   batchedPayloads.forEach((m) => {
     byChannelId[m.channelId] = byChannelId[m.channelId] || [];

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -429,38 +429,63 @@ export function* receiveDelete(action) {
   );
 }
 
+let savedMessages = [];
 export function* receiveNewMessage(action) {
-  let { channelId, message } = action.payload;
-  yield call(mapReceivedMessage, message);
-
-  const channel = yield select(rawChannelSelector(channelId));
-  const currentMessages = channel?.messages || [];
-  if (!channel || currentMessages.includes(message.id)) {
+  savedMessages.push(action.payload);
+  if (savedMessages.length > 1) {
+    // we already have a leading event that's awaiting the debounce delay
     return;
   }
+  yield delay(500);
+  // Clone and empty so follow up events can debounce again
+  const batchedPayloads = [...savedMessages];
+  savedMessages = [];
+  const byChannelId = {};
+  batchedPayloads.forEach((m) => {
+    byChannelId[m.channelId] = byChannelId[m.channelId] || [];
+    byChannelId[m.channelId].push(m.message);
+  });
 
-  const preview = yield call(getPreview, message.message);
+  for (const channelId of Object.keys(byChannelId)) {
+    const channel = yield select(rawChannelSelector(channelId));
+    let currentMessages = channel?.messages || [];
+    let modified = false;
+    for (let message of byChannelId[channelId]) {
+      yield call(mapReceivedMessage, message);
 
-  if (preview) {
-    message = { ...message, preview };
+      if (!channel || currentMessages.includes(message.id)) {
+        continue;
+      }
+      modified = true;
+
+      const preview = yield call(getPreview, message.message);
+
+      if (preview) {
+        message = { ...message, preview };
+      }
+
+      let newMessages = yield call(replaceOptimisticMessage, currentMessages, message);
+      if (!newMessages) {
+        newMessages = [
+          ...currentMessages,
+          message,
+        ];
+      }
+      currentMessages = newMessages;
+    }
+    if (modified) {
+      yield put(receive({ id: channelId, messages: currentMessages }));
+    }
+    if (yield select(_isActive(channelId))) {
+      const isChannel = yield select(_isChannel(channelId));
+      const markAllAsReadAction = isChannel ? markChannelAsRead : markConversationAsRead;
+      yield spawn(markAllAsReadAction, channelId);
+    }
   }
 
-  let newMessages = yield call(replaceOptimisticMessage, currentMessages, message);
-  if (!newMessages) {
-    newMessages = [
-      ...currentMessages,
-      message,
-    ];
-  }
-
-  yield put(receive({ id: channelId, messages: newMessages }));
-  yield spawn(sendBrowserNotification, channelId, message);
-
-  if (yield select(_isActive(channelId))) {
-    const isChannel = yield select(_isChannel(channelId));
-    const markAllAsReadAction = isChannel ? markChannelAsRead : markConversationAsRead;
-    yield spawn(markAllAsReadAction, channelId);
-  }
+  // Since the conversation load happens via these events now, this can't just happen. We need to figure out if this is a bullk load or a
+  // "fresh" message
+  // yield spawn(sendBrowserNotification, channelId, message);
 }
 
 export function* replaceOptimisticMessage(currentMessages, message) {


### PR DESCRIPTION
### What does this do?

Batches the saga processing of new message events

### Why are we making this change?

When loading messages from Matrix we get them as individual "decrypted" events. This means we publish the "new message" event multiple times. If you load a room with 100s of messages this causes multiple invocations of the saga which was causing lots of rerenders.

Batching the processing allows for fewer rerenders. Simplified timing results when loading and rendering a conversation with around 130 messages:
Before - 9 to 10 seconds
After - 800ms

### How do I test this?

Ensure you can load messages in a conversation/channel and verify that receiving real time messges still works.

