### PR TITLE
Add glass border back with pointer events disabled

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -28,9 +28,11 @@
   backdrop-filter: blur(32px);
 
   &:before {
+    content: '';
     position: absolute;
     inset: 0;
     border-radius: 16px;
+    pointer-events: none;
 
     //
     // Unfortunately, we can't have a gradient border with rounded corners.


### PR DESCRIPTION
### What does this do?

Adds the glass border back and prevents it from stealing pointer events

