### PR TITLE
feat: add members panel

### DIFF
--- a/src/components/messenger/list/add-members-panel/index.test.tsx
+++ b/src/components/messenger/list/add-members-panel/index.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { PanelHeader } from '../panel-header';
+import { AddMembersPanel, Properties } from '.';
+import { SelectedUserTag } from '../selected-user-tag';
+import { AutocompleteMembers } from '../../autocomplete-members';
+import { Button } from '@zero-tech/zui/components';
+
+describe(AddMembersPanel, () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      isSubmitting: false,
+      searchUsers: () => {},
+      onBack: () => {},
+      onSubmit: () => {},
+      ...props,
+    };
+
+    return shallow(<AddMembersPanel {...allProps} />);
+  };
+
+  it('forwards search function to Autocomplete', function () {
+    const searchUsers = jest.fn();
+    const wrapper = subject({ searchUsers });
+
+    expect(wrapper.find(AutocompleteMembers).prop('search')).toBe(searchUsers);
+  });
+
+  it('fires onBack when back icon clicked', function () {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    wrapper.find(PanelHeader).simulate('back');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('fires onSubmit when submit button is clicked', function () {
+    const onSubmit = jest.fn();
+    const wrapper = subject({ onSubmit });
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1' });
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-2' });
+    wrapper.find(Button).simulate('press');
+
+    expect(onSubmit).toHaveBeenCalledWith([
+      { value: 'id-1' },
+      { value: 'id-2' },
+    ]);
+  });
+
+  it('sets button to loading state if submitting', function () {
+    const wrapper = subject({ isSubmitting: true });
+
+    expect(wrapper.find(Button).prop('isLoading')).toBeTrue();
+  });
+
+  it('disables submit button when no users are selected', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find(Button).prop('isDisabled')).toBe(true);
+  });
+
+  it('enables submit button based on number of users', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find(Button).prop('isDisabled')).toBeTrue();
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1' });
+    expect(wrapper.find(Button).prop('isDisabled')).toBeFalse();
+
+    wrapper.find(SelectedUserTag).first().simulate('remove', 'id-1');
+    expect(wrapper.find(Button).prop('isDisabled')).toBeTrue();
+  });
+
+  it('shows selected member count', function () {
+    const wrapper = subject({});
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1' });
+    expect(wrapper.find('.add-members-panel__selected-count').text()).toEqual('1 member selected');
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-2' });
+    expect(wrapper.find('.add-members-panel__selected-count').text()).toEqual('2 members selected');
+  });
+
+  it('renders selected members', function () {
+    const wrapper = subject({});
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-2', label: 'User 2', image: 'url-2' });
+
+    expect(wrapper.find(SelectedUserTag).map(userLabel)).toEqual([
+      'User 1',
+      'User 2',
+    ]);
+  });
+
+  it('unselects users when X is clicked', function () {
+    const wrapper = subject({});
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-2', label: 'User 2', image: 'url-2' });
+
+    wrapper.find(SelectedUserTag).first().simulate('remove', 'id-1');
+
+    expect(wrapper.find(SelectedUserTag).map(userLabel)).toEqual(['User 2']);
+  });
+
+  it('renders unique list of selected users', function () {
+    const wrapper = subject({});
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+    // force select the same option (the same user can't be selected, but just in case)
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'id-1', label: 'User 1', image: 'url-1' });
+
+    expect(wrapper.find(SelectedUserTag).map(userLabel)).toEqual(['User 1']);
+  });
+});
+
+function userLabel(tag) {
+  return tag.prop('userOption').label;
+}

