### PR TITLE
Allow internal users to join and leave the global network

### DIFF
--- a/src/components/edit-profile/container.test.tsx
+++ b/src/components/edit-profile/container.test.tsx
@@ -14,6 +14,8 @@ describe('Container', () => {
       currentProfileImage: 'profile.jpg',
       editProfile: () => null,
       startProfileEdit: () => null,
+      leaveGlobalNetwork: () => null,
+      joinGlobalNetwork: () => null,
       ...props,
     };
 

--- a/src/components/edit-profile/container.tsx
+++ b/src/components/edit-profile/container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { EditProfile } from '.';
-import { State, editProfile, startProfileEdit } from '../../store/edit-profile';
+import { State, editProfile, joinGlobalNetwork, leaveGlobalNetwork, startProfileEdit } from '../../store/edit-profile';
 import { Container as RegistrationContainer } from '../../authentication/create-account-details/container';
 export interface PublicProperties {
   onClose?: () => void;
@@ -19,6 +19,8 @@ export interface Properties extends PublicProperties {
   currentProfileImage: string;
   editProfile: (data: { name: string; image: File }) => void;
   startProfileEdit: () => void;
+  leaveGlobalNetwork: () => void;
+  joinGlobalNetwork: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -36,7 +38,7 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { editProfile, startProfileEdit };
+    return { editProfile, startProfileEdit, joinGlobalNetwork, leaveGlobalNetwork };
   }
 
   componentDidMount(): void {
@@ -52,6 +54,8 @@ export class Container extends React.Component<Properties> {
         editProfileState={this.props.editProfileState}
         currentDisplayName={this.props.currentDisplayName}
         currentProfileImage={this.props.currentProfileImage}
+        onLeaveGlobal={this.props.leaveGlobalNetwork}
+        onJoinGlobal={this.props.joinGlobalNetwork}
       />
     );
   }

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -7,6 +7,7 @@ import { bem } from '../../lib/bem';
 import { ImageUpload } from '../../components/image-upload';
 import { IconUpload2, IconXClose } from '@zero-tech/zui/icons';
 import { State as EditProfileState } from '../../store/edit-profile';
+import { featureFlags } from '../../lib/feature-flags';
 
 const c = bem('edit-profile');
 
@@ -21,6 +22,9 @@ export interface Properties {
   currentProfileImage: string;
   onEdit: (data: { name: string; image: File }) => void;
   onClose?: () => void;
+
+  onLeaveGlobal: () => void;
+  onJoinGlobal: () => void;
 }
 
 interface State {
@@ -124,7 +128,19 @@ export class EditProfile extends React.Component<Properties, State> {
             Your changes have been saved
           </Alert>
         )}
+
         <div className={c('footer')}>
+          {featureFlags.internalUsage && (
+            <>
+              <Button className={c('zui-button-large')} onPress={this.props.onLeaveGlobal}>
+                Leave Global
+              </Button>
+              <Button className={c('zui-button-large')} onPress={this.props.onJoinGlobal}>
+                Join Global
+              </Button>
+            </>
+          )}
+
           <Button
             className={c('zui-button-large')}
             isLoading={this.isLoading}

--- a/src/components/edit-profile/styles.scss
+++ b/src/components/edit-profile/styles.scss
@@ -53,6 +53,7 @@
     margin-top: 40px;
     display: flex;
     justify-content: flex-end;
+    gap: 16px;
   }
 
   // TODO: pass 'large' as a prop to the zUI button component

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -1,8 +1,9 @@
 import { shallow } from 'enzyme';
 
 import { SecureBackup, Properties } from '.';
-import { Alert, Button, Input } from '@zero-tech/zui/components';
+import { Alert, Input } from '@zero-tech/zui/components';
 import { bem } from '../../lib/bem';
+import { buttonLabelled } from '../../test/utils';
 
 const c = bem('.secure-backup');
 
@@ -114,10 +115,6 @@ describe('SecureBackup', () => {
 
 function pressButton(wrapper, label: string) {
   buttonLabelled(wrapper, label).simulate('press');
-}
-
-function buttonLabelled(wrapper, label) {
-  return wrapper.findWhere((node) => node.type() === Button && node.children().text() === label);
 }
 
 function changeRecoveryKeyInput(wrapper, value) {

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -65,6 +65,14 @@ export class FeatureFlags {
   set enableMatrix(value: boolean) {
     this._setBoolean('enableMatrix', value);
   }
+
+  get internalUsage() {
+    return this._getBoolean('internalUsage', false);
+  }
+
+  set internalUsage(value: boolean) {
+    this._setBoolean('internalUsage', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/edit-profile/api.ts
+++ b/src/store/edit-profile/api.ts
@@ -28,3 +28,11 @@ export async function saveUserMatrixCredentials({
     success: response.status === 200,
   };
 }
+
+export async function leaveGlobalNetwork() {
+  await post('/networks/global/leave').send();
+}
+
+export async function joinGlobalNetwork() {
+  await post('/networks/global/join').send();
+}

--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -2,6 +2,8 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export enum SagaActionTypes {
   EditProfile = 'profile/edit',
+  LeaveGlobal = 'profile/edit/leaveGlobal',
+  JoinGlobal = 'profile/edit/joinGlobal',
 }
 
 export enum State {
@@ -25,6 +27,9 @@ export const editProfile = createAction<{
   name: string;
   image: File | null;
 }>(SagaActionTypes.EditProfile);
+
+export const leaveGlobalNetwork = createAction(SagaActionTypes.LeaveGlobal);
+export const joinGlobalNetwork = createAction(SagaActionTypes.JoinGlobal);
 
 const slice = createSlice({
   name: 'edit-profile',

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -3,6 +3,8 @@ import { SagaActionTypes, State, setErrors, setState } from '.';
 import {
   editUserProfile as apiEditUserProfile,
   saveUserMatrixCredentials as apiSaveUserMatrixCredentials,
+  joinGlobalNetwork as joinGlobalNetworkApi,
+  leaveGlobalNetwork as leaveGlobalNetworkApi,
 } from './api';
 import { ProfileDetailsErrors } from '../registration';
 import { uploadImage } from '../registration/api';
@@ -69,6 +71,16 @@ export function* updateUserProfile(payload) {
   yield put(setUser({ data: currentUser }));
 }
 
+export function* leaveGlobalNetwork() {
+  yield leaveGlobalNetworkApi();
+}
+
+export function* joinGlobalNetwork() {
+  yield joinGlobalNetworkApi();
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.EditProfile, editProfile);
+  yield takeLatest(SagaActionTypes.LeaveGlobal, leaveGlobalNetwork);
+  yield takeLatest(SagaActionTypes.JoinGlobal, joinGlobalNetwork);
 }

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,7 +1,13 @@
+import { Button } from '@zero-tech/zui/components';
+
 export function inputEvent(attrs = {}) {
   return {
     preventDefault: () => {},
     stopPropagation: () => {},
     ...attrs,
   };
+}
+
+export function buttonLabelled(wrapper, label) {
+  return wrapper.findWhere((node) => node.type() === Button && node.children().text() === label);
 }


### PR DESCRIPTION
### What does this do?

Adds "secret" buttons to allow internal users to leave/join the global network. Pretty basic. It doesn't even know if you are or are not in the global network. Just presents both buttons no matter what and assumes you know what you're doing.

### Why are we making this change?

Intended to allow internal Zero employees to leave the global network so they don't show up in search results for random people

![image](https://github.com/zer0-os/zOS/assets/43770/aa36ba77-028b-4823-bc32-07c78257fe87)
