### PR TITLE
Favor the latest event when processing batch messages

### DIFF
--- a/src/store/messages/saga.receiveNewMessage.test.ts
+++ b/src/store/messages/saga.receiveNewMessage.test.ts
@@ -234,7 +234,7 @@ describe(receiveNewMessage, () => {
       const channelId = 'channel-id';
       const eventPayloads = [
         { channelId, message: { id: 'new-message', message: 'a new message' } },
-        { channelId, message: { id: 'new-message', message: 'a new message' } },
+        { channelId, message: { id: 'new-message', message: 'second event' } },
       ];
 
       const existingMessages = [{ id: 'message-1', message: 'message_0001' }] as any;
@@ -246,6 +246,8 @@ describe(receiveNewMessage, () => {
 
       const channel = denormalizeChannel(channelId, storeState);
       expect(channel.messages.map((m) => m.id)).toEqual(['message-1', 'new-message']);
+      // Should favor the second event as it's the most recent
+      expect(channel.messages[1].message).toEqual('second event');
     });
   });
 });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -493,7 +493,7 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
       currentMessages = newMessages;
     }
     if (modified) {
-      yield put(receive({ id: channelId, messages: uniqNormalizedList(currentMessages) }));
+      yield put(receive({ id: channelId, messages: uniqNormalizedList(currentMessages, true) }));
     }
     if (yield select(_isActive(channelId))) {
       const isChannel = yield select(_isChannel(channelId));

--- a/src/store/utils.test.ts
+++ b/src/store/utils.test.ts
@@ -1,0 +1,34 @@
+import { uniqNormalizedList } from './utils';
+
+describe(uniqNormalizedList, () => {
+  it('uniqifies list with mix of ids and objects', async () => {
+    const list = ['a', { id: 'a' }];
+
+    const result = uniqNormalizedList(list, false);
+
+    expect(result).toEqual(['a']);
+  });
+
+  it('uniqifies list favoring the first entry', async () => {
+    const list = [
+      { id: 'b', other: '1' },
+      { id: 'b', other: '2' },
+    ];
+
+    const result = uniqNormalizedList(list, false);
+
+    expect(result).toEqual([{ id: 'b', other: '1' }]);
+  });
+
+  it('uniqifies list favoring the last entry', async () => {
+    const list = [
+      { id: 'b', other: '1' },
+      { id: 'b', other: '2' },
+      { id: 'b', other: '3' },
+    ];
+
+    const result = uniqNormalizedList(list, true);
+
+    expect(result).toEqual([{ id: 'b', other: '3' }]);
+  });
+});

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -1,5 +1,18 @@
 import uniqBy from 'lodash.uniqby';
 
-export function uniqNormalizedList(objectsAndIds: ({ id: string } | string)[]): any {
+export function uniqNormalizedList(objectsAndIds: ({ id: string } | string)[], favorLast = false): any {
+  if (favorLast) {
+    return uniqFavorLast(objectsAndIds);
+  }
+  return uniqFavorFirst(objectsAndIds);
+}
+
+function uniqFavorFirst(objectsAndIds: ({ id: string } | string)[]): any {
   return uniqBy(objectsAndIds, (c) => c.id ?? c);
+}
+
+function uniqFavorLast(objectsAndIds: ({ id: string } | string)[]): any {
+  const reversed = [...objectsAndIds].reverse();
+  const uniqued = uniqBy(reversed, (c) => c.id ?? c);
+  return uniqued.reverse();
 }


### PR DESCRIPTION
### What does this do?

When filtering duplicate events, favor the most recent

