### PR TITLE
feat: add group management menu to conversation header

### DIFF
--- a/src/components/group-management-menu/index.test.tsx
+++ b/src/components/group-management-menu/index.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Properties, GroupManagementMenu } from '.';
+import { DropdownMenu } from '@zero-tech/zui/components';
+
+describe(GroupManagementMenu, () => {
+  const subject = () => {
+    const allProps: Properties = {};
+
+    return shallow(<GroupManagementMenu {...allProps} />);
+  };
+
+  it('renders DropdownMenu component', function () {
+    const wrapper = subject();
+
+    expect(wrapper).toHaveElement(DropdownMenu);
+  });
+});

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import { IconDotsHorizontal, IconPlus } from '@zero-tech/zui/icons';
+import { DropdownMenu } from '@zero-tech/zui/components';
+
+import './styles.scss';
+
+export interface Properties {}
+
+interface State {}
+
+export class GroupManagementMenu extends React.Component<Properties, State> {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  handleOpenChange = () => {};
+
+  renderMenuItem(icon, label) {
+    return (
+      <div className={'menu-item'}>
+        {icon} {label}
+      </div>
+    );
+  }
+
+  // Update menuItems to add new menu items
+  get renderDropdownMenuItems() {
+    const menuItems = [
+      {
+        id: 'example_id',
+        label: this.renderMenuItem(<IconPlus />, 'Example Item'),
+        onSelect: () => {},
+      },
+    ];
+    return menuItems;
+  }
+
+  render() {
+    return (
+      <DropdownMenu
+        menuClassName={'group-management-menu'}
+        items={this.renderDropdownMenuItems}
+        side='bottom'
+        alignMenu='end'
+        onOpenChange={this.handleOpenChange}
+        trigger={<IconDotsHorizontal size={24} isFilled />}
+      />
+    );
+  }
+}

--- a/src/components/group-management-menu/styles.scss
+++ b/src/components/group-management-menu/styles.scss
@@ -1,0 +1,17 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.group-management-menu {
+  width: 248px;
+  padding: 8px;
+
+  align-self: stretch;
+
+  .menu-item {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    line-height: 24px;
+  }
+}

