### PR TITLE
Filter out rooms that the user has left

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -31,6 +31,7 @@ import {
   ConnectionStatus,
   CustomEventType,
   DecryptErrorConstants,
+  IN_ROOM_MEMBERSHIP_STATES,
   MatrixConstants,
   MembershipStateType,
 } from './matrix/types';
@@ -146,7 +147,7 @@ export class MatrixClient implements IChatClient {
 
   async getConversations() {
     await this.waitForConnection();
-    const rooms = await this.getRooms();
+    const rooms = await this.getRoomsUserIsIn();
 
     const failedToJoin = [];
     for (const room of rooms) {
@@ -593,7 +594,7 @@ export class MatrixClient implements IChatClient {
 
   async fetchConversationsWithUsers(users: User[]) {
     const userMatrixIds = users.map((u) => u.matrixId);
-    const rooms = await this.getRooms();
+    const rooms = await this.getRoomsUserIsIn();
     const matches = [];
     for (const room of rooms) {
       const roomMembers = room
@@ -932,9 +933,10 @@ export class MatrixClient implements IChatClient {
       .map((member) => member.userId);
   }
 
-  private async getRooms() {
+  private async getRoomsUserIsIn() {
     await this.waitForConnection();
-    return this.matrix.getRooms() || [];
+    const allUserRooms = this.matrix.getRooms() || [];
+    return allUserRooms.filter((room) => IN_ROOM_MEMBERSHIP_STATES.includes(room.getMyMembership()));
   }
 
   private async uploadCoverImage(image) {

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -10,6 +10,11 @@ export enum MembershipStateType {
   Leave = 'leave',
 }
 
+export const IN_ROOM_MEMBERSHIP_STATES = [
+  MembershipStateType.Invite,
+  MembershipStateType.Join,
+] as string[];
+
 export enum MatrixConstants {
   RELATES_TO = 'm.relates_to',
   NEW_CONTENT = 'm.new_content',


### PR DESCRIPTION
### What does this do?

When fetching the rooms for a user we need to filter out any rooms where their membership is "Leave"

### Why are we making this change?

It turns out that Matrix still returns rooms that you were kicked out of in the user's list of rooms. Technically, you can still see the history of those rooms if you'd like but for our purposes we just don't want them to show up for the user.

