### PR TITLE
feat: conversation item redesign updates

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -1,5 +1,21 @@
+// D/Glass/Text/Primary
 @mixin glass-text-primary-color {
   color: rgba(253, 253, 255, 0.93);
+}
+
+// D/Glass/Text/Secondary
+@mixin glass-text-secondary-color {
+  color: rgba(247, 245, 255, 0.62);
+}
+
+// D/Glass/Text/Tertiary
+@mixin glass-text-tertiary-color {
+  color: rgba(238, 236, 255, 0.42);
+}
+
+// D/Glass/Ui State/Hover
+@mixin glass-state-hover-color {
+  background-color: rgba(253, 252, 253, 0.05);
 }
 
 @mixin glass-outer {

--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -1,5 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../../../variables';
+@import '../../../../glass';
 
 .conversation-item {
   display: flex;
@@ -11,15 +12,10 @@
   margin-bottom: 8px;
   padding: 0 8px;
 
-  font-size: $font-size-small;
-  line-height: 17px;
-
-  color: theme.$color-greyscale-12;
-
   &:hover,
   &:focus,
   &[is-active='true'] {
-    background-color: theme.$color-primary-3;
+    @include glass-state-hover-color;
     border-radius: 8px;
     outline: none;
   }
@@ -38,32 +34,36 @@
     display: flex;
     align-items: baseline;
     width: 100%;
-    margin-bottom: 7px;
+    margin-bottom: 4.5px;
     overflow: hidden;
   }
 
   &__name {
+    @include glass-text-primary-color;
+
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
     flex-grow: 1;
     font-size: $font-size-medium;
+    line-height: 20px;
 
     &[is-unread='true'] {
-      font-weight: 700;
+      font-weight: 600;
     }
   }
 
   &__timestamp {
-    color: theme.$color-greyscale-11;
+    @include glass-text-tertiary-color;
     font-weight: 400;
     font-size: 10px;
-    line-height: 12px;
+    line-height: 15px;
     white-space: nowrap;
   }
 
   &__message {
-    color: theme.$color-greyscale-11;
+    @include glass-text-secondary-color;
+
     font-weight: 400;
     font-size: $font-size-small;
     line-height: 15px;
@@ -73,12 +73,12 @@
     padding-right: 1px;
 
     &[is-unread='true'] {
-      font-weight: 700;
-      color: theme.$color-greyscale-12;
+      font-weight: 600;
+      @include glass-text-primary-color;
 
       div {
-        font-weight: 700;
-        color: theme.$color-greyscale-12;
+        font-weight: 600;
+        @include glass-text-primary-color;
       }
     }
 


### PR DESCRIPTION
### What does this do?
- updates styles for the conversation item - text and colours (including for states)

### Why are we making this change?
- align with figma redesign


NOTE: Removing the users name from the message preview if its a one on one conversation is likely to be included in another task. This task simply updates the styles.

FIGMA:
<img width="703" alt="Screenshot 2023-12-15 at 13 48 06" src="https://github.com/zer0-os/zOS/assets/39112648/11d67e9a-d984-431c-8618-4aebd2d223ac">

DONE:
<img width="284" alt="Screenshot 2023-12-15 at 13 48 16" src="https://github.com/zer0-os/zOS/assets/39112648/1ded92a4-1bb8-485a-829a-3d3a3846fbeb">
<img width="284" alt="Screenshot 2023-12-15 at 13 50 32" src="https://github.com/zer0-os/zOS/assets/39112648/c0c6f05e-fd6a-436b-af38-beec5d3389fc">
