### PR TITLE
feat: enable add member menu option exclusively for room admins

### DIFF
--- a/src/components/group-management-menu/index.test.tsx
+++ b/src/components/group-management-menu/index.test.tsx
@@ -3,9 +3,19 @@ import { shallow } from 'enzyme';
 import { Properties, GroupManagementMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
+const featureFlags = { enableAddMemberToGroup: false };
+jest.mock('../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
+
 describe(GroupManagementMenu, () => {
-  const subject = () => {
-    const allProps: Properties = {};
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      isRoomAdmin: false,
+      onStartAddMember: () => {},
+
+      ...props,
+    };
 
     return shallow(<GroupManagementMenu {...allProps} />);
   };
@@ -14,5 +24,36 @@ describe(GroupManagementMenu, () => {
     const wrapper = subject();
 
     expect(wrapper).toHaveElement(DropdownMenu);
+  });
+
+  describe('Add Member', () => {
+    it('does not render add member menu item when isRoomAdmin is false and enableAddMemberToGroup feature flag is true', function () {
+      featureFlags.enableAddMemberToGroup = true;
+
+      const wrapper = subject({ isRoomAdmin: false });
+      const dropdownMenu = wrapper.find(DropdownMenu);
+      expect(dropdownMenu.prop('items').some((item) => item.id === 'add-member')).toBe(false);
+    });
+
+    it('renders add member menu item when isRoomAdmin is true and enableAddMemberToGroup feature flag is true', function () {
+      featureFlags.enableAddMemberToGroup = true;
+
+      const wrapper = subject({ isRoomAdmin: true });
+      const dropdownMenu = wrapper.find(DropdownMenu);
+      expect(dropdownMenu.prop('items').some((item) => item.id === 'add-member')).toBe(true);
+    });
+
+    it('calls onStartAddMember when the add member menu item is selected', function () {
+      featureFlags.enableAddMemberToGroup = true;
+
+      const mockOnStartAddMember = jest.fn();
+      const wrapper = subject({ isRoomAdmin: true, onStartAddMember: mockOnStartAddMember });
+      const dropdownMenu = wrapper.find(DropdownMenu);
+      const addMemberMenuItem = dropdownMenu.prop('items').find((item) => item.id === 'add-member');
+
+      addMemberMenuItem.onSelect();
+
+      expect(mockOnStartAddMember).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
 
+import { featureFlags } from '../../lib/feature-flags';
+
 import { IconDotsHorizontal, IconPlus } from '@zero-tech/zui/icons';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
 import './styles.scss';
 
-export interface Properties {}
+export interface Properties {
+  isRoomAdmin: boolean;
+  onStartAddMember: () => void;
+}
 
 interface State {}
 
@@ -17,6 +22,10 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
 
   handleOpenChange = () => {};
 
+  startAddMember = (_e) => {
+    this.props.onStartAddMember();
+  };
+
   renderMenuItem(icon, label) {
     return (
       <div className={'menu-item'}>
@@ -27,13 +36,16 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
 
   // Update menuItems to add new menu items
   get renderDropdownMenuItems() {
-    const menuItems = [
-      {
-        id: 'example_id',
-        label: this.renderMenuItem(<IconPlus />, 'Example Item'),
-        onSelect: () => {},
-      },
-    ];
+    const menuItems = [];
+
+    if (featureFlags.enableAddMemberToGroup && this.props.isRoomAdmin) {
+      menuItems.push({
+        id: 'add-member',
+        label: this.renderMenuItem(<IconPlus />, 'Add Member'),
+        onSelect: this.startAddMember,
+      });
+    }
+
     return menuItems;
   }
 

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -20,6 +20,7 @@ describe('messenger-chat', () => {
       isFullScreen: false,
       enterFullScreenMessenger: () => null,
       exitFullScreenMessenger: () => null,
+      isCurrentUserRoomAdmin: false,
       ...props,
     };
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -11,11 +11,11 @@ import { getProvider } from '../../../lib/cloudinary/provider';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { GroupManagementMenu } from '../../group-management-menu';
 import { featureFlags } from '../../../lib/feature-flags';
-
-import './styles.scss';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
 import { isCustomIcon } from '../list/utils/utils';
 import { IconButton } from '@zero-tech/zui/components';
+
+import './styles.scss';
 
 export interface PublicProperties {}
 
@@ -26,6 +26,7 @@ export interface Properties extends PublicProperties {
   isFullScreen: boolean;
   enterFullScreenMessenger: () => void;
   exitFullScreenMessenger: () => void;
+  isCurrentUserRoomAdmin: boolean;
 }
 
 interface State {
@@ -37,16 +38,19 @@ export class Container extends React.Component<Properties, State> {
 
   static mapState(state: RootState): Partial<Properties> {
     const {
+      authentication,
       chat: { activeConversationId },
       layout,
     } = state;
 
     const directMessage = denormalize(activeConversationId, state);
+    const isCurrentUserRoomAdmin = directMessage?.admin === authentication.user.data.matrixId;
 
     return {
       activeConversationId,
       directMessage,
       isFullScreen: layout.value?.isMessengerFullScreen,
+      isCurrentUserRoomAdmin,
     };
   }
 
@@ -182,7 +186,10 @@ export class Container extends React.Component<Properties, State> {
             </span>
             {featureFlags.enableGroupManagementMenu && (
               <div className='direct-message-chat__group-management-menu-container'>
-                <GroupManagementMenu />
+                <GroupManagementMenu
+                  isRoomAdmin={this.props.isCurrentUserRoomAdmin}
+                  onStartAddMember={() => console.log('group management: starting add group member')}
+                />
               </div>
             )}
           </div>

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -14,6 +14,7 @@ import { featureFlags } from '../../../lib/feature-flags';
 import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../store/layout';
 import { isCustomIcon } from '../list/utils/utils';
 import { IconButton } from '@zero-tech/zui/components';
+import { currentUserSelector } from '../../../store/authentication/selectors';
 
 import './styles.scss';
 
@@ -38,13 +39,13 @@ export class Container extends React.Component<Properties, State> {
 
   static mapState(state: RootState): Partial<Properties> {
     const {
-      authentication,
       chat: { activeConversationId },
       layout,
     } = state;
 
     const directMessage = denormalize(activeConversationId, state);
-    const isCurrentUserRoomAdmin = directMessage?.admin === authentication.user.data.matrixId;
+    const currentUser = currentUserSelector(state);
+    const isCurrentUserRoomAdmin = directMessage?.admin === currentUser.matrixId;
 
     return {
       activeConversationId,

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -81,6 +81,14 @@ export class FeatureFlags {
   set enableGroupManagementMenu(value: boolean) {
     this._setBoolean('enableGroupManagementMenu', value);
   }
+
+  get enableAddMemberToGroup() {
+    return this._getBoolean('enableAddMemberToGroup', false);
+  }
+
+  set enableAddMemberToGroup(value: boolean) {
+    this._setBoolean('enableAddMemberToGroup', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?
- Adds ‘Add Member’ as an option list to the triple dot menu, such that ONLY ROOM ADMINS can see it.

### Why are we making this change?
- So room admins are able to start the add member flow by selecting `Add Member` from the group management dropdown menu.

### How do I test this?
- `enableGroupManagementMenu` > `enableAddMemberToGroup` >  Create a room > Click three dot menu > Check if `Add Member` menu item renders > Click `Add Member` > Check console log for `group management: starting add group member`.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Add Group Member Menu Item Exclusively For Room Admin:

https://github.com/zer0-os/zOS/assets/39112648/d421a6e5-e93a-452a-90f3-493b5c998c1b

