### PR TITLE
ZOS Redesign: Update Message Input styles

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -31,3 +31,10 @@
   background: rgba(10, 10, 10, 0.75);
   backdrop-filter: blur(64px);
 }
+
+@mixin text-input {
+  background: var(--D-Glass-Ui-State-Active, rgba(163, 162, 163, 0.1));
+
+  /* D/Glass/Inset/Shadows */
+  box-shadow: -2px -2px 4px 0px rgba(246, 244, 246, 0.05) inset, 2px 2px 4px -1px rgba(10, 10, 10, 0.4) inset;
+}

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -1,5 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../animation';
+@import '../../glass';
 
 // Note: there are some classes in various other places (src/platform-apps/channels/styles.scss)
 
@@ -17,11 +18,11 @@
   &__message-input-container {
     margin-bottom: 16px;
     margin-right: 16px;
-    margin-top: 16px;
     border-radius: 16px;
     overflow: hidden;
     flex-shrink: 0;
-    background-color: theme.$color-primary-1;
+
+    @include flat-thick;
   }
 
   &__group-message {

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -23,6 +23,9 @@
     flex-shrink: 0;
 
     @include flat-thick;
+
+    // todo: remove this after extracting out the message input from chat-view
+    backdrop-filter: none;
   }
 
   &__group-message {

--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -124,7 +124,7 @@ describe('MessageInput', () => {
     const wrapper = subject({ sendDisabledMessage: '' });
     setInput(wrapper, 'Hello');
 
-    expect(wrapper).toHaveElement('.message-input__icon--highlighted');
+    expect(wrapper.find('IconButton[label="send"]').prop('isFilled')).toBe(true);
   });
 
   it('send icon is not highlighted if there is no input', () => {

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -498,13 +498,11 @@ export class MessageInput extends React.Component<Properties, State> {
               <div className='message-input__icon-wrapper'>
                 <Tooltip content={this.sendDisabledTooltipContent} open={this.state.isSendTooltipOpen}>
                   <IconButton
-                    className={classNames('message-input__icon', 'message-input__icon--end-action', {
-                      'message-input__icon--highlighted': this.sendHighlighted(),
-                    })}
+                    className={classNames('message-input__icon', 'message-input__icon--end-action')}
                     onClick={this.onSend}
                     Icon={IconSend3}
                     size='small'
-                    isFilled
+                    isFilled={this.sendHighlighted()}
                   />
                   {this.allowVoiceMessage && (
                     <IconButton

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -504,6 +504,7 @@ export class MessageInput extends React.Component<Properties, State> {
                     onClick={this.onSend}
                     Icon={IconSend3}
                     size='small'
+                    isFilled
                   />
                   {this.allowVoiceMessage && (
                     <IconButton

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -503,6 +503,7 @@ export class MessageInput extends React.Component<Properties, State> {
                     Icon={IconSend3}
                     size='small'
                     isFilled={this.sendHighlighted()}
+                    label='send'
                   />
                   {this.allowVoiceMessage && (
                     <IconButton

--- a/src/components/message-input/menu/menu.tsx
+++ b/src/components/message-input/menu/menu.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Dropzone from 'react-dropzone';
 import { bytesToMB, dropzoneToMedia, Media } from '../utils';
-import { IconPaperclip } from '@zero-tech/zui/icons';
+import { IconPlus } from '@zero-tech/zui/icons';
 
 import './styles.scss';
 import { IconButton, ToastNotification } from '@zero-tech/zui/components';
@@ -65,7 +65,7 @@ export default class Menu extends React.Component<Properties, State> {
             <div className='image-send'>
               <div {...getRootProps({ className: 'image-send__dropzone' })}>
                 <input {...getInputProps()} />
-                <IconButton onClick={open} Icon={IconPaperclip} size='small' />
+                <IconButton onClick={open} Icon={IconPlus} size='small' />
               </div>
             </div>
           )}

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -88,10 +88,6 @@
   &__icon {
     color: theme.$color-greyscale-12;
 
-    &--highlighted {
-      color: theme.$color-secondary-11;
-    }
-
     &--emoji {
       color: theme.$color-greyscale-11;
     }

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -144,7 +144,7 @@
 
     &__control {
       font-size: 16px;
-      line-height: 24px;
+      line-height: 22px;
     }
 
     &__highlighter {

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -144,7 +144,7 @@
 
     &__control {
       font-size: 16px;
-      line-height: 22px;
+      line-height: 23px;
     }
 
     &__highlighter {

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -240,7 +240,7 @@
   &__emoji-picker-container {
     position: absolute;
     right: 74px;
-    bottom: 65px;
+    bottom: 75px;
     z-index: 12;
     color: theme.$color-greyscale-11;
 

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -4,6 +4,7 @@
 
 @import '../../variables';
 @import '../../animation';
+@import '../../glass';
 
 @keyframes fade-background-in {
   from {
@@ -31,7 +32,7 @@
 
 .message-input {
   display: flex;
-  padding: 8px 16px;
+  padding: 16px 24px;
   flex-direction: column;
   justify-content: flex-end;
   align-items: flex-end;
@@ -57,7 +58,7 @@
   &__input-row {
     display: flex;
     align-items: flex-end;
-    gap: 16px;
+    gap: 24px;
     width: 100%;
 
     &--editing {
@@ -81,7 +82,6 @@
     display: flex;
     padding-bottom: 0px;
     align-items: flex-start;
-    gap: 8px;
     height: 32px;
   }
 
@@ -99,16 +99,15 @@
 
   &__chat-container {
     display: flex;
-    padding: 7px 0px 7px 16px;
+    padding: 8px 0px 8px 16px;
     flex-direction: column;
     justify-content: center;
     align-items: flex-end;
     gap: 8px;
     width: 100%;
-
-    background-color: theme.$color-primary-1;
-    border: 1px solid theme.$color-greyscale-6;
     border-radius: 8px;
+
+    @include text-input;
 
     &:focus-within {
       border-color: theme.$color-primary-7;
@@ -148,8 +147,8 @@
     overflow-y: visible;
 
     &__control {
-      font-size: 14px;
-      line-height: 17px;
+      font-size: 16px;
+      line-height: 24px;
     }
 
     &__highlighter {


### PR DESCRIPTION
### What does this do?

+ Adds flat/thick style to message input container
+ updates the "send icon" to be filled if there is a typed message
+ replace paper clip icon with "+" icon
+ update text input style to "inset glass style"
+ Update `fontSize` to 16, `font-height` to 23.


Before:
<img width="679" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/1c7c512e-90da-43e9-92c3-b52e2e53b3a7">
<img width="667" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2bdfc9a7-39a3-4850-b64e-90f1e2ff623d">
<img width="669" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/5be2f45d-a047-4b39-8733-f6275c3458f6">


After:
<img width="764" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/695676e0-4a17-42e6-b6ba-bc7fe354fce7">
<img width="697" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/c5f8f2c2-1ced-4113-911f-4cbbe1bd4661">
<img width="652" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/90251d5d-bafc-4c19-98ee-8eb538518bea">



