### PR TITLE
Add UI for editing a group by admin

### DIFF
--- a/src/components/messenger/list/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.test.tsx
@@ -1,20 +1,71 @@
 import { shallow } from 'enzyme';
 
 import { EditConversationPanel, Properties } from '.';
+import { ImageUpload } from '../../../image-upload';
+import { buttonLabelled } from '../../../../test/utils';
+import { Alert } from '@zero-tech/zui/components';
 
 describe(EditConversationPanel, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       onBack: () => null,
+      errors: {},
+      conversation: {} as any,
       ...props,
     };
 
     return shallow(<EditConversationPanel {...allProps} />);
   };
 
-  it('TODO renders', function () {
-    const wrapper = subject({});
+  describe('Edit Group Icon & Name', () => {
+    it('renders body with ImageUpload and Input', () => {
+      const wrapper = subject({ conversation: { name: 'Display Name', icon: 'icon-url' } as any });
+      expect(wrapper.find('.edit-conversation-panel__body').length).toEqual(1);
+      expect(wrapper.find(ImageUpload).props().imageSrc).toEqual('icon-url');
+      expect(wrapper.find('Input[name="name"]').props().label).toEqual('Display Name');
+    });
 
-    expect(wrapper.exists()).toBeTrue();
+    it('disables Save Changes button when name is empty', () => {
+      const wrapper = subject({ conversation: { name: '', icon: '' } as any });
+      expect(saveButton(wrapper).prop('isDisabled')).toEqual(true);
+    });
+
+    it('disables Save Changes button when no changes are made', () => {
+      const wrapper = subject({ conversation: { name: 'Display Name', icon: 'icon-url' } as any });
+
+      expect(saveButton(wrapper).prop('isDisabled')).toEqual(true);
+    });
+
+    it('enables Save Changes button when changes are made', () => {
+      const wrapper = subject({ conversation: { name: 'Display Name', icon: 'icon-url' } as any });
+
+      wrapper.find('Input[name="name"]').simulate('change', 'Jane Smith');
+      expect(saveButton(wrapper).prop('isDisabled')).toEqual(false);
+    });
+
+    it('renders name error when name is empty', () => {
+      const wrapper = subject({ conversation: { name: '', icon: 'some-url' } as any });
+
+      expect(wrapper.find('Input[name="name"]').prop('alert')).toEqual({
+        variant: 'error',
+        text: 'name cannot be empty',
+      });
+    });
+
+    it('does not render name error when name is not empty', () => {
+      const wrapper = subject({ conversation: { name: 'John Doe' } as any });
+
+      expect(wrapper.find('Input[name="name"]').prop('alert')).toBeNull();
+    });
+
+    it('renders general errors', () => {
+      const wrapper = subject({ errors: { general: 'invalid' } });
+
+      expect(wrapper.find(Alert).prop('children')).toEqual('invalid');
+    });
   });
 });
+
+function saveButton(wrapper) {
+  return buttonLabelled(wrapper, 'Save');
+}

--- a/src/components/messenger/list/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.tsx
@@ -1,15 +1,109 @@
 import * as React from 'react';
 import { PanelHeader } from '../panel-header';
+import { Channel } from '../../../../store/channels';
+import { bemClassName } from '../../../../lib/bem';
+import { Input, Button, Alert } from '@zero-tech/zui/components';
+import { ImageUpload } from '../../../image-upload';
+import { IconUpload2 } from '@zero-tech/zui/icons';
+
+import './styles.scss';
+import { EditConversationErrors } from '../../../../store/group-management/types';
+const cn = bemClassName('edit-conversation-panel');
 
 export interface Properties {
+  conversation: Channel;
+  errors: EditConversationErrors;
   onBack: () => void;
 }
 
