### PR TITLE
Force zOS into full screen Messenger mode

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -14,6 +14,7 @@ import './styles.scss';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
 import { isCustomIcon } from '../list/utils/utils';
 import { IconButton } from '@zero-tech/zui/components';
+import { featureFlags } from '../../../lib/feature-flags';
 
 export interface PublicProperties {}
 
@@ -43,11 +44,15 @@ export class Container extends React.Component<Properties, State> {
 
     const directMessage = denormalize(activeConversationId, state);
 
+    let allowCollapse = false;
+    if (featureFlags.internalUsage) {
+      allowCollapse = layout.value?.isMessengerFullScreen && user?.data?.isAMemberOfWorlds;
+    }
     return {
       activeConversationId,
       directMessage,
       isFullScreen: layout.value?.isMessengerFullScreen,
-      allowCollapse: layout.value?.isMessengerFullScreen && user?.data?.isAMemberOfWorlds,
+      allowCollapse,
     };
   }
 

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -253,7 +253,7 @@ describe(getCurrentUserWithChatAccessToken, () => {
 describe('clearUserState', () => {
   it('resets layout', async () => {
     await expectSaga(clearUserState)
-      .put(update({ isSidekickOpen: false, isMessengerFullScreen: false }))
+      .put(update({ isSidekickOpen: false, isMessengerFullScreen: true }))
       .put(receive([]))
       .withReducer(rootReducer)
       .run();

--- a/src/store/layout/saga.ts
+++ b/src/store/layout/saga.ts
@@ -37,7 +37,7 @@ export function* updateSidekick(action) {
 
 export function* initializeUserLayout(user: { id: string; isAMemberOfWorlds: boolean }) {
   const isSidekickOpen = resolveFromLocalStorageAsBoolean(keyForUser(user.id, SIDEKICK_OPEN_STORAGE), true);
-  const isMessengerFullScreen = !user.isAMemberOfWorlds;
+  const isMessengerFullScreen = true; // The main app view of zOS is no longer used
 
   yield put(
     update({
@@ -51,7 +51,7 @@ export function* initializePublicLayout() {
   yield put(
     update({
       isSidekickOpen: false,
-      isMessengerFullScreen: false,
+      isMessengerFullScreen: true,
     })
   );
 }
@@ -60,7 +60,7 @@ export function* clearUserLayout() {
   yield put(
     update({
       isSidekickOpen: false,
-      isMessengerFullScreen: false,
+      isMessengerFullScreen: true,
     })
   );
 }


### PR DESCRIPTION
### What does this do?

Forces all users regardless of network status into the full screen Messenger. I.E., there will no longer be Networks and Channels.

### Why are we making this change?

Starting from the raw Messenger for all users for now.

