### PR TITLE
Don't allow removing members if there are only 2 left

### DIFF
--- a/src/components/messenger/list/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.test.tsx
@@ -130,13 +130,23 @@ describe(EditConversationPanel, () => {
       const onRemoveMember = jest.fn();
       const wrapper = subject({
         onRemoveMember,
-        otherMembers: [{ userId: 'user-1' }] as any,
+        otherMembers: [{ userId: 'user-1' }, { userId: 'user-2' }] as any,
       });
 
       const item = wrapper.find(CitizenListItem).findWhere((c) => c.prop('user').userId === 'user-1');
       item.simulate('remove', 'user-1');
 
       expect(onRemoveMember).toHaveBeenCalledWith('user-1');
+    });
+
+    it('does not allow remove if there are only 2 people in the room', function () {
+      const wrapper = subject({
+        otherMembers: [{ userId: 'user-1' }] as any,
+      });
+
+      const item = wrapper.find(CitizenListItem).findWhere((c) => c.prop('user').userId === 'user-1');
+
+      expect(item.prop('onRemove')).toBeFalsy();
     });
   });
 });

--- a/src/components/messenger/list/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.tsx
@@ -61,7 +61,13 @@ export class EditConversationPanel extends React.Component<Properties, State> {
     return this.props.state === EditConversationState.SUCCESS;
   }
 
-  removeMember = (userId: string) => {
+  get removeMember() {
+    if (this.props.otherMembers.length < 2) return null;
+
+    return this.publishRemove;
+  }
+
+  publishRemove = (userId: string) => {
     this.props.onRemoveMember(userId);
   };
 


### PR DESCRIPTION
### What does this do?

To prevent "empty" conversations we don't allow you to remove members of a room to fewer than 2 for now.

