### PR TITLE
Remove quotes in test template

### DIFF
--- a/templates/component/index.test.tsx.mustache
+++ b/templates/component/index.test.tsx.mustache
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 
 import { {{ componentName }}, Properties } from '.';
 
-describe('{{ componentName }}', () => {
+describe({{ componentName }}, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       ...props,


### PR DESCRIPTION
### What does this do?

Removes the quotes in the `describe` block of the test template.