--- a/src/components/group-management-menu/styles.scss
+++ b/src/components/group-management-menu/styles.scss
@@ -1,10 +1,8 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .group-management-menu {
-  width: 248px;
+  width: 232px;
   padding: 8px;
-
-  align-self: stretch;
 
   .menu-item {
     display: flex;

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -6,6 +6,11 @@ import { Channel, User } from '../../../store/channels';
 import Tooltip from '../../tooltip';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
 
+const featureFlags = { enableGroupManagementMenu: false };
+jest.mock('../../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
+
 describe('messenger-chat', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
@@ -190,6 +195,25 @@ describe('messenger-chat', () => {
 
       expect(headerAvatar.prop('style').backgroundImage).toEqual('url(avatar-url)');
       expect(headerAvatar.find('IconUsers1').exists()).toBeFalse();
+    });
+
+    it('header renders group management menu icon button', function () {
+      featureFlags.enableGroupManagementMenu = true;
+
+      const wrapper = subject({
+        directMessage: {
+          isOneOnOne: true,
+          otherMembers: [
+            stubUser({
+              profileImage: 'avatar-url',
+            }),
+          ],
+        } as Channel,
+      });
+
+      const groupManagementMenuContainer = wrapper.find('.direct-message-chat__group-management-menu-container');
+
+      expect(groupManagementMenuContainer.exists()).toBeTrue();
     });
   });
 

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -6,11 +6,6 @@ import { Channel, User } from '../../../store/channels';
 import Tooltip from '../../tooltip';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
 
-const featureFlags = { enableGroupManagementMenu: false };
-jest.mock('../../../lib/feature-flags', () => ({
-  featureFlags: featureFlags,
-}));
-
 describe('messenger-chat', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
@@ -195,25 +190,6 @@ describe('messenger-chat', () => {
 
       expect(headerAvatar.prop('style').backgroundImage).toEqual('url(avatar-url)');
       expect(headerAvatar.find('IconUsers1').exists()).toBeFalse();
-    });
-
-    it('header renders group management menu icon button', function () {
-      featureFlags.enableGroupManagementMenu = true;
-
-      const wrapper = subject({
-        directMessage: {
-          isOneOnOne: true,
-          otherMembers: [
-            stubUser({
-              profileImage: 'avatar-url',
-            }),
-          ],
-        } as Channel,
-      });
-
-      const groupManagementMenuContainer = wrapper.find('.direct-message-chat__group-management-menu-container');
-
-      expect(groupManagementMenuContainer.exists()).toBeTrue();
     });
   });
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -9,8 +9,6 @@ import { Channel, denormalize } from '../../../store/channels';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
 import { getProvider } from '../../../lib/cloudinary/provider';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
-import { GroupManagementMenu } from '../../group-management-menu';
-import { featureFlags } from '../../../lib/feature-flags';
 
 import './styles.scss';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
@@ -180,11 +178,6 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__title'>{this.renderTitle()}</div>
               <div className='direct-message-chat__subtitle'>{this.renderSubTitle()}</div>
             </span>
-            {featureFlags.enableGroupManagementMenu && (
-              <div className='direct-message-chat__group-management-menu-container'>
-                <GroupManagementMenu />
-              </div>
-            )}
           </div>
 
           <ChatViewContainer

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -9,6 +9,8 @@ import { Channel, denormalize } from '../../../store/channels';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
 import { getProvider } from '../../../lib/cloudinary/provider';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
+import { GroupManagementMenu } from '../../group-management-menu';
+import { featureFlags } from '../../../lib/feature-flags';
 
 import './styles.scss';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
@@ -178,6 +180,11 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__title'>{this.renderTitle()}</div>
               <div className='direct-message-chat__subtitle'>{this.renderSubTitle()}</div>
             </span>
+            {featureFlags.enableGroupManagementMenu && (
+              <div className='direct-message-chat__group-management-menu-container'>
+                <GroupManagementMenu />
+              </div>
+            )}
           </div>
 
           <ChatViewContainer

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -157,6 +157,10 @@ $recent-indicator-size: 8px;
     color: theme.$color-greyscale-11;
   }
 
+  &__group-management-menu-container {
+    display: flex;
+  }
+
   &--transition {
     transition: all animation.$animation-duration-half ease-out;
 

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -157,10 +157,6 @@ $recent-indicator-size: 8px;
     color: theme.$color-greyscale-11;
   }
 
-  &__group-management-menu-container {
-    display: flex;
-  }
-
   &--transition {
     transition: all animation.$animation-duration-half ease-out;
 

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -73,14 +73,6 @@ export class FeatureFlags {
   set internalUsage(value: boolean) {
     this._setBoolean('internalUsage', value);
   }
-
-  get enableGroupManagementMenu() {
-    return this._getBoolean('enableGroupManagementMenu', false);
-  }
-
-  set enableGroupManagementMenu(value: boolean) {
-    this._setBoolean('enableGroupManagementMenu', value);
-  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -73,6 +73,14 @@ export class FeatureFlags {
   set internalUsage(value: boolean) {
     this._setBoolean('internalUsage', value);
   }
+
+  get enableGroupManagementMenu() {
+    return this._getBoolean('enableGroupManagementMenu', false);
+  }
+
+  set enableGroupManagementMenu(value: boolean) {
+    this._setBoolean('enableGroupManagementMenu', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?
- adds the group management menu to the conversation header
- adds feature flag for the group management dropdown menu in the conversation header
- adds test coverage

### Why are we making this change?
- to be able to manage groups i.e. leave group, add members.

### How do I test this?
- Open messenger > Enable menu by entering `window.FEATURE_FLAGS.enableGroupManagementMenu = true;` in the console > Check three dot menu in conversation header.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Menu in conversation header:

<img width="1261" alt="Screenshot 2023-11-29 at 11 05 36" src="https://github.com/zer0-os/zOS/assets/39112648/945e6df1-f44b-43a6-ae84-c64b0240a983">

