### PR TITLE
feat: remove url paths (replace zns route connect)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import ReactDOM from 'react-dom';
-import { ZnsRouteConnect } from './zns-route-connect';
+import { MessengerMain } from './messenger-main';
 import { store, runSagas } from './store';
 import { Provider } from 'react-redux';
 import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
@@ -29,11 +29,7 @@ showReleaseVersionInConsole();
 
 export const history = getHistory();
 
-const redirectToDefaults = ({ match: { params } }) => {
-  if (params.znsRoute === 'get-access') return <Redirect to={'/get-access'} />;
-  if (params.znsRoute === 'login') return <Redirect to={'/login'} />;
-  if (params.znsRoute === 'reset-password') return <Redirect to={'/reset-password'} />;
-
+const redirectToDefaults = () => {
   return <Redirect to={'/'} />;
 };
 
@@ -48,7 +44,7 @@ ReactDOM.render(
                 <Route path='/get-access' exact component={Invite} />
                 <Route path='/login' exact component={LoginPage} />
                 <Route path='/reset-password' exact component={ResetPassword} />
-                <Route path='/' exact component={ZnsRouteConnect} />
+                <Route path='/' exact component={MessengerMain} />
                 <Route render={redirectToDefaults} />
               </Web3Connect>
             </Web3ReactContextProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,6 @@ import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
 import { Router, Redirect, Route } from 'react-router-dom';
 import { ContextProvider as Web3ReactContextProvider } from './lib/web3/web3-react';
-import { config } from './config';
 import { showReleaseVersionInConsole, initializeErrorBoundary } from './utils';
 import { ErrorBoundary } from './components/error-boundary/';
 
@@ -31,12 +30,11 @@ showReleaseVersionInConsole();
 export const history = getHistory();
 
 const redirectToDefaults = ({ match: { params } }) => {
-  const route = params.znsRoute || `0.${config.defaultZnsRoute}`;
-  if (route === 'get-access') return <Redirect to={'/get-access'} />;
-  if (route === 'login') return <Redirect to={'/login'} />;
-  if (route === 'reset-password') return <ResetPassword />;
+  if (params.znsRoute === 'get-access') return <Redirect to={'/get-access'} />;
+  if (params.znsRoute === 'login') return <Redirect to={'/login'} />;
+  if (params.znsRoute === 'reset-password') return <Redirect to={'/reset-password'} />;
 
-  return <Redirect to={`/${route}/${config.defaultApp}`} />;
+  return <Redirect to={'/'} />;
 };
 
 ReactDOM.render(
@@ -50,8 +48,8 @@ ReactDOM.render(
                 <Route path='/get-access' exact component={Invite} />
                 <Route path='/login' exact component={LoginPage} />
                 <Route path='/reset-password' exact component={ResetPassword} />
-                <Route path='/:znsRoute?/' exact render={redirectToDefaults} />
-                <Route path='/:znsRoute/:app' component={ZnsRouteConnect} />
+                <Route path='/' exact component={ZnsRouteConnect} />
+                <Route render={redirectToDefaults} />
               </Web3Connect>
             </Web3ReactContextProvider>
           </Router>

--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Container } from './messenger-main';
+import { Create as CreateAccount } from './components/account/create';
+import { Provider as AuthenticationContextProvider } from './components/authentication/context';
+import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
+import { Main } from './Main';
+
+describe('MessengerMain', () => {
+  const mockIsAuthenticated = true;
+
+  const subject = (isAuthenticated = mockIsAuthenticated) => {
+    return shallow(<Container isAuthenticated={isAuthenticated} />);
+  };
+
+  it('renders the CreateAccount component', () => {
+    const wrapper = subject();
+    expect(wrapper.find(CreateAccount)).toHaveLength(1);
+  });
+
+  it('contains AuthenticationContextProvider with the correct context', () => {
+    const wrapper = subject();
+    const provider = wrapper.find(AuthenticationContextProvider);
+    expect(provider).toHaveLength(1);
+    expect(provider.prop('value')).toEqual({ isAuthenticated: mockIsAuthenticated });
+  });
+
+  it('contains the ZUIProvider', () => {
+    const wrapper = subject();
+    expect(wrapper.find(ZUIProvider)).toHaveLength(1);
+  });
+
+  it('renders the Main component', () => {
+    const wrapper = subject();
+    expect(wrapper.find(Main)).toHaveLength(1);
+  });
+});

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { RootState } from './store/reducer';
+import { connectContainer } from './store/redux-container';
+
+import { Main } from './Main';
+import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
+import { Create as CreateAccount } from './components/account/create';
+import { Provider as AuthenticationContextProvider } from './components/authentication/context';
+
+export interface Properties {
+  isAuthenticated: boolean;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    return {
+      isAuthenticated: !!state.authentication.user?.data,
+    };
+  }
+
+  static mapActions() {
+    return {};
+  }
+
+  get authenticationContext() {
+    const { isAuthenticated } = this.props;
+    return {
+      isAuthenticated,
+    };
+  }
+
+  render() {
+    return (
+      <>
+        <CreateAccount />
+        <AuthenticationContextProvider value={this.authenticationContext}>
+          <ZUIProvider>
+            <Main />
+          </ZUIProvider>
+        </AuthenticationContextProvider>
+      </>
+    );
+  }
+}
+
+export const MessengerMain = connectContainer<{}>(Container);

--- a/src/store/page-load/saga.test.ts
+++ b/src/store/page-load/saga.test.ts
@@ -42,8 +42,8 @@ describe('page-load saga', () => {
       .provide(stubResponses(history, true))
       .run();
 
-    // redirected from /login to /0.wilder.channels
-    expect(history.replace).toHaveBeenCalledWith({ pathname: '/0.wilder/channels' });
+    // redirected from /login to /
+    expect(history.replace).toHaveBeenCalledWith({ pathname: '/' });
     expect(loginStoreState.pageload.isComplete).toBe(true);
 
     // signup
@@ -53,8 +53,8 @@ describe('page-load saga', () => {
       .provide(stubResponses(history, true))
       .run();
 
-    // redirected from /get-access to /0.wilder.channels
-    expect(history.replace).toHaveBeenCalledWith({ pathname: '/0.wilder/channels' });
+    // redirected from /get-access to /
+    expect(history.replace).toHaveBeenCalledWith({ pathname: '/' });
     expect(getAccessStoreState.pageload.isComplete).toBe(true);
   });
 
@@ -80,7 +80,7 @@ describe('page-load saga', () => {
       pageload: { isComplete: false },
     };
 
-    const history = new StubHistory('/0.wilder/channels');
+    const history = new StubHistory('/');
     const { storeState } = await expectSaga(saga)
       .provide(stubResponses(history, false))
       .withReducer(rootReducer, initialState as any)
@@ -96,7 +96,7 @@ describe('page-load saga', () => {
       pageload: { isComplete: false },
     };
 
-    const history = new StubHistory('/0.wilder/channels');
+    const history = new StubHistory('/');
     featureFlags.allowPublicZOS = true;
     const { storeState } = await expectSaga(saga)
       .provide(stubResponses(history, false))
@@ -117,8 +117,8 @@ describe('page-load saga', () => {
       .provide(stubResponses(history, true))
       .run();
 
-    // redirected from /reset-password to /0.wilder.channels
-    expect(history.replace).toHaveBeenCalledWith({ pathname: '/0.wilder/channels' });
+    // redirected from /reset-password to /
+    expect(history.replace).toHaveBeenCalledWith({ pathname: '/' });
     expect(resetPasswordStoreState.pageload.isComplete).toBe(true);
   });
 

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -4,7 +4,6 @@ import { getHistory, getNavigator } from '../../lib/browser';
 import { featureFlags } from '../../lib/feature-flags';
 import { getCurrentUserWithChatAccessToken } from '../authentication/saga';
 import { initializePublicLayout } from '../layout/saga';
-import { config } from '../../config';
 
 const anonymousPaths = [
   '/get-access',
@@ -31,7 +30,7 @@ function handleAuthenticatedUser(history) {
   // we should redirect to index page in that case
   if (anonymousPaths.includes(history.location.pathname)) {
     history.replace({
-      pathname: `/0.${config.defaultZnsRoute}/${config.defaultApp}`,
+      pathname: '/',
     });
   }
 }

--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -63,22 +63,24 @@ export class Container extends React.Component<Properties> {
   }
 
   redirectOnInvalidRoute() {
+    console.log('HERE I THINK');
     const {
       location: { pathname, search },
     } = this.props;
 
-    if (/^\/0\./.test(pathname)) return false;
+    console.log(/^\/$/.test(pathname));
+    if (/^\/$/.test(pathname)) return false;
 
     this.props.history.replace({
-      pathname: pathname.replace(/^\//, '/0.'),
+      pathname: '/',
       search: search || '',
     });
 
     return true;
   }
 
-  extractRouteFromProps(props: Properties = this.props) {
-    return props.match.params.znsRoute.replace(/^0\./, '');
+  extractRouteFromProps(_props: Properties = this.props) {
+    return '/';
   }
 
   extractAppFromProps(props: Properties = this.props) {

--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -67,18 +67,18 @@ export class Container extends React.Component<Properties> {
       location: { pathname, search },
     } = this.props;
 
-    if (/^\/$/.test(pathname)) return false;
+    if (/^\/0\./.test(pathname)) return false;
 
     this.props.history.replace({
-      pathname: '/',
+      pathname: pathname.replace(/^\//, '/0.'),
       search: search || '',
     });
 
     return true;
   }
 
-  extractRouteFromProps(_props: Properties = this.props) {
-    return '/';
+  extractRouteFromProps(props: Properties = this.props) {
+    return props.match.params.znsRoute.replace(/^0\./, '');
   }
 
   extractAppFromProps(props: Properties = this.props) {

--- a/src/zns-route-connect.tsx
+++ b/src/zns-route-connect.tsx
@@ -63,12 +63,10 @@ export class Container extends React.Component<Properties> {
   }
 
   redirectOnInvalidRoute() {
-    console.log('HERE I THINK');
     const {
       location: { pathname, search },
     } = this.props;
 
-    console.log(/^\/$/.test(pathname));
     if (/^\/$/.test(pathname)) return false;
 
     this.props.history.replace({


### PR DESCRIPTION
### What does this do?
- removes url paths
- replaces zns route connect
- updates routing

### Why are we making this change?
- to remove url paths i.e. so the url does not contain `/0.znsRoute/app`

### How do I test this?
- load up messenger and check url > no paths should be added to the url unless the path is for `/login`, `/get-access`, `/reset-password`.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


