### PR TITLE
Remove the global enableGroupManagementMenu feature flag

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -204,8 +204,6 @@ describe('messenger-chat', () => {
     });
 
     it('header renders group management menu icon button', function () {
-      featureFlags.enableGroupManagementMenu = true;
-
       const wrapper = subject({
         directMessage: {
           isOneOnOne: true,
@@ -223,8 +221,6 @@ describe('messenger-chat', () => {
     });
 
     it('passes canLeaveRoom prop as false to group management menu if only 2 members are in conversation', function () {
-      featureFlags.enableGroupManagementMenu = true;
-
       const wrapper = subject({
         isCurrentUserRoomAdmin: false,
         directMessage: {
@@ -243,8 +239,6 @@ describe('messenger-chat', () => {
     });
 
     it('passes canLeaveRoom prop as true to group management menu if more than 2 members are in conversation', function () {
-      featureFlags.enableGroupManagementMenu = true;
-
       const wrapper = subject({
         isCurrentUserRoomAdmin: false,
         directMessage: {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -223,20 +223,16 @@ export class Container extends React.Component<Properties, State> {
               <div className='direct-message-chat__title'>{this.renderTitle()}</div>
               <div className='direct-message-chat__subtitle'>{this.renderSubTitle()}</div>
             </span>
-            {featureFlags.enableGroupManagementMenu && (
-              <div className='direct-message-chat__group-management-menu-container'>
-                <GroupManagementMenu
-                  canAddMembers={featureFlags.enableAddMemberToGroup && this.props.isCurrentUserRoomAdmin}
-                  onStartAddMember={this.props.startAddGroupMember}
-                  onLeave={this.openLeaveGroupDialog}
-                  canLeaveRoom={
-                    !this.props.isCurrentUserRoomAdmin && this.props.directMessage?.otherMembers?.length > 1
-                  }
-                  canEdit={featureFlags.enableEditRoom && this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
-                  onEdit={this.props.startEditConversation}
-                />
-              </div>
-            )}
+            <div className='direct-message-chat__group-management-menu-container'>
+              <GroupManagementMenu
+                canAddMembers={featureFlags.enableAddMemberToGroup && this.props.isCurrentUserRoomAdmin}
+                onStartAddMember={this.props.startAddGroupMember}
+                onLeave={this.openLeaveGroupDialog}
+                canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage?.otherMembers?.length > 1}
+                canEdit={featureFlags.enableEditRoom && this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+                onEdit={this.props.startEditConversation}
+              />
+            </div>
           </div>
 
           <ChatViewContainer

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -74,14 +74,6 @@ export class FeatureFlags {
     this._setBoolean('internalUsage', value);
   }
 
-  get enableGroupManagementMenu() {
-    return this._getBoolean('enableGroupManagementMenu', false);
-  }
-
-  set enableGroupManagementMenu(value: boolean) {
-    this._setBoolean('enableGroupManagementMenu', value);
-  }
-
   get enableAddMemberToGroup() {
     return this._getBoolean('enableAddMemberToGroup', false);
   }


### PR DESCRIPTION
### What does this do?

The conversation management features are all independently as necessary now

