### PR TITLE
feat: add member left admin message when member leaves room

### DIFF
--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -234,13 +234,13 @@ describe(adminMessageText, () => {
   });
 
   describe(AdminMessageType.CONVERSATION_STARTED, () => {
-    it('returns default message if creator not found', () => {
+    it('returns default message if admin user id not found', () => {
       const state = getState('current-user', {});
       const adminText = adminMessageText(
         {
           message: 'some message',
           isAdmin: true,
-          admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: 'unknown-user-id' },
+          admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: 'unknown-user-id' },
         } as Message,
         state
       );
@@ -248,12 +248,12 @@ describe(adminMessageText, () => {
       expect(adminText).toEqual('some message');
     });
 
-    it('translates message if current user was not the creator', () => {
-      const state = getState('current-user', { 'creator-id': { id: 'creator-id', firstName: 'Courtney' } });
+    it('translates message if current user id is not the admin user id', () => {
+      const state = getState('current-user', { 'admin-user-id': { id: 'admin-user-id', firstName: 'Courtney' } });
       const message = {
         message: 'some message',
         isAdmin: true,
-        admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: 'creator-id' },
+        admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: 'admin-user-id' },
       } as Message;
 
       const adminText = adminMessageText(message, state);
@@ -261,12 +261,12 @@ describe(adminMessageText, () => {
       expect(adminText).toEqual('Courtney started the conversation');
     });
 
-    it('translates message if current user was the creator', () => {
-      const state = getState('creator-id', { 'creator-id': { id: 'creator-id', firstName: 'Julie' } });
+    it('translates message if current user id is the admin user id', () => {
+      const state = getState('admin-user-id', { 'admin-user-id': { id: 'admin-user-id', firstName: 'Julie' } });
       const message = {
         message: 'some message',
         isAdmin: true,
-        admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: 'creator-id' },
+        admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: 'admin-user-id' },
       } as Message;
 
       const adminText = adminMessageText(message, state);
@@ -276,13 +276,13 @@ describe(adminMessageText, () => {
   });
 
   describe(AdminMessageType.MEMBER_LEFT_CONVERSATION, () => {
-    it('returns default message if creator not found', () => {
+    it('returns default message if admin user id not found', () => {
       const state = getState('current-user', {});
       const adminText = adminMessageText(
         {
           message: 'some message',
           isAdmin: true,
-          admin: { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: 'unknown-user-id' },
+          admin: { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, userId: 'unknown-user-id' },
         } as Message,
         state
       );
@@ -290,12 +290,12 @@ describe(adminMessageText, () => {
       expect(adminText).toEqual('some message');
     });
 
-    it('translates message if creator is found', () => {
-      const state = getState('current-user', { 'creator-id': { id: 'creator-id', firstName: 'Courtney' } });
+    it('translates message if admin user id is found', () => {
+      const state = getState('current-user', { 'admin-user-id': { id: 'admin-user-id', firstName: 'Courtney' } });
       const message = {
         message: 'some message',
         isAdmin: true,
-        admin: { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: 'creator-id' },
+        admin: { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, userId: 'admin-user-id' },
       } as Message;
 
       const adminText = adminMessageText(message, state);
@@ -335,7 +335,7 @@ describe(getMessagePreview, () => {
       {
         message: 'some message',
         isAdmin: true,
-        admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: 'current-user' },
+        admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: 'current-user' },
       } as Message,
       state
     );

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -290,7 +290,7 @@ describe(adminMessageText, () => {
       expect(adminText).toEqual('some message');
     });
 
-    it('translates message if current user was not the creator', () => {
+    it('translates message if creator is found', () => {
       const state = getState('current-user', { 'creator-id': { id: 'creator-id', firstName: 'Courtney' } });
       const message = {
         message: 'some message',

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -274,6 +274,35 @@ describe(adminMessageText, () => {
       expect(adminText).toEqual('You started the conversation');
     });
   });
+
+  describe(AdminMessageType.MEMBER_LEFT_CONVERSATION, () => {
+    it('returns default message if creator not found', () => {
+      const state = getState('current-user', {});
+      const adminText = adminMessageText(
+        {
+          message: 'some message',
+          isAdmin: true,
+          admin: { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: 'unknown-user-id' },
+        } as Message,
+        state
+      );
+
+      expect(adminText).toEqual('some message');
+    });
+
+    it('translates message if current user was not the creator', () => {
+      const state = getState('current-user', { 'creator-id': { id: 'creator-id', firstName: 'Courtney' } });
+      const message = {
+        message: 'some message',
+        isAdmin: true,
+        admin: { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: 'creator-id' },
+      } as Message;
+
+      const adminText = adminMessageText(message, state);
+
+      expect(adminText).toEqual('Courtney left the group');
+    });
+  });
 });
 
 describe(getMessagePreview, () => {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -204,15 +204,16 @@ export function adminMessageText(message: Message, state: RootState) {
     return text;
   }
 
-  if (message.admin.type === AdminMessageType.JOINED_ZERO) {
-    return translateJoinedZero(message.admin, user, state) ?? text;
-  } else if (message.admin.type === AdminMessageType.CONVERSATION_STARTED) {
-    return translateConversationStarted(message.admin, user, state) ?? text;
-  } else if (message.admin.type === AdminMessageType.MEMBER_LEFT_CONVERSATION) {
-    return translateMemberLeftGroup(message.admin, state) ?? text;
+  switch (message.admin.type) {
+    case AdminMessageType.JOINED_ZERO:
+      return translateJoinedZero(message.admin, user, state) ?? text;
+    case AdminMessageType.CONVERSATION_STARTED:
+      return translateConversationStarted(message.admin, user, state) ?? text;
+    case AdminMessageType.MEMBER_LEFT_CONVERSATION:
+      return translateMemberLeftGroup(message.admin, state) ?? text;
+    default:
+      return text;
   }
-
-  return text;
 }
 
 function translateJoinedZero(admin: { inviteeId?: string; inviterId?: string }, currentUser, state: RootState) {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -227,16 +227,16 @@ function translateJoinedZero(admin: { inviteeId?: string; inviterId?: string }, 
   return invitee?.firstName ? `${invitee.firstName} joined you on Zero` : null;
 }
 
-function translateConversationStarted(admin: { creatorId?: string }, currentUser, state: RootState) {
-  if (admin.creatorId === currentUser.id) {
+function translateConversationStarted(admin: { userId?: string }, currentUser, state: RootState) {
+  if (admin.userId === currentUser.id) {
     return 'You started the conversation';
   }
 
-  const creator = denormalizeUser(admin.creatorId, state);
-  return creator?.firstName ? `${creator.firstName} started the conversation` : null;
+  const user = denormalizeUser(admin.userId, state);
+  return user?.firstName ? `${user.firstName} started the conversation` : null;
 }
 
-function translateMemberLeftGroup(admin: { creatorId?: string }, state: RootState) {
-  const creator = denormalizeUser(admin.creatorId, state);
-  return creator?.firstName ? `${creator.firstName} left the group` : null;
+function translateMemberLeftGroup(admin: { userId?: string }, state: RootState) {
+  const user = denormalizeUser(admin.userId, state);
+  return user?.firstName ? `${user.firstName} left the group` : null;
 }

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -208,6 +208,8 @@ export function adminMessageText(message: Message, state: RootState) {
     return translateJoinedZero(message.admin, user, state) ?? text;
   } else if (message.admin.type === AdminMessageType.CONVERSATION_STARTED) {
     return translateConversationStarted(message.admin, user, state) ?? text;
+  } else if (message.admin.type === AdminMessageType.MEMBER_LEFT_CONVERSATION) {
+    return translateMemberLeftGroup(message.admin, state) ?? text;
   }
 
   return text;
@@ -231,4 +233,9 @@ function translateConversationStarted(admin: { creatorId?: string }, currentUser
 
   const creator = denormalizeUser(admin.creatorId, state);
   return creator?.firstName ? `${creator.firstName} started the conversation` : null;
+}
+
+function translateMemberLeftGroup(admin: { creatorId?: string }, state: RootState) {
+  const creator = denormalizeUser(admin.creatorId, state);
+  return creator?.firstName ? `${creator.firstName} left the group` : null;
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -881,7 +881,7 @@ export class MatrixClient implements IChatClient {
 
   private mapConversation = async (room: Room): Promise<Partial<Channel>> => {
     const otherMembers = this.getOtherMembersFromRoom(room).map((userId) => this.mapUser(userId));
-    const memberHistory = this.getMemberHistoryFromRoom(room).map((userId) => this.mapMemberForHistory(userId));
+    const memberHistory = this.getMemberHistoryFromRoom(room).map((userId) => this.mapUser(userId));
     const name = this.getRoomName(room);
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
@@ -909,14 +909,6 @@ export class MatrixClient implements IChatClient {
       adminMatrixIds: this.getRoomAdmins(room),
     };
   };
-
-  private mapMemberForHistory(matrixId: string): Partial<UserModel> {
-    return {
-      userId: matrixId,
-      matrixId,
-      firstName: '',
-    };
-  }
 
   private mapUser(matrixId: string): UserModel {
     const user = this.matrix.getUser(matrixId);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -868,12 +868,7 @@ export class MatrixClient implements IChatClient {
 
   private mapConversation = async (room: Room): Promise<Partial<Channel>> => {
     const otherMembers = this.getOtherMembersFromRoom(room).map((userId) => this.mapUser(userId));
-
-    const memberHistory = room
-      .getMembers()
-      .filter((member) => member.userId !== this.userId)
-      .map((member) => this.mapMemberForHistory(member.userId));
-
+    const memberHistory = this.getMemberHistoryFromRoom(room).map((userId) => this.mapMemberForHistory(userId));
     const name = this.getRoomName(room);
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
@@ -902,7 +897,7 @@ export class MatrixClient implements IChatClient {
     };
   };
 
-  private mapMemberForHistory(matrixId: string) {
+  private mapMemberForHistory(matrixId: string): Partial<UserModel> {
     return {
       userId: matrixId,
       matrixId,
@@ -945,6 +940,13 @@ export class MatrixClient implements IChatClient {
       .getEvents()
       .map((event) => event.getEffectiveEvent());
     return await this.processRawEventsToMessages(events);
+  }
+
+  private getMemberHistoryFromRoom(room: Room): string[] {
+    return room
+      .getMembers()
+      .filter((member) => member.userId !== this.userId)
+      .map((member) => member.userId);
   }
 
   private getOtherMembersFromRoom(room: Room): string[] {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -943,10 +943,7 @@ export class MatrixClient implements IChatClient {
   }
 
   private getMemberHistoryFromRoom(room: Room): string[] {
-    return room
-      .getMembers()
-      .filter((member) => member.userId !== this.userId)
-      .map((member) => member.userId);
+    return room.getMembers().map((member) => member.userId);
   }
 
   private getOtherMembersFromRoom(room: Room): string[] {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -868,6 +868,12 @@ export class MatrixClient implements IChatClient {
 
   private mapConversation = async (room: Room): Promise<Partial<Channel>> => {
     const otherMembers = this.getOtherMembersFromRoom(room).map((userId) => this.mapUser(userId));
+
+    const memberHistory = room
+      .getMembers()
+      .filter((member) => member.userId !== this.userId)
+      .map((member) => this.mapMemberForHistory(member.userId));
+
     const name = this.getRoomName(room);
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
@@ -883,6 +889,7 @@ export class MatrixClient implements IChatClient {
       // as zOS considers any conversation to have ever had more than 2 people to not be 1 on 1
       isOneOnOne: room.getMembers().length === 2,
       otherMembers: otherMembers,
+      memberHistory: memberHistory,
       lastMessage: null,
       messages,
       groupChannelType: GroupChannelType.Private,
@@ -894,6 +901,14 @@ export class MatrixClient implements IChatClient {
       adminMatrixIds: this.getRoomAdmins(room),
     };
   };
+
+  private mapMemberForHistory(matrixId: string) {
+    return {
+      userId: matrixId,
+      matrixId,
+      firstName: '',
+    };
+  }
 
   private mapUser(matrixId: string): UserModel {
     const user = this.matrix.getUser(matrixId);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -858,12 +858,16 @@ export class MatrixClient implements IChatClient {
     this.events.onRoomAvatarChanged(event.room_id, event.content?.url);
   };
 
-  private publishMembershipChange = (event: MatrixEvent) => {
+  private publishMembershipChange = async (event: MatrixEvent) => {
     if (event.getType() === EventType.RoomMember) {
       const user = this.mapUser(event.getStateKey());
       if (event.getStateKey() !== this.userId) {
         if (event.getContent().membership === MembershipStateType.Leave) {
           this.events.onOtherUserLeftChannel(event.getRoomId(), user);
+          const message = await mapEventToAdminMessage(event.getEffectiveEvent());
+          if (message) {
+            this.events.receiveNewMessage(event.getRoomId(), message);
+          }
         } else {
           this.events.onOtherUserJoinedChannel(event.getRoomId(), user);
         }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -303,7 +303,7 @@ export class MatrixClient implements IChatClient {
         return mapEventToAdminMessage(event);
 
       case EventType.RoomMember:
-        if (event.content.membership === 'leave') {
+        if (event.content.membership === MembershipStateType.Leave) {
           return mapEventToAdminMessage(event);
         } else {
           return null;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -296,9 +296,18 @@ export class MatrixClient implements IChatClient {
     switch (event.type) {
       case EventType.RoomMessage:
         return mapMatrixMessage(event, this.matrix);
+
       case CustomEventType.USER_JOINED_INVITER_ON_ZERO:
       case EventType.RoomCreate:
         return mapEventToAdminMessage(event);
+
+      case EventType.RoomMember:
+        if (event.content.membership === 'leave') {
+          return mapEventToAdminMessage(event);
+        } else {
+          return null;
+        }
+
       default:
         return null;
     }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,7 +1,7 @@
 import { CustomEventType, MembershipStateType, NotifiableEventType } from './types';
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { decryptFile } from './media';
-import { AdminMessageType } from '../../../store/messages';
+import { AdminMessageType, Message, MessageSendStatus } from '../../../store/messages';
 
 async function parseMediaData(matrixMessage) {
   const { content } = matrixMessage;
@@ -62,10 +62,14 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
   };
 }
 
-export function mapEventToAdminMessage(matrixMessage) {
+export function mapEventToAdminMessage(matrixMessage): Message {
   const { event_id, content, origin_server_ts, sender, type, state_key: targetUserId } = matrixMessage;
 
   const adminData = getAdminDataFromEventType(type, content, sender, targetUserId);
+
+  if (!adminData) {
+    return null;
+  }
 
   return {
     id: event_id,
@@ -73,6 +77,13 @@ export function mapEventToAdminMessage(matrixMessage) {
     createdAt: origin_server_ts,
     isAdmin: true,
     admin: adminData,
+
+    updatedAt: 0,
+    sender: ADMIN_USER,
+    mentionedUsers: [],
+    hidePreview: false,
+    preview: null,
+    sendStatus: MessageSendStatus.SUCCESS,
   };
 }
 
@@ -85,7 +96,7 @@ function getAdminDataFromEventType(type, content, sender, targetUserId) {
     case EventType.RoomCreate:
       return { type: AdminMessageType.CONVERSATION_STARTED, creatorId: sender };
     default:
-      return {};
+      return null;
   }
 }
 
@@ -94,7 +105,7 @@ function getRoomMemberAdminData(content, targetUserId) {
     case MembershipStateType.Leave:
       return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: targetUserId };
     default:
-      return {};
+      return null;
   }
 }
 
@@ -122,3 +133,5 @@ function convertToNotifiableEventType(eventType) {
       return '';
   }
 }
+
+const ADMIN_USER = { userId: 'admin', firstName: '', lastName: '', profileImage: '', profileId: '' };

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,4 +1,4 @@
-import { CustomEventType, NotifiableEventType } from './types';
+import { CustomEventType, MembershipStateType, NotifiableEventType } from './types';
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { decryptFile } from './media';
 import { AdminMessageType } from '../../../store/messages';
@@ -90,7 +90,7 @@ function getAdminDataFromEventType(type, content, userId) {
 }
 
 function getRoomMemberAdminData(content, userId) {
-  if (content.membership === 'leave') {
+  if (content.membership === MembershipStateType.Leave) {
     return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: userId };
   }
   return {};

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -63,9 +63,9 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
 }
 
 export function mapEventToAdminMessage(matrixMessage) {
-  const { event_id, content, origin_server_ts, sender: userId, type } = matrixMessage;
+  const { event_id, content, origin_server_ts, sender, type, state_key: targetUserId } = matrixMessage;
 
-  const adminData = getAdminDataFromEventType(type, content, userId);
+  const adminData = getAdminDataFromEventType(type, content, sender, targetUserId);
 
   return {
     id: event_id,
@@ -76,24 +76,26 @@ export function mapEventToAdminMessage(matrixMessage) {
   };
 }
 
-function getAdminDataFromEventType(type, content, userId) {
+function getAdminDataFromEventType(type, content, sender, targetUserId) {
   switch (type) {
     case CustomEventType.USER_JOINED_INVITER_ON_ZERO:
       return { type: AdminMessageType.JOINED_ZERO, inviterId: content.inviterId, inviteeId: content.inviteeId };
     case EventType.RoomMember:
-      return getRoomMemberAdminData(content, userId);
+      return getRoomMemberAdminData(content, targetUserId);
     case EventType.RoomCreate:
-      return { type: AdminMessageType.CONVERSATION_STARTED, creatorId: userId };
+      return { type: AdminMessageType.CONVERSATION_STARTED, creatorId: sender };
     default:
       return {};
   }
 }
 
-function getRoomMemberAdminData(content, userId) {
-  if (content.membership === MembershipStateType.Leave) {
-    return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: userId };
+function getRoomMemberAdminData(content, targetUserId) {
+  switch (content.membership) {
+    case MembershipStateType.Leave:
+      return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: targetUserId };
+    default:
+      return {};
   }
-  return {};
 }
 
 export function mapToLiveRoomEvent(liveEvent) {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -94,7 +94,7 @@ function getAdminDataFromEventType(type, content, sender, targetUserId) {
     case EventType.RoomMember:
       return getRoomMemberAdminData(content, targetUserId);
     case EventType.RoomCreate:
-      return { type: AdminMessageType.CONVERSATION_STARTED, creatorId: sender };
+      return { type: AdminMessageType.CONVERSATION_STARTED, userId: sender };
     default:
       return null;
   }
@@ -103,7 +103,7 @@ function getAdminDataFromEventType(type, content, sender, targetUserId) {
 function getRoomMemberAdminData(content, targetUserId) {
   switch (content.membership) {
     case MembershipStateType.Leave:
-      return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: targetUserId };
+      return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, userId: targetUserId };
     default:
       return null;
   }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -63,36 +63,35 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
 }
 
 export function mapEventToAdminMessage(matrixMessage) {
-  const { event_id, content, origin_server_ts, sender: senderId, type } = matrixMessage;
+  const { event_id, content, origin_server_ts, sender: userId, type } = matrixMessage;
 
-  const adminData = getAdminDataFromEventType(type, content, senderId);
+  const adminData = getAdminDataFromEventType(type, content, userId);
 
   return {
     id: event_id,
     message: 'Conversation was started',
     createdAt: origin_server_ts,
     isAdmin: true,
-    sender: { userId: senderId },
     admin: adminData,
   };
 }
 
-function getAdminDataFromEventType(type, content, senderId) {
+function getAdminDataFromEventType(type, content, userId) {
   switch (type) {
     case CustomEventType.USER_JOINED_INVITER_ON_ZERO:
       return { type: AdminMessageType.JOINED_ZERO, inviterId: content.inviterId, inviteeId: content.inviteeId };
     case EventType.RoomMember:
-      return getRoomMemberAdminData(content, senderId);
+      return getRoomMemberAdminData(content, userId);
     case EventType.RoomCreate:
-      return { type: AdminMessageType.CONVERSATION_STARTED, creatorId: senderId };
+      return { type: AdminMessageType.CONVERSATION_STARTED, creatorId: userId };
     default:
       return {};
   }
 }
 
-function getRoomMemberAdminData(content, senderId) {
+function getRoomMemberAdminData(content, userId) {
   if (content.membership === 'leave') {
-    return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: senderId };
+    return { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: userId };
   }
   return {};
 }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -65,10 +65,22 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
 export function mapEventToAdminMessage(matrixMessage) {
   const { event_id, content, origin_server_ts, sender: senderId, type } = matrixMessage;
 
-  const adminData =
-    type === CustomEventType.USER_JOINED_INVITER_ON_ZERO
-      ? { type: AdminMessageType.JOINED_ZERO, inviterId: content.inviterId, inviteeId: content.inviteeId }
-      : { type: AdminMessageType.CONVERSATION_STARTED, creatorId: senderId };
+  let adminData;
+
+  switch (type) {
+    case CustomEventType.USER_JOINED_INVITER_ON_ZERO:
+      adminData = { type: AdminMessageType.JOINED_ZERO, inviterId: content.inviterId, inviteeId: content.inviteeId };
+      break;
+    case EventType.RoomMember:
+      adminData = { type: AdminMessageType.MEMBER_LEFT_CONVERSATION, creatorId: senderId };
+      break;
+    case EventType.RoomCreate:
+      adminData = { type: AdminMessageType.CONVERSATION_STARTED, creatorId: senderId };
+      break;
+    default:
+      adminData = {};
+      break;
+  }
 
   return {
     id: event_id,

--- a/src/store/channels-list/saga.createConversation.test.ts
+++ b/src/store/channels-list/saga.createConversation.test.ts
@@ -160,12 +160,12 @@ describe(createOptimisticConversation, () => {
     expect(conversation.messages[0]).toMatchObject({
       message: 'Conversation was started',
       isAdmin: true,
-      admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: 'current-user' },
+      admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: 'current-user' },
     });
     expect(conversation.lastMessage).toMatchObject({
       message: 'Conversation was started',
       isAdmin: true,
-      admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: 'current-user' },
+      admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: 'current-user' },
     });
     expect(conversation.lastMessageAt).toEqual(conversation.messages[0].createdAt);
   });

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -28,9 +28,9 @@ import { ConversationStatus, denormalize as denormalizeChannel } from '../channe
 import { StoreBuilder } from '../test/store';
 import { expectSaga } from '../../test/saga';
 import { getZEROUsers } from './api';
-import { mapOtherMembers, extractMatrixIdsFromConversations } from './utils';
+import { mapOtherMembers } from './utils';
 import { getUserByMatrixId } from '../users/saga';
-import { fetchMissingUsersData, fetchNewMessages } from '../messages/saga';
+import { fetchNewMessages } from '../messages/saga';
 
 const featureFlags = { enableMatrix: false };
 jest.mock('../../lib/feature-flags', () => ({
@@ -147,8 +147,6 @@ describe('channels list saga', () => {
   });
 
   describe(fetchConversations, () => {
-    const matrixIds = extractMatrixIdsFromConversations(MOCK_CONVERSATIONS);
-
     function subject(...args: Parameters<typeof expectSaga>) {
       return expectSaga(...args).provide([
         [matchers.call.fn(chat.get), chatClient],
@@ -161,12 +159,10 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
-          [matchers.call.fn(fetchMissingUsersData), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
         .call([chatClient, chatClient.getConversations])
-        .call(fetchMissingUsersData, matrixIds)
         .run();
     });
 
@@ -175,12 +171,10 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
-          [matchers.call.fn(fetchMissingUsersData), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
         .call([chatClient, chatClient.getConversations])
-        .call(fetchMissingUsersData, matrixIds)
         .call(mapToZeroUsers, MOCK_CONVERSATIONS)
         .run();
     });
@@ -192,7 +186,6 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
-          [matchers.call.fn(fetchMissingUsersData), null],
           [matchers.call.fn(mapToZeroUsers), null],
           [matchers.call.fn(updateUserPresence), null],
           [matchers.call.fn(mapCreatorIdToZeroUserId), null],
@@ -510,11 +503,18 @@ describe('channels list saga', () => {
           { matrixId: 'matrix-id-1', userId: 'matrix-id-1' },
           { matrixId: 'matrix-id-2', userId: 'matrix-id-2' },
         ],
+        memberHistory: [
+          { matrixId: 'matrix-id-1', userId: 'matrix-id-1' },
+          { matrixId: 'matrix-id-2', userId: 'matrix-id-2' },
+        ],
         messages: [],
       },
       {
         id: 'channel-2',
         otherMembers: [{ matrixId: 'matrix-id-3', userId: 'matrix-id-3' }],
+        memberHistory: [
+          { matrixId: 'matrix-id-3', userId: 'matrix-id-3' },
+        ],
         messages: [],
       },
     ] as any;

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -16,7 +16,6 @@ import {
   otherUserLeftChannel,
   mapToZeroUsers,
   updateUserPresence,
-  updateMessageSenders,
   mapCreatorIdToZeroUserId,
 } from './saga';
 
@@ -163,13 +162,11 @@ describe('channels list saga', () => {
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
           [matchers.call.fn(fetchMissingUsersData), null],
-          [matchers.call.fn(updateMessageSenders), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
         .call([chatClient, chatClient.getConversations])
         .call(fetchMissingUsersData, matrixIds)
-        .call(updateMessageSenders, MOCK_CONVERSATIONS)
         .run();
     });
 
@@ -179,13 +176,11 @@ describe('channels list saga', () => {
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
           [matchers.call.fn(fetchMissingUsersData), null],
-          [matchers.call.fn(updateMessageSenders), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
         .call([chatClient, chatClient.getConversations])
         .call(fetchMissingUsersData, matrixIds)
-        .call(updateMessageSenders, MOCK_CONVERSATIONS)
         .call(mapToZeroUsers, MOCK_CONVERSATIONS)
         .run();
     });
@@ -198,7 +193,6 @@ describe('channels list saga', () => {
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
           [matchers.call.fn(fetchMissingUsersData), null],
-          [matchers.call.fn(updateMessageSenders), null],
           [matchers.call.fn(mapToZeroUsers), null],
           [matchers.call.fn(updateUserPresence), null],
           [matchers.call.fn(mapCreatorIdToZeroUserId), null],

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -14,7 +14,6 @@ import {
   otherUserLeftChannel,
   mapToZeroUsers,
   updateUserPresence,
-  mapCreatorIdToZeroUserId,
 } from './saga';
 
 import { SagaActionTypes } from '.';
@@ -25,7 +24,7 @@ import { ConversationStatus, denormalize as denormalizeChannel } from '../channe
 import { StoreBuilder } from '../test/store';
 import { expectSaga } from '../../test/saga';
 import { getZEROUsers } from './api';
-import { mapOtherMembers } from './utils';
+import { mapCreatorIdToZeroUserId, mapChannelMembers } from './utils';
 import { getUserByMatrixId } from '../users/saga';
 import { fetchNewMessages } from '../messages/saga';
 
@@ -438,7 +437,7 @@ describe('channels list saga', () => {
       await expectSaga(mapToZeroUsers, channels)
         .withReducer(rootReducer)
         .provide([[call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers]])
-        .call(mapOtherMembers, channels, expectedMap)
+        .call(mapChannelMembers, channels, expectedMap)
         .run();
     });
 

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -24,7 +24,7 @@ import { ConversationStatus, denormalize as denormalizeChannel } from '../channe
 import { StoreBuilder } from '../test/store';
 import { expectSaga } from '../../test/saga';
 import { getZEROUsers } from './api';
-import { mapCreatorIdToZeroUserId, mapChannelMembers } from './utils';
+import { mapAdminUserIdToZeroUserId, mapChannelMembers } from './utils';
 
 const mockChannel = (id: string) => ({
   id: `channel_${id}`,
@@ -41,7 +41,7 @@ const mockConversation = (id: string) => ({
   hasJoined: true,
   isChannel: false,
   messages: [
-    { isAdmin: true, admin: { creatorId: 'admin-id-1' } },
+    { isAdmin: true, admin: { userId: 'admin-id-1' } },
     { sender: { userId: 'user-id-1' } },
   ],
 });
@@ -100,7 +100,7 @@ describe('channels list saga', () => {
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
           [matchers.call.fn(mapToZeroUsers), null],
           [matchers.call.fn(updateUserPresence), null],
-          [matchers.call.fn(mapCreatorIdToZeroUserId), null],
+          [matchers.call.fn(mapAdminUserIdToZeroUserId), null],
           [matchers.call.fn(getConversationsBus), conversationsChannelStub],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -159,10 +159,17 @@ describe('channels list saga', () => {
 
     it('fetches direct messages', async () => {
       await subject(fetchConversations, undefined)
+        .provide([
+          [matchers.call.fn(chat.get), chatClient],
+          [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
+          [matchers.call.fn(fetchMissingUsersData), null],
+          [matchers.call.fn(updateMessageSenders), null],
+        ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
         .call([chatClient, chatClient.getConversations])
         .call(fetchMissingUsersData, matrixIds)
+        .call(updateMessageSenders, MOCK_CONVERSATIONS)
         .run();
     });
 

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -157,14 +157,14 @@ describe('channels list saga', () => {
       ]);
     }
 
-    it('fetches direct messages', async () => {
-      await subject(fetchConversations, undefined)
-        .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
-        .call(chat.get)
-        .call([chatClient, chatClient.getConversations])
-        .call(fetchMissingUsersData, matrixIds)
-        .run();
-    });
+    // it('fetches direct messages', async () => {
+    //   await subject(fetchConversations, undefined)
+    //     .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
+    //     .call(chat.get)
+    //     .call([chatClient, chatClient.getConversations])
+    //     .call(fetchMissingUsersData, matrixIds)
+    //     .run();
+    // });
 
     it('calls mapToZeroUsers after fetch', async () => {
       await subject(fetchConversations, undefined)

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -157,14 +157,14 @@ describe('channels list saga', () => {
       ]);
     }
 
-    // it('fetches direct messages', async () => {
-    //   await subject(fetchConversations, undefined)
-    //     .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
-    //     .call(chat.get)
-    //     .call([chatClient, chatClient.getConversations])
-    //     .call(fetchMissingUsersData, matrixIds)
-    //     .run();
-    // });
+    it('fetches direct messages', async () => {
+      await subject(fetchConversations, undefined)
+        .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
+        .call(chat.get)
+        .call([chatClient, chatClient.getConversations])
+        .call(fetchMissingUsersData, matrixIds)
+        .run();
+    });
 
     it('calls mapToZeroUsers after fetch', async () => {
       await subject(fetchConversations, undefined)

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -7,13 +7,7 @@ import { SagaActionTypes, receive, denormalizeConversations } from '.';
 import { chat } from '../../lib/chat';
 
 import { AsyncListStatus } from '../normalized';
-import {
-  toLocalChannel,
-  filterChannelsList,
-  mapChannelMembers,
-  mapChannelMessages,
-  rawUserToDomainUser,
-} from './utils';
+import { toLocalChannel, filterChannelsList, mapChannelMembers, mapChannelMessages } from './utils';
 import { setactiveConversationId } from '../chat';
 import { clearChannels } from '../channels/saga';
 import { ConversationEvents, getConversationsBus } from './channels';

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -23,7 +23,7 @@ import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/selectors';
 import { ConversationStatus, GroupChannelType, MessagesFetchState, User, receive as receiveChannel } from '../channels';
 import { AdminMessageType } from '../messages';
-import { fetchNewMessages, rawMessagesSelector, replaceOptimisticMessage } from '../messages/saga';
+import { rawMessagesSelector, replaceOptimisticMessage } from '../messages/saga';
 import { getUserByMatrixId } from '../users/saga';
 import { rawChannel } from '../channels/selectors';
 import { getZEROUsers } from './api';
@@ -434,7 +434,4 @@ export function* otherUserLeftChannel(roomId: string, user: User) {
       otherMembers: channel?.otherMembers?.filter((userId) => userId !== existingUser.userId) || [],
     })
   );
-
-  // Fetch latest message events to update channel with admin message when a user leaves.
-  yield call(fetchNewMessages, channel.id);
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -86,7 +86,8 @@ export function* mapCreatorIdToZeroUserId(messageContainers) {
         if (message.admin.creatorId === currentUser.matrixId) {
           message.admin.creatorId = currentUserId;
         } else {
-          message.admin.creatorId = message.sender.userId;
+          const user = yield call(getUserByMatrixId, message.admin.creatorId);
+          message.admin.creatorId = user.userId;
         }
       }
     }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -25,7 +25,6 @@ import { currentUserSelector } from '../authentication/selectors';
 import { ConversationStatus, GroupChannelType, MessagesFetchState, User, receive as receiveChannel } from '../channels';
 import { AdminMessageType } from '../messages';
 import { fetchNewMessages, rawMessagesSelector, replaceOptimisticMessage } from '../messages/saga';
-import { featureFlags } from '../../lib/feature-flags';
 import { getUserByMatrixId } from '../users/saga';
 import { rawChannel } from '../channels/selectors';
 import { getZEROUsers } from './api';

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -157,7 +157,7 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
     message: 'Conversation was started',
     createdAt: timestamp,
     isAdmin: true,
-    admin: { type: AdminMessageType.CONVERSATION_STARTED, creatorId: currentUser.id },
+    admin: { type: AdminMessageType.CONVERSATION_STARTED, userId: currentUser.id },
   };
   const conversation = {
     ...defaultConversationProperties,

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -82,11 +82,7 @@ export function* mapCreatorIdToZeroUserId(messageContainers) {
 
   for (const container of messageContainers) {
     for (const message of container.messages) {
-      if (
-        message.isAdmin &&
-        (message.admin.type === AdminMessageType.CONVERSATION_STARTED ||
-          message.admin.type === AdminMessageType.MEMBER_LEFT_CONVERSATION)
-      ) {
+      if (message.isAdmin && message.admin.creatorId) {
         if (message.admin.creatorId === currentUser.matrixId) {
           message.admin.creatorId = currentUserId;
         } else {

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -64,7 +64,7 @@ export function* mapToZeroUsers(channels: any[]) {
   return;
 }
 
-export function* mapCreatorIdToZeroUserId(channels) {
+export function* mapCreatorIdToZeroUserId(messageContainers) {
   const currentUser = yield select(currentUserSelector());
   if (!currentUser || !currentUser.matrixId) {
     return;
@@ -72,8 +72,8 @@ export function* mapCreatorIdToZeroUserId(channels) {
 
   const currentUserId = currentUser.id;
 
-  for (const channel of channels) {
-    for (const message of channel.messages) {
+  for (const container of messageContainers) {
+    for (const message of container.messages) {
       if (
         message.isAdmin &&
         (message.admin.type === AdminMessageType.CONVERSATION_STARTED ||

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -74,7 +74,11 @@ export function* mapCreatorIdToZeroUserId(channels) {
 
   for (const channel of channels) {
     for (const message of channel.messages) {
-      if (message.isAdmin && message.admin.type === AdminMessageType.CONVERSATION_STARTED) {
+      if (
+        message.isAdmin &&
+        (message.admin.type === AdminMessageType.CONVERSATION_STARTED ||
+          message.admin.type === AdminMessageType.MEMBER_LEFT_CONVERSATION)
+      ) {
         if (message.admin.creatorId === currentUser.matrixId) {
           message.admin.creatorId = currentUserId;
         } else {
@@ -139,6 +143,7 @@ export function* fetchConversations() {
     chatClient,
     chatClient.getConversations,
   ]);
+
   yield call(mapToZeroUsers, conversations);
   yield call(updateUserPresence, conversations);
   yield call(mapCreatorIdToZeroUserId, conversations);

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -22,7 +22,7 @@ import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
 import { ConversationStatus, GroupChannelType, MessagesFetchState, User, receive as receiveChannel } from '../channels';
 import { AdminMessageType } from '../messages';
-import { rawMessagesSelector, replaceOptimisticMessage } from '../messages/saga';
+import { fetchNewMessages, rawMessagesSelector, replaceOptimisticMessage } from '../messages/saga';
 import { featureFlags } from '../../lib/feature-flags';
 import { getUserByMatrixId } from '../users/saga';
 import { rawChannel } from '../channels/selectors';
@@ -502,4 +502,7 @@ export function* otherUserLeftChannel(roomId: string, user: User) {
       otherMembers: channel.otherMembers.filter((userId) => userId !== existingUser.userId),
     })
   );
+
+  // Fetch latest message events to update channel with admin message when a user leaves.
+  yield call(fetchNewMessages, channel.id);
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -72,7 +72,7 @@ export function* mapToZeroUsers(channels: any[]) {
 }
 
 export function* mapCreatorIdToZeroUserId(messageContainers) {
-  const currentUser = yield select(currentUserSelector());
+  const currentUser = yield select(currentUserSelector);
 
   if (!currentUser || !currentUser.matrixId) {
     return;

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -56,6 +56,10 @@ export const mapOtherMembers = (channels: Channel[], zeroUsersMap: { [id: string
 export const mapChannelMessages = (channels: Channel[], zeroUsersMap: { [id: string]: User }) => {
   for (const channel of channels) {
     for (const message of channel.messages) {
+      if (message.isAdmin) {
+        continue;
+      }
+
       const zeroUser = zeroUsersMap[message.sender.userId];
       if (zeroUser && zeroUser?.profileSummary) {
         message.sender.userId = zeroUser.id;

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -53,6 +53,22 @@ export const mapOtherMembers = (channels: Channel[], zeroUsersMap: { [id: string
   }
 };
 
+export const mapMemberHistory = (channels: Channel[], zeroUsersMap: { [id: string]: User }) => {
+  for (const channel of channels) {
+    channel.memberHistory = channel.memberHistory.map((member) => {
+      const zeroUser = zeroUsersMap[member.matrixId];
+      if (zeroUser && zeroUser.profileSummary) {
+        return {
+          matrixId: member.matrixId,
+          userId: zeroUser.id,
+          firstName: zeroUser.profileSummary.firstName,
+        };
+      }
+      return member;
+    });
+  }
+};
+
 export const mapChannelMessages = (channels: Channel[], zeroUsersMap: { [id: string]: User }) => {
   for (const channel of channels) {
     for (const message of channel.messages) {
@@ -71,17 +87,3 @@ export const mapChannelMessages = (channels: Channel[], zeroUsersMap: { [id: str
     }
   }
 };
-
-export function extractMatrixIdsFromConversations(conversations) {
-  const matrixIdsSet = new Set();
-  for (const conv of conversations) {
-    for (const msg of conv.messages) {
-      if (msg.isAdmin && msg.admin.creatorId) {
-        matrixIdsSet.add(msg.admin.creatorId);
-      } else if (msg.sender?.userId) {
-        matrixIdsSet.add(msg.sender.userId);
-      }
-    }
-  }
-  return Array.from(matrixIdsSet);
-}

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -4,7 +4,6 @@ import { denormalize } from './../channels/index';
 import getDeepProperty from 'lodash.get';
 import { select } from 'redux-saga/effects';
 import { currentUserSelector } from '../authentication/selectors';
-import { getUserByMatrixId } from '../users/saga';
 
 export function filterChannelsList(state, filter: ChannelType) {
   const channelIdList = getDeepProperty(state, 'channelsList.value', []);

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -55,17 +55,13 @@ export const mapOtherMembers = (channels: Channel[], zeroUsersMap: { [id: string
 
 export const mapMemberHistory = (channels: Channel[], zeroUsersMap: { [id: string]: User }) => {
   for (const channel of channels) {
-    channel.memberHistory = channel.memberHistory.map((member) => {
+    for (const member of channel.memberHistory) {
       const zeroUser = zeroUsersMap[member.matrixId];
-      if (zeroUser && zeroUser.profileSummary) {
-        return {
-          matrixId: member.matrixId,
-          userId: zeroUser.id,
-          firstName: zeroUser.profileSummary.firstName,
-        };
+      if (zeroUser && zeroUser?.profileSummary) {
+        member.userId = zeroUser.id;
+        member.firstName = zeroUser.profileSummary.firstName;
       }
-      return member;
-    });
+    }
   }
 };
 

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -49,9 +49,9 @@ export const mapMemberHistory = (channels: Channel[], zeroUsersMap: { [id: strin
   for (const channel of channels) {
     for (const member of channel.memberHistory) {
       const zeroUser = zeroUsersMap[member.matrixId];
-      if (zeroUser && zeroUser?.profileSummary) {
-        member.userId = zeroUser.id;
-        member.firstName = zeroUser.profileSummary.firstName;
+      if (zeroUser) {
+        member.userId = zeroUser.userId;
+        member.firstName = zeroUser.firstName;
       }
     }
   }
@@ -62,15 +62,6 @@ export const mapChannelMessages = (channels: Channel[], zeroUsersMap: { [id: str
     for (const message of channel.messages) {
       if (message.isAdmin) {
         continue;
-      }
-
-      const zeroUser = zeroUsersMap[message.sender.userId];
-      if (zeroUser && zeroUser?.profileSummary) {
-        message.sender.userId = zeroUser.id;
-        message.sender.profileId = zeroUser.profileSummary.id;
-        message.sender.firstName = zeroUser.profileSummary.firstName;
-        message.sender.lastName = zeroUser.profileSummary.lastName;
-        message.sender.profileImage = zeroUser.profileSummary.profileImage;
       }
       replaceZOSUserFields(message.sender, zeroUsersMap[message.sender.userId]);
     }

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -59,10 +59,10 @@ export function* mapChannelMessages(channels: Channel[], zeroUsersMap: { [id: st
       replaceZOSUserFields(message.sender, zeroUsersMap[message.sender.userId]);
     }
   }
-  yield mapCreatorIdToZeroUserId(channels, zeroUsersMap);
+  yield mapAdminUserIdToZeroUserId(channels, zeroUsersMap);
 }
 
-export function* mapCreatorIdToZeroUserId(messageContainers, zeroUsersMap) {
+export function* mapAdminUserIdToZeroUserId(messageContainers, zeroUsersMap) {
   const currentUser = yield select(currentUserSelector);
 
   if (!currentUser || !currentUser.matrixId) {
@@ -73,12 +73,12 @@ export function* mapCreatorIdToZeroUserId(messageContainers, zeroUsersMap) {
 
   for (const container of messageContainers) {
     for (const message of container.messages) {
-      if (message.isAdmin && message.admin.creatorId) {
-        if (message.admin.creatorId === currentUser.matrixId) {
-          message.admin.creatorId = currentUserId;
+      if (message.isAdmin && message.admin.userId) {
+        if (message.admin.userId === currentUser.matrixId) {
+          message.admin.userId = currentUserId;
         } else {
-          const user = zeroUsersMap[message.admin.creatorId];
-          message.admin.creatorId = user?.userId || message.admin.creatorId;
+          const user = zeroUsersMap[message.admin.userId];
+          message.admin.userId = user?.userId || message.admin.userId;
         }
       }
     }

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -67,3 +67,17 @@ export const mapChannelMessages = (channels: Channel[], zeroUsersMap: { [id: str
     }
   }
 };
+
+export function extractMatrixIdsFromConversations(conversations) {
+  const matrixIdsSet = new Set();
+  for (const conv of conversations) {
+    for (const msg of conv.messages) {
+      if (msg.isAdmin && msg.admin.creatorId) {
+        matrixIdsSet.add(msg.admin.creatorId);
+      } else if (msg.sender?.userId) {
+        matrixIdsSet.add(msg.sender.userId);
+      }
+    }
+  }
+  return Array.from(matrixIdsSet);
+}

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -40,6 +40,7 @@ export interface Channel {
   name: string;
   messages: Message[];
   otherMembers: User[];
+  memberHistory: Partial<User>[];
   hasMore: boolean;
   createdAt: number;
   lastMessage: Message;
@@ -73,6 +74,7 @@ const slice = createNormalizedSlice({
   schemaDefinition: {
     messages: [messageSchema],
     otherMembers: [userSchema],
+    memberHistory: [userSchema],
   },
 });
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -40,7 +40,7 @@ export interface Channel {
   name: string;
   messages: Message[];
   otherMembers: User[];
-  memberHistory: Partial<User>[];
+  memberHistory: User[];
   hasMore: boolean;
   createdAt: number;
   lastMessage: Message;

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -8,6 +8,7 @@ import { getAuthChannel, Events as AuthEvents } from '../authentication/channels
 import { getSSOToken } from '../authentication/api';
 import { currentUserSelector } from '../authentication/saga';
 import { saveUserMatrixCredentials } from '../edit-profile/saga';
+import { receive } from '../users';
 
 function* listenForReconnectStart(_action) {
   yield put(setReconnecting(true));
@@ -57,9 +58,15 @@ function* clearOnLogout() {
   yield put(setactiveConversationId(null));
 }
 
+function* addAdminUser() {
+  yield put(receive({ userId: 'admin', firstName: 'Admin', profileImage: null, matrixId: 'admin' }));
+}
+
 export function* saga() {
   yield spawn(connectOnLogin);
-  yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
+  const authBus = yield call(getAuthChannel);
+  yield takeEveryFromBus(authBus, AuthEvents.UserLogout, clearOnLogout);
+  yield takeEveryFromBus(authBus, AuthEvents.UserLogin, addAdminUser);
 
   const chatBus = yield call(getChatBus);
   yield takeEveryFromBus(chatBus, Events.ReconnectStart, listenForReconnectStart);

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -74,7 +74,7 @@ export interface Message {
     type: AdminMessageType;
     inviterId?: string;
     inviteeId?: string;
-    creatorId?: string;
+    userId?: string;
   };
   optimisticId?: string;
   rootMessageId?: string;

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -48,6 +48,7 @@ export interface InfoUploadResponse {
 export enum AdminMessageType {
   JOINED_ZERO = 'JOINED_ZERO',
   CONVERSATION_STARTED = 'CONVERSATION_STARTED',
+  MEMBER_LEFT_CONVERSATION = 'MEMBER_LEFT_CONVERSATION',
 }
 
 export enum MessageSendStatus {

--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -7,7 +7,7 @@ import { chat } from '../../lib/chat';
 import { StoreBuilder } from '../test/store';
 import { call } from 'redux-saga/effects';
 import { expectSaga } from '../../test/saga';
-import { mapCreatorIdToZeroUserId } from '../channels-list/saga';
+import { mapCreatorIdToZeroUserId } from '../channels-list/utils';
 
 const chatClient = {
   getMessagesByChannelId: (_channelId: string, _referenceTimestamp?: number) => ({}),

--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -7,7 +7,6 @@ import { chat } from '../../lib/chat';
 import { StoreBuilder } from '../test/store';
 import { call } from 'redux-saga/effects';
 import { expectSaga } from '../../test/saga';
-import { mapCreatorIdToZeroUserId } from '../channels-list/utils';
 
 const chatClient = {
   getMessagesByChannelId: (_channelId: string, _referenceTimestamp?: number) => ({}),
@@ -38,7 +37,6 @@ describe(fetch, () => {
       .provide([
         [call([chatClient, chatClient.getMessagesByChannelId], channel.id), messageResponse],
         [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
-        [matchers.call.fn(mapCreatorIdToZeroUserId), null],
       ])
       .withReducer(rootReducer, initialChannelState(channel) as any)
       .run();

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -9,6 +9,7 @@ import {
   sendBrowserNotification,
   receiveUpdateMessage,
   replaceOptimisticMessage,
+  fetchMissingUsersData,
 } from './saga';
 
 import { RootState, rootReducer } from '../reducer';
@@ -18,6 +19,8 @@ import { StoreBuilder } from '../test/store';
 import { MessageSendStatus } from '.';
 import { chat } from '../../lib/chat';
 import { NotifiableEventType } from '../../lib/chat/matrix/types';
+import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
+import { receive as receiveUser } from '../users';
 
 const chatClient = {
   editMessage: (_channelId: string, _messageId: string, _message: string, _mentionedUserIds: string[]) => ({}),
@@ -301,5 +304,73 @@ describe(replaceOptimisticMessage, () => {
       .run();
 
     expect(returnValue[0].preview).toEqual({ url: 'example.com/old-preview' });
+  });
+});
+
+describe(fetchMissingUsersData, () => {
+  const matrixIds = ['matrixId1', 'matrixId2', 'matrixId3'];
+
+  it('fetches missing user data when no users are in the map', async () => {
+    const zeroUsers = [
+      { matrixId: 'matrixId1', id: 'id1', profileSummary: { firstName: 'Alice', profileImage: 'image1' } },
+      { matrixId: 'matrixId2', id: 'id2', profileSummary: { firstName: 'Bob', profileImage: 'image2' } },
+    ];
+
+    await expectSaga(fetchMissingUsersData, matrixIds)
+      .provide([
+        [matchers.call.fn(getZEROUsersAPI), zeroUsers],
+      ])
+      .put(
+        receiveUser({
+          userId: 'id1',
+          firstName: 'Alice',
+          profileImage: 'image1',
+          matrixId: 'matrixId1',
+        })
+      )
+      .put(
+        receiveUser({
+          userId: 'id2',
+          firstName: 'Bob',
+          profileImage: 'image2',
+          matrixId: 'matrixId2',
+        })
+      )
+      .run();
+  });
+
+  it('does not fetch user data if all users are already in the map', async () => {
+    const matrixIds = ['matrixId1', 'matrixId2'];
+    const zeroUsersMap = {
+      matrixId1: { userId: 'id1', firstName: 'Alice', profileImage: 'image1', matrixId: 'matrixId1' },
+      matrixId2: { userId: 'id2', firstName: 'Bob', profileImage: 'image2', matrixId: 'matrixId2' },
+    };
+
+    const getZeroUsersMapFn = () => zeroUsersMap;
+
+    await expectSaga(fetchMissingUsersData, matrixIds, getZeroUsersMapFn).not.call.fn(getZEROUsersAPI).run();
+  });
+
+  it('fetches only missing user data when some users are already in the map', async () => {
+    const getZeroUsersMapFn = () => ({
+      matrixId1: { userId: 'id1', firstName: 'Alice', profileImage: 'image1', matrixId: 'matrixId1' },
+    });
+    const zeroUsers = [
+      { matrixId: 'matrixId2', id: 'id2', profileSummary: { firstName: 'Bob', profileImage: 'image2' } },
+    ];
+
+    await expectSaga(fetchMissingUsersData, matrixIds, getZeroUsersMapFn)
+      .provide([
+        [matchers.call.fn(getZEROUsersAPI), zeroUsers],
+      ])
+      .put(
+        receiveUser({
+          userId: 'id2',
+          firstName: 'Bob',
+          profileImage: 'image2',
+          matrixId: 'matrixId2',
+        })
+      )
+      .run();
   });
 });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -20,7 +20,7 @@ import { User } from '../channels';
 import { mapMessageSenders } from './utils.matrix';
 import { uniqNormalizedList } from '../utils';
 import { NotifiableEventType } from '../../lib/chat/matrix/types';
-import { mapCreatorIdToZeroUserId } from '../channels-list/utils';
+import { mapAdminUserIdToZeroUserId } from '../channels-list/utils';
 
 export interface Payload {
   channelId: string;
@@ -109,7 +109,7 @@ export function* getLocalZeroUsersMap() {
 
 export function* mapMessagesAndPreview(messages, channelId) {
   const zeroUsersMap = yield call(mapMessageSenders, messages, channelId);
-  yield call(mapCreatorIdToZeroUserId, [{ messages }], zeroUsersMap);
+  yield call(mapAdminUserIdToZeroUserId, [{ messages }], zeroUsersMap);
   for (const message of messages) {
     const preview = yield call(getPreview, message.message);
     if (preview) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -21,8 +21,6 @@ import { mapMessageSenders, mapReceivedMessage } from './utils.matrix';
 import { mapCreatorIdToZeroUserId } from '../channels-list/saga';
 import { uniqNormalizedList } from '../utils';
 import { NotifiableEventType } from '../../lib/chat/matrix/types';
-import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
-import { receive as receiveUser } from '../users';
 
 export interface Payload {
   channelId: string;
@@ -123,37 +121,6 @@ function* mapMessagesAndPreview(messagesResponse, channelId) {
   return messagesResponse.messages;
 }
 
-function mapZeroUsers(zeroUsers) {
-  const zeroUsersMap = {};
-  for (const user of zeroUsers) {
-    zeroUsersMap[user.matrixId] = {
-      userId: user.id,
-      firstName: user.profileSummary?.firstName,
-      profileImage: user.profileSummary?.profileImage,
-      matrixId: user.matrixId,
-    };
-  }
-  return zeroUsersMap;
-}
-
-export function* fetchMissingUsersData(matrixIds, getZeroUsersMapFn?) {
-  let missingMatrixIds = matrixIds;
-
-  if (getZeroUsersMapFn) {
-    const zeroUsersMap = yield call(getZeroUsersMapFn);
-    missingMatrixIds = matrixIds.filter((id) => !zeroUsersMap[id]);
-  }
-
-  if (missingMatrixIds.length) {
-    const zeroUsers = yield call(getZEROUsersAPI, missingMatrixIds);
-    const mappedZeroUsers = mapZeroUsers(zeroUsers);
-
-    for (const user of Object.values(mappedZeroUsers)) {
-      yield put(receiveUser(user));
-    }
-  }
-}
-
 export function* fetch(action) {
   const { channelId, referenceTimestamp } = action.payload;
   const channel = yield select(rawChannelSelector(channelId));
@@ -174,13 +141,6 @@ export function* fetch(action) {
       yield put(receive({ id: channelId, messagesFetchStatus: MessagesFetchState.IN_PROGRESS }));
       messagesResponse = yield call([chatClient, chatClient.getMessagesByChannelId], channelId);
     }
-
-    // Check for users not present in the local users map. This scenario can occur when a user,
-    // who has sent messages in the conversation, has since left the room and is therefore not in the current user list.
-    // In such cases, we fetch these missing users' profiles from the API to ensure we have complete user data for all messages.
-    // This is crucial for accurately displaying sender information in the UI.
-    const matrixIds = messagesResponse.messages.map((m) => m.sender?.userId).filter(Boolean);
-    yield call(fetchMissingUsersData, matrixIds);
 
     messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse, channelId);
     yield call(mapCreatorIdToZeroUserId, [messagesResponse]);

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -18,9 +18,9 @@ import { chat } from '../../lib/chat';
 import { activeChannelIdSelector } from '../chat/selectors';
 import { User } from '../channels';
 import { mapMessageSenders } from './utils.matrix';
-import { mapCreatorIdToZeroUserId } from '../channels-list/saga';
 import { uniqNormalizedList } from '../utils';
 import { NotifiableEventType } from '../../lib/chat/matrix/types';
+import { mapCreatorIdToZeroUserId } from '../channels-list/utils';
 
 export interface Payload {
   channelId: string;
@@ -108,7 +108,8 @@ export function* getLocalZeroUsersMap() {
 }
 
 export function* mapMessagesAndPreview(messages, channelId) {
-  yield call(mapMessageSenders, messages, channelId);
+  const zeroUsersMap = yield call(mapMessageSenders, messages, channelId);
+  yield call(mapCreatorIdToZeroUserId, [{ messages }], zeroUsersMap);
   for (const message of messages) {
     const preview = yield call(getPreview, message.message);
     if (preview) {
@@ -141,7 +142,6 @@ export function* fetch(action) {
     }
 
     messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse.messages, channelId);
-    yield call(mapCreatorIdToZeroUserId, [messagesResponse]);
     const existingMessages = yield select(rawMessagesSelector(channelId));
 
     // we prefer this order (new messages first), so that if any new message has an updated property
@@ -313,7 +313,6 @@ export function* fetchNewMessages(channelId: string) {
       channelId
     );
     messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse.messages, channelId);
-    yield call(mapCreatorIdToZeroUserId, [messagesResponse]);
 
     yield put(
       receive({
@@ -460,16 +459,14 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
 
   for (const channelId of Object.keys(byChannelId)) {
     const channel = yield select(rawChannelSelector(channelId));
+    if (!channel) {
+      continue;
+    }
+
     let currentMessages = channel?.messages || [];
-    let modified = false;
     for (let message of byChannelId[channelId]) {
       const messageList = yield call(mapMessagesAndPreview, [message], channelId);
       message = messageList[0];
-
-      if (!channel) {
-        continue;
-      }
-      modified = true;
 
       let newMessages = yield call(replaceOptimisticMessage, currentMessages, message);
       if (!newMessages) {
@@ -480,9 +477,8 @@ export function* batchedReceiveNewMessage(batchedPayloads) {
       }
       currentMessages = newMessages;
     }
-    if (modified) {
-      yield put(receive({ id: channelId, messages: uniqNormalizedList(currentMessages, true) }));
-    }
+
+    yield put(receive({ id: channelId, messages: uniqNormalizedList(currentMessages, true) }));
     if (yield select(_isActive(channelId))) {
       const isChannel = yield select(_isChannel(channelId));
       const markAllAsReadAction = isChannel ? markChannelAsRead : markConversationAsRead;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -354,7 +354,9 @@ export function* fetchNewMessages(channelId: string) {
       ],
       channelId
     );
+
     messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse, channelId);
+    yield call(mapCreatorIdToZeroUserId, [messagesResponse]);
 
     yield put(
       receive({

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -56,4 +56,6 @@ export function* mapMessageSenders(messages, channelId) {
   });
 
   yield call(mapParentForMessages, messages, channelId, localUsersMap);
+
+  return localUsersMap;
 }


### PR DESCRIPTION
### What does this do?
- admin message for when a member leaves a room

### Why are we making this change?
- to highlight to other users that a member has left the room

### How do I test this?
- with two test users on different browser profiles, initiate the leave room flow and leave the room with one of your test users. once you have left the room, check on the other test users conversation that the admin message clearly states which user has left.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="1108" alt="Screenshot 2023-12-07 at 14 20 31" src="https://github.com/zer0-os/zOS/assets/39112648/328dc7ba-b277-40e7-94c6-3dccaddb126f">

DEMO


https://github.com/zer0-os/zOS/assets/39112648/cb20bd68-cbfb-468e-995b-bfa0eaf97af7

