### PR TITLE
feat: update conversation list panel header and list padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^0.28.0",
+        "@zero-tech/zui": "^0.30.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8796,9 +8796,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.28.0.tgz",
-      "integrity": "sha512-KNyNbZc6idpDhsR9h6iPFnt+IJ2R7MfiIMcnlFyMVpdSAunSVDMMhEfZOBlIERaxTYvSb0cwc3Wkl18mPmNAFA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.30.0.tgz",
+      "integrity": "sha512-wKNXFu+iohPOjKNwUi1b1D2yfioVg2QUNq3DrNCXTYuA8eKKc1Q5ugWx0+ij991f2Koj/5lvkNGZnnLAoLz6Kw==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -38414,9 +38414,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.28.0.tgz",
-      "integrity": "sha512-KNyNbZc6idpDhsR9h6iPFnt+IJ2R7MfiIMcnlFyMVpdSAunSVDMMhEfZOBlIERaxTYvSb0cwc3Wkl18mPmNAFA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.30.0.tgz",
+      "integrity": "sha512-wKNXFu+iohPOjKNwUi1b1D2yfioVg2QUNq3DrNCXTYuA8eKKc1Q5ugWx0+ij991f2Koj/5lvkNGZnnLAoLz6Kw==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^0.28.0",
+    "@zero-tech/zui": "^0.30.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",

--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -20,7 +20,7 @@ $side-padding: 16px;
     display: flex;
     gap: 24px;
     flex-direction: column;
-    padding: $side-padding 0;
+    padding: 24px 0 16px;
 
     animation: conversation-slide-in 600ms ease-in forwards;
 

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -132,7 +132,6 @@ export class ConversationListPanel extends React.Component<Properties, State> {
               onChange={this.searchChanged}
               size={'small'}
               type={'search'}
-              placeholder='Search'
               value={this.state.filter}
             />
           </div>

--- a/src/components/messenger/list/user-header/styles.scss
+++ b/src/components/messenger/list/user-header/styles.scss
@@ -5,7 +5,7 @@
 .user-header {
   display: flex;
   align-items: center;
-  padding: 16px;
+  padding: 16px 16px 0;
   height: 32px;
   gap: 8px;
 


### PR DESCRIPTION
### What does this do?
- updates the padding of the header and list

### Why are we making this change?
- align with figma designs

Subtle differences.

Before:
<img width="286" alt="Screenshot 2023-12-15 at 12 15 27" src="https://github.com/zer0-os/zOS/assets/39112648/e77a161a-a7d5-42af-a365-d20477b55723">

After:
<img width="286" alt="Screenshot 2023-12-15 at 12 16 25" src="https://github.com/zer0-os/zOS/assets/39112648/eec69e22-3ff9-4dab-8424-743705b1b91c">

