### PR TITLE
Set `power_levels` for each user while creating a conversation

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -281,6 +281,12 @@ export class MatrixClient implements IChatClient {
       invite: users.map((u) => u.matrixId),
       is_direct: true,
       initial_state,
+      power_level_content_override: {
+        users: {
+          ...users.reduce((acc, u) => ({ ...acc, [u.matrixId]: 0 }), {}),
+          [this.userId]: 100,
+        },
+      },
     };
     if (name) {
       options.name = name;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -22,7 +22,7 @@ import { mapEventToAdminMessage, mapMatrixMessage } from './matrix/chat-message'
 import { ConversationStatus, GroupChannelType, Channel, User as UserModel } from '../../store/channels';
 import { EditMessageOptions, Message, MessagesResponse } from '../../store/messages';
 import { FileUploadResult } from '../../store/messages/saga';
-import { ParentMessage, User } from './types';
+import { ParentMessage, PowerLevels, User } from './types';
 import { config } from '../../config';
 import { get, post } from '../api/rest';
 import { MemberNetworks } from '../../store/users/types';
@@ -283,8 +283,8 @@ export class MatrixClient implements IChatClient {
       initial_state,
       power_level_content_override: {
         users: {
-          ...users.reduce((acc, u) => ({ ...acc, [u.matrixId]: 0 }), {}),
-          [this.userId]: 100,
+          ...users.reduce((acc, u) => ({ ...acc, [u.matrixId]: PowerLevels.Viewer }), {}),
+          [this.userId]: PowerLevels.Owner,
         },
       },
     };

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -30,3 +30,9 @@ export interface User {
   userId: string;
   matrixId: string;
 }
+
+export enum PowerLevels {
+  Viewer = 0, // Default
+  Editor = 50, // "Moderator" or ~PL50
+  Owner = 100, // "Admin" or PL100
+}


### PR DESCRIPTION
### What does this do?

Sets the appropriate `power_level` for each user while creating a conversation. The creator is set as `100` (i.e admin), and everyone else as "viewer" (`0`).

### Why are we making this change?

Previously everyone's power level was set to "100", which means everyone had admin functionality. This is not desirable. 

### How do I test this?

Log the `PowerLevels` events using the eventTimeline, and check for the power_levels for each user in a room.

<img width="748" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/5ea3c349-e9a5-416a-b226-4db53a28aa10">

