### PR TITLE
Delay event publishing until all conversations have been loaded once

### DIFF
--- a/src/store/chat/bus.test.ts
+++ b/src/store/chat/bus.test.ts
@@ -1,0 +1,43 @@
+import { createChatConnection } from './bus';
+
+describe('chat bus', () => {
+  it('emits user joined channel event', async () => {
+    const receivedEvents = [];
+    function trackEvents(action) {
+      receivedEvents.push(action);
+    }
+
+    const { chatConnection, activate } = createChatConnection('user-id', 'token', stubClient as any);
+    chatConnection.take(trackEvents);
+    await activate();
+
+    await stubClient.handlers.onOtherUserJoinedChannel('channel-id', 'user-id');
+
+    expect(receivedEvents.map((e) => e.type)).toEqual(['chat/channel/otherUserJoined']);
+  });
+
+  it('delays events until system is prepared to receive them', async () => {
+    const receivedEvents = [];
+    function trackEvents(action) {
+      receivedEvents.push(action);
+    }
+
+    const { chatConnection, activate } = createChatConnection('user-id', 'token', stubClient as any);
+    chatConnection.take(trackEvents);
+
+    stubClient.handlers.onOtherUserJoinedChannel('channel-id', 'user-id');
+    expect(receivedEvents.map((e) => e.type)).toEqual([]);
+
+    await activate();
+    expect(receivedEvents.map((e) => e.type)).toEqual(['chat/channel/otherUserJoined']);
+  });
+});
+
+const stubClient = {
+  handlers: null,
+  initChat(handlers) {
+    this.handlers = handlers;
+  },
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+};


### PR DESCRIPTION
### What does this do?

This adds functionality to the chat client/saga event boundary (the Chat Bus) which delays chat events from being published until the system indicates that it's prepared to receive them.

### Why are we making this change?

There's currently race condition bugs related to the Matrix "snapshot" being loaded and various "catch up events" being consumed. Eg:
1 We load the conversation list and are processin it but, since it's async, other things are being processed
2 While that is happening, an event such as "User Joined Room" happens and publishes to the sagas. The saga tries to find the room but since the room list is still empty due to #1 being in progress it does nothing.
3 Subsequently, #1 finishes and we have all the room data loaded into state that is the snapshot version which does not yet include the user who joined.

Before:
https://github.com/zer0-os/zOS/assets/43770/3b04c8a9-ffe4-47f9-8bb8-74edc0a02b43

After:
https://github.com/zer0-os/zOS/assets/43770/95652839-5448-4747-98a5-7e2b8913e70e