--- a/src/components/messenger/list/add-members-panel/index.tsx
+++ b/src/components/messenger/list/add-members-panel/index.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+
+import { Button } from '@zero-tech/zui/components';
+
+import { Option } from '../../lib/types';
+
+import { AutocompleteMembers } from '../../autocomplete-members';
+import { PanelHeader } from '../panel-header';
+import { SelectedUserTag } from '../selected-user-tag';
+
+import { bemClassName } from '../../../../lib/bem';
+import './styles.scss';
+
+const cn = bemClassName('add-members-panel');
+
+export interface Properties {
+  isSubmitting: boolean;
+
+  searchUsers: (input: string) => any;
+  onBack: () => void;
+  onSubmit: (options: Option[]) => void;
+}
+
+interface State {
+  selectedOptions: Option[];
+}
+
+export class AddMembersPanel extends React.Component<Properties, State> {
+  state = { selectedOptions: [] };
+
+  constructor(props) {
+    super(props);
+    this.state = { selectedOptions: [] };
+  }
+
+  submitSelectedOptions = () => {
+    this.props.onSubmit(this.state.selectedOptions);
+  };
+
+  selectOption = (selectedOption) => {
+    if (this.state.selectedOptions.find((o) => o.value === selectedOption.value)) {
+      return;
+    }
+
+    this.setState({
+      selectedOptions: [
+        ...this.state.selectedOptions,
+        selectedOption,
+      ],
+    });
+  };
+
+  unselectOption = (value: string) => {
+    this.setState({
+      selectedOptions: this.state.selectedOptions.filter((o) => o.value !== value),
+    });
+  };
+
+  get hasSelectedOptions() {
+    return this.state.selectedOptions.length > 0;
+  }
+
+  get memberCountSuffix() {
+    return this.state.selectedOptions.length >= 2 ? 's' : '';
+  }
+
+  renderSelectCount() {
+    return (
+      <div {...cn('selected-count')}>
+        <span {...cn('selected-number')}>{this.state.selectedOptions.length}</span> member
+        {this.memberCountSuffix} selected
+      </div>
+    );
+  }
+
+  renderSelectedUserTags() {
+    return (
+      <div>
+        {this.state.selectedOptions.map((option) => (
+          <SelectedUserTag key={option.value} userOption={option} onRemove={this.unselectOption} />
+        ))}
+      </div>
+    );
+  }
+
+  renderSubmitButton() {
+    return (
+      <Button
+        {...cn('submit-button')}
+        onPress={this.submitSelectedOptions}
+        isDisabled={!this.hasSelectedOptions}
+        isLoading={this.props.isSubmitting}
+      >
+        {`Add Member${this.memberCountSuffix}`}
+      </Button>
+    );
+  }
+
+  render() {
+    return (
+      <>
+        <PanelHeader title={'Add Members'} onBack={this.props.onBack} />
+        <div {...cn('search')}>
+          <AutocompleteMembers
+            search={this.props.searchUsers}
+            onSelect={this.selectOption}
+            selectedOptions={this.state.selectedOptions}
+          >
+            {this.hasSelectedOptions && this.renderSelectCount()}
+            {this.renderSelectedUserTags()}
+          </AutocompleteMembers>
+        </div>
+        {this.renderSubmitButton()}
+      </>
+    );
+  }
+}

--- a/src/components/messenger/list/add-members-panel/styles.scss
+++ b/src/components/messenger/list/add-members-panel/styles.scss
@@ -1,0 +1,37 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../variables';
+@import '../../../../layout';
+
+$side-padding: 16px;
+
+.add-members-panel {
+  &__selected-count {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+    padding-top: 18px;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__selected-number {
+    color: theme.$color-greyscale-12;
+  }
+
+  &__content {
+    flex-grow: 99;
+
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__search {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__submit-button {
+    margin: 16px $side-padding;
+  }
+}


### PR DESCRIPTION
### What does this do?
- adds the `Add Members` panel under `messenger/list`.

### Why are we making this change?
- to select and add new members to a room.

### How do I test this?
- you could swap this panel for an existing panel in the create conversation flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="275" alt="Screenshot 2023-12-01 at 10 44 49" src="https://github.com/zer0-os/zOS/assets/39112648/4551b48f-61c7-4391-af73-9c36c0240df1">

<img width="275" alt="Screenshot 2023-12-01 at 10 46 06" src="https://github.com/zer0-os/zOS/assets/39112648/3849844b-3129-41fb-b006-4b1772caf688">

<img width="275" alt="Screenshot 2023-12-01 at 10 46 10" src="https://github.com/zer0-os/zOS/assets/39112648/d1ff5ff2-a708-4f60-846a-f500934b75cd">
<img width="275" alt="Screenshot 2023-12-01 at 10 46 20" src="https://github.com/zer0-os/zOS/assets/39112648/48d721cb-015e-4338-8d9f-4f0a921c03d4">



