### PR TITLE
refactor: reduce duplication of mapping message events with fully loaded data

### DIFF
--- a/src/store/messages/saga.receiveNewMessage.test.ts
+++ b/src/store/messages/saga.receiveNewMessage.test.ts
@@ -37,6 +37,21 @@ describe(receiveNewMessage, () => {
     expect(channel.messages[1].id).toEqual('new-message');
   });
 
+  it('maps the message users', async () => {
+    const channelId = 'channel-id';
+    const message = { id: 'message-id', message: 'test message', sender: { userId: 'matrix-id' } };
+    const initialState = new StoreBuilder()
+      .withConversationList({ id: channelId })
+      .withUsers({ userId: 'user-1', matrixId: 'matrix-id', firstName: 'the real user' });
+
+    const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .withReducer(rootReducer, initialState.build())
+      .run();
+
+    const channel = denormalizeChannel(channelId, storeState);
+    expect(channel.messages[0].sender.firstName).toEqual('the real user');
+  });
+
   it('adds the link previews to the message', async () => {
     const channelId = 'channel-id';
     const message = { id: 'message-id', message: 'www.google.com' };

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -192,15 +192,13 @@ describe(receiveUpdateMessage, () => {
       updatedAt: 1678861290000,
     };
 
-    const messages = { 8667728016: message };
+    const initialState = new StoreBuilder().withConversationList({ id: 'channel-1', messages: [message] as any });
 
     const { storeState } = await expectSaga(receiveUpdateMessage, {
       payload: { channelId: 'channel-1', message: editedMessage },
     })
-      .provide([
-        ...successResponses(),
-      ])
-      .withReducer(rootReducer, { normalized: { messages } as any } as RootState)
+      .provide([...successResponses()])
+      .withReducer(rootReducer, initialState.build())
       .run();
 
     expect(storeState.normalized.messages).toEqual({ 8667728016: editedMessage });
@@ -208,21 +206,19 @@ describe(receiveUpdateMessage, () => {
 
   it('adds the preview if exists', async () => {
     const message = { id: 8667728016, message: 'original message' };
-    const messages = { 8667728016: message };
     const editedMessage = { id: 8667728016, message: 'edited message: www.example.com' };
     const preview = { id: 'fdf2ce2b-062e-4a83-9c27-03f36c81c0c0', type: 'link' };
+
+    const initialState = new StoreBuilder().withConversationList({ id: 'channel-1', messages: [message] as any });
 
     const { storeState } = await expectSaga(receiveUpdateMessage, {
       payload: { channelId: 'channel-1', message: editedMessage },
     })
       .provide([
-        [
-          call(getPreview, editedMessage.message),
-          preview,
-        ],
+        [call(getPreview, editedMessage.message), preview],
         ...successResponses(),
       ])
-      .withReducer(rootReducer, { normalized: { messages } as any } as RootState)
+      .withReducer(rootReducer, initialState.build())
       .run();
 
     expect(storeState.normalized.messages[message.id]).toEqual({ ...editedMessage, preview });

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -11,7 +11,7 @@ import {
   replaceOptimisticMessage,
 } from './saga';
 
-import { RootState, rootReducer } from '../reducer';
+import { rootReducer } from '../reducer';
 import { mapMessage, send as sendBrowserMessage } from '../../lib/browser';
 import { call } from 'redux-saga/effects';
 import { StoreBuilder } from '../test/store';

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -87,7 +87,7 @@ const _isActive = (channelId) => (state) => {
 const FETCH_CHAT_CHANNEL_INTERVAL = 60000;
 
 export function* getLocalZeroUsersMap() {
-  const users = yield select((state) => state.normalized.users);
+  const users = yield select((state) => state.normalized.users || {});
   const zeroUsersMap: { [matrixId: string]: User } = {};
   for (const user of Object.values(users)) {
     zeroUsersMap[(user as User).matrixId] = user as User;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -107,16 +107,16 @@ export function* getLocalZeroUsersMap() {
   return zeroUsersMap;
 }
 
-export function* mapMessagesAndPreview(messagesResponse, channelId) {
-  yield call(mapMessageSenders, messagesResponse.messages, channelId);
-  for (const message of messagesResponse.messages) {
+export function* mapMessagesAndPreview(messages, channelId) {
+  yield call(mapMessageSenders, messages, channelId);
+  for (const message of messages) {
     const preview = yield call(getPreview, message.message);
     if (preview) {
       message.preview = preview;
     }
   }
 
-  return messagesResponse.messages;
+  return messages;
 }
 
 export function* fetch(action) {
@@ -140,7 +140,7 @@ export function* fetch(action) {
       messagesResponse = yield call([chatClient, chatClient.getMessagesByChannelId], channelId);
     }
 
-    messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse, channelId);
+    messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse.messages, channelId);
     yield call(mapCreatorIdToZeroUserId, [messagesResponse]);
     const existingMessages = yield select(rawMessagesSelector(channelId));
 
@@ -312,7 +312,7 @@ export function* fetchNewMessages(channelId: string) {
       ],
       channelId
     );
-    messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse, channelId);
+    messagesResponse.messages = yield call(mapMessagesAndPreview, messagesResponse.messages, channelId);
 
     yield put(
       receive({

--- a/src/store/messages/utils.matrix.test.ts
+++ b/src/store/messages/utils.matrix.test.ts
@@ -101,7 +101,7 @@ describe(mapMessageSenders, () => {
     });
   });
 
-  it('sets the parentMessage to message if present in state', async () => {
+  it('sets the parentMessage to message if present in the message list', async () => {
     const initialState = {
       normalized: {
         users: {
@@ -119,7 +119,20 @@ describe(mapMessageSenders, () => {
     expect(messages[1].parentMessage).toEqual(messages[0]); // check if the parent message is assigned properly
   });
 
-  it('calls matrix API to fetch parent message if not present in state', async () => {
+  it('sets the parentMessage to message if not present in the message list but IS present in state', async () => {
+    const messages = [
+      { id: '1', parentMessageId: 'existing-message-1', message: 'message-1', sender: { userId: 'matrix-1' } } as any,
+    ];
+    const initialState = new StoreBuilder()
+      .withUsers({ userId: 'user-1', matrixId: 'matrix-1' })
+      .withConversationList({ id: '1', messages: [{ id: 'existing-message-1', message: 'the parent!' } as any] });
+
+    await expectSaga(mapMessageSenders, messages, 'channel-id').withState(initialState.build()).run();
+
+    expect(messages[0].parentMessageText).toEqual('the parent!');
+  });
+
+  it('calls matrix API to fetch parent message if not present in the message list OR state', async () => {
     const initialState = {
       normalized: {
         users: {

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -2,8 +2,6 @@ import { call, select } from 'redux-saga/effects';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
 import { getLocalZeroUsersMap, messageSelector } from './saga';
 import { chat } from '../../lib/chat';
-import { userByMatrixIdSelector } from '../users/selectors';
-import { currentUserSelector } from '../authentication/saga';
 
 function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
   const chatClient = yield call(chat.get);

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -59,28 +59,3 @@ export function* mapMessageSenders(messages, channelId) {
 
   yield call(mapParentForMessages, messages, channelId, localUsersMap);
 }
-
-// maps a newly sent/received message sender + parentMessage to a ZERO user
-export function* mapReceivedMessage(message) {
-  const matrixId = message.sender?.userId;
-
-  const currentUser = yield select(currentUserSelector());
-  if (currentUser && matrixId === currentUser.matrixId) {
-    message.sender = {
-      userId: currentUser.id,
-      profileId: currentUser.profileSummary?.id,
-      firstName: currentUser.profileSummary?.firstName,
-      lastName: currentUser.profileSummary?.lastName,
-      profileImage: currentUser.profileSummary?.profileImage,
-    };
-  } else {
-    const user = yield select(userByMatrixIdSelector, matrixId);
-    message.sender = user || message.sender;
-  }
-
-  if (message.parentMessageId) {
-    const parentMessage = yield select(messageSelector(message.parentMessageId));
-    message.parentMessage = parentMessage || {};
-    message.parentMessageText = parentMessage?.message;
-  }
-}

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -17,7 +17,12 @@ function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
     if (message.parentMessageId) {
       let parentMessage = messagesById[message.parentMessageId];
       if (!parentMessage) {
-        // if we don't have the parent message in our list, we need to fetch it
+        // Check the state for the message
+        parentMessage = yield select(messageSelector(message.parentMessageId));
+      }
+
+      if (!parentMessage) {
+        // if we don't have the parent message in our list or in state we need to fetch it
         // this can happen when a message is a reply to a message which is not in the current page/list
         parentMessage = yield call([chatClient, chatClient.getMessageByRoomId], channelId, message.parentMessageId);
         parentMessage.sender = zeroUsersMap[parentMessage.sender?.userId] || parentMessage.sender;


### PR DESCRIPTION
### What does this do?

We had multiple places where we mapped raw message event data to include senders, previews, parentMessage, etc. This consolidates.

