### PR TITLE
fix: handle real-time undecryptable message edits

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -446,11 +446,18 @@ export class MatrixClient implements IChatClient {
   private async onMessageUpdated(event): Promise<void> {
     const relatedEventId = this.getRelatedEventId(event);
     const originalMessage = await this.getMessageByRoomId(event.room_id, relatedEventId);
-    const newContent = this.getNewContent(event);
 
-    if (originalMessage && newContent) {
-      originalMessage.message = newContent.body;
-      originalMessage.updatedAt = event.origin_server_ts;
+    if (event.content.msgtype === MatrixConstants.BAD_ENCRYPTED_MSGTYPE) {
+      if (originalMessage) {
+        originalMessage.message = 'Message edit cannot be decrypted.';
+        originalMessage.updatedAt = event.origin_server_ts;
+      }
+    } else {
+      const newContent = this.getNewContent(event);
+      if (originalMessage && newContent) {
+        originalMessage.message = newContent.body;
+        originalMessage.updatedAt = event.origin_server_ts;
+      }
     }
 
     this.events.onMessageUpdated(event.room_id, originalMessage as any);


### PR DESCRIPTION
### What does this do?
- checks if the edit event's msgtype is `MatrixConstants.BAD_ENCRYPTED_MSGTYPE`. If so, it updates the original message to indicate that the message edit cannot be decrypted.

- If the msgtype is not indicative of an undecryptable message, it then proceeds to handle the edit as usual, updating the message with the new content if available.

### Why are we making this change?
- The update ensures consistency in handling real-time undecryptable edits and aligns with the logic used in processing historical events (previous PR).

### How do I test this?
- testing this is a little tricky as you would need to edit a message that is not able to be decrypted. If you are able find a scenario where you can edit a message that can not be decrypted, you should see the `'Message edit cannot be decrypted.' message content. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
