### PR TITLE
Update some github action dependency versions

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
       uses: actions/setup-node@v3

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -10,10 +10,10 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ssh-key: '${{ secrets.COMMIT_KEY }}'
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - run: ./.github/create-tag

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       REACT_APP_INFURA_URL: ${{secrets.INFURA_URL}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Common Setup
         uses: ./.github/actions/common
 
@@ -53,7 +53,7 @@ jobs:
       REACT_APP_ANDROID_STORE_PATH: ${{vars.ANDROID_STORE_PATH}}
       REACT_APP_MATRIX_HOME_SERVER_URL: ${{vars.MATRIX_HOME_SERVER_URL}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Common Setup
         uses: ./.github/actions/common
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,8 +36,8 @@ jobs:
       REACT_APP_ANDROID_STORE_PATH: ${{vars.ANDROID_STORE_PATH}}
       REACT_APP_MATRIX_HOME_SERVER_URL: ${{vars.MATRIX_HOME_SERVER_URL}}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - run: echo '//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}' >> .npmrc

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       REACT_APP_INFURA_URL: ${{secrets.INFURA_URL}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Common Setup
         uses: ./.github/actions/common
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       REACT_APP_INFURA_URL: ${{secrets.INFURA_URL}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Common Setup
         uses: ./.github/actions/common
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       REACT_APP_INFURA_URL: ${{secrets.INFURA_URL}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Common Setup
         uses: ./.github/actions/common
 

--- a/.github/workflows/run-typecheck.yml
+++ b/.github/workflows/run-typecheck.yml
@@ -10,7 +10,7 @@ jobs:
   run-typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Common Setup
         uses: ./.github/actions/common
 


### PR DESCRIPTION
### What does this do?

Updates some github action dependencies (checkout@v4 and setup-node@v3)

### Why are we making this change?

It may resolve some github action warnings about deprecations.

