### PR TITLE
Record an event that an image message was sent

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -336,6 +336,7 @@ export class MatrixClient implements IChatClient {
     };
 
     const messageResult = await this.matrix.sendMessage(roomId, content);
+    this.recordMessageSent(roomId);
 
     // Don't return a full message, only the pertinent attributes that changed.
     return {


### PR DESCRIPTION
While sending an image, we should also record that a message was sent (for rewards calculation)