### PR TITLE
Remove the 'network' message on the InviteDialog

### DIFF
--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -14,7 +14,6 @@ describe('Container', () => {
       assetPath: '',
       invitesUsed: 0,
       maxUses: 0,
-      isAMemberOfWorlds: false,
       isLoading: false,
       fetchInvite: () => null,
       ...props,
@@ -31,21 +30,9 @@ describe('Container', () => {
   });
 
   describe('mapState', () => {
-    const subject = (
-      invitationState: Partial<CreateInvitationState> = {},
-      userState: Partial<RootState['authentication']['user']['data']> = {}
-    ) => {
+    const subject = (invitationState: Partial<CreateInvitationState> = {}) => {
       const state = {
         createInvitation: { code: '', ...invitationState },
-        authentication: {
-          user: {
-            data: {
-              id: 'some-id',
-              isAMemberOfWorlds: false,
-              ...userState,
-            },
-          },
-        },
       } as RootState;
       return Container.mapState(state);
     };
@@ -60,12 +47,6 @@ describe('Container', () => {
       const props = subject({ url: 'some-url' });
 
       expect(props.inviteUrl).toEqual('some-url');
-    });
-
-    it('isAMemberOfWorlds', () => {
-      const props = subject({}, { isAMemberOfWorlds: true });
-
-      expect(props.isAMemberOfWorlds).toEqual(true);
     });
   });
 });

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -15,7 +15,6 @@ export interface Properties extends PublicProperties {
   maxUses: number;
   inviteUrl: string;
   assetPath: string;
-  isAMemberOfWorlds: boolean;
   isLoading: boolean;
 
   fetchInvite: () => void;
@@ -23,10 +22,7 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
-    const {
-      createInvitation,
-      authentication: { user },
-    } = state;
+    const { createInvitation } = state;
 
     return {
       inviteCode: createInvitation.code,
@@ -34,7 +30,6 @@ export class Container extends React.Component<Properties> {
       assetPath: config.assetsPath,
       invitesUsed: createInvitation.invitesUsed,
       maxUses: createInvitation.maxUses,
-      isAMemberOfWorlds: user?.data?.isAMemberOfWorlds,
       isLoading: createInvitation.isLoading,
     };
   }
@@ -56,7 +51,6 @@ export class Container extends React.Component<Properties> {
         inviteUrl={this.props.inviteUrl}
         assetsPath={this.props.assetPath}
         onClose={this.props.onClose}
-        isUserAMemberOfWorlds={this.props.isAMemberOfWorlds}
         isLoading={this.props.isLoading}
       />
     );

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -12,7 +12,6 @@ describe('InviteDialog', () => {
       assetsPath: '',
       invitesUsed: 0,
       maxUses: 0,
-      isUserAMemberOfWorlds: false,
       clipboard: { write: () => null },
       isLoading: false,
       ...props,
@@ -99,13 +98,5 @@ describe('InviteDialog', () => {
     // no invite left
     wrapper = subject({ inviteCode: '123456', invitesUsed: 5, maxUses: 5 });
     expect(wrapper.find('.invite-dialog__invite-left').exists()).toBeFalse();
-  });
-
-  it('renders network notification alert if user is in full screen, and is a part of networks', function () {
-    let wrapper = subject({ inviteCode: '123456', isUserAMemberOfWorlds: false });
-    expect(wrapper.find('.invite-dialog__network-alert').exists()).toBeFalse();
-
-    wrapper = subject({ inviteCode: '123456', isUserAMemberOfWorlds: true });
-    expect(wrapper.find('.invite-dialog__network-alert').exists()).toBeTrue();
   });
 });

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Image, Skeleton, Alert, IconButton } from '@zero-tech/zui/components';
+import { Image, Skeleton, IconButton } from '@zero-tech/zui/components';
 import { IconXClose, IconGift1 } from '@zero-tech/zui/icons';
 
 import { clipboard } from '../../lib/clipboard';
@@ -23,7 +23,6 @@ export interface Properties {
   maxUses: number;
   inviteUrl: string;
   assetsPath: string;
-  isUserAMemberOfWorlds: boolean;
   isLoading: boolean;
   clipboard?: Clipboard;
 
@@ -81,12 +80,6 @@ export class InviteDialog extends React.Component<Properties, State> {
             alt='Hands reaching out to connect'
             {...cn('image')}
           />
-
-          {this.props.isUserAMemberOfWorlds && (
-            <Alert variant='info' {...cn('network-alert')}>
-              This invite will add someone to your direct messages, <b>not</b> your current network.
-            </Alert>
-          )}
 
           <div {...cn('heading')}>Invite a friend. Chat on ZERO. Earn rewards.</div>
           <div {...cn('byline')}>

--- a/src/components/invite-dialog/styles.scss
+++ b/src/components/invite-dialog/styles.scss
@@ -104,10 +104,6 @@
     }
   }
 
-  &__network-alert {
-    margin: 12px 0px;
-  }
-
   &__inline-button--right {
     padding: 8px;
     margin: 0px;


### PR DESCRIPTION
### What does this do?

Removes the message about inviting a user to a network since we're no longer considering networks for the time being.

