### PR TITLE
Modify key backups to use cross-signing

### DIFF
--- a/src/components/secure-backup/container.tsx
+++ b/src/components/secure-backup/container.tsx
@@ -12,6 +12,7 @@ export interface Properties extends PublicProperties {
   isLoaded: boolean;
   backupExists: boolean;
   isBackupRecovered: boolean;
+  isLegacy: boolean;
   recoveryKey: string;
   successMessage: string;
   errorMessage: string;
@@ -30,6 +31,7 @@ export class Container extends React.Component<Properties> {
       isLoaded,
       backupExists: !!trustInfo,
       isBackupRecovered: trustInfo?.usable || trustInfo?.trustedLocally,
+      isLegacy: trustInfo?.isLegacy,
       recoveryKey: generatedRecoveryKey || '',
       successMessage,
       errorMessage,
@@ -57,6 +59,7 @@ export class Container extends React.Component<Properties> {
       <SecureBackup
         backupExists={this.props.backupExists}
         isBackupRecovered={this.props.isBackupRecovered}
+        isLegacy={this.props.isLegacy}
         recoveryKey={this.props.recoveryKey}
         successMessage={this.props.successMessage}
         errorMessage={this.props.errorMessage}

--- a/src/components/secure-backup/container.tsx
+++ b/src/components/secure-backup/container.tsx
@@ -25,12 +25,12 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState) {
-    const { isLoaded, backup, trustInfo, successMessage, errorMessage } = state.matrix;
+    const { isLoaded, generatedRecoveryKey, trustInfo, successMessage, errorMessage } = state.matrix;
     return {
       isLoaded,
       backupExists: !!trustInfo,
       isBackupRecovered: trustInfo?.usable || trustInfo?.trustedLocally,
-      recoveryKey: backup?.recovery_key,
+      recoveryKey: generatedRecoveryKey || '',
       successMessage,
       errorMessage,
     };

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 
 import { SecureBackup, Properties } from '.';
-import { Alert, Input } from '@zero-tech/zui/components';
+import { Alert, Button, Input } from '@zero-tech/zui/components';
 import { bem } from '../../lib/bem';
 import { buttonLabelled } from '../../test/utils';
 
@@ -13,6 +13,7 @@ describe('SecureBackup', () => {
       recoveryKey: 'stub-key',
       backupExists: false,
       isBackupRecovered: false,
+      isLegacy: false,
       successMessage: '',
       errorMessage: '',
       onGenerate: () => null,
@@ -96,6 +97,20 @@ describe('SecureBackup', () => {
     const wrapper = subject({ onRestore, backupExists: true, isBackupRecovered: true, recoveryKey: '' });
 
     expect(wrapper).toHaveElement(c('backed-up'));
+    expect(wrapper).not.toHaveElement(Button);
+  });
+
+  it('renders button to generate a new backup if the current one is a legacy backup', function () {
+    const onRestore = jest.fn();
+    const wrapper = subject({
+      onRestore,
+      isLegacy: true,
+      backupExists: true,
+      isBackupRecovered: true,
+      recoveryKey: '',
+    });
+
+    expect(wrapper).toHaveElement(Button);
   });
 
   it('renders success message', function () {

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -18,6 +18,7 @@ export interface Properties {
   recoveryKey: string;
   backupExists: boolean;
   isBackupRecovered: boolean;
+  isLegacy: boolean;
   successMessage: string;
   errorMessage: string;
 
@@ -61,11 +62,13 @@ export class SecureBackup extends React.PureComponent<Properties, State> {
   }
 
   renderBackedUpMode() {
+    const { isLegacy } = this.props;
+    const button = isLegacy ? <Button onPress={() => this.props.onGenerate()}>Generate new backup</Button> : null;
     return (
       <div {...cn('backed-up')}>
         <p>This session is backing up your keys.</p>
         <p>This backup is trusted because it has been restored on this session.</p>
-        {this.renderButtons(<Button onPress={() => this.props.onGenerate()}>Generate new backup</Button>)}
+        {this.renderButtons(button)}
       </div>
     );
   }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -180,7 +180,7 @@ export class Chat {
   }
 
   async saveSecureBackup(backup: MatrixKeyBackupInfo): Promise<void> {
-    this.client.saveSecureBackup(backup);
+    await this.client.saveSecureBackup(backup);
   }
 
   async restoreSecureBackup(recoveryKey: string): Promise<any> {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -162,10 +162,12 @@ describe('matrix client', () => {
 
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(createClient).toHaveBeenCalledWith({
-        baseUrl: config.matrix.homeServerUrl,
-        ...matrixSession,
-      });
+      expect(createClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: config.matrix.homeServerUrl,
+          ...matrixSession,
+        })
+      );
     });
 
     it('logs in and creates SDK client with new session if none exists', async () => {
@@ -189,10 +191,13 @@ describe('matrix client', () => {
 
       await resolve();
 
-      expect(createClient).toHaveBeenNthCalledWith(2, {
-        baseUrl: config.matrix.homeServerUrl,
-        ...matrixSession,
-      });
+      expect(createClient).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          baseUrl: config.matrix.homeServerUrl,
+          ...matrixSession,
+        })
+      );
     });
 
     it('saves session if none exists', async () => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -137,7 +137,10 @@ export class MatrixClient implements IChatClient {
   }
 
   async getSecureBackup() {
-    return await this.matrix.checkKeyBackup();
+    const crossSigning = await this.matrix.getStoredCrossSigningForUser(this.userId);
+    const backupInfo = await this.matrix.checkKeyBackup();
+    (backupInfo as any).isLegacy = !crossSigning;
+    return backupInfo;
   }
 
   async generateSecureBackup() {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -52,6 +52,7 @@ export class MatrixClient implements IChatClient {
   private connectionAwaiter: Promise<void>;
   private unreadNotificationHandlers = [];
   private initializationTimestamp: number;
+  private secretStorageKey: string;
 
   constructor(private sdk = { createClient }, private sessionStorage = new SessionStorage()) {
     this.addConnectionAwaiter();
@@ -140,21 +141,25 @@ export class MatrixClient implements IChatClient {
   }
 
   async generateSecureBackup() {
-    return await this.matrix.prepareKeyBackupVersion();
+    const recoveryKey = await this.matrix.getCrypto()!.createRecoveryKeyFromPassphrase();
+    return recoveryKey.encodedPrivateKey;
   }
 
-  async saveSecureBackup(backup) {
-    // Clone the backup object because the save mutates it.
-    const cleanBackup = {
-      algorithm: backup.algorithm,
-      auth_data: { ...backup.auth_data },
-      recovery_key: backup.recovery_key,
-    };
+  async saveSecureBackup(recoveryKey: string) {
+    await this.matrix.bootstrapCrossSigning({
+      authUploadDeviceSigningKeys: async (makeRequest) => {
+        await makeRequest({ identifier: { type: 'm.id.user', user: this.userId } });
+      },
+    });
 
+    // Set this because bootstrapping the secret storage will call back
+    // and require this value. Not ideal but given the callback nature of
+    // setting up the secret storage, this suffices for now.
+    this.secretStorageKey = recoveryKey;
     try {
-      await this.matrix.createKeyBackupVersion(cleanBackup);
-    } catch (e) {
-      throw new Error('Error creating key backup');
+      await this.matrix.getCrypto().bootstrapSecretStorage({ setupNewKeyBackup: true });
+    } finally {
+      this.secretStorageKey = null;
     }
   }
 
@@ -164,12 +169,20 @@ export class MatrixClient implements IChatClient {
       throw new Error('Backup broken or not there');
     }
 
+    // Set this because bootstrapping the secret storage will call back
+    // and require this value. Not ideal but given the callback nature of
+    // setting up the secret storage, this suffices for now.
+    this.secretStorageKey = recoveryKey;
     try {
-      if (!backup.trustInfo.usable) {
-        await this.matrix.restoreKeyBackupWithRecoveryKey(recoveryKey, undefined, undefined, backup.backupInfo);
-      }
+      // Since cross signing is already setup when we get here we don't have to provide signing keys
+      await this.matrix.bootstrapCrossSigning({ authUploadDeviceSigningKeys: async (_makeRequest) => {} });
+      await this.matrix.getCrypto().bootstrapSecretStorage({});
+      await this.matrix.restoreKeyBackupWithSecretStorage(backup.backupInfo);
     } catch (e) {
+      console.log('error restoring backup', e);
       throw new Error('Error while restoring backup');
+    } finally {
+      this.secretStorageKey = null;
     }
   }
 
@@ -681,6 +694,7 @@ export class MatrixClient implements IChatClient {
     if (!this.matrix) {
       const opts: any = {
         baseUrl: config.matrix.homeServerUrl,
+        cryptoCallbacks: { getSecretStorageKey: this.getSecretStorageKey },
         ...(await this.getCredentials(ssoToken)),
       };
 
@@ -865,6 +879,16 @@ export class MatrixClient implements IChatClient {
   private getLatestEvent(room: Room, type: EventType) {
     return room.getLiveTimeline().getState(EventTimeline.FORWARDS).getStateEvents(type, '');
   }
+
+  private getSecretStorageKey = async ({ keys: keyInfos }) => {
+    const keyInfoEntries = Object.entries(keyInfos);
+    if (keyInfoEntries.length > 1) {
+      throw new Error('Multiple storage key requests not implemented');
+    }
+    const [keyId] = keyInfoEntries[0];
+    const key = this.matrix.keyBackupKeyFromRecoveryKey(this.secretStorageKey);
+    return [keyId, key];
+  };
 
   /*
    * DEBUGGING

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -1,5 +1,4 @@
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { MatrixKeyBackupInfo } from '../../lib/chat';
 
 export enum SagaActionTypes {
   GetBackup = 'chat/get-backup',
@@ -19,7 +18,7 @@ export enum SagaActionTypes {
 export type MatrixState = {
   isLoaded: boolean;
   trustInfo: { trustedLocally: boolean; usable: boolean } | null;
-  backup: MatrixKeyBackupInfo | null;
+  generatedRecoveryKey: string | null;
   successMessage: string;
   errorMessage: string;
   deviceId: string;
@@ -28,7 +27,7 @@ export type MatrixState = {
 export const initialState: MatrixState = {
   isLoaded: false,
   trustInfo: null,
-  backup: null,
+  generatedRecoveryKey: null,
   successMessage: '',
   errorMessage: '',
   deviceId: '',
@@ -54,8 +53,8 @@ const slice = createSlice({
     setLoaded: (state, action: PayloadAction<MatrixState['isLoaded']>) => {
       state.isLoaded = action.payload;
     },
-    setBackup: (state, action: PayloadAction<MatrixState['backup']>) => {
-      state.backup = action.payload;
+    setGeneratedRecoveryKey: (state, action: PayloadAction<MatrixState['generatedRecoveryKey']>) => {
+      state.generatedRecoveryKey = action.payload;
     },
     setTrustInfo: (state, action: PayloadAction<MatrixState['trustInfo']>) => {
       state.trustInfo = action.payload;
@@ -72,5 +71,6 @@ const slice = createSlice({
   },
 });
 
-export const { setLoaded, setBackup, setTrustInfo, setSuccessMessage, setErrorMessage, setDeviceId } = slice.actions;
+export const { setLoaded, setGeneratedRecoveryKey, setTrustInfo, setSuccessMessage, setErrorMessage, setDeviceId } =
+  slice.actions;
 export const { reducer } = slice;

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -17,7 +17,7 @@ export enum SagaActionTypes {
 
 export type MatrixState = {
   isLoaded: boolean;
-  trustInfo: { trustedLocally: boolean; usable: boolean } | null;
+  trustInfo: { trustedLocally: boolean; usable: boolean; isLegacy: boolean } | null;
   generatedRecoveryKey: string | null;
   successMessage: string;
   errorMessage: string;

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -35,7 +35,7 @@ describe(getBackup, () => {
 
     expect(storeState.matrix).toEqual(
       expect.objectContaining({
-        backup: null,
+        generatedRecoveryKey: null,
         isLoaded: true,
         trustInfo: { usable: true, trustedLocally: true },
         successMessage: '',
@@ -52,7 +52,7 @@ describe(getBackup, () => {
 
     expect(storeState.matrix).toEqual(
       expect.objectContaining({
-        backup: null,
+        generatedRecoveryKey: null,
         isLoaded: true,
         trustInfo: null,
         successMessage: '',
@@ -69,7 +69,7 @@ describe(getBackup, () => {
 
     expect(storeState.matrix).toEqual(
       expect.objectContaining({
-        backup: null,
+        generatedRecoveryKey: null,
         isLoaded: true,
         trustInfo: null,
         successMessage: '',
@@ -82,27 +82,27 @@ describe(getBackup, () => {
 describe(generateBackup, () => {
   it('generates a new backup', async () => {
     const { storeState } = await subject(generateBackup)
-      .provide([[call([chatClient, chatClient.generateSecureBackup]), { data: 'here' }]])
+      .provide([[call([chatClient, chatClient.generateSecureBackup]), 'new key']])
       .withReducer(rootReducer)
       .run();
 
-    expect(storeState.matrix.backup).toEqual({ data: 'here' });
+    expect(storeState.matrix.generatedRecoveryKey).toEqual('new key');
   });
 });
 
 describe(saveBackup, () => {
   describe('success', () => {
     function successSubject() {
-      const initialState = { matrix: { backup: { generated: 'backup' } } };
+      const initialState = { matrix: { generatedRecoveryKey: 'the key' } };
 
       return subject(saveBackup)
-        .provide([[call([chatClient, chatClient.saveSecureBackup], { generated: 'backup' }), { version: 1 }]])
+        .provide([[call([chatClient, chatClient.saveSecureBackup], 'the key'), { version: 1 }]])
         .withReducer(rootReducer, initialState as any);
     }
     it('clears the generated backup', async () => {
       const { storeState } = await successSubject().run();
 
-      expect(storeState.matrix.backup).toEqual(null);
+      expect(storeState.matrix.generatedRecoveryKey).toEqual(null);
     });
 
     it('fetches the saved backup', async () => {
@@ -118,7 +118,7 @@ describe(saveBackup, () => {
 
   describe('failure', () => {
     it('sets a failure message', async () => {
-      const initialState = { matrix: { backup: {} } };
+      const initialState = { matrix: { generatedRecoveryKey: 'a key' } };
 
       const { storeState } = await subject(saveBackup)
         .provide([
@@ -181,7 +181,7 @@ describe(clearBackupState, () => {
     const initialState = {
       matrix: {
         isLoaded: true,
-        backup: { data: 'here' },
+        generatedRecoveryKey: 'a key',
         trustInfo: { trustData: 'here' },
         successMessage: 'Stuff happened',
         errorMessage: 'An error',
@@ -192,7 +192,7 @@ describe(clearBackupState, () => {
       .run();
 
     expect(storeState.matrix).toEqual({
-      backup: null,
+      generatedRecoveryKey: null,
       isLoaded: false,
       trustInfo: null,
       successMessage: '',

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -27,7 +27,7 @@ describe(getBackup, () => {
       .provide([
         [
           call([chatClient, chatClient.getSecureBackup]),
-          { backupInfo: {}, trustInfo: { usable: true, trusted_locally: true } },
+          { backupInfo: {}, trustInfo: { usable: true, trusted_locally: true }, isLegacy: true },
         ],
       ])
       .withReducer(rootReducer)
@@ -37,7 +37,7 @@ describe(getBackup, () => {
       expect.objectContaining({
         generatedRecoveryKey: null,
         isLoaded: true,
-        trustInfo: { usable: true, trustedLocally: true },
+        trustInfo: { usable: true, trustedLocally: true, isLegacy: true },
         successMessage: '',
         errorMessage: '',
       })

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -2,7 +2,7 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import {
   SagaActionTypes,
-  setBackup,
+  setGeneratedRecoveryKey,
   setDeviceId,
   setErrorMessage,
   setLoaded,
@@ -47,18 +47,18 @@ export function* getBackup() {
 
 export function* generateBackup() {
   const chatClient = yield call(chat.get);
-  const newBackup = yield call([chatClient, chatClient.generateSecureBackup]);
-  yield put(setBackup(newBackup));
+  const key = yield call([chatClient, chatClient.generateSecureBackup]);
+  yield put(setGeneratedRecoveryKey(key));
 }
 
 export function* saveBackup() {
   yield put(setSuccessMessage(''));
   yield put(setErrorMessage(''));
-  const backup = yield select((state) => state.matrix.backup);
+  const key = yield select((state) => state.matrix.generatedRecoveryKey);
   const chatClient = yield call(chat.get);
   try {
-    yield call([chatClient, chatClient.saveSecureBackup], backup);
-    yield put(setBackup(null));
+    yield call([chatClient, chatClient.saveSecureBackup], key);
+    yield put(setGeneratedRecoveryKey(null));
     yield call(getBackup);
     yield put(setSuccessMessage('Backup saved successfully'));
   } catch {
@@ -83,7 +83,7 @@ export function* restoreBackup(action) {
 export function* clearBackupState() {
   yield put(setLoaded(false));
   yield put(setTrustInfo(null));
-  yield put(setBackup(null));
+  yield put(setGeneratedRecoveryKey(null));
   yield put(setSuccessMessage(''));
   yield put(setErrorMessage(''));
 }

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -39,6 +39,7 @@ export function* getBackup() {
       setTrustInfo({
         usable: existingBackup.trustInfo.usable,
         trustedLocally: existingBackup.trustInfo.trusted_locally,
+        isLegacy: existingBackup.isLegacy,
       })
     );
   }


### PR DESCRIPTION
### What does this do?

This changes the key backup to use cross-signing and secure storage.

### Why are we making this change?

The cross-signing allows us to 'verify' the new device properly so that all future messages are also available upon subsequent key backup restores.

### How do I test this?

Create a backup, send some messaages, logout, restore the backup, send more messages, logout again and restore again. You should be able to decrypt all the messaages from both before the restore and after.
