### PR TITLE
feat(autocomplete-members): clear input and search results

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -24,6 +24,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
 
   searchChanged = async (searchString: string) => {
     this.setState({ searchString });
+
     if (!searchString) {
       return this.setState({ results: null });
     }
@@ -35,18 +36,15 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     this.setState({ results: filteredOptions });
   };
 
-  itemSelected(event) {
+  itemSelected = (event) => {
     const clickedId = event.currentTarget.dataset.id;
     const selectedUser = this.state.results.find((r) => r.value === clickedId);
 
     if (selectedUser) {
       this.props.onSelect(selectedUser);
-      // exclude selected user from results
-      this.setState({
-        results: this.state.results.filter((r) => r.value !== clickedId),
-      });
+      this.setState({ results: null, searchString: '' });
     }
-  }
+  };
 
   itemClicked = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     this.itemSelected(event);


### PR DESCRIPTION
### What does this do?
- where `AutoCompleteMembers` is being used, i.e. `New Conversation` (create conversation), `Select Member` (create group), `Add Members` (group management), when selecting a member, the input will be cleared, and the search results will be reset.

### Why are we making this change?
- behaviour requested (n3o).

### How do I test this?
- open messenger and go through one of the flows mentioned above that use the `AutoCompleteMembers` component. When selecting a member, the input should clear and the search results should also clear. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

To note: A follow up PR should probably be to ensure the input is focussed once cleared.


Before:

https://github.com/zer0-os/zOS/assets/39112648/7ca7b0bf-379a-49b5-a827-c2d5f41e3bb5

After:

https://github.com/zer0-os/zOS/assets/39112648/f2a3efca-1c3b-407e-8e16-1d4ab749d421

