### PR TITLE
Update messages immediately when a backup restore occurs

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -464,7 +464,7 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
     for (let message of byChannelId[channelId]) {
       yield call(mapReceivedMessage, message);
 
-      if (!channel || currentMessages.includes(message.id)) {
+      if (!channel) {
         continue;
       }
       modified = true;


### PR DESCRIPTION
### What does this do?

This changes the message event handler to favor newer updates to messages.

### Why are we making this change?

Due to various event timing we sometimes have a message in the list that shows "could not decrypt" message but a later event comes in with the properly decrypted version. Previously, since the message was already in the list, we were ignoring the new event. This is particularly obvious during a key backup restore as all messages are undecryptable and performing the restore wouldn't immediately update the view.