-export class EditConversationPanel extends React.Component<Properties> {
+interface State {
+  name: string;
+  image: File | null;
+}
+
+export class EditConversationPanel extends React.Component<Properties, State> {
+  state = {
+    name: this.props.conversation.name || '',
+    image: null,
+  };
+
+  get isValid() {
+    return this.state.name.trim().length > 0;
+  }
+
+  get nameError() {
+    if (!this.isValid) {
+      return { variant: 'error', text: 'name cannot be empty' } as any;
+    }
+    return null;
+  }
+
+  get generalError() {
+    return this.props.errors?.general;
+  }
+
+  trackName = (value) => this.setState({ name: value });
+  trackImage = (image) => this.setState({ image });
+  renderImageUploadIcon = (): JSX.Element => <IconUpload2 isFilled={true} />;
+
+  handleEdit = () => {
+    // do edit here
+  };
+
+  get isDisabled() {
+    return !!this.nameError || (this.state.name === this.props.conversation.name && this.state.image === null);
+  }
+
+  get changesSaved() {
+    return false;
+  }
+
+  renderEditImageAndIcon = () => {
+    <div {...cn('body')}>
+      <div {...cn('image-upload')}>
+        <ImageUpload
+          onChange={this.trackImage}
+          icon={this.renderImageUploadIcon()}
+          uploadText='Select or drag and drop'
+          imageSrc={this.props.conversation.icon} // to show the existing image
+          isError={Boolean(this.props.errors?.image)}
+          errorMessage={this.props.errors?.image}
+        />
+      </div>
+
+      <Input
+        label='Display Name'
+        name='name'
+        value={this.state.name}
+        onChange={this.trackName}
+        error={!!this.nameError}
+        alert={this.nameError}
+        {...cn('body-input')}
+      />
+
+      {this.generalError && (
+        <Alert {...cn('alert')} variant='error'>
+          {this.generalError}
+        </Alert>
+      )}
+      {this.changesSaved && (
+        <Alert {...cn('alert')} variant='success'>
+          {' '}
+          Changes saved{' '}
+        </Alert>
+      )}
+
+      <Button {...cn('zui-button-large')} isSubmit isDisabled={this.isDisabled} onPress={this.handleEdit}>
+        Save
+      </Button>
+    </div>;
+  };
+
   render() {
     return (
       <>
         <PanelHeader title={'Edit Group'} onBack={this.props.onBack} />
+        {this.renderEditImageAndIcon()}
       </>
     );
   }

--- a/src/components/messenger/list/edit-conversation-panel/styles.scss
+++ b/src/components/messenger/list/edit-conversation-panel/styles.scss
@@ -1,0 +1,29 @@
+.edit-conversation-panel {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    margin: 0px 16px;
+  }
+
+  &__image-upload {
+    margin: 8px 0px 24px 0px;
+    align-self: center;
+  }
+
+  &__body-input {
+    width: 240px;
+    gap: 4px;
+    line-height: 24px;
+  }
+
+  &__zui-button-large {
+    margin-top: 16px;
+    height: 40px;
+    width: 71px;
+    align-self: flex-end;
+  }
+
+  &__alert {
+    margin-top: 8px;
+  }
+}

--- a/src/components/messenger/list/group-management/container.test.tsx
+++ b/src/components/messenger/list/group-management/container.test.tsx
@@ -21,5 +21,16 @@ describe(Container, () => {
 
       expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ addMemberError: 'error' }));
     });
+
+    test('gets errors', () => {
+      const state = new StoreBuilder().managingGroup({
+        errors: { editConversationErrors: { image: 'image error', general: 'general error' } },
+      });
+      expect(Container.mapState(state.build())).toEqual(
+        expect.objectContaining({
+          errors: { editConversationErrors: { image: 'image error', general: 'general error' } },
+        })
+      );
+    });
   });
 });

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -6,8 +6,11 @@ import { Option } from '../../lib/types';
 
 import { GroupManagement } from '.';
 import { RootState } from '../../../../store/reducer';
+import { Channel } from '../../../../store/channels';
+import { GroupManagementErrors } from '../../../../store/group-management/types';
 
 export interface PublicProperties {
+  conversation: Channel;
   searchUsers: (search: string) => Promise<any>;
 }
 
@@ -16,6 +19,7 @@ export interface Properties extends PublicProperties {
   activeConversationId?: string;
   isAddingMembers: boolean;
   addMemberError: string;
+  errors: GroupManagementErrors;
 
   back: () => void;
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
@@ -33,6 +37,7 @@ export class Container extends React.Component<Properties> {
       stage: groupManagement.stage,
       isAddingMembers: groupManagement.isAddingMembers,
       addMemberError: groupManagement.addMemberError,
+      errors: groupManagement.errors,
     };
   }
 
@@ -56,6 +61,8 @@ export class Container extends React.Component<Properties> {
         onAddMembers={this.onAddMembers}
         isAddingMembers={this.props.isAddingMembers}
         addMemberError={this.props.addMemberError}
+        conversation={this.props.conversation}
+        errors={this.props.errors}
       />
     );
   }

