### PR TITLE
feat: initiate creator conversation admin messages

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -44,8 +44,8 @@ export interface IChatClient {
     name: string,
     image: File,
     optimisticId: string,
-    adminMessageType?: AdminMessageType,
-    currentUserId?: string
+    adminMessageType: AdminMessageType,
+    currentUserId: string
   ) => Promise<Partial<Channel> | void>;
   sendMessagesByChannelId: (
     channelId: string,
@@ -104,8 +104,8 @@ export class Chat {
     name: string,
     image: File,
     optimisticId: string,
-    adminMessageType?: AdminMessageType,
-    currentUserId?: string
+    adminMessageType: AdminMessageType,
+    currentUserId: string
   ) {
     return this.client.createConversation(users, name, image, optimisticId, adminMessageType, currentUserId);
   }

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -4,6 +4,7 @@ import { setAsDM } from './matrix/utils';
 import { uploadImage as _uploadImage } from '../../store/channels-list/api';
 import { when } from 'jest-when';
 import { config } from '../../config';
+import { AdminMessageType } from '../../store/messages';
 
 jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
 
@@ -478,7 +479,14 @@ describe('matrix client', () => {
       const sendEvent = jest.fn().mockResolvedValue(undefined);
       const client = await subject({ createRoom, sendEvent });
 
-      await client.createConversation([{ userId: 'id', matrixId: '@somebody.else' }], null, null, null);
+      await client.createConversation(
+        [{ userId: 'id', matrixId: '@somebody.else' }],
+        null,
+        null,
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
+      );
 
       expect(createRoom).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -495,7 +503,14 @@ describe('matrix client', () => {
 
       const client = await subject({ createRoom, sendEvent });
 
-      await client.createConversation([{ userId: 'id', matrixId: '@somebody.else' }], null, null, null);
+      await client.createConversation(
+        [{ userId: 'id', matrixId: '@somebody.else' }],
+        null,
+        null,
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
+      );
 
       expect(createRoom).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -511,7 +526,14 @@ describe('matrix client', () => {
       const sendEvent = jest.fn().mockResolvedValue(undefined);
       const client = await subject({ createRoom, sendEvent });
 
-      await client.createConversation([{ userId: 'id', matrixId: '@somebody.else' }], null, null, null);
+      await client.createConversation(
+        [{ userId: 'id', matrixId: '@somebody.else' }],
+        null,
+        null,
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
+      );
 
       expect(createRoom).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -531,7 +553,14 @@ describe('matrix client', () => {
       ];
       const client = await subject({ createRoom, sendEvent });
 
-      await client.createConversation(users, null, null, null);
+      await client.createConversation(
+        users,
+        null,
+        null,
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
+      );
 
       expect(createRoom).toHaveBeenCalledWith(expect.objectContaining({ invite: ['@first.user', '@second.user'] }));
     });
@@ -542,7 +571,14 @@ describe('matrix client', () => {
       const users = [{ userId: 'id-1', matrixId: '@first.user' }];
       const client = await subject({ createRoom, sendEvent });
 
-      await client.createConversation(users, null, null, null);
+      await client.createConversation(
+        users,
+        null,
+        null,
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
+      );
 
       expect(setAsDM).toHaveBeenCalledWith(expect.anything(), 'test-room', '@first.user');
     });
@@ -552,7 +588,14 @@ describe('matrix client', () => {
       const sendEvent = jest.fn().mockResolvedValue(undefined);
       const client = await subject({ createRoom, sendEvent });
 
-      await client.createConversation([{ userId: 'id', matrixId: '@somebody.else' }], 'room-name', null, null);
+      await client.createConversation(
+        [{ userId: 'id', matrixId: '@somebody.else' }],
+        'room-name',
+        null,
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
+      );
 
       expect(createRoom).toHaveBeenCalledWith(expect.objectContaining({ name: 'room-name' }));
     });
@@ -567,7 +610,9 @@ describe('matrix client', () => {
         [{ userId: 'id', matrixId: '@somebody.else' }],
         null,
         { name: 'test file' } as File,
-        null
+        null,
+        AdminMessageType.CONVERSATION_STARTED,
+        'current-user-id'
       );
 
       expect(createRoom).toHaveBeenCalledWith(

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -221,8 +221,8 @@ export class MatrixClient implements IChatClient {
     name: string = null,
     image: File = null,
     _optimisticId: string,
-    adminMessageType?: AdminMessageType,
-    currentUserId?: string
+    adminMessageType: AdminMessageType,
+    currentUserId: string
   ) {
     await this.waitForConnection();
     const coverUrl = await this.uploadCoverImage(image);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -254,12 +254,7 @@ export class MatrixClient implements IChatClient {
     return this.mapConversation(this.matrix.getRoom(result.room_id));
   }
 
-  private async sendAdminMessage(
-    roomId: string,
-    inviterId: string,
-    currentUserId: string,
-    type: AdminMessageType = AdminMessageType.CONVERSATION_STARTED
-  ) {
+  private async sendAdminMessage(roomId: string, inviterId: string, currentUserId: string, type: AdminMessageType) {
     let content: any = {
       type,
       body: 'You have joined a conversation.',

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -179,7 +179,10 @@ export class MatrixClient implements IChatClient {
 
   private processRawEventsToMessages(events): any[] {
     const messages = events.filter(
-      (event) => event.type === EventType.RoomMessage && !this.isDeleted(event) && !this.isEditEvent(event)
+      (event) =>
+        (event.type === EventType.RoomMessage || event.type === CustomEventType.SEND_ADMIN_MESSAGE) &&
+        !this.isDeleted(event) &&
+        !this.isEditEvent(event)
     );
 
     events.filter(this.isEditEvent).forEach((event) => {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -28,7 +28,7 @@ export function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient
       profileImage: '',
       profileId: '',
     },
-    isAdmin: isAdmin,
+    isAdmin,
     admin: adminData,
     optimisticId: content.optimisticId,
     ...{

--- a/src/store/channels-list/saga.createConversation.test.ts
+++ b/src/store/channels-list/saga.createConversation.test.ts
@@ -67,6 +67,8 @@ describe(createConversation, () => {
     const otherUserIds = ['user-1'];
     const name = 'name';
     const image = { name: 'file' } as File;
+    const adminMessageType = AdminMessageType.CONVERSATION_STARTED;
+    const currentUser = 'current-user';
 
     const stubOptimisticConversation = { id: 'optimistic-id' };
 
@@ -75,7 +77,7 @@ describe(createConversation, () => {
       createConversation: () => undefined,
     };
 
-    testSaga(createConversation, otherUserIds, name, image)
+    testSaga(createConversation, otherUserIds, name, image, adminMessageType, currentUser)
       .next()
       .call(chat.get)
       .next(chatClient)

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -150,7 +150,7 @@ export function* createConversation(
   userIds: string[],
   name: string = null,
   image: File = null,
-  adminMessageType?: AdminMessageType,
+  adminMessageType: AdminMessageType,
   currentUserId: string = null
 ) {
   const chatClient = yield call(chat.get);

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -15,6 +15,8 @@ import { channelsReceived, createConversation as performCreateConversation } fro
 import { rootReducer } from '../reducer';
 import { StoreBuilder } from '../test/store';
 import { chat } from '../../lib/chat';
+import { AdminMessageType } from '../messages';
+import { currentUserSelector } from '../authentication/selectors';
 
 describe('create conversation saga', () => {
   describe('startConversation', () => {
@@ -174,13 +176,26 @@ describe('create conversation saga', () => {
         userIds: ['test'],
         name: 'test name',
         image: {},
+        adminMessageType: AdminMessageType.CONVERSATION_STARTED,
+        currentUserId: 'current-user-id',
       };
+
+      const currentUser = { id: 'current-user-id' };
 
       return testSaga(createConversation, { payload: testPayload })
         .next()
+        .select(currentUserSelector)
+        .next(currentUser)
         .put(setGroupCreating(true))
         .next()
-        .call(performCreateConversation, ['test'], 'test name', {})
+        .call(
+          performCreateConversation,
+          ['test'],
+          'test name',
+          {},
+          AdminMessageType.CONVERSATION_STARTED,
+          'current-user-id'
+        )
         .next()
         .put(setGroupCreating(false));
     });

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -6,6 +6,7 @@ import { Events, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/selectors';
 import { Chat, chat } from '../../lib/chat';
 import { denormalize as denormalizeUsers } from '../users';
+import { AdminMessageType } from '../messages';
 
 export function* reset() {
   yield put(setGroupUsers([]));
@@ -48,10 +49,11 @@ export function* performGroupMembersSelected(userSelections: { value: string; la
 }
 
 export function* createConversation(action) {
+  const currentUser = yield select(currentUserSelector);
   const { userIds, name, image } = action.payload;
   try {
     yield put(setGroupCreating(true));
-    yield call(performCreateConversation, userIds, name, image);
+    yield call(performCreateConversation, userIds, name, image, AdminMessageType.CONVERSATION_STARTED, currentUser.id);
   } finally {
     yield put(setGroupCreating(false));
   }

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -182,7 +182,7 @@ export function* updateProfile(action) {
         return {
           userId: userData.id,
           firstName: userData.profileSummary.firstName,
-          profileImage: userData.profileImage,
+          profileImage: userData.profileSummary.profileImage,
           matrixId: userData.matrixId,
         };
       };


### PR DESCRIPTION
Follow up Admin Messages PR.

### What does this do?
- adds the correct admin messages to creator conversations (rather than joined conversations).

### Why are we making this change?
- to ensure a conversation is created and initiated with an admin message.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Creator Demo:

https://github.com/zer0-os/zOS/assets/39112648/e34028e2-f05b-4f7a-8dd5-6ab2482f4d34


<img width="1110" alt="Screenshot 2023-11-06 at 14 47 58" src="https://github.com/zer0-os/zOS/assets/39112648/452396d0-3f93-42be-9a82-09110b8ea5c4">

<img width="844" alt="Screenshot 2023-11-07 at 10 36 11" src="https://github.com/zer0-os/zOS/assets/39112648/cfabe3a9-a442-4461-a14e-89fc29d02a00">
