### PR TITLE
All rooms are now considered Conversations

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconXClose, IconMinus, IconExpand1, IconCollapse1 } from '@zero-tech/zui/icons';
+import { IconXClose, IconMinus, IconExpand1 } from '@zero-tech/zui/icons';
 import { shallow } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import { Channel, User } from '../../../store/channels';
@@ -13,7 +13,6 @@ describe('messenger-chat', () => {
       setactiveConversationId: jest.fn(),
       directMessage: { id: '1', otherMembers: [] } as any,
       isFullScreen: false,
-      allowCollapse: false,
       enterFullScreenMessenger: () => null,
       exitFullScreenMessenger: () => null,
       ...props,
@@ -65,15 +64,6 @@ describe('messenger-chat', () => {
     icon(wrapper, IconExpand1).simulate('click');
 
     expect(enterFullScreenMessenger).toHaveBeenCalledOnce();
-  });
-
-  it('publishes exit full screen event', function () {
-    const exitFullScreenMessenger = jest.fn();
-    const wrapper = subject({ exitFullScreenMessenger, isFullScreen: true, allowCollapse: true });
-
-    icon(wrapper, IconCollapse1).simulate('click');
-
-    expect(exitFullScreenMessenger).toHaveBeenCalledOnce();
   });
 
   describe('title', () => {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconExpand1, IconMinus, IconUsers1, IconXClose, IconCollapse1 } from '@zero-tech/zui/icons';
+import { IconExpand1, IconMinus, IconUsers1, IconXClose } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import { setactiveConversationId } from '../../../store/chat';
 import { RootState } from '../../../store/reducer';
@@ -14,7 +14,6 @@ import './styles.scss';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
 import { isCustomIcon } from '../list/utils/utils';
 import { IconButton } from '@zero-tech/zui/components';
-import { featureFlags } from '../../../lib/feature-flags';
 
 export interface PublicProperties {}
 
@@ -23,7 +22,6 @@ export interface Properties extends PublicProperties {
   setactiveConversationId: (activeDirectMessageId: string) => void;
   directMessage: Channel;
   isFullScreen: boolean;
-  allowCollapse: boolean;
   enterFullScreenMessenger: () => void;
   exitFullScreenMessenger: () => void;
 }
@@ -39,20 +37,14 @@ export class Container extends React.Component<Properties, State> {
     const {
       chat: { activeConversationId },
       layout,
-      authentication: { user },
     } = state;
 
     const directMessage = denormalize(activeConversationId, state);
 
-    let allowCollapse = false;
-    if (featureFlags.internalUsage) {
-      allowCollapse = layout.value?.isMessengerFullScreen && user?.data?.isAMemberOfWorlds;
-    }
     return {
       activeConversationId,
       directMessage,
       isFullScreen: layout.value?.isMessengerFullScreen,
-      allowCollapse,
     };
   }
 
@@ -186,12 +178,6 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__title'>{this.renderTitle()}</div>
               <div className='direct-message-chat__subtitle'>{this.renderSubTitle()}</div>
             </span>
-
-            {this.props.allowCollapse && (
-              <div>
-                <IconButton onClick={this.handleDockRight} Icon={IconCollapse1} size='small' />
-              </div>
-            )}
           </div>
 
           <ChatViewContainer

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -18,7 +18,6 @@ export interface RealtimeChatEvents {
   onUserJoinedChannel: (conversation) => void;
   invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;
-  onConversationListChanged: (conversationIds: string[]) => void;
   onUserPresenceChanged: (matrixId: string, isOnline: boolean, lastSeenAt: string) => void;
   onRoomNameChanged: (channelId: string, name: string) => void;
   onRoomAvatarChanged: (roomId: string, url: string) => void;

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -45,20 +45,6 @@ function stubTimeline(stubs = {}) {
   };
 }
 
-const getMockAccountData = (data = {}) => {
-  return jest.fn((eventType) => {
-    if (eventType === EventType.Direct) {
-      return {
-        event: { content: data },
-        getContent: () => data,
-      };
-    }
-    return {
-      getContent: () => ({}),
-    };
-  });
-};
-
 const getSdkClient = (sdkClient = {}) => ({
   login: async () => ({}),
   initCrypto: async () => null,
@@ -69,7 +55,6 @@ const getSdkClient = (sdkClient = {}) => ({
   }),
   getRooms: jest.fn(),
   getRoom: jest.fn().mockReturnValue(stubRoom()),
-  getAccountData: jest.fn(),
   getUser: jest.fn(),
   setGlobalErrorOnUnknownDevices: () => undefined,
   fetchRoomEvent: jest.fn(),
@@ -254,109 +239,6 @@ describe('matrix client', () => {
 
       expect(on).toHaveBeenNthCalledWith(1, 'sync', expect.any(Function));
     });
-
-    it('gets rooms', async () => {
-      const rooms = [stubRoom({ roomId: 'room-id' })];
-      const getAccountData = getMockAccountData();
-
-      const getRooms = jest.fn(() => {
-        return rooms;
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
-      });
-
-      await client.connect(null, 'token');
-
-      await client.getChannels('network-id');
-
-      expect(getRooms).toHaveBeenCalledOnce();
-    });
-
-    it('waits for sync to get rooms', async () => {
-      const rooms = [stubRoom({ roomId: 'room-id' })];
-      const getAccountData = getMockAccountData();
-      let syncCallback: any;
-
-      const on = (topic, callback) => {
-        if (topic === 'sync') syncCallback = callback;
-      };
-
-      const getRooms = jest.fn(() => {
-        return rooms;
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ on, getRooms, getAccountData })),
-      });
-
-      client.connect(null, 'token');
-
-      const channelFetch = client.getChannels('network-id');
-
-      await new Promise((resolve) => setImmediate(resolve));
-
-      expect(getRooms).not.toHaveBeenCalled();
-
-      syncCallback('PREPARED');
-
-      await channelFetch;
-
-      expect(getRooms).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe('getChannels', () => {
-    it('returns only non-direct rooms as channels', async () => {
-      const rooms = [
-        stubRoom({ roomId: 'channel-id' }),
-        stubRoom({ roomId: 'dm-id' }),
-        stubRoom({ roomId: 'dm-id-without-account-data', getDMInviter: () => 'somebody' }),
-      ];
-
-      const getRooms = jest.fn(() => rooms);
-      const getAccountData = getMockAccountData({ id: 'dm-id' });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
-      });
-
-      await client.connect(null, 'token');
-      const channels = await client.getChannels('network-id');
-
-      expect(channels).toHaveLength(1);
-      expect(channels[0].id).toEqual('channel-id');
-    });
-
-    it('returns empty array if no rooms exist', async () => {
-      const getRooms = jest.fn(() => []);
-      const getAccountData = getMockAccountData();
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
-      });
-
-      await client.connect(null, 'token');
-      const channels = await client.getChannels('network-id');
-
-      expect(channels).toHaveLength(0);
-    });
-
-    it('returns all rooms as channels if no direct room data exists', async () => {
-      const rooms = [stubRoom({ roomId: 'channel-id' }), stubRoom({ roomId: 'dm-id' })];
-      const getRooms = jest.fn(() => rooms);
-      const getAccountData = getMockAccountData();
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRooms, getAccountData })),
-      });
-
-      await client.connect(null, 'token');
-      const channels = await client.getChannels('network-id');
-
-      expect(channels).toHaveLength(2);
-    });
   });
 
   describe('getConversations', () => {
@@ -375,96 +257,25 @@ describe('matrix client', () => {
       return client;
     };
 
-    it('returns only direct rooms as conversations', async () => {
+    it('returns all rooms as conversations', async () => {
       const rooms = [stubRoom({ roomId: 'channel-id' }), stubRoom({ roomId: 'dm-id' })];
-      const getRooms = jest.fn(() => rooms);
-      const getAccountData = getMockAccountData({ id: 'dm-id' });
-      const client = await subject({ getRooms, getAccountData });
-
-      const conversations = await client.getConversations();
-
-      expect(conversations).toHaveLength(1);
-      expect(conversations[0].id).toEqual('dm-id');
-    });
-
-    it('returns rooms that do not have account data yet but do have a DM inviter', async () => {
-      const rooms = [stubRoom({ roomId: 'channel-id' }), stubRoom({ roomId: 'dm-id', getDMInviter: () => 'somebody' })];
       const getRooms = jest.fn(() => rooms);
       const client = await subject({ getRooms });
 
       const conversations = await client.getConversations();
 
-      expect(conversations).toHaveLength(1);
-      expect(conversations[0].id).toEqual('dm-id');
+      expect(conversations).toHaveLength(2);
+      expect(conversations[0].id).toEqual('channel-id');
+      expect(conversations[1].id).toEqual('dm-id');
     });
 
     it('returns empty array if no direct rooms exist', async () => {
       const getRooms = jest.fn(() => []);
-      const getAccountData = getMockAccountData();
-      const client = await subject({ getRooms, getAccountData });
+      const client = await subject({ getRooms });
 
       const conversations = await client.getConversations();
 
       expect(conversations).toHaveLength(0);
-    });
-  });
-
-  describe('getAccountData', () => {
-    it('get account data', async () => {
-      const getAccountData = getMockAccountData({
-        '@mockuser1': ['!abcdefg'],
-        '@mockuser2:': ['!hijklmn', '!opqrstuv'],
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getAccountData })),
-      });
-
-      await client.connect(null, 'token');
-
-      await client.getConversations();
-
-      expect(getAccountData).toHaveBeenCalledWith(EventType.Direct);
-    });
-
-    it('waits for connection if matrix client is connecting to get account data', async () => {
-      const sdkClient = getSdkClient();
-      const createClient = jest.fn(() => sdkClient);
-
-      const client = subject({ createClient });
-      client.connect(null, 'token');
-
-      const accountDataFetch = client.getAccountData(EventType.Direct);
-      expect(sdkClient.getAccountData).not.toHaveBeenCalled();
-
-      await new Promise((resolve) => setImmediate(resolve));
-
-      await accountDataFetch;
-
-      expect(sdkClient.getAccountData).toHaveBeenCalledWith(EventType.Direct);
-    });
-
-    it('fetches and returns correct account data when type is "m.direct"', async () => {
-      const getAccountData = getMockAccountData({
-        '@mockuser1': ['!abcdefg'],
-        '@mockuser2:': ['!hijklmn', '!opqrstuv'],
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getAccountData })),
-      });
-
-      await client.connect(null, 'token');
-
-      const result = await client.getAccountData(EventType.Direct);
-      expect(result).toMatchObject({
-        event: {
-          content: {
-            '@mockuser1': ['!abcdefg'],
-            '@mockuser2:': ['!hijklmn', '!opqrstuv'],
-          },
-        },
-      });
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -71,11 +71,6 @@ export class MatrixClient implements IChatClient {
 
   reconnect: () => void;
 
-  async getAccountData(eventType: string) {
-    await this.waitForConnection();
-    return this.matrix.getAccountData(eventType);
-  }
-
   async getUserPresence(userId: string) {
     await this.waitForConnection();
 
@@ -101,19 +96,12 @@ export class MatrixClient implements IChatClient {
   }
 
   async getChannels(_id: string) {
-    await this.waitForConnection();
-    const rooms = await this.getFilteredRooms(this.isChannel);
-    for (const room of rooms) {
-      await room.decryptAllEvents();
-      await room.loadMembersIfNeeded();
-    }
-
-    return await Promise.all(rooms.map((r) => this.mapChannel(r)));
+    return [];
   }
 
   async getConversations() {
     await this.waitForConnection();
-    const rooms = await this.getFilteredRooms(this.isConversation);
+    const rooms = await this.getRooms();
 
     const failedToJoin = [];
     for (const room of rooms) {
@@ -181,14 +169,6 @@ export class MatrixClient implements IChatClient {
       return false;
     }
   }
-
-  private isChannel = (room: Room, dmConversationIds: string[]) => {
-    return !this.isConversation(room, dmConversationIds);
-  };
-
-  private isConversation = (room: Room, dmConversationIds: string[]) => {
-    return dmConversationIds.includes(room.roomId) || !!room.getDMInviter();
-  };
 
   private isDeleted(event) {
     return event?.unsigned?.redacted_because;
@@ -417,7 +397,7 @@ export class MatrixClient implements IChatClient {
 
   async fetchConversationsWithUsers(users: User[]) {
     const userMatrixIds = users.map((u) => u.matrixId);
-    const rooms = await this.getFilteredRooms(this.isConversation);
+    const rooms = await this.getRooms();
     const matches = [];
     for (const room of rooms) {
       const roomMembers = room
@@ -503,7 +483,6 @@ export class MatrixClient implements IChatClient {
       }
     });
 
-    this.matrix.on(ClientEvent.AccountData, this.publishConversationListChange);
     this.matrix.on(ClientEvent.Event, this.publishUserPresenceChange);
     this.matrix.on(RoomEvent.Name, this.publishRoomNameChange);
     this.matrix.on(RoomStateEvent.Members, this.publishMembershipChange);
@@ -607,13 +586,6 @@ export class MatrixClient implements IChatClient {
     this.events.receiveNewMessage(event.room_id, (await mapMatrixMessage(event, this.matrix)) as any);
   }
 
-  private publishConversationListChange = async (event: MatrixEvent) => {
-    if (event.getType() === EventType.Direct) {
-      const rooms = await this.getFilteredRooms(this.isConversation);
-      this.events.onConversationListChanged(rooms.map((r) => r.roomId));
-    }
-  };
-
   private publishUserPresenceChange = (event: MatrixEvent) => {
     if (event.getType() === EventType.Presence) {
       const content = event.getContent();
@@ -646,7 +618,7 @@ export class MatrixClient implements IChatClient {
     }
   };
 
-  private async mapToGeneralChannel(room: Room) {
+  private mapConversation = async (room: Room): Promise<Partial<Channel>> => {
     const otherMembers = this.getOtherMembersFromRoom(room).map((userId) => this.mapUser(userId));
     const name = this.getRoomName(room);
     const avatarUrl = this.getRoomAvatar(room);
@@ -658,7 +630,7 @@ export class MatrixClient implements IChatClient {
       id: room.roomId,
       name,
       icon: avatarUrl,
-      isChannel: true,
+      isChannel: false,
       // Even if a member leaves they stay in the member list so this will still be correct
       // as zOS considers any conversation to have ever had more than 2 people to not be 1 on 1
       isOneOnOne: room.getMembers().length === 2,
@@ -671,17 +643,6 @@ export class MatrixClient implements IChatClient {
       hasJoined: true,
       createdAt,
       conversationStatus: ConversationStatus.CREATED,
-    };
-  }
-
-  private mapChannel = async (room: Room): Promise<Partial<Channel>> => {
-    return await this.mapToGeneralChannel(room);
-  };
-
-  private mapConversation = async (room: Room): Promise<Partial<Channel>> => {
-    return {
-      ...(await this.mapToGeneralChannel(room)),
-      isChannel: false,
     };
   };
 
@@ -732,20 +693,9 @@ export class MatrixClient implements IChatClient {
       .map((member) => member.userId);
   }
 
-  private async getFilteredRooms(filterFunc: (room: Room, dmConversationIds: string[]) => boolean) {
+  private async getRooms() {
     await this.waitForConnection();
-
-    const dmConversationIds = await this.getConversationIds();
-    const rooms = this.matrix.getRooms() || [];
-
-    return rooms.filter((r) => filterFunc(r, dmConversationIds));
-  }
-
-  private async getConversationIds() {
-    const accountData = await this.getAccountData(EventType.Direct);
-    const content = accountData?.getContent();
-
-    return Object.values(content ?? {}).flat();
+    return this.matrix.getRooms() || [];
   }
 
   private async uploadCoverImage(image) {

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -12,7 +12,6 @@ import {
   clearChannelsAndConversations,
   userLeftChannel,
   addChannel,
-  setConversations,
   otherUserJoinedChannel,
   otherUserLeftChannel,
   mapToZeroUsers,
@@ -384,48 +383,6 @@ describe('channels list saga', () => {
         .run();
 
       expect(storeState.channelsList.value).toIncludeSameMembers(['existing-conversation-id']);
-    });
-  });
-
-  describe(setConversations, () => {
-    it('changes channels to conversation', async () => {
-      const initialState = new StoreBuilder().withChannelList(
-        { id: 'channel-1', isChannel: true },
-        { id: 'channel-2', isChannel: true },
-        { id: 'channel-3', isChannel: true }
-      );
-
-      const { storeState } = await expectSaga(setConversations, ['channel-1', 'channel-3'])
-        .withReducer(rootReducer, initialState.build())
-        .run();
-
-      const channel1 = denormalizeChannel('channel-1', storeState);
-      expect(channel1.isChannel).toEqual(false);
-      const channel3 = denormalizeChannel('channel-3', storeState);
-      expect(channel3.isChannel).toEqual(false);
-
-      const channel2 = denormalizeChannel('channel-2', storeState);
-      expect(channel2.isChannel).toEqual(true);
-    });
-
-    it('changes conversations to channels', async () => {
-      const initialState = new StoreBuilder().withChannelList(
-        { id: 'channel-1', isChannel: false },
-        { id: 'channel-2', isChannel: false },
-        { id: 'channel-3', isChannel: false }
-      );
-
-      const { storeState } = await expectSaga(setConversations, ['channel-2'])
-        .withReducer(rootReducer, initialState.build())
-        .run();
-
-      const channel1 = denormalizeChannel('channel-1', storeState);
-      expect(channel1.isChannel).toEqual(true);
-      const channel3 = denormalizeChannel('channel-3', storeState);
-      expect(channel3.isChannel).toEqual(true);
-
-      const channel2 = denormalizeChannel('channel-2', storeState);
-      expect(channel2.isChannel).toEqual(false);
     });
   });
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -377,7 +377,6 @@ export function* saga() {
     userLeftChannel(payload.channelId, payload.userId)
   );
   yield takeEveryFromBus(chatBus, ChatEvents.UserJoinedChannel, userJoinedChannelAction);
-  yield takeEveryFromBus(chatBus, ChatEvents.ConversationListChanged, conversationListChangedAction);
   yield takeEveryFromBus(chatBus, ChatEvents.RoomNameChanged, roomNameChangedAction);
   yield takeEveryFromBus(chatBus, ChatEvents.RoomAvatarChanged, roomAvatarChangedAction);
   yield takeEveryFromBus(chatBus, ChatEvents.OtherUserJoinedChannel, otherUserJoinedChannelAction);
@@ -386,10 +385,6 @@ export function* saga() {
 
 function* userJoinedChannelAction({ payload }) {
   yield addChannel(payload.channel);
-}
-
-function* conversationListChangedAction({ payload }) {
-  yield setConversations(payload.conversationIds);
 }
 
 function* roomNameChangedAction(action) {
@@ -413,14 +408,6 @@ export function* addChannel(channel) {
   const channelsList = yield select(rawChannelsList());
 
   yield put(receive(uniqNormalizedList([...channelsList, ...conversationsList, channel])));
-}
-
-export function* setConversations(conversationIds: string[]) {
-  const allChannelIds = yield select((state) => getDeepProperty(state, 'channelsList.value', []));
-  for (const id of allChannelIds) {
-    const isChannel = !conversationIds.includes(id);
-    yield put(receiveChannel({ id, isChannel }));
-  }
 }
 
 export function* roomNameChanged(id: string, name: string) {

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -13,7 +13,6 @@ export enum Events {
   ChannelInvitationReceived = 'chat/channel/invitationReceived',
   UserLeftChannel = 'chat/channel/userLeft',
   UserJoinedChannel = 'chat/channel/userJoined',
-  ConversationListChanged = 'chat/conversationListChanged',
   UserPresenceChanged = 'chat/user/presenceChanged',
   RoomNameChanged = 'chat/roomNameChanged',
   RoomAvatarChanged = 'chat/roomAvatarChanged',
@@ -49,8 +48,6 @@ export function createChatConnection(userId, chatAccessToken) {
       emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
-    const onConversationListChanged = (conversationIds) =>
-      emit({ type: Events.ConversationListChanged, payload: { conversationIds } });
     const onUserPresenceChanged = (matrixId, isOnline, lastSeenAt) =>
       emit({ type: Events.UserPresenceChanged, payload: { matrixId, isOnline, lastSeenAt } });
     const onRoomNameChanged = (roomId, name) => emit({ type: Events.RoomNameChanged, payload: { id: roomId, name } });
@@ -71,7 +68,6 @@ export function createChatConnection(userId, chatAccessToken) {
       onUserReceivedInvitation,
       onUserLeft,
       onUserJoinedChannel,
-      onConversationListChanged,
       onUserPresenceChanged,
       onRoomNameChanged,
       onRoomAvatarChanged,


### PR DESCRIPTION
### What does this do?

This removes the distinction between Channels and Rooms from Matrix. All rooms are now considered a Conversation.

### Why are we making this change?

We no longer have a distinction in zOS between channels and conversations so no need to filter any more.

