### PR TITLE
feat: add browser notifications

### DIFF
--- a/src/lib/browser/index.ts
+++ b/src/lib/browser/index.ts
@@ -11,7 +11,7 @@ export const send = (options: { body; heading; tag }) => {
   new Notification(heading, {
     tag: tag,
     body,
-    icon: getProvider().getSource({ src: 'v1681525214/zero-logo-round.png', local: false, options: {} }),
+    icon: getProvider().getSource({ src: '', local: false, options: {} }),
   });
 };
 

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,6 +23,7 @@ export interface RealtimeChatEvents {
   onRoomAvatarChanged: (roomId: string, url: string) => void;
   onOtherUserJoinedChannel: (channelId: string, user: UserModel) => void;
   onOtherUserLeftChannel: (channelId: string, user: UserModel) => void;
+  receiveLiveRoomEvent: (roomId: string, message: Message) => void;
 }
 
 export interface MatrixKeyBackupInfo {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,7 +23,7 @@ export interface RealtimeChatEvents {
   onRoomAvatarChanged: (roomId: string, url: string) => void;
   onOtherUserJoinedChannel: (channelId: string, user: UserModel) => void;
   onOtherUserLeftChannel: (channelId: string, user: UserModel) => void;
-  receiveLiveRoomEvent: (roomId: string, message: Message) => void;
+  receiveLiveRoomEvent: (eventData) => void;
 }
 
 export interface MatrixKeyBackupInfo {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -22,12 +22,6 @@ jest.mock('../../store/messages/api', () => {
   return { uploadAttachment: (...args) => mockUploadAttachment(...args) };
 });
 
-global.Notification = {
-  permission: 'granted',
-  requestPermission: jest.fn().mockResolvedValue('granted'),
-  prototype: {},
-} as unknown as typeof Notification;
-
 const stubRoom = (attrs = {}) => ({
   roomId: 'some-id',
   getAvatarUrl: () => '',
@@ -70,7 +64,6 @@ const getSdkClient = (sdkClient = {}) => ({
   fetchRoomEvent: jest.fn(),
   paginateEventTimeline: () => true,
   isRoomEncrypted: () => true,
-  handleNotificationPermissions: jest.fn(),
   ...sdkClient,
 });
 

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -22,6 +22,12 @@ jest.mock('../../store/messages/api', () => {
   return { uploadAttachment: (...args) => mockUploadAttachment(...args) };
 });
 
+global.Notification = {
+  permission: 'granted',
+  requestPermission: jest.fn().mockResolvedValue('granted'),
+  prototype: {},
+} as unknown as typeof Notification;
+
 const stubRoom = (attrs = {}) => ({
   roomId: 'some-id',
   getAvatarUrl: () => '',
@@ -64,6 +70,7 @@ const getSdkClient = (sdkClient = {}) => ({
   fetchRoomEvent: jest.fn(),
   paginateEventTimeline: () => true,
   isRoomEncrypted: () => true,
+  handleNotificationPermissions: jest.fn(),
   ...sdkClient,
 });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -676,12 +676,12 @@ export class MatrixClient implements IChatClient {
         switch (state) {
           case SyncState.Syncing:
           case SyncState.Catchup:
-            this.isSyncing = true;
+            this.updateSyncingStatus(true);
             break;
           case SyncState.Stopped:
           case SyncState.Error: // Error includes state - 'FAILED_SYNC_ERROR_THRESHOLD'
           case SyncState.Reconnecting:
-            this.isSyncing = false;
+            this.updateSyncingStatus(false);
             break;
           case SyncState.Prepared:
             resolve();
@@ -689,6 +689,10 @@ export class MatrixClient implements IChatClient {
         }
       });
     });
+  }
+
+  private updateSyncingStatus(isSyncing: boolean) {
+    this.isSyncing = isSyncing;
   }
 
   private async roomCreated(event) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -532,7 +532,7 @@ export class MatrixClient implements IChatClient {
     }
   };
 
-  public onSyncStateChange = (state: SyncState, _prevState: SyncState): void => {
+  private onSyncStateChange = (state: SyncState, _prevState: SyncState): void => {
     if (state === SyncState.Syncing) {
       this.isSyncing = true;
     } else if (state === SyncState.Stopped || state === SyncState.Error) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -607,6 +607,29 @@ export class MatrixClient implements IChatClient {
 
       await this.matrix.initCrypto();
 
+      // Check if notification permissions are already granted
+      if (Notification.permission === 'granted') {
+        // You have permission to show notifications.
+        // Continue with other initialization logic.
+      } else if (Notification.permission === 'denied') {
+        // The user has denied permission.
+        // You can inform the user to enable notifications in the browser settings.
+        // Optionally, you can handle this situation accordingly.
+      } else {
+        // Permission is not granted.
+        // You can request permission using Notification.requestPermission().
+        const permission = await Notification.requestPermission();
+
+        // Check the permission status after requesting it.
+        if (permission === 'granted') {
+          // Permission has been granted.
+          // Continue with other initialization logic.
+        } else {
+          // Permission was not granted.
+          // You can inform the user or adjust your application's behavior accordingly.
+          // Optionally, you can handle this situation accordingly.
+        }
+      }
       // suppsedly the setter is deprecated, but the direct property set doesn't seem to work.
       // this is hopefully only a short-term setting anyway, so just leaving for now.
       // this.matrix.getCrypto().globalBlacklistUnverifiedDevices = false;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -607,29 +607,8 @@ export class MatrixClient implements IChatClient {
 
       await this.matrix.initCrypto();
 
-      // Check if notification permissions are already granted
-      if (Notification.permission === 'granted') {
-        // You have permission to show notifications.
-        // Continue with other initialization logic.
-      } else if (Notification.permission === 'denied') {
-        // The user has denied permission.
-        // You can inform the user to enable notifications in the browser settings.
-        // Optionally, you can handle this situation accordingly.
-      } else {
-        // Permission is not granted.
-        // You can request permission using Notification.requestPermission().
-        const permission = await Notification.requestPermission();
+      await this.handleNotificationPermissions();
 
-        // Check the permission status after requesting it.
-        if (permission === 'granted') {
-          // Permission has been granted.
-          // Continue with other initialization logic.
-        } else {
-          // Permission was not granted.
-          // You can inform the user or adjust your application's behavior accordingly.
-          // Optionally, you can handle this situation accordingly.
-        }
-      }
       // suppsedly the setter is deprecated, but the direct property set doesn't seem to work.
       // this is hopefully only a short-term setting anyway, so just leaving for now.
       // this.matrix.getCrypto().globalBlacklistUnverifiedDevices = false;
@@ -640,6 +619,32 @@ export class MatrixClient implements IChatClient {
       await this.waitForSync();
 
       return opts.userId;
+    }
+  }
+
+  private async handleNotificationPermissions() {
+    // Check if notification permissions are already granted
+    if (Notification.permission === 'granted') {
+      // You have permission to show notifications.
+      // Continue with other initialization logic.
+    } else if (Notification.permission === 'denied') {
+      // The user has denied permission.
+      // You can inform the user to enable notifications in the browser settings.
+      // Optionally, you can handle this situation accordingly.
+    } else {
+      // Permission is not granted.
+      // You can request permission using Notification.requestPermission().
+      const permission = await Notification.requestPermission();
+
+      // Check the permission status after requesting it.
+      if (permission === 'granted') {
+        // Permission has been granted.
+        // Continue with other initialization logic.
+      } else {
+        // Permission was not granted.
+        // You can inform the user or adjust your application's behavior accordingly.
+        // Optionally, you can handle this situation accordingly.
+      }
     }
   }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -532,14 +532,6 @@ export class MatrixClient implements IChatClient {
     }
   };
 
-  private onSyncStateChange = (state: SyncState, _prevState: SyncState): void => {
-    if (state === SyncState.Syncing) {
-      this.isSyncing = true;
-    } else if (state === SyncState.Stopped || state === SyncState.Error) {
-      this.isSyncing = false;
-    }
-  };
-
   private async initializeEventHandlers() {
     this.matrix.on('event' as any, async ({ event }) => {
       console.log('event: ', event);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -20,7 +20,7 @@ import {
   SyncState,
 } from 'matrix-js-sdk';
 import { RealtimeChatEvents, IChatClient } from './';
-import { mapEventToAdminMessage, mapMatrixMessage, mapEventToBrowserNotificationMessage } from './matrix/chat-message';
+import { mapEventToAdminMessage, mapMatrixMessage, mapToLiveRoomEvent } from './matrix/chat-message';
 import { ConversationStatus, GroupChannelType, Channel, User as UserModel } from '../../store/channels';
 import { EditMessageOptions, Message, MessagesResponse } from '../../store/messages';
 import { FileUploadResult } from '../../store/messages/saga';
@@ -501,7 +501,7 @@ export class MatrixClient implements IChatClient {
 
   private async processRoomTimelineEvent(
     event: MatrixEvent,
-    room: Room | undefined,
+    _room: Room | undefined,
     toStartOfTimeline: boolean | undefined,
     removed: boolean,
     data: IRoomTimelineData
@@ -511,7 +511,7 @@ export class MatrixClient implements IChatClient {
     if (!this.isSyncing) return; // only notify if syncing is complete
     if (event.getSender() === this.userId) return; // only notify for other users events
 
-    this.events.receiveLiveRoomEvent(room.roomId, mapEventToBrowserNotificationMessage(event) as any);
+    this.events.receiveLiveRoomEvent(mapToLiveRoomEvent(event) as any);
   }
 
   private async initializeRoomEventHandlers(room: Room) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -627,8 +627,6 @@ export class MatrixClient implements IChatClient {
 
       await this.matrix.initCrypto();
 
-      await this.handleNotificationPermissions();
-
       // suppsedly the setter is deprecated, but the direct property set doesn't seem to work.
       // this is hopefully only a short-term setting anyway, so just leaving for now.
       // this.matrix.getCrypto().globalBlacklistUnverifiedDevices = false;
@@ -639,16 +637,6 @@ export class MatrixClient implements IChatClient {
       await this.waitForSync();
 
       return opts.userId;
-    }
-  }
-
-  private async handleNotificationPermissions() {
-    if (Notification.permission === 'granted') {
-      return;
-    } else if (Notification.permission === 'denied') {
-      return;
-    } else {
-      await Notification.requestPermission();
     }
   }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -508,7 +508,6 @@ export class MatrixClient implements IChatClient {
     if (removed) return; // only notify for new events, not removed ones
     if (!data.liveEvent || !!toStartOfTimeline) return; // only notify for new things, not old.
     if (!this.isSyncing()) return; // only notify if syncing is complete
-    if (event.getSender() === this.userId) return; // only notify for other users events
 
     this.events.receiveLiveRoomEvent(mapToLiveRoomEvent(event) as any);
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -522,8 +522,6 @@ export class MatrixClient implements IChatClient {
     this.unreadNotificationHandlers[room.roomId] = (unreadNotification) =>
       this.handleUnreadNotifications(room.roomId, unreadNotification);
     room.on(RoomEvent.UnreadNotifications, this.unreadNotificationHandlers[room.roomId]);
-
-    room.on(RoomEvent.Timeline, this.processRoomTimelineEvent.bind(this));
   }
 
   private handleUnreadNotifications = (roomId, unreadNotifications) => {
@@ -569,6 +567,7 @@ export class MatrixClient implements IChatClient {
     this.matrix.on(ClientEvent.Event, this.publishUserPresenceChange);
     this.matrix.on(RoomEvent.Name, this.publishRoomNameChange);
     this.matrix.on(RoomStateEvent.Members, this.publishMembershipChange);
+    this.matrix.on(RoomEvent.Timeline, this.processRoomTimelineEvent.bind(this));
 
     // Log events during development to help with understanding which events are happening
     Object.keys(ClientEvent).forEach((key) => {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -83,12 +83,11 @@ export function mapEventToAdminMessage(matrixMessage) {
 
 export function mapToLiveRoomEvent(liveEvent) {
   const { event } = liveEvent;
-
   return {
     id: event.event_id,
     createdAt: event.origin_server_ts,
     sender: {
-      userId: event.senderId,
+      userId: event.sender,
     },
   };
 }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -103,6 +103,6 @@ function convertToNotifiableEventType(eventType) {
     case EventType.RoomMessage:
       return NotifiableEventType.RoomMessage;
     default:
-      return;
+      return '';
   }
 }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -81,8 +81,8 @@ export function mapEventToAdminMessage(matrixMessage) {
   };
 }
 
-export function mapEventToBrowserNotificationMessage(matrixMessage) {
-  const { event } = matrixMessage;
+export function mapToLiveRoomEvent(liveEvent) {
+  const { event } = liveEvent;
 
   return {
     id: event.event_id,

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,5 +1,5 @@
-import { CustomEventType } from './types';
-import { MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
+import { CustomEventType, NotifiableEventType } from './types';
+import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { decryptFile } from './media';
 import { AdminMessageType } from '../../../store/messages';
 
@@ -84,12 +84,25 @@ export function mapEventToAdminMessage(matrixMessage) {
 
 export function mapToLiveRoomEvent(liveEvent) {
   const { event } = liveEvent;
+
+  const eventType = convertToNotifiableEventType(event.type);
+
   return {
     id: event.event_id,
-    type: event.type,
+    type: eventType,
     createdAt: event.origin_server_ts,
     sender: {
       userId: event.sender,
     },
   };
+}
+
+function convertToNotifiableEventType(eventType) {
+  switch (eventType) {
+    case EventType.RoomMessageEncrypted:
+    case EventType.RoomMessage:
+      return NotifiableEventType.RoomMessage;
+    default:
+      return;
+  }
 }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -85,6 +85,7 @@ export function mapToLiveRoomEvent(liveEvent) {
   const { event } = liveEvent;
   return {
     id: event.event_id,
+    type: event.type,
     createdAt: event.origin_server_ts,
     sender: {
       userId: event.sender,

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -80,3 +80,15 @@ export function mapEventToAdminMessage(matrixMessage) {
     admin: adminData,
   };
 }
+
+export function mapEventToBrowserNotificationMessage(matrixMessage) {
+  const { event } = matrixMessage;
+
+  return {
+    id: event.event_id,
+    createdAt: event.origin_server_ts,
+    sender: {
+      userId: event.senderId,
+    },
+  };
+}

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -19,3 +19,7 @@ export enum MatrixConstants {
 export enum CustomEventType {
   USER_JOINED_INVITER_ON_ZERO = 'user_joined_inviter_on_zero',
 }
+
+export enum NotifiableEventType {
+  RoomMessage = 'RoomMessage',
+}

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -18,6 +18,7 @@ export enum Events {
   RoomAvatarChanged = 'chat/roomAvatarChanged',
   OtherUserJoinedChannel = 'chat/channel/otherUserJoined',
   OtherUserLeftChannel = 'chat/channel/otherUserLeft',
+  LiveTimelineEventReceived = 'chat/message/liveTimelineEventReceived',
 }
 
 let theBus;
@@ -56,6 +57,8 @@ export function createChatConnection(userId, chatAccessToken) {
       emit({ type: Events.OtherUserJoinedChannel, payload: { channelId, user } });
     const onOtherUserLeftChannel = (channelId, user) =>
       emit({ type: Events.OtherUserLeftChannel, payload: { channelId, user } });
+    const receiveLiveRoomEvent = (roomId, message) =>
+      emit({ type: Events.LiveTimelineEventReceived, payload: { roomId, message } });
 
     chatClient.initChat({
       reconnectStart,
@@ -73,6 +76,7 @@ export function createChatConnection(userId, chatAccessToken) {
       onRoomAvatarChanged,
       onOtherUserJoinedChannel,
       onOtherUserLeftChannel,
+      receiveLiveRoomEvent,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -18,7 +18,7 @@ export enum Events {
   RoomAvatarChanged = 'chat/roomAvatarChanged',
   OtherUserJoinedChannel = 'chat/channel/otherUserJoined',
   OtherUserLeftChannel = 'chat/channel/otherUserLeft',
-  LiveTimelineEventReceived = 'chat/message/liveTimelineEventReceived',
+  LiveRoomEventReceived = 'chat/message/liveRoomEventReceived',
 }
 
 let theBus;
@@ -57,8 +57,7 @@ export function createChatConnection(userId, chatAccessToken) {
       emit({ type: Events.OtherUserJoinedChannel, payload: { channelId, user } });
     const onOtherUserLeftChannel = (channelId, user) =>
       emit({ type: Events.OtherUserLeftChannel, payload: { channelId, user } });
-    const receiveLiveRoomEvent = (roomId, message) =>
-      emit({ type: Events.LiveTimelineEventReceived, payload: { roomId, message } });
+    const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
 
     chatClient.initChat({
       reconnectStart,

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -24,36 +24,20 @@ const chatClient = {
 
 describe('messages saga', () => {
   it('sends a browser notification for a conversation', async () => {
-    const channelId = '0x000000000000000000000000000000000000000A';
-
-    const message = {
+    const eventData = {
       id: 8667728016,
-      message: 'Hello',
-      parentMessageText: null,
+      sender: { userId: 'sender-id' },
       createdAt: 1678861267433,
-      updatedAt: 0,
     };
 
-    const initialState = {
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            isChannel: false,
-          },
-        },
-      },
-    };
-
-    await expectSaga(sendBrowserNotification, channelId, message as any)
+    await expectSaga(sendBrowserNotification, eventData as any)
       .provide([
         [
           matchers.call.fn(sendBrowserMessage),
           undefined,
         ],
       ])
-      .call(sendBrowserMessage, mapMessage(message as any))
-      .withState(initialState)
+      .call(sendBrowserMessage, mapMessage(eventData as any))
       .run();
   });
 
@@ -61,37 +45,25 @@ describe('messages saga', () => {
     const user = {
       id: 'the-user-id',
     };
-    const channelId = '0x000000000000000000000000000000000000000A';
 
-    const message = {
+    const eventData = {
       id: 8667728016,
-      message: 'I should not receive this message, because I sent it',
-      parentMessageText: null,
-      createdAt: 1678861267433,
-      updatedAt: 0,
       sender: { userId: user.id },
+      createdAt: 1678861267433,
     };
 
     const initialState = {
       authentication: { user: { data: user } },
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            isChannel: false,
-          },
-        },
-      },
     };
 
-    await expectSaga(sendBrowserNotification, channelId, message as any)
+    await expectSaga(sendBrowserNotification, eventData as any)
       .provide([
         [
           matchers.call.fn(sendBrowserMessage),
           undefined,
         ],
       ])
-      .not.call(sendBrowserMessage, mapMessage(message as any))
+      .not.call(sendBrowserMessage, mapMessage(eventData as any))
       .withState(initialState)
       .run();
   });

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -23,11 +23,12 @@ const chatClient = {
 };
 
 describe('messages saga', () => {
-  it('sends a browser notification for a conversation', async () => {
+  it('sends a browser notification for a conversation when event type is room message', async () => {
     const eventData = {
       id: 8667728016,
       sender: { userId: 'sender-id' },
       createdAt: 1678861267433,
+      type: 'm.room.message',
     };
 
     await expectSaga(sendBrowserNotification, eventData as any)
@@ -38,6 +39,44 @@ describe('messages saga', () => {
         ],
       ])
       .call(sendBrowserMessage, mapMessage(eventData as any))
+      .run();
+  });
+
+  it('sends a browser notification for a conversation when event type is encrytped message', async () => {
+    const eventData = {
+      id: 8667728016,
+      sender: { userId: 'sender-id' },
+      createdAt: 1678861267433,
+      type: 'm.room.encrypted',
+    };
+
+    await expectSaga(sendBrowserNotification, eventData as any)
+      .provide([
+        [
+          matchers.call.fn(sendBrowserMessage),
+          undefined,
+        ],
+      ])
+      .call(sendBrowserMessage, mapMessage(eventData as any))
+      .run();
+  });
+
+  it('does not send a browser notification for a conversation when event type is not a message event', async () => {
+    const eventData = {
+      id: 8667728016,
+      sender: { userId: 'sender-id' },
+      createdAt: 1678861267433,
+      type: 'm.room.created',
+    };
+
+    await expectSaga(sendBrowserNotification, eventData as any)
+      .provide([
+        [
+          matchers.call.fn(sendBrowserMessage),
+          undefined,
+        ],
+      ])
+      .not.call(sendBrowserMessage, mapMessage(eventData as any))
       .run();
   });
 

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -44,11 +44,12 @@ describe('messages saga', () => {
   it('does not send a browser notification when the user is the sender', async () => {
     const user = {
       id: 'the-user-id',
+      matrixId: 'the-user-matrix-id',
     };
 
     const eventData = {
       id: 8667728016,
-      sender: { userId: user.id },
+      sender: { userId: user.matrixId },
       createdAt: 1678861267433,
     };
 

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -17,37 +17,19 @@ import { call } from 'redux-saga/effects';
 import { StoreBuilder } from '../test/store';
 import { MessageSendStatus } from '.';
 import { chat } from '../../lib/chat';
+import { NotifiableEventType } from '../../lib/chat/matrix/types';
 
 const chatClient = {
   editMessage: (_channelId: string, _messageId: string, _message: string, _mentionedUserIds: string[]) => ({}),
 };
 
 describe('messages saga', () => {
-  it('sends a browser notification for a conversation when event type is room message', async () => {
+  it('sends a browser notification for a conversation when event type is notifiable', async () => {
     const eventData = {
       id: 8667728016,
       sender: { userId: 'sender-id' },
       createdAt: 1678861267433,
-      type: 'm.room.message',
-    };
-
-    await expectSaga(sendBrowserNotification, eventData as any)
-      .provide([
-        [
-          matchers.call.fn(sendBrowserMessage),
-          undefined,
-        ],
-      ])
-      .call(sendBrowserMessage, mapMessage(eventData as any))
-      .run();
-  });
-
-  it('sends a browser notification for a conversation when event type is encrytped message', async () => {
-    const eventData = {
-      id: 8667728016,
-      sender: { userId: 'sender-id' },
-      createdAt: 1678861267433,
-      type: 'm.room.encrypted',
+      type: NotifiableEventType.RoomMessage,
     };
 
     await expectSaga(sendBrowserNotification, eventData as any)
@@ -66,7 +48,7 @@ describe('messages saga', () => {
       id: 8667728016,
       sender: { userId: 'sender-id' },
       createdAt: 1678861267433,
-      type: 'm.room.created',
+      type: '',
     };
 
     await expectSaga(sendBrowserNotification, eventData as any)

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -96,40 +96,6 @@ describe('messages saga', () => {
       .run();
   });
 
-  it('does not send a browser notification for a channel', async () => {
-    const channelId = '0x000000000000000000000000000000000000000A';
-
-    const message = {
-      id: 8667728016,
-      message: 'Hello',
-      parentMessageText: null,
-      createdAt: 1678861267433,
-      updatedAt: 0,
-    };
-
-    const initialState = {
-      normalized: {
-        channels: {
-          [channelId]: {
-            id: channelId,
-            isChannel: true,
-          },
-        },
-      },
-    };
-
-    await expectSaga(sendBrowserNotification, channelId, message as any)
-      .provide([
-        [
-          matchers.call.fn(sendBrowserMessage),
-          undefined,
-        ],
-      ])
-      .not.call(sendBrowserMessage, mapMessage(message as any))
-      .withState(initialState)
-      .run();
-  });
-
   it('edit message', async () => {
     const channelId = '0x000000000000000000000000000000000000000A';
     const message = 'update message';

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -560,10 +560,10 @@ export function* clearMessages() {
   yield put(removeAll({ schema: schema.key }));
 }
 
-export function isOwner(currentUser, entityUserId) {
-  if (!currentUser || !entityUserId) return false;
+export function isOwner(currentUser, entityUserMatrixId) {
+  if (!currentUser || !entityUserMatrixId) return false;
 
-  return currentUser.id === entityUserId;
+  return currentUser.matrixId === entityUserMatrixId;
 }
 
 export function* sendBrowserNotification(eventData) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -566,11 +566,11 @@ export function isOwner(currentUser, entityUserId) {
   return currentUser.id === entityUserId;
 }
 
-export function* sendBrowserNotification(roomId, message) {
+export function* sendBrowserNotification(eventData) {
   // This is not well defined. We need to respect muted channels, ignore messages from the current user, etc.
-  if (isOwner(yield select(currentUserSelector()), message.sender?.userId)) return;
+  if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return;
 
-  yield call(sendBrowserMessage, mapMessage(message));
+  yield call(sendBrowserMessage, mapMessage(eventData));
 }
 
 export function* saga() {
@@ -585,9 +585,9 @@ export function* saga() {
   yield takeEveryFromBus(chatBus, ChatEvents.MessageReceived, receiveNewMessage);
   yield takeEveryFromBus(chatBus, ChatEvents.MessageUpdated, receiveUpdateMessage);
   yield takeEveryFromBus(chatBus, ChatEvents.MessageDeleted, receiveDelete);
-  yield takeEveryFromBus(chatBus, ChatEvents.LiveTimelineEventReceived, receiveLiveTimelineEventAction);
+  yield takeEveryFromBus(chatBus, ChatEvents.LiveRoomEventReceived, receiveLiveRoomEventAction);
 }
 
-function* receiveLiveTimelineEventAction({ payload }) {
-  yield sendBrowserNotification(payload.roomId, payload.message);
+function* receiveLiveRoomEventAction({ payload }) {
+  yield sendBrowserNotification(payload.eventData);
 }

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -569,13 +569,13 @@ export function isOwner(currentUser, entityUserMatrixId) {
 }
 
 export function* sendBrowserNotification(eventData) {
-  if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return; // only notify for other users events
-  if (!shouldNotifyForEventType(eventData.type)) return; // for now, only notify for message events
+  if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return;
+  if (!shouldNotifyForMessageEvent(eventData.type)) return;
 
   yield call(sendBrowserMessage, mapMessage(eventData));
 }
 
-function shouldNotifyForEventType(eventType) {
+function shouldNotifyForMessageEvent(eventType) {
   return eventType === EventType.RoomMessageEncrypted || eventType === EventType.RoomMessage;
 }
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -568,10 +568,6 @@ export function isOwner(currentUser, entityUserId) {
 
 export function* sendBrowserNotification(roomId, message) {
   // This is not well defined. We need to respect muted channels, ignore messages from the current user, etc.
-  const room = yield select(rawChannelSelector(roomId));
-
-  if (room?.isChannel) return;
-
   if (isOwner(yield select(currentUserSelector()), message.sender?.userId)) return;
 
   yield call(sendBrowserMessage, mapMessage(message));

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -19,8 +19,8 @@ import { activeChannelIdSelector } from '../chat/selectors';
 import { User } from '../channels';
 import { mapMessageSenders, mapReceivedMessage } from './utils.matrix';
 import { mapCreatorIdToZeroUserId } from '../channels-list/saga';
-import { EventType } from 'matrix-js-sdk';
 import { uniqNormalizedList } from '../utils';
+import { NotifiableEventType } from '../../lib/chat/matrix/types';
 
 export interface Payload {
   channelId: string;
@@ -570,13 +570,10 @@ export function isOwner(currentUser, entityUserMatrixId) {
 
 export function* sendBrowserNotification(eventData) {
   if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return;
-  if (!shouldNotifyForMessageEvent(eventData.type)) return;
 
-  yield call(sendBrowserMessage, mapMessage(eventData));
-}
-
-function shouldNotifyForMessageEvent(eventType) {
-  return eventType === EventType.RoomMessageEncrypted || eventType === EventType.RoomMessage;
+  if (eventData.type === NotifiableEventType.RoomMessage) {
+    yield call(sendBrowserMessage, mapMessage(eventData));
+  }
 }
 
 export function* saga() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -568,7 +568,6 @@ export function isOwner(currentUser, entityUserMatrixId) {
 }
 
 export function* sendBrowserNotification(eventData) {
-  // This is not well defined. We need to respect muted channels, ignore messages from the current user, etc.
   if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return; // only notify for other users events
   if (!shouldNotifyForEventType(eventData.type)) return; // for now, only notify for message events
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -474,7 +474,6 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
       }
 
       let newMessages = yield call(replaceOptimisticMessage, currentMessages, message);
-
       if (!newMessages) {
         newMessages = [
           ...currentMessages,
@@ -483,7 +482,6 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
       }
       currentMessages = newMessages;
     }
-
     if (modified) {
       yield put(receive({ id: channelId, messages: currentMessages }));
     }

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -436,8 +436,6 @@ export function* receiveDelete(action) {
 
 let savedMessages = [];
 export function* receiveNewMessage(action) {
-  console.log('REAL TIME RECEIVE NEW MESSAGE');
-  console.log('ACTION', action);
   savedMessages.push(action.payload);
   if (savedMessages.length > 1) {
     // we already have a leading event that's awaiting the debounce delay


### PR DESCRIPTION
First iteration of adding browser notifications. If the approach is in line with how we expect to handle browser notifications, it should be straight forward enough to add additional logic of when to send browser notifications.

Changes were made in reference to how Element handles browser notifications.

### What does this do?
- handles Notification Permissions when initialising the client.
- listens for timeline room events.
- processes room timeline events and maps the event to a browser notification message.
- once timeline event is processed we action real time chat event `receiveLiveRoomEvent`.
- messages saga actions sending the browser notifications.

### Why are we making this change?
- to handle and add browser notifications to zOS.

### How do I test this?
- pull branch > login to zOS > enable notifications on initialisation >  send your current user a message with another user > check browser notification is sent.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Due to screen recording software blocking the browser notifications when active, I'm unable to provide a demo. To see this the branch will need to be pulled and follow the steps on how to test.

<img width="1176" alt="Screenshot 2023-11-16 at 17 51 46" src="https://github.com/zer0-os/zOS/assets/39112648/036987dc-fcd4-470f-9d39-a5b756757e78">
