### PR TITLE
feat: wire up and trigger add member action from messenger chat

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -5,6 +5,7 @@ import { Container as DirectMessageChat, Properties } from '.';
 import { Channel, User } from '../../../store/channels';
 import Tooltip from '../../tooltip';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
+import { GroupManagementMenu } from '../../group-management-menu';
 
 const featureFlags = { enableGroupManagementMenu: false };
 jest.mock('../../../lib/feature-flags', () => ({
@@ -21,6 +22,7 @@ describe('messenger-chat', () => {
       enterFullScreenMessenger: () => null,
       exitFullScreenMessenger: () => null,
       isCurrentUserRoomAdmin: false,
+      startAddGroupMember: () => null,
       ...props,
     };
 
@@ -215,6 +217,15 @@ describe('messenger-chat', () => {
       const groupManagementMenuContainer = wrapper.find('.direct-message-chat__group-management-menu-container');
 
       expect(groupManagementMenuContainer.exists()).toBeTrue();
+    });
+
+    it('can start add group member group management saga', async function () {
+      const startAddGroupMember = jest.fn();
+      const wrapper = subject({ startAddGroupMember });
+
+      wrapper.find(GroupManagementMenu).prop('onStartAddMember')();
+
+      expect(startAddGroupMember).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -15,6 +15,7 @@ import { enterFullScreenMessenger, exitFullScreenMessenger } from '../../../stor
 import { isCustomIcon } from '../list/utils/utils';
 import { IconButton } from '@zero-tech/zui/components';
 import { currentUserSelector } from '../../../store/authentication/selectors';
+import { startAddGroupMember } from '../../../store/group-management';
 
 import './styles.scss';
 
@@ -28,6 +29,7 @@ export interface Properties extends PublicProperties {
   enterFullScreenMessenger: () => void;
   exitFullScreenMessenger: () => void;
   isCurrentUserRoomAdmin: boolean;
+  startAddGroupMember: () => void;
 }
 
 interface State {
@@ -60,6 +62,7 @@ export class Container extends React.Component<Properties, State> {
       setactiveConversationId,
       enterFullScreenMessenger,
       exitFullScreenMessenger,
+      startAddGroupMember,
     };
   }
 
@@ -189,7 +192,7 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__group-management-menu-container'>
                 <GroupManagementMenu
                   isRoomAdmin={this.props.isCurrentUserRoomAdmin}
-                  onStartAddMember={() => console.log('group management: starting add group member')}
+                  onStartAddMember={this.props.startAddGroupMember}
                 />
               </div>
             )}


### PR DESCRIPTION
### What does this do?
- wires up and triggers add member action from messenger chat.

### Why are we making this change?
- to initiate the group management add member flow.

### How do I test this?
- Open messenger > `window.FEATURE_FLAGS.enableGroupManagementMenu = true;` > `window.FEATURE_FLAGS.enableAddMemberToGroup = true;` > Click three dot menu > Select Add Member > Add Member panel should be displayed in the sidekick (messenger list)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/e5926a42-3807-4539-b73b-c6e61ea17d60

