### PR TITLE
Switch to Matrix SDK logout rather than stopClient

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -52,7 +52,7 @@ const getSdkClient = (sdkClient = {}) => ({
   login: async () => ({}),
   initCrypto: async () => null,
   startClient: jest.fn(async () => undefined),
-  stopClient: jest.fn(),
+  logout: jest.fn(),
   removeAllListeners: jest.fn(),
   clearStores: jest.fn(),
   on: jest.fn((topic, callback) => {
@@ -116,7 +116,7 @@ describe('matrix client', () => {
 
       await client.disconnect();
 
-      expect(sdkClient.stopClient).toHaveBeenCalledOnce();
+      expect(sdkClient.logout).toHaveBeenCalledOnce();
       expect(sdkClient.removeAllListeners).toHaveBeenCalledOnce();
       expect(sdkClient.clearStores).toHaveBeenCalledOnce();
     });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -67,7 +67,7 @@ export class MatrixClient implements IChatClient {
   }
 
   async disconnect() {
-    this.matrix.stopClient();
+    this.matrix.logout(true);
     this.matrix.removeAllListeners();
     await this.matrix.clearStores();
     this.matrix.store?.destroy();


### PR DESCRIPTION
### What does this do?

Uses the more complete `logout` message rather than just `stopClient`

### Why are we making this change?

I believe the logout method will actually "remove" the device from the room list since we'll never connect as that device again. This keeps things trim.

