### PR TITLE
fix: blend zero logo for cross-browser background consistency

### DIFF
--- a/src/invite.scss
+++ b/src/invite.scss
@@ -37,6 +37,7 @@
   &__logo-container {
     margin-bottom: 76px;
     padding-left: 8px;
+    mix-blend-mode: screen;
 
     &--is-landing-page {
       margin-bottom: 0;

--- a/src/pages/login/login.scss
+++ b/src/pages/login/login.scss
@@ -52,6 +52,7 @@ $login-padding-bottom: 24px;
   &__logo-container {
     padding-left: 8px;
     margin-bottom: 76px;
+    mix-blend-mode: screen;
   }
 
   &__inner-content-wrapper {

--- a/src/reset-password.scss
+++ b/src/reset-password.scss
@@ -31,5 +31,6 @@
 
   &__logo-container {
     padding-left: 8px;
+    mix-blend-mode: screen;
   }
 }


### PR DESCRIPTION
### What does this do?
- This change adds the CSS property `mix-blend-mode: screen` to the styling of our logo container. This property ensures that the logo's black background is rendered as transparent across different browsers.

### Why are we making this change?
- We are implementing this change to address the issue of inconsistent logo background rendering across various browsers.

### How do I test this?
- load zOS login, invite, create account screens and check logo background.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  

**Examples**
 
Firefox Before:

<img width="937" alt="Screenshot 2023-11-24 at 12 15 43" src="https://github.com/zer0-os/zOS/assets/39112648/efb851e9-a7b6-48bb-bbc1-6657b8d3fafe">


Firefox After:

<img width="937" alt="Screenshot 2023-11-24 at 12 14 40" src="https://github.com/zer0-os/zOS/assets/39112648/f534c7d9-4bfb-4600-b8b7-9fa5077b8710">

Safari After:

<img width="1172" alt="Screenshot 2023-11-24 at 12 21 45" src="https://github.com/zer0-os/zOS/assets/39112648/3c7874b0-c309-49db-845f-3b77421a63e1">

Edge After:

<img width="1172" alt="Screenshot 2023-11-24 at 12 20 10" src="https://github.com/zer0-os/zOS/assets/39112648/1834c0e9-1ea4-4e09-8ed8-8ebacc340ee4">