### PR TITLE
Refactor: extract GroupManagement sub-component

### DIFF
--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+
+import { GroupManagement, Properties } from '.';
+
+describe('GroupManagement', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      ...props,
+    };
+
+    return shallow(<GroupManagement {...allProps} />);
+  };
+
+  it('TODO renders', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.exists()).toBeTrue();
+  });
+});

--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -1,19 +1,64 @@
 import { shallow } from 'enzyme';
 
 import { GroupManagement, Properties } from '.';
+import { Stage } from '../../../../store/group-management';
+import { AddMembersPanel } from '../add-members-panel';
 
 describe('GroupManagement', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
+      groupManagementStage: Stage.None,
+      isFetchingExistingConversations: false,
+      backGroupManagement: () => null,
+      usersInMyNetworks: () => null,
       ...props,
     };
 
     return shallow(<GroupManagement {...allProps} />);
   };
 
-  it('TODO renders', function () {
-    const wrapper = subject({});
+  it('renders AddMembersPanel', function () {
+    let wrapper = subject({ groupManagementStage: Stage.StartAddMemberToRoom });
 
-    expect(wrapper.exists()).toBeTrue();
+    expect(wrapper).toHaveElement(AddMembersPanel);
+  });
+
+  it('does not render AddMembersPanel if group management stage is none', function () {
+    const wrapper = subject({ groupManagementStage: Stage.None });
+
+    expect(wrapper).not.toHaveElement(GroupManagement);
+  });
+
+  it('moves back from AddMembersPanel', async function () {
+    const backGroupManagement = jest.fn();
+    const wrapper = subject({
+      groupManagementStage: Stage.StartAddMemberToRoom,
+      backGroupManagement,
+    });
+
+    await wrapper.find(AddMembersPanel).simulate('back');
+
+    expect(backGroupManagement).toHaveBeenCalledOnce();
+  });
+
+  it('searches for citizens when adding new members', async function () {
+    const usersInMyNetworks = jest.fn();
+    const wrapper = subject({
+      groupManagementStage: Stage.StartAddMemberToRoom,
+      usersInMyNetworks,
+    });
+
+    await wrapper.find(AddMembersPanel).prop('searchUsers')('jac');
+
+    expect(usersInMyNetworks).toHaveBeenCalledWith('jac');
+  });
+
+  it('sets AddMembersPanel to Submitting while data is loading', async function () {
+    const wrapper = subject({
+      groupManagementStage: Stage.StartAddMemberToRoom,
+      isFetchingExistingConversations: true,
+    });
+
+    expect(wrapper.find(AddMembersPanel).prop('isSubmitting')).toBeTrue();
   });
 });

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -5,7 +5,7 @@ import { AddMembersPanel } from '../add-members-panel';
 
 export interface Properties {
   groupManagementStage: GroupManagementSagaStage;
-  isFetchingExistingConversations: boolean; // XXX: This is totally wrong
+  isFetchingExistingConversations: boolean; // This is wrong as it's a flag related to creating conversations
   backGroupManagement: () => void;
   usersInMyNetworks: (search: string) => Promise<any>;
 }

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { Stage as GroupManagementSagaStage, back as backGroupManagement } from '../../../../store/group-management';
+import { AddMembersPanel } from '../add-members-panel';
+
+export interface Properties {
+  groupManangemenetStage: GroupManagementSagaStage;
+  isFetchingExistingConversations: boolean; // XXX: This is totally wrong
+  backGroupManagement: () => void;
+  usersInMyNetworks: (search: string) => Promise<any>;
+}
+
+export class GroupManagement extends React.Component<Properties> {
+  render() {
+    return (
+      <>
+        {this.props.groupManangemenetStage === GroupManagementSagaStage.StartAddMemberToRoom && (
+          <AddMembersPanel
+            isSubmitting={this.props.isFetchingExistingConversations}
+            onBack={this.props.backGroupManagement}
+            onSubmit={() => console.log('addMembersSelected: Submit Add New Group members')}
+            searchUsers={this.props.usersInMyNetworks}
+          />
+        )}
+      </>
+    );
+  }
+}

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 
-import { Stage as GroupManagementSagaStage, back as backGroupManagement } from '../../../../store/group-management';
+import { Stage as GroupManagementSagaStage } from '../../../../store/group-management';
 import { AddMembersPanel } from '../add-members-panel';
 
 export interface Properties {
-  groupManangemenetStage: GroupManagementSagaStage;
+  groupManagementStage: GroupManagementSagaStage;
   isFetchingExistingConversations: boolean; // XXX: This is totally wrong
   backGroupManagement: () => void;
   usersInMyNetworks: (search: string) => Promise<any>;
 }
 
