### PR TITLE
feat: add users online status to profile avatar

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -90,6 +90,18 @@ describe('messenger-list', () => {
     expect(wrapper).not.toHaveElement(SettingsMenu);
   });
 
+  it('renders users name when stage is equal to none', function () {
+    const wrapper = subject({ stage: Stage.None, userName: 'Joe Bloggs' });
+
+    expect(wrapper.find('.messenger-list__user-name').text()).toEqual('Joe Bloggs');
+  });
+
+  it('does not render users name when stage is not equal to none', function () {
+    const wrapper = subject({ stage: Stage.CreateOneOnOne, userName: 'Joe Bloggs' });
+
+    expect(wrapper).not.toHaveElement('.messenger-list__user-name');
+  });
+
   it('renders CreateConversationPanel', function () {
     const wrapper = subject({ stage: Stage.CreateOneOnOne });
 

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -13,8 +13,6 @@ import { Stage } from '../../../store/create-conversation';
 import { Stage as GroupManagementStage } from '../../../store/group-management';
 import { RegistrationState } from '../../../store/registration';
 import { LayoutState } from '../../../store/layout/types';
-import { RewardsState } from '../../../store/rewards';
-import { RewardsContainer } from '../../rewards-container';
 import { previewDisplayDate } from '../../../lib/chat/chat-message';
 import { SettingsMenu } from '../../settings-menu';
 import { GroupManagementContainer } from './group-management/container';
@@ -41,12 +39,8 @@ describe('messenger-list', () => {
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
-      meowPreviousDay: '',
-      isRewardsLoading: false,
       isInviteNotificationOpen: false,
       myUserId: '',
-      showRewardsInTooltip: false,
-      showRewardsInPopup: false,
       onConversationClick: jest.fn(),
       createConversation: jest.fn(),
       startCreateConversation: () => null,
@@ -54,9 +48,6 @@ describe('messenger-list', () => {
       startGroup: () => null,
       back: () => null,
       enterFullScreenMessenger: () => null,
-      fetchRewards: () => null,
-      rewardsPopupClosed: () => null,
-      rewardsTooltipClosed: () => null,
       receiveSearchResults: () => null,
       logout: () => null,
 
@@ -79,18 +70,6 @@ describe('messenger-list', () => {
     wrapper.find(ConversationListPanel).prop('startConversation')();
 
     expect(startCreateConversation).toHaveBeenCalledOnce();
-  });
-
-  it('renders RewardsContainer when stage is equal to none', function () {
-    const wrapper = subject({ stage: Stage.None });
-
-    expect(wrapper).toHaveElement(RewardsContainer);
-  });
-
-  it('does not render RewardsContainer when stage is not equal to none', function () {
-    const wrapper = subject({ stage: Stage.CreateOneOnOne });
-
-    expect(wrapper).not.toHaveElement(RewardsContainer);
   });
 
   it('renders SettingsMenu when stage is equal to none and messenger is fullscreen', function () {
@@ -294,18 +273,16 @@ describe('messenger-list', () => {
       channels,
       createConversationState = {},
       currentUser = [{ userId: '', firstName: '', isAMemberOfWorlds: true }],
-      chat = { activeConversationId: '' },
-      rewardsState = {}
+      chat = { activeConversationId: '' }
     ) => {
-      return DirectMessageChat.mapState(getState(channels, createConversationState, currentUser, chat, rewardsState));
+      return DirectMessageChat.mapState(getState(channels, createConversationState, currentUser, chat));
     };
 
     const getState = (
       channels,
       createConversationState = {},
       users = [{ userId: '', isAMemberOfWorlds: true }],
-      chat = { activeConversationId: '' },
-      rewardsState: Partial<RewardsState> = {}
+      chat = { activeConversationId: '' }
     ) => {
       const channelData = normalize(channels);
       const userData = normalizeUsers(users);
@@ -330,10 +307,6 @@ describe('messenger-list', () => {
           ...createConversationState,
         },
         registration: {},
-        rewards: {
-          loading: false,
-          ...rewardsState,
-        },
         groupManagement: {},
       } as RootState;
     };
@@ -430,12 +403,6 @@ describe('messenger-list', () => {
       ]);
 
       expect(state.conversations.map((c) => c.previewDisplayDate)).toEqual([previewDisplayDate(date)]);
-    });
-
-    test('isLoading', () => {
-      const state = subject([], {}, undefined, undefined, { loading: true });
-
-      expect(state.isRewardsLoading).toEqual(true);
     });
 
     test('activeConversationId', () => {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -39,6 +39,7 @@ describe('messenger-list', () => {
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
+      userIsOnline: true,
       isInviteNotificationOpen: false,
       myUserId: '',
       onConversationClick: jest.fn(),

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -28,11 +28,8 @@ import { getMessagePreview, previewDisplayDate } from '../../../lib/chat/chat-me
 import { enterFullScreenMessenger } from '../../../store/layout';
 import { Modal, ToastNotification } from '@zero-tech/zui/components';
 import { InviteDialogContainer } from '../../invite-dialog/container';
-import { fetch as fetchRewards, rewardsPopupClosed, rewardsTooltipClosed } from '../../../store/rewards';
-import { RewardsContainer } from '../../rewards-container';
 import { receiveSearchResults } from '../../../store/users';
 import { SettingsMenu } from '../../settings-menu';
-import { FeatureFlag } from '../../feature-flag';
 import { Stage as GroupManagementSagaStage } from '../../../store/group-management';
 import { GroupManagementContainer } from './group-management/container';
 
@@ -56,15 +53,11 @@ export interface Properties extends PublicProperties {
   userName: string;
   userHandle: string;
   userAvatarUrl: string;
-  meowPreviousDay: string;
   includeUserSettings: boolean;
   isMessengerFullScreen: boolean;
-  isRewardsLoading: boolean;
   isInviteNotificationOpen: boolean;
   myUserId: string;
   activeConversationId?: string;
-  showRewardsInTooltip: boolean;
-  showRewardsInPopup: boolean;
   groupManangemenetStage: GroupManagementSagaStage;
 
   startCreateConversation: () => void;
@@ -74,9 +67,6 @@ export interface Properties extends PublicProperties {
   createConversation: (payload: CreateMessengerConversation) => void;
   onConversationClick: (payload: { conversationId: string }) => void;
   enterFullScreenMessenger: () => void;
-  fetchRewards: (_obj: any) => void;
-  rewardsPopupClosed: () => void;
-  rewardsTooltipClosed: () => void;
   logout: () => void;
   receiveSearchResults: (data) => void;
 }
@@ -93,7 +83,6 @@ export class Container extends React.Component<Properties, State> {
       authentication: { user },
       chat: { activeConversationId },
       layout,
-      rewards,
       groupManagement,
     } = state;
     const hasWallet = user?.data?.wallets?.length > 0;
@@ -117,10 +106,6 @@ export class Container extends React.Component<Properties, State> {
       userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
       myUserId: user?.data?.id,
-      meowPreviousDay: rewards.meowPreviousDay,
-      isRewardsLoading: rewards.loading,
-      showRewardsInTooltip: rewards.showRewardsInTooltip,
-      showRewardsInPopup: rewards.showRewardsInPopup,
       groupManangemenetStage: groupManagement.stage,
     };
   }
@@ -133,10 +118,7 @@ export class Container extends React.Component<Properties, State> {
       back,
       startGroup,
       membersSelected,
-      fetchRewards,
       enterFullScreenMessenger: () => enterFullScreenMessenger(),
-      rewardsPopupClosed,
-      rewardsTooltipClosed,
       logout,
       receiveSearchResults,
     };
@@ -145,10 +127,6 @@ export class Container extends React.Component<Properties, State> {
   state = {
     isInviteDialogOpen: false,
   };
-
-  componentDidMount(): void {
-    this.props.fetchRewards({});
-  }
 
   usersInMyNetworks = async (search: string) => {
     const users: MemberNetworks[] = await searchMyNetworksByName(search);
@@ -227,22 +205,6 @@ export class Container extends React.Component<Properties, State> {
             />
           </div>
         )}
-
-        <FeatureFlag featureFlag='enableRewards'>
-          <div {...cnMessageList('rewards-container', !this.props.includeUserSettings && 'center')}>
-            <RewardsContainer
-              meowPreviousDay={this.props.meowPreviousDay}
-              isRewardsLoading={this.props.isRewardsLoading}
-              isMessengerFullScreen={this.props.isMessengerFullScreen}
-              showRewardsInTooltip={this.props.showRewardsInTooltip}
-              showRewardsInPopup={this.props.showRewardsInPopup}
-              isFirstTimeLogin={this.props.isFirstTimeLogin}
-              onRewardsPopupClose={this.props.rewardsPopupClosed}
-              onRewardsTooltipClose={this.props.rewardsTooltipClosed}
-              hasLoadedConversation={this.props?.conversations[0]?.hasLoadedMessages}
-            />
-          </div>
-        </FeatureFlag>
       </div>
     );
   }

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -196,15 +196,14 @@ export class Container extends React.Component<Properties, State> {
     return (
       <div {...cnMessageList('user-account-container')}>
         {this.props.includeUserSettings && (
-          <div {...cnMessageList('settings-menu-container')}>
-            <SettingsMenu
-              onLogout={this.props.logout}
-              userName={this.props.userName}
-              userHandle={this.props.userHandle}
-              userAvatarUrl={this.props.userAvatarUrl}
-            />
-          </div>
+          <SettingsMenu
+            onLogout={this.props.logout}
+            userName={this.props.userName}
+            userHandle={this.props.userHandle}
+            userAvatarUrl={this.props.userAvatarUrl}
+          />
         )}
+        <div {...cnMessageList('user-name')}>{this.props.userName}</div>
       </div>
     );
   }

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -53,6 +53,7 @@ export interface Properties extends PublicProperties {
   userName: string;
   userHandle: string;
   userAvatarUrl: string;
+  userIsOnline: boolean;
   includeUserSettings: boolean;
   isMessengerFullScreen: boolean;
   isInviteNotificationOpen: boolean;
@@ -105,6 +106,7 @@ export class Container extends React.Component<Properties, State> {
       userName: user?.data?.profileSummary?.firstName || '',
       userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
+      userIsOnline: !!user?.data?.isOnline,
       myUserId: user?.data?.id,
       groupManangemenetStage: groupManagement.stage,
     };
@@ -164,9 +166,14 @@ export class Container extends React.Component<Properties, State> {
   openInviteDialog = () => {
     this.setState({ isInviteDialogOpen: true });
   };
+
   closeInviteDialog = () => {
     this.setState({ isInviteDialogOpen: false });
   };
+
+  get userStatus(): 'active' | 'offline' {
+    return this.props.userIsOnline ? 'active' : 'offline';
+  }
 
   renderInviteDialog = (): JSX.Element => {
     return (
@@ -201,6 +208,7 @@ export class Container extends React.Component<Properties, State> {
             userName={this.props.userName}
             userHandle={this.props.userHandle}
             userAvatarUrl={this.props.userAvatarUrl}
+            userStatus={this.userStatus}
           />
         )}
         <div {...cnMessageList('user-name')}>{this.props.userName}</div>

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -17,17 +17,6 @@ $side-padding: 16px;
 }
 
 .messenger-list {
-  &__header {
-    height: 32px;
-    background-color: theme.$color-primary-3;
-    border-radius: 8px 8px 0px 0px;
-    display: flex;
-    justify-content: flex-end;
-    gap: 2px;
-    align-items: center;
-    padding-right: 13px;
-  }
-
   &__user-account-container {
     display: flex;
     align-items: center;

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -29,43 +29,6 @@ $side-padding: 16px;
     height: 64px;
     background-color: theme.$color-primary-3;
   }
-
-  &__rewards-container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-right: 8px;
-    height: 64px;
-    background-color: theme.$color-primary-3;
-
-    &--center {
-      width: 100%;
-      padding-right: 0px;
-    }
-  }
-
-  &__icon-button {
-    border-radius: 50%;
-    padding: 2px;
-    line-height: 0px;
-    width: 24px;
-    height: 24px;
-
-    cursor: pointer;
-    background: none;
-    border: none;
-    display: inline-block;
-    margin: 0px;
-
-    &:hover {
-      color: theme.$color-error-transparency-11;
-      background-color: theme.$color-primary-5;
-    }
-
-    & > * {
-      margin: auto;
-    }
-  }
 }
 
 .highlighted-text {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -20,14 +20,17 @@ $side-padding: 16px;
   &__user-account-container {
     display: flex;
     align-items: center;
+    padding: 16px;
+    height: 32px;
+    gap: 8px;
+    background-color: theme.$color-primary-3;
   }
 
-  &__settings-menu-container {
-    display: flex;
-    padding-left: 16px;
-    width: 100%;
-    height: 64px;
-    background-color: theme.$color-primary-3;
+  &__user-name {
+    font-size: $font-size-small;
+    font-weight: 600;
+    line-height: 15px;
+    color: rgba(253, 253, 255, 0.93);
   }
 }
 

--- a/src/components/settings-menu/index.test.tsx
+++ b/src/components/settings-menu/index.test.tsx
@@ -11,6 +11,7 @@ describe('settings-menu', () => {
       userName: '',
       userHandle: '',
       userAvatarUrl: '',
+      userStatus: 'active',
       onLogout: () => {},
 
       ...props,

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -15,6 +15,7 @@ export interface Properties {
   userName: string;
   userHandle: string;
   userAvatarUrl: string;
+  userStatus: 'active' | 'offline';
 
   onLogout: () => void;
 }
@@ -157,6 +158,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
               size={'medium'}
               type={'circle'}
               imageURL={this.props.userAvatarUrl}
+              statusType={this.props.userStatus}
             />
           }
         />


### PR DESCRIPTION
### What does this do?
- add users online status to profile avatar

NOTE: this is updating the settings menu dropdown trigger attributes to include the online status of the user (the avatar) for now. At  some point the settings menu will be removed. When this happens the dev working on this will just need to pull out the avatar component from the dropdown in settings menu.

Before:
<img width="425" alt="Screenshot 2023-12-13 at 12 21 51" src="https://github.com/zer0-os/zOS/assets/39112648/c31638ed-7736-4656-9f85-441cc3bd5182">

After:
<img width="425" alt="Screenshot 2023-12-13 at 12 21 39" src="https://github.com/zer0-os/zOS/assets/39112648/18d8a799-b834-490d-9d04-a09441727946">
