### PR TITLE
zOS Redesign: Increase z-index by 1 for the header gradient

### DIFF
--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -73,7 +73,7 @@ $recent-indicator-size: 8px;
     width: 100%;
     height: 64px;
     background: linear-gradient(180deg, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.492172) 22px, rgba(0, 0, 0, 0) 64px);
-    z-index: 1;
+    z-index: 2;
   }
 
   &__header-position {

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -81,7 +81,7 @@ $recent-indicator-size: 8px;
     width: 100%;
     padding: 16px 16px 16px 0px;
     box-sizing: border-box;
-    z-index: 2;
+    z-index: 3;
   }
 
   &__header {


### PR DESCRIPTION
### What does this do?

I wasn't able to see the gradient on the top messages going behind the header. Works after increasing the gradient by 1. (possibly because of z-index: 1 being default of browser)

Before:
<img width="644" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/94158746-6bba-44f3-a731-18b1119867b6">

After:
![image](https://github.com/zer0-os/zOS/assets/33264364/b179a733-cbce-4d97-a1f7-6735ff721ba8)