-export class GroupManagement extends React.Component<Properties> {
+export class GroupManagement extends React.PureComponent<Properties> {
   render() {
     return (
       <>
-        {this.props.groupManangemenetStage === GroupManagementSagaStage.StartAddMemberToRoom && (
+        {this.props.groupManagementStage === GroupManagementSagaStage.StartAddMemberToRoom && (
           <AddMembersPanel
             isSubmitting={this.props.isFetchingExistingConversations}
             onBack={this.props.backGroupManagement}

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -17,7 +17,6 @@ import { RewardsState } from '../../../store/rewards';
 import { RewardsContainer } from '../../rewards-container';
 import { previewDisplayDate } from '../../../lib/chat/chat-message';
 import { SettingsMenu } from '../../settings-menu';
-import { AddMembersPanel } from './add-members-panel';
 import { GroupManagement } from './group-management';
 
 const mockSearchMyNetworksByName = jest.fn();
@@ -324,67 +323,16 @@ describe('messenger-list', () => {
     expect(enterFullScreenMessenger).toHaveBeenCalledOnce();
   });
 
-  describe('group management', () => {
-    const groupSubject = (props: Partial<Properties> = {}) => {
-      const wrapper = subject(props);
-      return wrapper.find(GroupManagement).dive();
-    };
+  it('renders GroupManagement if group management stage is NOT none', function () {
+    const wrapper = subject({ stage: Stage.None, groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom });
 
-    it('renders AddMembersPanel', function () {
-      let wrapper = groupSubject({
-        stage: Stage.None,
-        groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
-      });
+    expect(wrapper).toHaveElement(GroupManagement);
+  });
 
-      expect(wrapper).not.toHaveElement(ConversationListPanel);
-      expect(wrapper).not.toHaveElement(CreateConversationPanel);
-      expect(wrapper).not.toHaveElement(StartGroupPanel);
-      expect(wrapper).not.toHaveElement(GroupDetailsPanel);
-      expect(wrapper).toHaveElement(AddMembersPanel);
-    });
+  it('does not render GroupManagement if group management stage is none', function () {
+    const wrapper = subject({ stage: Stage.None, groupManangemenetStage: GroupManagementStage.None });
 
-    it('does not render AddMembersPanel if group management stage is none', function () {
-      const wrapper = subject({ stage: Stage.None, groupManangemenetStage: GroupManagementStage.None });
-
-      expect(wrapper).not.toHaveElement(GroupManagement);
-    });
-
-    it('moves back from AddMembersPanel', async function () {
-      const backGroupManagement = jest.fn();
-      const wrapper = groupSubject({
-        stage: Stage.None,
-        groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
-        backGroupManagement,
-      });
-
-      await wrapper.find(AddMembersPanel).simulate('back');
-
-      expect(backGroupManagement).toHaveBeenCalledOnce();
-    });
-
-    it('searches for citizens when adding new members', async function () {
-      when(mockSearchMyNetworksByName)
-        .calledWith('jac')
-        .mockResolvedValue([{ id: 'user-id', profileImage: 'image-url' }]);
-      const wrapper = groupSubject({
-        stage: Stage.None,
-        groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
-      });
-
-      const searchResults = await wrapper.find(AddMembersPanel).prop('searchUsers')('jac');
-
-      expect(searchResults).toStrictEqual([{ id: 'user-id', image: 'image-url', profileImage: 'image-url' }]);
-    });
-
-    it('sets AddMembersPanel to Submitting while data is loading', async function () {
-      const wrapper = groupSubject({
-        stage: Stage.None,
-        groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
-        isFetchingExistingConversations: true,
-      });
-
-      expect(wrapper.find(AddMembersPanel).prop('isSubmitting')).toBeTrue();
-    });
+    expect(wrapper).not.toHaveElement(GroupManagement);
   });
 
   describe('mapState', () => {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -18,6 +18,7 @@ import { RewardsContainer } from '../../rewards-container';
 import { previewDisplayDate } from '../../../lib/chat/chat-message';
 import { SettingsMenu } from '../../settings-menu';
 import { AddMembersPanel } from './add-members-panel';
+import { GroupManagement } from './group-management';
 
 const mockSearchMyNetworksByName = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -324,8 +325,16 @@ describe('messenger-list', () => {
   });
 
   describe('group management', () => {
+    const groupSubject = (props: Partial<Properties> = {}) => {
+      const wrapper = subject(props);
+      return wrapper.find(GroupManagement).dive();
+    };
+
     it('renders AddMembersPanel', function () {
-      const wrapper = subject({ stage: Stage.None, groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom });
+      let wrapper = groupSubject({
+        stage: Stage.None,
+        groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
+      });
 
       expect(wrapper).not.toHaveElement(ConversationListPanel);
       expect(wrapper).not.toHaveElement(CreateConversationPanel);
@@ -337,12 +346,12 @@ describe('messenger-list', () => {
     it('does not render AddMembersPanel if group management stage is none', function () {
       const wrapper = subject({ stage: Stage.None, groupManangemenetStage: GroupManagementStage.None });
 
-      expect(wrapper).not.toHaveElement(AddMembersPanel);
+      expect(wrapper).not.toHaveElement(GroupManagement);
     });
 
     it('moves back from AddMembersPanel', async function () {
       const backGroupManagement = jest.fn();
-      const wrapper = subject({
+      const wrapper = groupSubject({
         stage: Stage.None,
         groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
         backGroupManagement,
@@ -357,7 +366,10 @@ describe('messenger-list', () => {
       when(mockSearchMyNetworksByName)
         .calledWith('jac')
         .mockResolvedValue([{ id: 'user-id', profileImage: 'image-url' }]);
-      const wrapper = subject({ stage: Stage.None, groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom });
+      const wrapper = groupSubject({
+        stage: Stage.None,
+        groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
+      });
 
       const searchResults = await wrapper.find(AddMembersPanel).prop('searchUsers')('jac');
 
@@ -365,7 +377,7 @@ describe('messenger-list', () => {
     });
 
     it('sets AddMembersPanel to Submitting while data is loading', async function () {
-      const wrapper = subject({
+      const wrapper = groupSubject({
         stage: Stage.None,
         groupManangemenetStage: GroupManagementStage.StartAddMemberToRoom,
         isFetchingExistingConversations: true,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -38,7 +38,7 @@ import { Stage as GroupManagementSagaStage, back as backGroupManagement } from '
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
-import { AddMembersPanel } from './add-members-panel';
+import { GroupManagement } from './group-management';
 
 const cn = bemClassName('direct-message-members');
 const cnMessageList = bemClassName('messenger-list');
@@ -271,16 +271,12 @@ export class Container extends React.Component<Properties, State> {
 
   renderGroupManagement() {
     return (
-      <>
-        {this.props.groupManangemenetStage === GroupManagementSagaStage.StartAddMemberToRoom && (
-          <AddMembersPanel
-            isSubmitting={this.props.isFetchingExistingConversations}
-            onBack={this.props.backGroupManagement}
-            onSubmit={() => console.log('addMembersSelected: Submit Add New Group members')}
-            searchUsers={this.usersInMyNetworks}
-          />
-        )}
-      </>
+      <GroupManagement
+        groupManangemenetStage={this.props.groupManangemenetStage}
+        isFetchingExistingConversations={this.props.isFetchingExistingConversations}
+        backGroupManagement={this.props.backGroupManagement}
+        usersInMyNetworks={this.usersInMyNetworks}
+      />
     );
   }
 
@@ -326,7 +322,7 @@ export class Container extends React.Component<Properties, State> {
     return this.props.groupManangemenetStage !== GroupManagementSagaStage.None;
   }
 
-  get renderPanel() {
+  renderPanel() {
     return this.isGroupManagementActive ? this.renderGroupManagement() : this.renderCreateConversation();
   }
 
@@ -337,7 +333,7 @@ export class Container extends React.Component<Properties, State> {
         {this.props.stage === SagaStage.None && !this.isGroupManagementActive && this.renderUserAccountContainer()}
 
         <div {...cn('')}>
-          {this.renderPanel}
+          {this.renderPanel()}
           {this.state.isInviteDialogOpen && this.renderInviteDialog()}
           {this.renderToastNotification()}
         </div>

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -272,7 +272,7 @@ export class Container extends React.Component<Properties, State> {
   renderGroupManagement() {
     return (
       <GroupManagement
-        groupManangemenetStage={this.props.groupManangemenetStage}
+        groupManagementStage={this.props.groupManangemenetStage}
         isFetchingExistingConversations={this.props.isFetchingExistingConversations}
         backGroupManagement={this.props.backGroupManagement}
         usersInMyNetworks={this.usersInMyNetworks}


### PR DESCRIPTION
### What does this do?

Refactoring to pull the GroupManagement panel stuff into its own component so the messenger list doesn't have to manage as much.

