### PR TITLE
refactor: replace three dot icon with icon button

### DIFF
--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { IconDotsHorizontal, IconEdit5, IconPlus, IconUserRight1 } from '@zero-tech/zui/icons';
-import { DropdownMenu } from '@zero-tech/zui/components';
+import { DropdownMenu, IconButton } from '@zero-tech/zui/components';
 
 import './styles.scss';
 
@@ -81,7 +81,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
         side='bottom'
         alignMenu='end'
         onOpenChange={this.handleOpenChange}
-        trigger={<IconDotsHorizontal size={24} isFilled />}
+        trigger={<IconButton Icon={IconDotsHorizontal} size={32} isFilled onClick={() => {}} />}
       />
     );
   }


### PR DESCRIPTION
### What does this do?
- replaces group management three dot icon with the `IconButton` component that contains the three dot icon. This component 

### Why are we making this change?
- the styles of the icon button align with figma, i.e. correct padding and size.
- the icon button will have a hover.


<img width="441" alt="Screenshot 2023-12-13 at 14 53 21" src="https://github.com/zer0-os/zOS/assets/39112648/5c8c48ce-4014-4417-b5be-bf0cbc3cf48a">
<img width="441" alt="Screenshot 2023-12-13 at 14 50 13" src="https://github.com/zer0-os/zOS/assets/39112648/af2d5bac-c470-47c5-846c-b0c2ff235dc9">
<img width="441" alt="Screenshot 2023-12-13 at 14 50 24" src="https://github.com/zer0-os/zOS/assets/39112648/80cfe80a-f6fc-4d0d-8ec1-29c38648aab6">
