### PR TITLE
Map to a proper user object after api call

### DIFF
--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -40,5 +40,12 @@ export async function uploadImage(file: File): Promise<FileResult> {
 export async function getZEROUsers(matrixIds: string[]) {
   return await get('/matrix/users/zero', { matrixIds })
     .catch((_error) => null)
-    .then((response) => response?.body || []);
+    .then((response) => {
+      if (!response?.body) {
+        return [];
+      }
+
+      // The api endpoint does not return the standard user object, so we need to map it
+      return response.body.map((u) => ({ ...u, userId: u.id }));
+    });
 }


### PR DESCRIPTION
### What does this do?

This adds a mapping from the server side user response to the format the app expects

### Why are we making this change?

In the app a user record has the primary key of `userId` not `id`. Adding this to the api fetch so all callers will get the right data.

