### PR TITLE
Remove "name" error while editing a group

### DIFF
--- a/src/components/messenger/list/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.test.tsx
@@ -44,19 +44,22 @@ describe(EditConversationPanel, () => {
       expect(saveButton(wrapper).prop('isDisabled')).toEqual(false);
     });
 
-    it('renders name error when name is empty', () => {
+    it('does not render name error when name is empty', () => {
       const wrapper = subject({ name: '', icon: 'some-url' });
 
-      expect(wrapper.find('Input[name="name"]').prop('alert')).toEqual({
-        variant: 'error',
-        text: 'name cannot be empty',
-      });
+      expect(wrapper.find('Input[name="name"]').prop('alert')).toBe(undefined);
     });
 
     it('does not render name error when name is not empty', () => {
       const wrapper = subject({ name: 'John Doe' });
 
-      expect(wrapper.find('Input[name="name"]').prop('alert')).toBeNull();
+      expect(wrapper.find('Input[name="name"]').prop('alert')).toBe(undefined);
+    });
+
+    it('does not render image errror when image is empty', () => {
+      const wrapper = subject({ icon: '' });
+
+      expect(wrapper.find(ImageUpload).prop('isError')).toBe(false);
     });
 
     it('renders general errors', () => {

--- a/src/components/messenger/list/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.tsx
@@ -27,21 +27,6 @@ export class EditConversationPanel extends React.Component<Properties, State> {
     image: null,
   };
 
-  get isValid() {
-    return this.state.name.trim().length > 0;
-  }
-
-  get nameError() {
-    if (!this.isValid) {
-      return { variant: 'error', text: 'name cannot be empty' } as any;
-    }
-    return null;
-  }
-
-  get generalError() {
-    return this.props.errors?.general;
-  }
-
   trackName = (value) => this.setState({ name: value });
   trackImage = (image) => this.setState({ image });
   renderImageUploadIcon = (): JSX.Element => <IconUpload2 isFilled={true} />;
@@ -50,8 +35,12 @@ export class EditConversationPanel extends React.Component<Properties, State> {
     // do edit here
   };
 
+  get generalError() {
+    return this.props.errors?.general;
+  }
+
   get isDisabled() {
-    return !!this.nameError || (this.state.name === this.props.name && this.state.image === null);
+    return this.state.name === this.props.name && this.state.image === null;
   }
 
   get changesSaved() {
@@ -77,8 +66,6 @@ export class EditConversationPanel extends React.Component<Properties, State> {
           name='name'
           value={this.state.name}
           onChange={this.trackName}
-          error={!!this.nameError}
-          alert={this.nameError}
           {...cn('body-input')}
         />
 


### PR DESCRIPTION
### What does this do?

Removes "Name cannot be empty" error, since it can be.