### PR TITLE
chore: bump matrix-js-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "zOS",
       "version": "0.71.0",
       "dependencies": {
         "@craco/craco": "^6.4.3",
@@ -42,7 +41,7 @@
         "lodash.get": "^4.4.2",
         "lodash.kebabcase": "^4.1.1",
         "lodash.uniqby": "^4.7.0",
-        "matrix-js-sdk": "^26.2.0",
+        "matrix-js-sdk": "^29.1.0",
         "millify": "^6.1.0",
         "moment": "^2.29.4",
         "normalizr": "^3.6.2",
@@ -4208,10 +4207,10 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@matrix-org/matrix-sdk-crypto-js": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.4.tgz",
-      "integrity": "sha512-OxG84iSeR89zYLFeb+DCaFtZT+DDiIu+kTkqY8OYfhE5vpGLFX2sDVBRrAdos1IUqEoboDloDBR9+yU7hNRyog==",
+    "node_modules/@matrix-org/matrix-sdk-crypto-wasm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-2.2.0.tgz",
+      "integrity": "sha512-txmvaTiZpVV0/kWCRcE7tZvRESCEc1ynLJDVh9OUsFlaXfl13c7qdD3E6IJEJ8YiPMIn+PHogdfBZsO84reaMg==",
       "engines": {
         "node": ">= 10"
       }
@@ -6951,9 +6950,9 @@
       "license": "MIT"
     },
     "node_modules/@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.2.tgz",
+      "integrity": "sha512-v4Mr60wJuF069iZZCdY5DKhfj0l6eXNJtbSM/oMDNdRLoBEUsktmKnswkz0X3OAic5W8Qy/YU6owKE4A66Y46A=="
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.28",
@@ -12027,6 +12026,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "1.0.0",
@@ -20539,6 +20543,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "node_modules/keccak": {
       "version": "1.4.0",
       "hasInstallScript": true,
@@ -21035,25 +21044,28 @@
       "integrity": "sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA=="
     },
     "node_modules/matrix-js-sdk": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-26.2.0.tgz",
-      "integrity": "sha512-Om6p8iC/2ojw0MQBmz/DYqbz3sFSJF2jE92sZcpLA/cki1SaXLpD2V5N9RcZgcHGmtm3w49822sIs8nWVyBAFQ==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-29.1.0.tgz",
+      "integrity": "sha512-nF+ACFioDltGCf2KFfXK7QoJ70Ytnzm4Jse2UI+BDXeR9WCjtKefXJtboN2rmU4MFmLCTHcnBTmu6yig67YUqw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-js": "^0.1.0-alpha.11",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^2.0.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",
+        "jwt-decode": "^3.1.2",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "0.0.1",
-        "matrix-widget-api": "^1.3.1",
+        "matrix-widget-api": "^1.6.0",
+        "oidc-client-ts": "^2.2.4",
         "p-retry": "4",
         "sdp-transform": "^2.14.1",
         "unhomoglyph": "^1.0.6",
         "uuid": "9"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/matrix-js-sdk/node_modules/base-x": {
@@ -21090,9 +21102,9 @@
       }
     },
     "node_modules/matrix-widget-api": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/matrix-widget-api/-/matrix-widget-api-1.4.0.tgz",
-      "integrity": "sha512-dw0dRylGQzDUoiaY/g5xx1tBbS7aoov31PRtFMAvG58/4uerYllV9Gfou7w+I1aglwB6hihTREzKltVjARWV6A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/matrix-widget-api/-/matrix-widget-api-1.6.0.tgz",
+      "integrity": "sha512-VXIJyAZ/WnBmT4C7ePqevgMYGneKMCP/0JuCOqntSsaNlCRHJvwvTxmqUU+ufOpzIF5gYNyIrAjbgrEbK3iqJQ==",
       "dependencies": {
         "@types/events": "^3.0.0",
         "events": "^3.2.0"
@@ -22903,6 +22915,18 @@
     "node_modules/obuf": {
       "version": "1.1.2",
       "license": "MIT"
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.4.0.tgz",
+      "integrity": "sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "jwt-decode": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -34844,10 +34868,10 @@
         "tmp-promise": "^3.0.2"
       }
     },
