### PR TITLE
Fix create conversation in Matrix

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -282,7 +282,7 @@ export class MatrixClient implements IChatClient {
     // Any room is only set as a DM based on a single user. We'll use the first one.
     await setAsDM(this.matrix, result.room_id, users[0].matrixId);
 
-    return this.mapConversation(this.matrix.getRoom(result.room_id));
+    return await this.mapConversation(this.matrix.getRoom(result.room_id));
   }
 
   async sendMessagesByChannelId(
@@ -477,7 +477,7 @@ export class MatrixClient implements IChatClient {
       }
 
       if (event.type === EventType.RoomCreate) {
-        this.roomCreated(event);
+        await this.roomCreated(event);
       }
       if (event.type === EventType.RoomAvatar) {
         this.publishRoomAvatarChange(event);
@@ -596,7 +596,7 @@ export class MatrixClient implements IChatClient {
   }
 
   private async roomCreated(event) {
-    this.events.onUserJoinedChannel(this.mapConversation(this.matrix.getRoom(event.room_id)));
+    this.events.onUserJoinedChannel(await this.mapConversation(this.matrix.getRoom(event.room_id)));
   }
 
   private receiveDeleteMessage = (event) => {


### PR DESCRIPTION
### What does this do?

Fixes the bug we're having while creating a new conversation with Matrix. It was related to not `awaiting` the promise returned by `mapMatrixMessage`
