### PR TITLE
Change the remove icon to not render when cursor isn't hovering

### DIFF
--- a/src/components/citizen-list-item/styles.scss
+++ b/src/components/citizen-list-item/styles.scss
@@ -27,11 +27,11 @@
   }
 
   &__remove {
-    visibility: hidden;
+    display: none;
   }
 
   &:hover &__remove {
-    visibility: visible;
+    display: block;
   }
 
   &__tag {


### PR DESCRIPTION
### What does this do?

Minor style tweak to allow the user name to fill the space when not hovering over the item

Before:
![image](https://github.com/zer0-os/zOS/assets/43770/6e3882f1-f01a-4f66-a20f-1ef4a9a74bb5)

After (No Hover):
![image](https://github.com/zer0-os/zOS/assets/43770/265a2f34-dfd1-4f7e-bb69-eafe444ae39f)

After (Hover):
![image](https://github.com/zer0-os/zOS/assets/43770/2381bb34-082a-4015-bc06-b0995bede119)


