### PR TITLE
chore: bump zui version `(0.28.0)` -> `(0.30.0)`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^0.28.0",
+        "@zero-tech/zui": "^0.30.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8796,9 +8796,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.28.0.tgz",
-      "integrity": "sha512-KNyNbZc6idpDhsR9h6iPFnt+IJ2R7MfiIMcnlFyMVpdSAunSVDMMhEfZOBlIERaxTYvSb0cwc3Wkl18mPmNAFA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.30.0.tgz",
+      "integrity": "sha512-wKNXFu+iohPOjKNwUi1b1D2yfioVg2QUNq3DrNCXTYuA8eKKc1Q5ugWx0+ij991f2Koj/5lvkNGZnnLAoLz6Kw==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -38414,9 +38414,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.28.0.tgz",
-      "integrity": "sha512-KNyNbZc6idpDhsR9h6iPFnt+IJ2R7MfiIMcnlFyMVpdSAunSVDMMhEfZOBlIERaxTYvSb0cwc3Wkl18mPmNAFA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.30.0.tgz",
+      "integrity": "sha512-wKNXFu+iohPOjKNwUi1b1D2yfioVg2QUNq3DrNCXTYuA8eKKc1Q5ugWx0+ij991f2Koj/5lvkNGZnnLAoLz6Kw==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^0.28.0",
+    "@zero-tech/zui": "^0.30.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
- bump zui version `(0.28.0)` -> `(0.30.0)`