### PR TITLE
fix: map zero users and update presence when user adds room

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -411,7 +411,8 @@ function* otherUserLeftChannelAction({ payload }) {
 export function* addChannel(channel) {
   const conversationsList = yield select(rawConversationsList());
   const channelsList = yield select(rawChannelsList());
-
+  yield call(mapToZeroUsers, [channel]);
+  yield call(updateUserPresence, [channel]);
   yield put(receive(uniqNormalizedList([...channelsList, ...conversationsList, channel])));
 }
 


### PR DESCRIPTION
### What does this do?
- when a user creates a room and the channel is added, the members will be mapped to zero users & user presence will be updated.

### Why are we making this change?
- fixes the app crashing when adding channels due to a users presence data not being available, and ensures the correct user data (such as name) is rendered correctly.

### How do I test this?
- create a conversation with another user > check the correct user data is rendered.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


BEFORE: 


https://github.com/zer0-os/zOS/assets/39112648/c609f619-1f2e-4c64-8283-68c99c3cdd72


AFTER:


https://github.com/zer0-os/zOS/assets/39112648/7b37762e-5d24-4a9d-a8d0-bf4750c01aa8

