### PR TITLE
Fully log out of Matrix and chat when logging out

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -85,7 +85,7 @@ export interface IChatClient {
 }
 
 export class Chat {
-  constructor(private client: IChatClient = null) {}
+  constructor(private client: IChatClient = null, private onDisconnect: () => void) {}
 
   supportsOptimisticCreateConversation = () => this.client.supportsOptimisticCreateConversation();
 
@@ -219,8 +219,9 @@ export class Chat {
     this.client.reconnect();
   }
 
-  disconnect(): void {
-    this.client.disconnect();
+  async disconnect(): Promise<void> {
+    await this.client.disconnect();
+    this.onDisconnect();
   }
 
   get matrix() {
@@ -242,7 +243,9 @@ let chatClient: Chat;
 export const chat = {
   get() {
     if (!chatClient) {
-      chatClient = new Chat(ClientFactory.get());
+      chatClient = new Chat(ClientFactory.get(), () => {
+        chatClient = null;
+      });
     }
 
     return chatClient;

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -53,6 +53,8 @@ const getSdkClient = (sdkClient = {}) => ({
   initCrypto: async () => null,
   startClient: jest.fn(async () => undefined),
   stopClient: jest.fn(),
+  removeAllListeners: jest.fn(),
+  clearStores: jest.fn(),
   on: jest.fn((topic, callback) => {
     if (topic === 'sync') callback('PREPARED');
   }),
@@ -98,7 +100,7 @@ function resolveWith<T>(valueToResolve: T) {
 
 describe('matrix client', () => {
   describe('disconnect', () => {
-    it('stops client on disconnect', async () => {
+    it('stops client completely on disconnect', async () => {
       const sdkClient = getSdkClient();
       const createClient = jest.fn(() => sdkClient);
       const matrixSession = {
@@ -112,9 +114,11 @@ describe('matrix client', () => {
       // initializes underlying matrix client
       await client.connect(null, 'token');
 
-      client.disconnect();
+      await client.disconnect();
 
       expect(sdkClient.stopClient).toHaveBeenCalledOnce();
+      expect(sdkClient.removeAllListeners).toHaveBeenCalledOnce();
+      expect(sdkClient.clearStores).toHaveBeenCalledOnce();
     });
 
     it('clears session storage on disconnect', async () => {
@@ -135,7 +139,7 @@ describe('matrix client', () => {
 
       expect(clearSession).not.toHaveBeenCalled();
 
-      client.disconnect();
+      await client.disconnect();
 
       expect(clearSession).toHaveBeenCalledOnce();
     });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -66,8 +66,11 @@ export class MatrixClient implements IChatClient {
     return this.userId;
   }
 
-  disconnect() {
+  async disconnect() {
     this.matrix.stopClient();
+    this.matrix.removeAllListeners();
+    await this.matrix.clearStores();
+    this.matrix.store?.destroy();
     this.sessionStorage.clear();
   }
 

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -77,8 +77,8 @@ export function createChatConnection(userId, chatAccessToken) {
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);
 
-    const unsubscribe = () => {
-      chatClient.disconnect();
+    const unsubscribe = async () => {
+      await chatClient.disconnect();
     };
     return unsubscribe;
   });


### PR DESCRIPTION
### What does this do?

Adds code to more fully cleanup Matrix data when a user logs out

### Why are we making this change?

Turns out we weren't cleaning up enough of the Matrix sdk cached data when logging a user out. This causes strange behaviour when a user logs in again as themselves or someone else.

