### PR TITLE
fix: channel list saga type error failure

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -355,8 +355,7 @@ function* listenForUserLogout() {
   }
 }
 
-export function* currentUserAddedToChannel(action) {
-  console.log('OR HERE', action);
+export function* currentUserAddedToChannel(_action) {
   // For now, just force a fetch of conversations to refresh the list.
   yield fetchConversations();
 }
@@ -407,7 +406,6 @@ export function* saga() {
 }
 
 function* userJoinedChannelAction({ payload }) {
-  console.log('USER JOINED CHANNEL', payload);
   yield addChannel(payload.channel);
 }
 
@@ -420,7 +418,6 @@ function* roomAvatarChangedAction(action) {
 }
 
 function* otherUserJoinedChannelAction({ payload }) {
-  console.log('PAYLOAD', payload);
   yield otherUserJoinedChannel(payload.channelId, payload.user);
 }
 
@@ -447,24 +444,17 @@ export function* roomAvatarChanged(id: string, url: string) {
 }
 
 export function* otherUserJoinedChannel(roomId: string, user: User) {
-  console.log('USER', user);
-
   const channel = yield select(rawChannel, roomId);
-
-  console.log('CHANNEL', channel);
-
   if (!channel) {
     return;
   }
 
   if (user.userId === user.matrixId) {
     user = yield call(getUserByMatrixId, user.matrixId) || user;
-    console.log('UPDATED USER', user);
   }
 
   if (!channel?.otherMembers?.includes(user.userId)) {
     const otherMembers = [...(channel?.otherMembers || []), user];
-    console.log('OTHER MEMBERS', otherMembers);
     yield put(
       receiveChannel({
         id: channel.id,

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -355,7 +355,8 @@ function* listenForUserLogout() {
   }
 }
 
-export function* currentUserAddedToChannel(_action) {
+export function* currentUserAddedToChannel(action) {
+  console.log('OR HERE', action);
   // For now, just force a fetch of conversations to refresh the list.
   yield fetchConversations();
 }
@@ -406,6 +407,7 @@ export function* saga() {
 }
 
 function* userJoinedChannelAction({ payload }) {
+  console.log('USER JOINED CHANNEL', payload);
   yield addChannel(payload.channel);
 }
 
@@ -418,6 +420,7 @@ function* roomAvatarChangedAction(action) {
 }
 
 function* otherUserJoinedChannelAction({ payload }) {
+  console.log('PAYLOAD', payload);
   yield otherUserJoinedChannel(payload.channelId, payload.user);
 }
 
@@ -444,21 +447,28 @@ export function* roomAvatarChanged(id: string, url: string) {
 }
 
 export function* otherUserJoinedChannel(roomId: string, user: User) {
+  console.log('USER', user);
+
   const channel = yield select(rawChannel, roomId);
+
+  console.log('CHANNEL', channel);
+
   if (!channel) {
     return;
   }
 
   if (user.userId === user.matrixId) {
     user = yield call(getUserByMatrixId, user.matrixId) || user;
+    console.log('UPDATED USER', user);
   }
 
-  if (!channel?.otherMembers.includes(user.userId)) {
-    const otherMembers = [...channel.otherMembers, user];
+  if (!channel?.otherMembers?.includes(user.userId)) {
+    const otherMembers = [...(channel?.otherMembers || []), user];
+    console.log('OTHER MEMBERS', otherMembers);
     yield put(
       receiveChannel({
         id: channel.id,
-        isOneOnOne: channel.isChannel === true ? false : otherMembers.length === 1,
+        isOneOnOne: channel?.isChannel === true ? false : otherMembers.length === 1,
         otherMembers,
       })
     );

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -458,7 +458,7 @@ export function* otherUserJoinedChannel(roomId: string, user: User) {
     yield put(
       receiveChannel({
         id: channel.id,
-        isOneOnOne: channel?.isChannel === true ? false : otherMembers.length === 1,
+        isOneOnOne: otherMembers.length === 1,
         otherMembers,
       })
     );


### PR DESCRIPTION
### What does this do?
- fixes a type error in the channel list saga.

### Why are we making this change?
- fixing the type error in the channel list saga prevents the saga failing and therefore the names of the user are correctly rendered in the conversation list items. 
- this fix also appears to prevent users from creating more than one conversation with another user.

### How do I test this?
- create a conversation between two users > check name in conversation list item is rendered as expected > check that you can not create another conversation with the same user as they should not appear in the search results.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


BEFORE DEMOS:

UserId in place of User Name when creating a conversation & creating more than 1 conversation with user.

https://github.com/zer0-os/zOS/assets/39112648/3bc92578-dea0-4c66-bcae-667636ded33c

Audio with this demo explaining what we see. Blank conversation names & Creating more than 1 conversation with user.

https://github.com/zer0-os/zOS/assets/39112648/43625e61-fa3a-446f-928c-a804640a3af1

AFTER DEMO:

Audio with this demo explaining what we see.

https://github.com/zer0-os/zOS/assets/39112648/50ee4229-ffcf-417f-9f43-b006a3edadfc

