### PR TITLE
Remove background color/fill from conversationList header

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -27,7 +27,6 @@ $side-padding: 16px;
     padding-left: 16px;
     width: 100%;
     height: 64px;
-    background-color: theme.$color-primary-3;
   }
 
   &__rewards-container {


### PR DESCRIPTION
### What does this do?

Before:
![image](https://github.com/zer0-os/zOS/assets/33264364/19998319-2d30-4d9f-8d91-6dcf7da956f2)

After:
![image](https://github.com/zer0-os/zOS/assets/33264364/85b46759-d14a-44d4-9821-0f60393e24b3)

