### PR TITLE
Adds modal for creating and restoring a key backup

### DIFF
--- a/src/components/secure-backup/container.tsx
+++ b/src/components/secure-backup/container.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
+import { SecureBackup } from '.';
+import { clearBackup, generateBackup, getBackup, restoreBackup, saveBackup } from '../../store/matrix';
+
+export interface PublicProperties {
+  onClose?: () => void;
+}
+
+export interface Properties extends PublicProperties {
+  isLoaded: boolean;
+  backupExists: boolean;
+  isBackupRecovered: boolean;
+  recoveryKey: string;
+
+  getBackup: () => void;
+  generateBackup: () => void;
+  saveBackup: () => void;
+  restoreBackup: (recoveryKey: string) => void;
+  clearBackup: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState) {
+    const { isLoaded, backup, trustInfo } = state.matrix;
+    return {
+      isLoaded,
+      backupExists: !!trustInfo,
+      isBackupRecovered: trustInfo?.usable || trustInfo?.trustedLocally,
+      recoveryKey: backup?.recovery_key,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { generateBackup, saveBackup, restoreBackup, getBackup, clearBackup };
+  }
+
+  componentDidMount(): void {
+    this.props.getBackup();
+  }
+
+  componentWillUnmount(): void {
+    this.props.clearBackup();
+  }
+
+  render() {
+    if (!this.props.isLoaded) {
+      return null;
+    }
+
+    return (
+      <SecureBackup
+        backupExists={this.props.backupExists}
+        isBackupRecovered={this.props.isBackupRecovered}
+        recoveryKey={this.props.recoveryKey}
+        onClose={this.props.onClose}
+        onGenerate={this.props.generateBackup}
+        onSave={this.props.saveBackup}
+        onRestore={this.props.restoreBackup}
+      />
+    );
+  }
+}
+
+export const SecureBackupContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -1,0 +1,109 @@
+import { shallow } from 'enzyme';
+
+import { SecureBackup, Properties } from '.';
+import { Button, Input } from '@zero-tech/zui/components';
+import { bem } from '../../lib/bem';
+
+const c = bem('.secure-backup');
+
+describe('SecureBackup', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      recoveryKey: 'stub-key',
+      backupExists: false,
+      isBackupRecovered: false,
+      onGenerate: () => null,
+      onRestore: () => null,
+      onSave: () => null,
+      onClose: () => null,
+      clipboard: { write: () => null },
+      ...props,
+    };
+
+    return shallow(<SecureBackup {...allProps} />);
+  };
+
+  it('generates a backup when Generate is pressed', function () {
+    const onGenerate = jest.fn();
+    const wrapper = subject({ onGenerate, recoveryKey: '' });
+
+    pressButton(wrapper, 'Generate backup');
+
+    expect(onGenerate).toHaveBeenCalledOnce();
+  });
+
+  it('renders the recovery key when in create mode', function () {
+    const wrapper = subject({ recoveryKey: 'stuff' });
+
+    expect(wrapper.find(c('recovery-key')).text()).toEqual('stuff');
+  });
+
+  it('does not render the recovery key if none is provided', function () {
+    const wrapper = subject({ recoveryKey: '' });
+
+    expect(wrapper).not.toHaveElement(c('recovery-key'));
+  });
+
+  it('copies the recovery key to the clipboard', function () {
+    const clipboard = { write: jest.fn() };
+    const wrapper = subject({ clipboard, recoveryKey: '2938 1929' });
+
+    pressButton(wrapper, 'Copy');
+
+    expect(clipboard.write).toHaveBeenCalledWith(expect.stringContaining('2938 1929'));
+  });
+
+  it('enables the Save Backup button when code has been copied', function () {
+    const wrapper = subject({ recoveryKey: '2938 1929' });
+
+    expect(buttonLabelled(wrapper, 'Save backup').prop('isDisabled')).toBeTrue();
+    pressButton(wrapper, 'Copy');
+
+    expect(buttonLabelled(wrapper, 'Save backup').prop('isDisabled')).toBeFalse();
+  });
+
+  it('publishes event when Save is clicked', function () {
+    const onSave = jest.fn();
+    const wrapper = subject({ onSave, recoveryKey: '2938 1929' });
+
+    pressButton(wrapper, 'Copy');
+    pressButton(wrapper, 'Save backup');
+
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it('does not show Restore button if backup does not exist', function () {
+    const wrapper = subject({ backupExists: false });
+
+    expect(buttonLabelled(wrapper, 'Restore backup').exists()).toBe(false);
+  });
+
+  it('publishes event when Restore is clicked', function () {
+    const onRestore = jest.fn();
+    const wrapper = subject({ onRestore, backupExists: true, recoveryKey: '' });
+
+    changeRecoveryKeyInput(wrapper, 'abcd 1234');
+    pressButton(wrapper, 'Restore backup');
+
+    expect(onRestore).toHaveBeenCalledWith('abcd 1234');
+  });
+
+  it('renders backed up state if existing backup is fully trusted', function () {
+    const onRestore = jest.fn();
+    const wrapper = subject({ onRestore, backupExists: true, isBackupRecovered: true, recoveryKey: '' });
+
+    expect(wrapper).toHaveElement(c('backed-up'));
+  });
+});
+
+function pressButton(wrapper, label: string) {
+  buttonLabelled(wrapper, label).simulate('press');
+}
+
+function buttonLabelled(wrapper, label) {
+  return wrapper.findWhere((node) => node.type() === Button && node.children().text() === label);
+}
+
+function changeRecoveryKeyInput(wrapper, value) {
+  wrapper.find(Input).simulate('change', value);
+}

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+
+import { Button, IconButton, Input } from '@zero-tech/zui/components';
+
+import { clipboard } from '../../lib/clipboard';
+
+import { bemClassName } from '../../lib/bem';
+import './styles.scss';
+import { IconXClose } from '@zero-tech/zui/icons';
+
+const cn = bemClassName('secure-backup');
+
+export interface Clipboard {
+  write: (text: string) => Promise<void>;
+}
+
+export interface Properties {
+  recoveryKey: string;
+  backupExists: boolean;
+  isBackupRecovered: boolean;
+
+  clipboard?: Clipboard;
+
+  onClose: () => void;
+  onGenerate: () => void;
+  onSave: () => void;
+  onRestore: (recoveryKey) => void;
+}
+
+export interface State {
+  userInputRecoveryKey: string;
+  hasCopied: boolean;
+}
+
+export class SecureBackup extends React.PureComponent<Properties, State> {
+  static defaultProps = { clipboard: clipboard };
+
+  state = { userInputRecoveryKey: '', hasCopied: false };
+
+  copyKey = () => {
+    this.props.clipboard.write(this.props.recoveryKey);
+    this.setState({ hasCopied: true });
+  };
+
+  trackRecoveryKey = (value) => {
+    this.setState({ userInputRecoveryKey: value });
+  };
+
+  get isRecovered() {
+    return this.props.backupExists && this.props.isBackupRecovered && !this.props.recoveryKey;
+  }
+
+  get noBackupExists() {
+    return !this.props.backupExists && !this.props.recoveryKey;
+  }
+
+  get backupNotRestored() {
+    return this.props.backupExists && !this.props.isBackupRecovered;
+  }
+
+  renderBackedUpMode() {
+    return (
+      <div {...cn('backed-up')}>
+        <p>This session is backing up your keys.</p>
+        <p>This backup is trusted because it has been restored on this session.</p>
+        {this.renderButtons(<Button onPress={() => this.props.onGenerate()}>Generate new backup</Button>)}
+      </div>
+    );
+  }
+
+  renderNoBackupMode() {
+    return (
+      <>
+        <p>
+          Your keys are <b>not being backed up from this session.</b>
+        </p>
+        <p>Back up your keys before signing out to avoid losing them.</p>
+        {this.renderButtons(<Button onPress={() => this.props.onGenerate()}>Generate backup</Button>)}
+      </>
+    );
+  }
+
+  renderCreationMode() {
+    return (
+      <>
+        <p>
+          The following recovery key has been generated for you. Click `Copy` to copy it to your clipboard. Store it in
+          a secure place such as a password manager of vault then click `Save Backup` to complete the backup process.
+        </p>
+        {this.props.recoveryKey && <div {...cn('recovery-key')}>{this.props.recoveryKey}</div>}
+        {this.renderButtons(
+          <>
+            {this.props.recoveryKey && <Button onPress={this.copyKey}>Copy</Button>}
+            <Button onPress={() => this.props.onSave()} isDisabled={!this.state.hasCopied}>
+              Save backup
+            </Button>
+          </>
+        )}
+      </>
+    );
+  }
+
+  renderRestoreMode() {
+    return (
+      <>
+        <Input
+          placeholder='Enter your recovery key'
+          onChange={this.trackRecoveryKey}
+          value={this.state.userInputRecoveryKey}
+        />
+        {this.renderButtons(
+          <Button onPress={() => this.props.onRestore(this.state.userInputRecoveryKey)}>Restore backup</Button>
+        )}
+      </>
+    );
+  }
+
+  renderButtons = (buttons) => {
+    return <div {...cn('footer')}>{buttons}</div>;
+  };
+
+  render() {
+    return (
+      <div {...cn()}>
+        <div {...cn('header')}>
+          <h3 {...cn('title')}>Secure Backup</h3>
+          <IconButton {...cn('close')} Icon={IconXClose} onClick={this.props.onClose} size={32} />
+        </div>
+        <p>
+          Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will
+          be secured with a unique Security Key.
+        </p>
+        {this.isRecovered && this.renderBackedUpMode()}
+        {this.noBackupExists && this.renderNoBackupMode()}
+        {this.props.recoveryKey && this.renderCreationMode()}
+        {this.backupNotRestored && this.renderRestoreMode()}
+      </div>
+    );
+  }
+}

