### PR TITLE
Unique the list we use when batch fetching the user presence

### DIFF
--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -14,7 +14,7 @@ import {
   otherUserJoinedChannel,
   otherUserLeftChannel,
   mapToZeroUsers,
-  updateUserPresence,
+  fetchUserPresence,
 } from './saga';
 
 import { SagaActionTypes } from '.';
@@ -63,7 +63,7 @@ describe('channels list saga', () => {
         [matchers.call.fn(chat.get), chatClient],
         [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
         [matchers.call.fn(mapToZeroUsers), null],
-        [matchers.call.fn(updateUserPresence), null],
+        [matchers.call.fn(fetchUserPresence), null],
       ]);
     }
 
@@ -256,7 +256,7 @@ describe('channels list saga', () => {
     function subject(...args: Parameters<typeof expectSaga>) {
       return expectSaga(...args).provide([
         [matchers.call.fn(mapToZeroUsers), null],
-        [matchers.call.fn(updateUserPresence), null],
+        [matchers.call.fn(fetchUserPresence), null],
       ]);
     }
 
@@ -499,9 +499,9 @@ describe('channels list saga', () => {
     });
   });
 
-  describe(updateUserPresence, () => {
+  describe(fetchUserPresence, () => {
     function subject(users, provide = []) {
-      return expectSaga(updateUserPresence, users).provide([
+      return expectSaga(fetchUserPresence, users).provide([
         [matchers.call.fn(chat.get), chatClient],
         ...provide,
       ]);
@@ -545,7 +545,7 @@ describe('channels list saga', () => {
 
       const mockPresenceData1 = { lastSeenAt: '2023-10-17T10:00:00.000Z', isOnline: true };
 
-      testSaga(updateUserPresence, mockUsers)
+      testSaga(fetchUserPresence, mockUsers)
         .next()
         .call(chat.get)
         .next(chatClient)
@@ -574,7 +574,7 @@ describe('channels list saga', () => {
 
       const mockPresenceData1 = { lastSeenAt: null, isOnline: false };
 
-      testSaga(updateUserPresence, mockUsers)
+      testSaga(fetchUserPresence, mockUsers)
         .next()
         .call(chat.get)
         .next(chatClient)

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -68,7 +68,7 @@ describe('channels list saga', () => {
     }
 
     it('fetches direct messages', async () => {
-      await subject(fetchConversations, undefined)
+      await subject(fetchConversations)
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
@@ -80,7 +80,7 @@ describe('channels list saga', () => {
     });
 
     it('calls mapToZeroUsers after fetch', async () => {
-      await subject(fetchConversations, undefined)
+      await subject(fetchConversations)
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
@@ -95,12 +95,12 @@ describe('channels list saga', () => {
     it('announces conversations loaded', async () => {
       const conversationsChannelStub = multicastChannel();
 
-      await subject(fetchConversations, undefined)
+      await subject(fetchConversations)
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
           [matchers.call.fn(mapToZeroUsers), null],
-          [matchers.call.fn(updateUserPresence), null],
+          [matchers.call.fn(fetchUserPresence), null],
           [matchers.call.fn(mapAdminUserIdToZeroUserId), null],
           [matchers.call.fn(getConversationsBus), conversationsChannelStub],
         ])
@@ -116,7 +116,7 @@ describe('channels list saga', () => {
 
       const initialState = new StoreBuilder().withConversationList(optimisticChannel1, optimisticChannel2).build();
 
-      const { storeState } = await subject(fetchConversations, undefined)
+      const { storeState } = await subject(fetchConversations)
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call([chatClient, chatClient.getConversations]), [fetchedChannel]],
@@ -136,7 +136,7 @@ describe('channels list saga', () => {
 
       const initialState = new StoreBuilder().withChannelList({ id: 'previously-a-channel' });
 
-      const { storeState } = await subject(fetchConversations, undefined)
+      const { storeState } = await subject(fetchConversations)
         .provide([[matchers.call([chatClient, chatClient.getConversations]), fetchedConversations]])
         .withReducer(rootReducer, initialState.build())
         .run();

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -63,7 +63,7 @@ describe('channels list saga', () => {
         [matchers.call.fn(chat.get), chatClient],
         [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
         [matchers.call.fn(mapToZeroUsers), null],
-        [matchers.call.fn(fetchUserPresence), null],
+        [matchers.fork.fn(fetchUserPresence), null],
       ]);
     }
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -50,7 +50,7 @@ export function* mapToZeroUsers(channels: any[]) {
   return;
 }
 
-export function* updateUserPresence(users) {
+export function* fetchUserPresence(users) {
   const chatClient = yield call(chat.get);
   for (let user of users) {
     const matrixId = user?.matrixId;
@@ -76,7 +76,7 @@ export function* fetchConversations() {
   yield call(mapToZeroUsers, conversations);
 
   const otherMembersOfConversations = conversations.flatMap((c) => c.otherMembers);
-  yield fork(updateUserPresence, otherMembersOfConversations);
+  yield fork(fetchUserPresence, otherMembersOfConversations);
 
   const existingConversationList = yield select(denormalizeConversations);
   const optimisticConversationIds = existingConversationList
@@ -372,7 +372,7 @@ export function* addChannel(channel) {
   const conversationsList = yield select(rawConversationsList());
   const channelsList = yield select(rawChannelsList());
   yield call(mapToZeroUsers, [channel]);
-  yield fork(updateUserPresence, channel.otherMembers);
+  yield fork(fetchUserPresence, channel.otherMembers);
 
   yield put(receive(uniqNormalizedList([...channelsList, ...conversationsList, channel])));
 }

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -52,8 +52,9 @@ export function* mapToZeroUsers(channels: any[]) {
 
 export function* fetchUserPresence(users) {
   const chatClient = yield call(chat.get);
-  for (let user of users) {
-    const matrixId = user?.matrixId;
+  const uniqueUsers = uniqBy(users, (u) => u.matrixId);
+  for (let user of uniqueUsers) {
+    const matrixId = user.matrixId;
     if (!matrixId) continue;
     const presenceData = yield call([chatClient, chatClient.getUserPresence], matrixId);
     if (!presenceData) continue;


### PR DESCRIPTION
### What does this do?

Prevents fetching user presence for the same users many times, particularly when first loading the conversations.
