### PR TITLE
fix: group management menu conditions

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -216,45 +216,6 @@ describe('messenger-chat', () => {
       expect(groupManagementMenuContainer.exists()).toBeTrue();
     });
 
-    it('passes canLeaveRoom prop as false to group management menu if only 2 members are in conversation', function () {
-      const wrapper = subject({
-        isCurrentUserRoomAdmin: false,
-        directMessage: {
-          isOneOnOne: true,
-          otherMembers: [
-            stubUser({
-              profileImage: 'avatar-url',
-            }),
-          ],
-        } as Channel,
-      });
-
-      const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-      expect(groupManagementMenu.prop('canLeaveRoom')).toBe(false);
-    });
-
-    it('passes canLeaveRoom prop as true to group management menu if more than 2 members are in conversation', function () {
-      const wrapper = subject({
-        isCurrentUserRoomAdmin: false,
-        directMessage: {
-          isOneOnOne: true,
-          otherMembers: [
-            stubUser({
-              profileImage: 'avatar-url',
-            }),
-            stubUser({
-              profileImage: 'avatar-url',
-            }),
-          ],
-        } as Channel,
-      });
-
-      const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-      expect(groupManagementMenu.prop('canLeaveRoom')).toBe(true);
-    });
-
     it('can start add group member group management saga', async function () {
       const startAddGroupMember = jest.fn();
       const wrapper = subject({ startAddGroupMember });
@@ -414,25 +375,82 @@ describe('messenger-chat', () => {
   });
 
   describe('room management', () => {
-    it('allows editing if user is an admin and conversation is not a 1 on 1', () => {
-      const wrapper = subject({ isCurrentUserRoomAdmin: true });
+    describe('edit members', () => {
+      it('allows editing if user is an admin and conversation is not a 1 on 1', () => {
+        const wrapper = subject({ isCurrentUserRoomAdmin: true });
 
-      expect(wrapper.find(GroupManagementMenu).prop('canEdit')).toBe(true);
-    });
-
-    it('does NOT allow editing if user is NOT an admin', () => {
-      const wrapper = subject({
-        isCurrentUserRoomAdmin: false,
-        directMessage: stubConversation({ isOneOnOne: false }),
+        expect(wrapper.find(GroupManagementMenu).prop('canEdit')).toBe(true);
       });
 
-      expect(wrapper.find(GroupManagementMenu).prop('canEdit')).toBe(false);
+      it('does NOT allow editing if user is NOT an admin', () => {
+        const wrapper = subject({
+          isCurrentUserRoomAdmin: false,
+          directMessage: stubConversation({ isOneOnOne: false }),
+        });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canEdit')).toBe(false);
+      });
+
+      it('does NOT allow editing if conversation is considered a 1 on 1', () => {
+        const wrapper = subject({
+          isCurrentUserRoomAdmin: true,
+          directMessage: stubConversation({ isOneOnOne: true }),
+        });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canEdit')).toBe(false);
+      });
     });
 
-    it('does NOT allow editing if conversation is considered a 1 on 1', () => {
-      const wrapper = subject({ isCurrentUserRoomAdmin: true, directMessage: stubConversation({ isOneOnOne: true }) });
+    describe('add members', () => {
+      it('allows adding of members if user is an admin and conversation is not a 1 on 1', () => {
+        const wrapper = subject({ isCurrentUserRoomAdmin: true });
 
-      expect(wrapper.find(GroupManagementMenu).prop('canEdit')).toBe(false);
+        expect(wrapper.find(GroupManagementMenu).prop('canAddMembers')).toBe(true);
+      });
+
+      it('does NOT allow adding of members if user is NOT an admin', () => {
+        const wrapper = subject({
+          isCurrentUserRoomAdmin: false,
+          directMessage: stubConversation({ isOneOnOne: false }),
+        });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canAddMembers')).toBe(false);
+      });
+
+      it('does NOT allow adding of members if conversation is considered a 1 on 1', () => {
+        const wrapper = subject({
+          isCurrentUserRoomAdmin: true,
+          directMessage: stubConversation({ isOneOnOne: true }),
+        });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canAddMembers')).toBe(false);
+      });
+    });
+
+    describe('leave', () => {
+      it('allows user to leave if user is not an admin and conversation is not a 1 on 1', () => {
+        const wrapper = subject({ isCurrentUserRoomAdmin: false });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canLeaveRoom')).toBe(true);
+      });
+
+      it('does NOT allow user to leave if user is an admin', () => {
+        const wrapper = subject({
+          isCurrentUserRoomAdmin: true,
+          directMessage: stubConversation({ isOneOnOne: false }),
+        });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canLeaveRoom')).toBe(false);
+      });
+
+      it('does NOT allow user to leave if conversation is considered a 1 on 1', () => {
+        const wrapper = subject({
+          isCurrentUserRoomAdmin: false,
+          directMessage: stubConversation({ isOneOnOne: true }),
+        });
+
+        expect(wrapper.find(GroupManagementMenu).prop('canLeaveRoom')).toBe(false);
+      });
     });
   });
 });

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -224,10 +224,10 @@ export class Container extends React.Component<Properties, State> {
             </span>
             <div className='direct-message-chat__group-management-menu-container'>
               <GroupManagementMenu
-                canAddMembers={this.props.isCurrentUserRoomAdmin}
+                canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                 onStartAddMember={this.props.startAddGroupMember}
                 onLeave={this.openLeaveGroupDialog}
-                canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage?.otherMembers?.length > 1}
+                canLeaveRoom={!this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                 canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                 onEdit={this.props.startEditConversation}
               />

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -478,10 +478,13 @@ export function* otherUserLeftChannel(roomId: string, user: User) {
     return;
   }
 
+  const updatedMembers = channel.otherMembers.filter((userId) => userId !== existingUser.userId);
+
   yield put(
     receiveChannel({
       id: channel.id,
-      otherMembers: channel.otherMembers.filter((userId) => userId !== existingUser.userId),
+      isOneOnOne: updatedMembers.length === 1,
+      otherMembers: updatedMembers,
     })
   );
 }


### PR DESCRIPTION
### What does this do?
- fixes bug where a 'one to many' conversation becomes a 'one to one' conversation and the user can still Edit/Add members. 
- adds/enhances test coverage.
- organises tests.

### Why are we making this change?
- `isOneOnOne` will still be set as false and otherMembers not updating when conversation becomes a one to one conversation.

### How do I test this?
- Start a conversation > check you are unable to Add or Edit members (you shouldn't see the three dot menu).
- Start a group conversation > remove members until conversation is one to one > check you are unable to Add or Edit members (you shouldn't see the three dot menu).

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE - With Redux State Check:

https://github.com/zer0-os/zOS/assets/39112648/02e87406-6446-4cca-afb7-0fa7c9cd5c2e


AFTER - With Redux State Check:

https://github.com/zer0-os/zOS/assets/39112648/26c42c00-0151-4052-a304-a005e6a9bccc

AFTER (COMPLETE FIX) - With Updated Conditions:

https://github.com/zer0-os/zOS/assets/39112648/041b18c4-abf9-4dcc-a949-40c39dddff83


NOTE: A follow up for this task should probably be reset the panel stage?