--- a/src/components/secure-backup/styles.scss
+++ b/src/components/secure-backup/styles.scss
@@ -39,4 +39,14 @@
     justify-content: flex-end;
     gap: 16px;
   }
+
+  &__recovery-key {
+    padding: 16px;
+    border: 1px solid var(--color-greyscale-6);
+    background: var(--color-greyscale-2);
+    border-radius: 8px;
+    color: var(--color-greyscale-11);
+    font-weight: 400;
+    font-size: 16px;
+  }
 }

--- a/src/components/secure-backup/styles.scss
+++ b/src/components/secure-backup/styles.scss
@@ -1,0 +1,42 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.secure-backup {
+  max-width: 350px;
+
+  &__header {
+    display: flex;
+    height: 52px;
+    border-bottom: 1px solid theme.$color-primary-4;
+    margin-bottom: 40px;
+
+    color: theme.$color-greyscale-12;
+
+    > *:first-child {
+      flex-grow: 1;
+    }
+
+    > *:last-child {
+      flex-grow: 0;
+    }
+  }
+
+  &__title {
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 29px;
+    margin: 0px;
+  }
+
+  &__close {
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  &__footer {
+    margin-top: 40px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+  }
+}

--- a/src/components/settings-menu/index.test.tsx
+++ b/src/components/settings-menu/index.test.tsx
@@ -3,6 +3,12 @@ import { shallow } from 'enzyme';
 import { Properties, SettingsMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
 import { EditProfileContainer } from '../edit-profile/container';
+import { SecureBackupContainer } from '../secure-backup/container';
+
+const featureFlags = { enableMatrix: false };
+jest.mock('../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
 
 describe('settings-menu', () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -31,8 +37,18 @@ describe('settings-menu', () => {
     const editProfileItem = dropdownMenu.prop('items').find((item) => item.id === 'edit_profile');
     editProfileItem.onSelect();
 
-    // Verify that the EditProfileContainer component is rendered
-    expect(wrapper.find(EditProfileContainer).exists()).toBe(true);
+    expect(wrapper.find(EditProfileContainer).parent().prop('open')).toBe(true);
+  });
+
+  it('opens secure backup dialog', function () {
+    featureFlags.enableMatrix = true;
+
+    const wrapper = subject({});
+    const dropdownMenu = wrapper.find(DropdownMenu);
+    const menuItem = dropdownMenu.prop('items').find((item) => item.id === 'secure_backup');
+    menuItem.onSelect();
+
+    expect(wrapper.find(SecureBackupContainer).parent().prop('open')).toBe(true);
   });
 
   it('calls onLogout prop when logout item is selected', function () {

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
 import { EditProfileContainer } from '../edit-profile/container';
-import { IconLogOut3, IconUser1 } from '@zero-tech/zui/icons';
+import { IconLock1, IconLogOut3, IconUser1 } from '@zero-tech/zui/icons';
 import { Address, Avatar, DropdownMenu, Modal } from '@zero-tech/zui/components';
 
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
+import { SecureBackupContainer } from '../secure-backup/container';
+import { featureFlags } from '../../lib/feature-flags';
 
 export interface Properties {
   userName: string;
@@ -19,6 +21,7 @@ export interface Properties {
 interface State {
   isDropdownOpen: boolean;
   editProfileDialogOpen: boolean;
+  backupDialogOpen: boolean;
 }
 
 export class SettingsMenu extends React.Component<Properties, State> {
@@ -27,6 +30,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
     this.state = {
       isDropdownOpen: false,
       editProfileDialogOpen: false,
+      backupDialogOpen: false,
     };
   }
 
@@ -67,10 +71,25 @@ export class SettingsMenu extends React.Component<Properties, State> {
     this.setState({ editProfileDialogOpen: false });
   };
 
+  openBackupDialog = (): void => {
+    this.setState({ backupDialogOpen: true });
+  };
+  closeBackupDialog = (): void => {
+    this.setState({ backupDialogOpen: false });
+  };
+
   renderEditProfileDialog = (): JSX.Element => {
     return (
       <Modal open={this.state.editProfileDialogOpen} onOpenChange={this.closeEditProfileDialog}>
         <EditProfileContainer onClose={this.closeEditProfileDialog} />
+      </Modal>
+    );
+  };
+
+  renderBackupDialog = (): JSX.Element => {
+    return (
+      <Modal open={this.state.backupDialogOpen} onOpenChange={this.closeBackupDialog}>
+        <SecureBackupContainer onClose={this.closeBackupDialog} />
       </Modal>
     );
   };
@@ -83,36 +102,53 @@ export class SettingsMenu extends React.Component<Properties, State> {
     );
   }
 
+  get menuItems() {
+    const options = [
+      {
+        className: 'edit_profile',
+        id: 'edit_profile',
+        label: this.renderSettingsOption(<IconUser1 />, 'Edit Profile'),
+        onSelect: this.openEditProfileDialog,
+      },
+    ];
+
+    if (featureFlags.enableMatrix) {
+      options.push({
+        className: 'secure_backup',
+        id: 'secure_backup',
+        label: this.renderSettingsOption(<IconLock1 />, 'Secure Backup'),
+        onSelect: this.openBackupDialog,
+      });
+    }
+
+    return [
+      {
+        id: 'header',
+        label: this.renderSettingsHeader(),
+        onSelect: () => {},
+      },
+      ...options,
+      {
+        className: 'divider',
+        id: 'divider',
+        label: <div />,
+        onSelect: () => {},
+      },
+      {
+        className: 'logout',
+        id: 'logout',
+        label: this.renderSettingsOption(<IconLogOut3 />, 'Log Out'),
+        onSelect: () => this.handleLogout(),
+      },
+    ];
+  }
+
   render() {
     return (
       <>
         <DropdownMenu
           menuClassName={'settings-menu'}
-          items={[
-            {
-              id: 'header',
-              label: this.renderSettingsHeader(),
-              onSelect: () => {},
-            },
-            {
-              className: 'edit_profile',
-              id: 'edit_profile',
-              label: this.renderSettingsOption(<IconUser1 />, 'Edit Profile'),
-              onSelect: this.openEditProfileDialog,
-            },
-            {
-              className: 'divider',
-              id: 'divider',
-              label: <div />,
-              onSelect: () => {},
-            },
-            {
-              className: 'logout',
-              id: 'logout',
-              label: this.renderSettingsOption(<IconLogOut3 />, 'Log Out'),
-              onSelect: () => this.handleLogout(),
-            },
-          ]}
+          items={this.menuItems}
           side='right'
           alignMenu='start'
           onOpenChange={this.handleOpenChange}
@@ -126,6 +162,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
           }
         />
         {this.renderEditProfileDialog()}
+        {this.renderBackupDialog()}
       </>
     );
   }

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -10,6 +10,8 @@ import './styles.scss';
 import { SecureBackupContainer } from '../secure-backup/container';
 import { featureFlags } from '../../lib/feature-flags';
 
+const cn = bemClassName('settings-menu');
+
 export interface Properties {
   userName: string;
   userHandle: string;
@@ -88,7 +90,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
 
   renderBackupDialog = (): JSX.Element => {
     return (
-      <Modal open={this.state.backupDialogOpen} onOpenChange={this.closeBackupDialog}>
+      <Modal open={this.state.backupDialogOpen} onOpenChange={this.closeBackupDialog} {...cn('secure-backup-modal')}>
         <SecureBackupContainer onClose={this.closeBackupDialog} />
       </Modal>
     );

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -58,4 +58,10 @@
   .zui-dropdown-item.logout {
     color: theme.$color-failure-11;
   }
+
+  &__secure-backup-modal {
+    &:focus-visible {
+      outline: none;
+    }
+  }
 }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -62,6 +62,10 @@ export interface IChatClient {
     mentionedUserIds: string[],
     data?: Partial<EditMessageOptions>
   ): Promise<any>;
+  getSecureBackup: () => Promise<any>;
+  generateSecureBackup: () => Promise<any>;
+  saveSecureBackup: (any) => Promise<any>;
+  restoreSecureBackup: (recoveryKey: string) => Promise<any>;
 }
 
 export class Chat {
@@ -136,6 +140,22 @@ export class Chat {
 
   async fetchConversationsWithUsers(users: User[]): Promise<any[]> {
     return this.client.fetchConversationsWithUsers(users);
+  }
+
+  async getSecureBackup(): Promise<any> {
+    return this.client.getSecureBackup();
+  }
+
+  async generateSecureBackup(): Promise<any> {
+    return this.client.generateSecureBackup();
+  }
+
+  async saveSecureBackup(backup: any): Promise<any> {
+    return this.client.saveSecureBackup(backup);
+  }
+
+  async restoreSecureBackup(recoveryKey: string): Promise<any> {
+    return this.client.restoreSecureBackup(recoveryKey);
   }
 
   initChat(events: RealtimeChatEvents): void {

--- a/src/lib/chat/sendbird-client.ts
+++ b/src/lib/chat/sendbird-client.ts
@@ -36,6 +36,22 @@ export class SendbirdClient implements IChatClient {
     }, 10 * 1000);
   }
 
+  async getSecureBackup() {
+    return null;
+  }
+
+  async generateSecureBackup() {
+    return null;
+  }
+
+  async saveSecureBackup(_backup) {
+    return null;
+  }
+
+  async restoreSecureBackup() {
+    return null;
+  }
+
   supportsOptimisticCreateConversation() {
     return true;
   }

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -1,0 +1,46 @@
+import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export enum SagaActionTypes {
+  GetBackup = 'chat/get-backup',
+  GenerateBackup = 'chat/generate-backup',
+  SaveBackup = 'chat/save-backup',
+  RestoreBackup = 'chat/restore-backup',
+  ClearBackup = 'chat/clear-backup',
+}
+
+export type MatrixState = {
+  isLoaded: boolean;
+  trustInfo: { trustedLocally: boolean; usable: boolean } | null;
+  backup: any | null;
+};
+
+export const initialState: MatrixState = {
+  isLoaded: false,
+  trustInfo: null,
+  backup: null,
+};
+
+export const getBackup = createAction(SagaActionTypes.GetBackup);
+export const generateBackup = createAction(SagaActionTypes.GenerateBackup);
+export const saveBackup = createAction(SagaActionTypes.SaveBackup);
+export const restoreBackup = createAction<string>(SagaActionTypes.RestoreBackup);
+export const clearBackup = createAction(SagaActionTypes.ClearBackup);
+
+const slice = createSlice({
+  name: 'matrix',
+  initialState,
+  reducers: {
+    setLoaded: (state, action: PayloadAction<MatrixState['isLoaded']>) => {
+      state.isLoaded = action.payload;
+    },
+    setBackup: (state, action: PayloadAction<MatrixState['backup']>) => {
+      state.backup = action.payload;
+    },
+    setTrustInfo: (state, action: PayloadAction<MatrixState['trustInfo']>) => {
+      state.trustInfo = action.payload;
+    },
+  },
+});
+
+export const { setLoaded, setBackup, setTrustInfo } = slice.actions;
+export const { reducer } = slice;

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -1,0 +1,33 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { call } from 'redux-saga/effects';
+import { throwError } from 'redux-saga-test-plan/providers';
+
+import { start } from './saga';
+import { apiCall } from './api';
+import { MatrixState, initialState as initialMatrixState } from '.';
+
+import { rootReducer } from '../reducer';
+
+describe('start', () => {
+  it('makes api call', async () => {
+    await expectSaga(start, { payload: {} })
+      .provide([
+        [
+          call(apiCall, {}),
+          { success: true, response: {} },
+        ],
+      ])
+      .withReducer(rootReducer, initialState({}))
+      .call(apiCall, {})
+      .run();
+  });
+});
+
+function initialState(attrs: Partial<MatrixState> = {}) {
+  return {
+    matrix: {
+      ...initialMatrixState,
+      ...attrs,
+    },
+  } as any;
+}

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -24,7 +24,10 @@ describe(getBackup, () => {
   it('fetches the existing backup', async () => {
     const { storeState } = await subject(getBackup)
       .provide([
-        [call([chatClient, chatClient.getSecureBackup]), { trustInfo: { usable: true, trusted_locally: true } }],
+        [
+          call([chatClient, chatClient.getSecureBackup]),
+          { backupInfo: {}, trustInfo: { usable: true, trusted_locally: true } },
+        ],
       ])
       .withReducer(rootReducer)
       .run();
@@ -39,6 +42,19 @@ describe(getBackup, () => {
   it('clears the backup if none found', async () => {
     const { storeState } = await subject(getBackup)
       .provide([[call([chatClient, chatClient.getSecureBackup]), undefined]])
+      .withReducer(rootReducer)
+      .run();
+
+    expect(storeState.matrix).toEqual({
+      backup: null,
+      isLoaded: true,
+      trustInfo: null,
+    });
+  });
+
+  it('clears the backup if backupInfo not found', async () => {
+    const { storeState } = await subject(getBackup)
+      .provide([[call([chatClient, chatClient.getSecureBackup]), { backupInfo: undefined }]])
       .withReducer(rootReducer)
       .run();
 

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -107,6 +107,14 @@ describe(restoreBackup, () => {
       .call([chatClient, chatClient.restoreSecureBackup], 'recovery-key')
       .run();
   });
+
+  it('resets the state when restoring is successsful', async () => {
+    await subject(restoreBackup, { payload: 'recovery-key' })
+      .provide([[call([chatClient, chatClient.restoreSecureBackup], 'recovery-key'), undefined]])
+      .withReducer(rootReducer)
+      .call(getBackup)
+      .run();
+  });
 });
 
 describe(clearBackupState, () => {

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -15,7 +15,7 @@ export function* getBackup() {
   yield put(setLoaded(false));
   const chatClient = yield call(chat.get);
   const existingBackup = yield call([chatClient, chatClient.getSecureBackup]);
-  if (!existingBackup) {
+  if (!existingBackup || !existingBackup.backupInfo) {
     yield put(setTrustInfo(null));
   } else {
     yield put(

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -1,0 +1,50 @@
+import { put, select, takeLatest } from 'redux-saga/effects';
+
+import { SagaActionTypes, setBackup, setLoaded, setTrustInfo } from '.';
+import { chat } from '../../lib/chat';
+
+export function* saga() {
+  yield takeLatest(SagaActionTypes.GetBackup, getBackup);
+  yield takeLatest(SagaActionTypes.GenerateBackup, generateBackup);
+  yield takeLatest(SagaActionTypes.SaveBackup, saveBackup);
+  yield takeLatest(SagaActionTypes.RestoreBackup, restoreBackup);
+  yield takeLatest(SagaActionTypes.ClearBackup, clearBackupState);
+}
+
+export function* getBackup() {
+  const existingBackup = yield chat.get().getSecureBackup();
+  if (!existingBackup) {
+    yield put(setTrustInfo(null));
+  } else {
+    yield put(
+      setTrustInfo({
+        usable: existingBackup.trustInfo.usable,
+        trustedLocally: existingBackup.trustInfo.trusted_locally,
+      })
+    );
+  }
+  yield put(setLoaded(true));
+}
+
+export function* generateBackup() {
+  const newBackup = yield chat.get().generateSecureBackup();
+  yield put(setBackup(newBackup));
+}
+
+export function* saveBackup() {
+  const backup = yield select((state) => state.matrix.backup);
+  yield chat.get().saveSecureBackup(backup);
+  yield put(setBackup(null));
+  yield getBackup();
+}
+
+export function* restoreBackup(action) {
+  const recoveryKey = action.payload;
+  return yield chat.get().restoreSecureBackup(recoveryKey);
+}
+
+export function* clearBackupState() {
+  yield put(setLoaded(false));
+  yield put(setTrustInfo(null));
+  yield put(setBackup(null));
+}

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -47,7 +47,8 @@ export function* saveBackup() {
 export function* restoreBackup(action) {
   const chatClient = yield call(chat.get);
   const recoveryKey = action.payload;
-  return yield call([chatClient, chatClient.restoreSecureBackup], recoveryKey);
+  yield call([chatClient, chatClient.restoreSecureBackup], recoveryKey);
+  yield call(getBackup);
 }
 
 export function* clearBackupState() {

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -19,6 +19,7 @@ import { reducer as rewards } from './rewards';
 import { reducer as editProfile } from './edit-profile';
 import { reducer as requestPasswordReset } from './request-password-reset';
 import { reducer as confirmPasswordReset } from './confirm-password-reset';
+import { reducer as matrix } from './matrix';
 
 export const rootReducer = combineReducers({
   pageload,
@@ -40,6 +41,7 @@ export const rootReducer = combineReducers({
   editProfile,
   requestPasswordReset,
   confirmPasswordReset,
+  matrix,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -21,6 +21,7 @@ import { saga as editProfile } from './edit-profile/saga';
 import { saga as users } from './users/saga';
 import { saga as requestPasswordReset } from './request-password-reset/saga';
 import { saga as confirmPasswordReset } from './confirm-password-reset/saga';
+import { saga as matrix } from './matrix/saga';
 
 export function* rootSaga() {
   const allSagas = {
@@ -45,6 +46,7 @@ export function* rootSaga() {
     users,
     requestPasswordReset,
     confirmPasswordReset,
+    matrix,
   };
 
   yield all(


### PR DESCRIPTION
### What does this do?

Modal for managing the Matrix key backup

Note: Success messaging and error messaging to be handled in follow ups.

### Why are we making this change?

To allow users to login to a completely different session and decrypt old messages.


![image](https://github.com/zer0-os/zOS/assets/43770/691b3cff-40c6-4968-8ed3-5abe50875232)

![image](https://github.com/zer0-os/zOS/assets/43770/611d28f9-53f2-4069-9b44-083063060d38)

![image](https://github.com/zer0-os/zOS/assets/43770/7482857f-3db2-49db-afa8-85046a7c197a)
