### PR TITLE
ZOS Redesign (glass style): Conversations Panel

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -1,6 +1,17 @@
 // "glass" style mixin
 @mixin glass-outer {
-  border: 1px solid rgba(255, 255, 255, 0.25); // stroke should be applied to the outer div
+  // border-width: 1px;
+  // border-image-slice: 1;
+  // border-style: solid;
+  // border-radius: 16px;
+
+  // border-image-source: linear-gradient(
+  //   153.33deg,
+  //   rgba(255, 255, 255, 0.25) 0%,
+  //   rgba(255, 255, 255, 0) 24.43%,
+  //   rgba(255, 255, 255, 0.01) 79.12%,
+  //   rgba(255, 255, 255, 0.05) 100%
+  // );
 }
 
 @mixin glass-inner {

--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -1,0 +1,13 @@
+// "glass" style mixin
+@mixin glass-outer {
+  border: 1px solid rgba(255, 255, 255, 0.25); // stroke should be applied to the outer div
+}
+
+@mixin glass-inner {
+  background: radial-gradient(273.54% 141.42% at 0% 0%, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0) 100%),
+    rgba(10, 10, 10, 0.75);
+  box-shadow: 2px 3px 9px 0px rgba(0, 0, 0, 0.31), 10px 12px 16px 0px rgba(0, 0, 0, 0.27),
+    22px 27px 21px 0px rgba(0, 0, 0, 0.16), 39px 48px 25px 0px rgba(0, 0, 0, 0.05),
+    61px 75px 27px 0px rgba(0, 0, 0, 0.01);
+  backdrop-filter: blur(32px);
+}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -27,7 +27,6 @@ $side-padding: 16px;
     padding-left: 16px;
     width: 100%;
     height: 64px;
-    background-color: theme.$color-primary-3;
   }
 
   &__rewards-container {

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -24,9 +24,11 @@ export class Container extends React.Component<Properties> {
     return (
       <IfAuthenticated showChildren>
         <div className='sidekick'>
-          <div className='sidekick__tab-content'>
-            <div className='sidekick__tab-content--messages'>
-              <MessengerList />
+          <div className='sidekick__tab-content-outer'>
+            <div className='sidekick__tab-content'>
+              <div className='sidekick__tab-content--messages'>
+                <MessengerList />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -2,14 +2,13 @@
 @use '../../modules/animation' as animation;
 
 @import '../../layout';
+@import '../../glass';
 
 .sidekick {
   position: relative;
   width: $width-sidekick + 32px;
   height: 100%;
   transition: margin animation.$animation-duration-double var(--sidekick-transition-easing-function);
-
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.492172) 22px, rgba(0, 0, 0, 0) 64px);
 
   box-sizing: border-box;
   position: relative;
@@ -27,11 +26,23 @@
     background: linear-gradient(to top, transparent, theme.$background-color-tertiary-hover 100%);
   }
 
+  &__tab-content-outer {
+    box-sizing: border-box;
+    display: flex;
+    flex-shrink: 0;
+    pointer-events: auto;
+    width: $width-sidekick;
+    border-radius: 16px;
+
+    @include glass-outer;
+  }
+
   &__tab-content {
     width: inherit;
-    background-color: theme.$background-color-tertiary-hover;
     border-radius: 16px;
     overflow: hidden;
+
+    @include glass-inner;
 
     &--messages {
       height: 100%;


### PR DESCRIPTION
### What does this do?

Applies "glass" styles (stroke, fill, box-shadow, and blur), to the conversation list panel.

Before:
<img width="311" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/f00e1263-2c58-48eb-9c94-13ac640eff9a">

After:
<img width="303" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/1ce090dd-c55d-41dc-a527-43ac122ce097">
