### PR TITLE
Don't render the group management menu if no options are available

### DIFF
--- a/src/components/group-management-menu/index.test.tsx
+++ b/src/components/group-management-menu/index.test.tsx
@@ -17,10 +17,13 @@ describe(GroupManagementMenu, () => {
     return shallow(<GroupManagementMenu {...allProps} />);
   };
 
-  it('renders DropdownMenu component', function () {
-    const wrapper = subject();
+  it('does not render the menu if user cannot do anything', function () {
+    const wrapper = subject({
+      canAddMembers: false,
+      canLeaveRoom: false,
+    });
 
-    expect(wrapper).toHaveElement(DropdownMenu);
+    expect(wrapper).not.toHaveElement(DropdownMenu);
   });
 
   describe('Add Member', () => {

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -60,10 +60,14 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
   }
 
   render() {
+    const items = this.dropdownMenuItems;
+    if (items.length === 0) {
+      return null;
+    }
     return (
       <DropdownMenu
         menuClassName={'group-management-menu'}
-        items={this.dropdownMenuItems}
+        items={items}
         side='bottom'
         alignMenu='end'
         onOpenChange={this.handleOpenChange}


### PR DESCRIPTION
### What does this do?

If there are no menu options available then don't render the menu at all

