### PR TITLE
Fix re-login without refresh

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -30,8 +30,6 @@ import { getZEROUsers } from './api';
 import { union } from 'lodash';
 import { uniqNormalizedList } from '../utils';
 
-const FETCH_CHAT_CHANNEL_INTERVAL = 60000;
-
 const rawAsyncListStatus = () => (state) => getDeepProperty(state, 'channelsList.status', 'idle');
 const rawChannelsList = () => (state) => filterChannelsList(state, ChannelType.Channel);
 export const rawConversationsList = () => (state) => filterChannelsList(state, ChannelType.DirectMessage);
@@ -298,8 +296,6 @@ export function* fetchChannelsAndConversations() {
     }
 
     yield call(fetchConversations);
-
-    yield call(delay, FETCH_CHAT_CHANNEL_INTERVAL);
   }
 }
 
@@ -341,7 +337,8 @@ function* listenForUserLogin() {
     yield take(userChannel, Events.UserLogin);
     if (featureFlags.enableMatrix) {
       // Do not poll when in Matrix mode just fetch once
-      return yield call(fetchChannelsAndConversations);
+      yield call(fetchChannelsAndConversations);
+      continue;
     }
 
     yield startChannelsAndConversationsRefresh();


### PR DESCRIPTION
### What does this do?

This fixes a re-login issue we were seeing

### Why are we making this change?

Previously if you had logged out and then tried to log in again right away without refreshing the page we wouldn't fetch the conversation list because we were returning out of the listener after 1 successful run.

### How do I test this?

Logout and login again. You should see your conversation list.

