### PR TITLE
Uniqify messages before saving them in batch processing

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -28,6 +28,7 @@ import { getUserByMatrixId } from '../users/saga';
 import { rawChannel } from '../channels/selectors';
 import { getZEROUsers } from './api';
 import { union } from 'lodash';
+import { uniqNormalizedList } from '../utils';
 
 const FETCH_CHAT_CHANNEL_INTERVAL = 60000;
 
@@ -482,8 +483,4 @@ export function* otherUserLeftChannel(roomId: string, user: User) {
       otherMembers: channel.otherMembers.filter((userId) => userId !== existingUser.userId),
     })
   );
-}
-
-function uniqNormalizedList(objectsAndIds: ({ id: string } | string)[]): any {
-  return uniqBy(objectsAndIds, (c) => c.id ?? c);
 }

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -28,6 +28,7 @@ import { activeChannelIdSelector } from '../chat/selectors';
 import { User } from '../channels';
 import { mapMessageSenders, mapReceivedMessage } from './utils.matrix';
 import { mapCreatorIdToZeroUserId } from '../channels-list/saga';
+import { uniqNormalizedList } from '../utils';
 
 export interface Payload {
   channelId: string;
@@ -492,7 +493,7 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
       currentMessages = newMessages;
     }
     if (modified) {
-      yield put(receive({ id: channelId, messages: currentMessages }));
+      yield put(receive({ id: channelId, messages: uniqNormalizedList(currentMessages) }));
     }
     if (yield select(_isActive(channelId))) {
       const isChannel = yield select(_isChannel(channelId));

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -1,0 +1,5 @@
+import uniqBy from 'lodash.uniqby';
+
+export function uniqNormalizedList(objectsAndIds: ({ id: string } | string)[]): any {
+  return uniqBy(objectsAndIds, (c) => c.id ?? c);
+}


### PR DESCRIPTION
### What does this do?

When batch processing incoming messages ensure only 1 copy of the message is used.

### Why are we making this change?

Sometimes we receive multiple events for the same message in quick succession and they end up being processed in the same batch. This uniqifies the message in the list before saving to the store.

