### PR TITLE
chore: bump zui major version `(0.30.0)` -> `(1.0.0)`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^0.30.0",
+        "@zero-tech/zui": "^1.0.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8796,9 +8796,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.30.0.tgz",
-      "integrity": "sha512-wKNXFu+iohPOjKNwUi1b1D2yfioVg2QUNq3DrNCXTYuA8eKKc1Q5ugWx0+ij991f2Koj/5lvkNGZnnLAoLz6Kw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.0.0.tgz",
+      "integrity": "sha512-X1OykYYn5UrqPYkIZ7umYvwC7AMBc2S/J31dgCsV39i1CaHdblWZFa1KkuWhPuPlN0bk7nm5lAu+3gJyFUorTQ==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -38414,9 +38414,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.30.0.tgz",
-      "integrity": "sha512-wKNXFu+iohPOjKNwUi1b1D2yfioVg2QUNq3DrNCXTYuA8eKKc1Q5ugWx0+ij991f2Koj/5lvkNGZnnLAoLz6Kw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.0.0.tgz",
+      "integrity": "sha512-X1OykYYn5UrqPYkIZ7umYvwC7AMBc2S/J31dgCsV39i1CaHdblWZFa1KkuWhPuPlN0bk7nm5lAu+3gJyFUorTQ==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^0.30.0",
+    "@zero-tech/zui": "^1.0.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
- bump zui major version `(0.30.0)` -> `(1.0.0)`
