### PR TITLE
[FIX] Render Link Previews in Message Bubbles

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -4,7 +4,7 @@ import { decryptFile } from './media';
 async function parseMediaData(matrixMessage) {
   const { content } = matrixMessage;
 
-  let media: any = {};
+  let media = null;
   try {
     if (content?.msgtype === MsgType.Image) {
       const { file, info } = content;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -135,6 +135,13 @@ export function* fetch(action) {
     }
 
     yield call(mapMessageSenders, messagesResponse.messages, channelId);
+    for (const message of messagesResponse.messages) {
+      const preview = yield call(getPreview, message.message);
+      if (preview) {
+        message.preview = preview;
+      }
+    }
+
     const existingMessages = yield select(rawMessagesSelector(channelId));
 
     // we prefer this order (new messages first), so that if any new message has an updated property
@@ -306,6 +313,12 @@ export function* fetchNewMessages(channelId: string) {
       channelId
     );
     yield call(mapMessageSenders, messagesResponse.messages, channelId);
+    for (const message of messagesResponse.messages) {
+      const preview = yield call(getPreview, message.message);
+      if (preview) {
+        message.preview = preview;
+      }
+    }
 
     yield put(
       receive({

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -113,6 +113,18 @@ export function* getZeroUsersMap() {
   return zeroUsersMap;
 }
 
+function* mapMessagesAndPreview(messagesResponse, channelId) {
+  yield call(mapMessageSenders, messagesResponse.messages, channelId);
+  for (const message of messagesResponse.messages) {
+    const preview = yield call(getPreview, message.message);
+    if (preview) {
+      message.preview = preview;
+    }
+  }
+
+  return messagesResponse.messages;
+}
+
 export function* fetch(action) {
   const { channelId, referenceTimestamp } = action.payload;
   const channel = yield select(rawChannelSelector(channelId));
@@ -134,14 +146,7 @@ export function* fetch(action) {
       messagesResponse = yield call([chatClient, chatClient.getMessagesByChannelId], channelId);
     }
 
-    yield call(mapMessageSenders, messagesResponse.messages, channelId);
-    for (const message of messagesResponse.messages) {
-      const preview = yield call(getPreview, message.message);
-      if (preview) {
-        message.preview = preview;
-      }
-    }
-
+    messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse, channelId);
     const existingMessages = yield select(rawMessagesSelector(channelId));
 
     // we prefer this order (new messages first), so that if any new message has an updated property
@@ -312,13 +317,7 @@ export function* fetchNewMessages(channelId: string) {
       ],
       channelId
     );
-    yield call(mapMessageSenders, messagesResponse.messages, channelId);
-    for (const message of messagesResponse.messages) {
-      const preview = yield call(getPreview, message.message);
-      if (preview) {
-        message.preview = preview;
-      }
-    }
+    messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse, channelId);
 
     yield put(
       receive({


### PR DESCRIPTION
### What does this do?

Fetches the link preview for each message after `fetch` 

Before:
<img width="1104" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/23b1881e-24e9-4176-93e4-62e5f6be7a47">

After
![image](https://github.com/zer0-os/zOS/assets/33264364/26f0d36e-76e3-45f1-8573-387d33a1d856)