--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -11,7 +11,8 @@ describe(GroupManagement, () => {
       stage: Stage.None,
       isAddingMembers: false,
       addMemberError: '',
-
+      conversation: {} as any,
+      errors: {},
       onBack: () => null,
       searchUsers: () => null,
       onAddMembers: () => null,

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -4,11 +4,15 @@ import { Stage } from '../../../../store/group-management';
 import { AddMembersPanel } from '../add-members-panel';
 import { Option } from '../../lib/types';
 import { EditConversationPanel } from '../edit-conversation-panel';
+import { Channel } from '../../../../store/channels';
+import { GroupManagementErrors } from '../../../../store/group-management/types';
 
 export interface Properties {
   stage: Stage;
   addMemberError: string;
   isAddingMembers: boolean;
+  errors: GroupManagementErrors;
+  conversation: Channel;
 
   onBack: () => void;
   onAddMembers: (options: Option[]) => void;
@@ -21,14 +25,20 @@ export class GroupManagement extends React.PureComponent<Properties> {
       <>
         {this.props.stage === Stage.StartAddMemberToRoom && (
           <AddMembersPanel
-            error={this.props.addMemberError}
+            error={this.props.addMemberError} // TODO: use this.props.errors.addMemberError
             isSubmitting={this.props.isAddingMembers}
             onBack={this.props.onBack}
             onSubmit={this.props.onAddMembers}
             searchUsers={this.props.searchUsers}
           />
         )}
-        {this.props.stage === Stage.EditConversation && <EditConversationPanel onBack={this.props.onBack} />}
+        {this.props.stage === Stage.EditConversation && (
+          <EditConversationPanel
+            conversation={this.props.conversation}
+            errors={this.props.errors.editConversationErrors}
+            onBack={this.props.onBack}
+          />
+        )}
       </>
     );
   }

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -267,8 +267,14 @@ export class Container extends React.Component<Properties, State> {
     );
   }
 
+  getActiveConversation() {
+    return this.props.conversations.find((c) => c.id === this.props.activeConversationId);
+  }
+
   renderGroupManagement() {
-    return <GroupManagementContainer searchUsers={this.usersInMyNetworks} />;
+    return (
+      <GroupManagementContainer searchUsers={this.usersInMyNetworks} conversation={this.getActiveConversation()} />
+    );
   }
 
   renderCreateConversation() {

--- a/src/store/group-management/index.ts
+++ b/src/store/group-management/index.ts
@@ -1,4 +1,5 @@
 import { PayloadAction, createAction, createSlice } from '@reduxjs/toolkit';
+import { GroupManagementErrors } from './types';
 
 export interface MembersSelectedPayload {
   roomId: string;
@@ -38,6 +39,7 @@ export type GroupManagementState = {
   isAddingMembers: boolean;
   addMemberError: string;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
+  errors: GroupManagementErrors;
 };
 
 const initialState: GroupManagementState = {
@@ -45,6 +47,7 @@ const initialState: GroupManagementState = {
   isAddingMembers: false,
   addMemberError: null,
   leaveGroupDialogStatus: LeaveGroupDialogStatus.CLOSED,
+  errors: {},
 };
 
 const slice = createSlice({

--- a/src/store/group-management/types.ts
+++ b/src/store/group-management/types.ts
@@ -1,0 +1,9 @@
+export interface EditConversationErrors {
+  image?: string;
+  general?: string;
+}
+
+export interface GroupManagementErrors {
+  addMemberError?: string; // TODO: use this instead of "addMemberError"
+  editConversationErrors?: EditConversationErrors;
+}


### PR DESCRIPTION
Default State:
![image](https://github.com/zer0-os/zOS/assets/33264364/3de533a8-7488-43ed-9deb-efd691c81f27)

(if there is no image uploaded on original group)
![image](https://github.com/zer0-os/zOS/assets/33264364/eb42e742-d44a-47a1-8e9e-a7f63827125a)


(edit name)
![image](https://github.com/zer0-os/zOS/assets/33264364/44546328-d19f-49a7-9503-c34523f0e7a4)

(edit image)
![image](https://github.com/zer0-os/zOS/assets/33264364/3ba41e3d-8e3f-49f9-8e17-bad8d799c57e)

(success state)
<img width="454" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/20644087-6ca1-4f27-b285-0e28f77b1915">


(image error)
![image](https://github.com/zer0-os/zOS/assets/33264364/79fc8081-969e-4771-b27e-917030a5e0c2)

(name error)
![image](https://github.com/zer0-os/zOS/assets/33264364/6a6d0d52-bdbb-4517-a6b0-be1d440afce6)

(general error)
<img width="503" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/450da018-2a2e-42fe-a24c-2c440ca3ed9d">