-    "@matrix-org/matrix-sdk-crypto-js": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.4.tgz",
-      "integrity": "sha512-OxG84iSeR89zYLFeb+DCaFtZT+DDiIu+kTkqY8OYfhE5vpGLFX2sDVBRrAdos1IUqEoboDloDBR9+yU7hNRyog=="
+    "@matrix-org/matrix-sdk-crypto-wasm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-2.2.0.tgz",
+      "integrity": "sha512-txmvaTiZpVV0/kWCRcE7tZvRESCEc1ynLJDVh9OUsFlaXfl13c7qdD3E6IJEJ8YiPMIn+PHogdfBZsO84reaMg=="
     },
     "@metamask/safe-event-emitter": {
       "version": "2.0.0"
@@ -35437,7 +35461,7 @@
         "@radix-ui/react-focus-guards": "0.1.0",
         "@radix-ui/react-focus-scope": "0.1.4",
         "@radix-ui/react-id": "0.1.5",
-        "@radix-ui/react-popper": "1.0.0",
+        "@radix-ui/react-popper": "0.1.4",
         "@radix-ui/react-portal": "0.1.4",
         "@radix-ui/react-presence": "0.1.2",
         "@radix-ui/react-primitive": "0.1.4",
@@ -36695,7 +36719,7 @@
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
-        "@types/react": "^16.14.21"
+        "@types/react": "*"
       }
     },
     "@types/eslint": {
@@ -36709,9 +36733,9 @@
       "version": "0.0.39"
     },
     "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.2.tgz",
+      "integrity": "sha512-v4Mr60wJuF069iZZCdY5DKhfj0l6eXNJtbSM/oMDNdRLoBEUsktmKnswkz0X3OAic5W8Qy/YU6owKE4A66Y46A=="
     },
     "@types/express-serve-static-core": {
       "version": "4.17.28",
@@ -36752,7 +36776,7 @@
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "requires": {
-        "@types/react": "^16.14.21",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -36924,21 +36948,21 @@
     "@types/react-dom": {
       "version": "16.9.14",
       "requires": {
-        "@types/react": "^16.14.21"
+        "@types/react": "^16"
       }
     },
     "@types/react-portal": {
       "version": "4.0.4",
       "dev": true,
       "requires": {
-        "@types/react": "^16.14.21"
+        "@types/react": "*"
       }
     },
     "@types/react-redux": {
       "version": "7.1.20",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "^16.14.21",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
       }
@@ -40198,6 +40222,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "crypto-random-string": {
       "version": "1.0.0"
@@ -45724,6 +45753,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "keccak": {
       "version": "1.4.0",
       "requires": {
@@ -46076,18 +46110,20 @@
       "integrity": "sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA=="
     },
     "matrix-js-sdk": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-26.2.0.tgz",
-      "integrity": "sha512-Om6p8iC/2ojw0MQBmz/DYqbz3sFSJF2jE92sZcpLA/cki1SaXLpD2V5N9RcZgcHGmtm3w49822sIs8nWVyBAFQ==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-29.1.0.tgz",
+      "integrity": "sha512-nF+ACFioDltGCf2KFfXK7QoJ70Ytnzm4Jse2UI+BDXeR9WCjtKefXJtboN2rmU4MFmLCTHcnBTmu6yig67YUqw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-js": "^0.1.0-alpha.11",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^2.0.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",
+        "jwt-decode": "^3.1.2",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "0.0.1",
-        "matrix-widget-api": "^1.3.1",
+        "matrix-widget-api": "^1.6.0",
+        "oidc-client-ts": "^2.2.4",
         "p-retry": "4",
         "sdp-transform": "^2.14.1",
         "unhomoglyph": "^1.0.6",
@@ -46124,9 +46160,9 @@
       }
     },
     "matrix-widget-api": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/matrix-widget-api/-/matrix-widget-api-1.4.0.tgz",
-      "integrity": "sha512-dw0dRylGQzDUoiaY/g5xx1tBbS7aoov31PRtFMAvG58/4uerYllV9Gfou7w+I1aglwB6hihTREzKltVjARWV6A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/matrix-widget-api/-/matrix-widget-api-1.6.0.tgz",
+      "integrity": "sha512-VXIJyAZ/WnBmT4C7ePqevgMYGneKMCP/0JuCOqntSsaNlCRHJvwvTxmqUU+ufOpzIF5gYNyIrAjbgrEbK3iqJQ==",
       "requires": {
         "@types/events": "^3.0.0",
         "events": "^3.2.0"
@@ -47246,6 +47282,15 @@
     },
     "obuf": {
       "version": "1.1.2"
+    },
+    "oidc-client-ts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.4.0.tgz",
+      "integrity": "sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==",
+      "requires": {
+        "crypto-js": "^4.2.0",
+        "jwt-decode": "^3.1.2"
+      }
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
     "lodash.uniqby": "^4.7.0",
-    "matrix-js-sdk": "^26.2.0",
+    "matrix-js-sdk": "^29.1.0",
     "millify": "^6.1.0",
     "moment": "^2.29.4",
     "normalizr": "^3.6.2",


### PR DESCRIPTION
### What does this do?
- bumps matrix-js-sdk `^26.2.0` -> `^29.1.0`

### Why are we making this change?
- fixes notifications count property value

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
