### PR TITLE
ZOS Redesign: Apply flat/thick style to conversation header

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -25,3 +25,9 @@
     61px 75px 27px 0px rgba(0, 0, 0, 0.01);
   backdrop-filter: blur(32px);
 }
+
+// "flat" style mixin
+@mixin flat-thick {
+  background: var(--d-glass-materials-flat-thick, rgba(10, 10, 10, 0.75));
+  backdrop-filter: blur(64px);
+}

--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -28,6 +28,6 @@
 
 // "flat" style mixin
 @mixin flat-thick {
-  background: var(--d-glass-materials-flat-thick, rgba(10, 10, 10, 0.75));
+  background: rgba(10, 10, 10, 0.75);
   backdrop-filter: blur(64px);
 }

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -4,6 +4,7 @@
 @import '../../../variables';
 @import '../../../layout';
 @import '../../../animation';
+@import '../../../glass';
 
 $title-bar-height: 32px;
 $header-height: 66px;
@@ -85,12 +86,13 @@ $recent-indicator-size: 8px;
   }
 
   &__header {
-    background-color: theme.$color-primary-1;
     height: $header-height - (16px * 2);
     display: flex;
     gap: 8px;
     border-radius: 16px;
     padding: 16px;
+
+    @include flat-thick;
 
     > div:last-child {
       flex-grow: 1;


### PR DESCRIPTION
Before:

<img width="676" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/8d521b2a-7136-48d2-bdbb-e6c6de0edc8b">


After:
<img width="814" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/f1e650b8-6aec-435c-96e3-2d8998573046">
