### PR TITLE
feat: (conversation-list) group avatar appearance redesign

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -73,3 +73,25 @@
   /* D/Glass/Inset/Shadows */
   box-shadow: -2px -2px 4px 0px rgba(246, 244, 246, 0.05) inset, 2px 2px 4px -1px rgba(10, 10, 10, 0.4) inset;
 }
+
+// D/Glass/Materials/Raised
+@mixin glass-materials-raised {
+  background: linear-gradient(
+    153.33deg,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0) 24.43%,
+    rgba(255, 255, 255, 0.01) 79.12%,
+    rgba(255, 255, 255, 0.75) 100%
+  );
+}
+
+// L/Glass/Separator/Primary
+@mixin glass-separator-primary {
+  background: rgba(13, 2, 24, 0.09);
+}
+
+// D/Glass/Ui/Shadow Low
+@mixin glass-shadow-low {
+  box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.25), 1px 1px 1px 0px rgba(0, 0, 0, 0.21),
+    2px 2px 2px 0px rgba(0, 0, 0, 0.13), 4px 4px 2px 0px rgba(0, 0, 0, 0.04), 6px 6px 2px 0px rgba(0, 0, 0, 0);
+}

--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -126,12 +126,27 @@
     display: flex;
     justify-content: center;
     align-items: center;
-
-    background: linear-gradient(223deg, #421349 14.62%, #0d0416 36.73%, #0b060e 59.58%, #2b0659 85.38%);
     border-radius: 9999px;
+
+    @include glass-separator-primary;
+    @include glass-shadow-low;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border-radius: inherit;
+      z-index: -1;
+
+      @include glass-materials-raised;
+    }
 
     & > * {
       margin: auto;
+      position: relative;
     }
   }
 


### PR DESCRIPTION
### What does this do?
- updates the group avatar appearance in the conversation list.

### Why are we making this change?
- align with figma designs.

Appearance confirmed with design team.

Before:

<img width="261" alt="Screenshot 2023-12-15 at 18 34 14" src="https://github.com/zer0-os/zOS/assets/39112648/06a93e29-6fb9-4ce1-afc2-5c0f49b9a190">
<img width="261" alt="Screenshot 2023-12-15 at 18 34 52" src="https://github.com/zer0-os/zOS/assets/39112648/0aff5c32-d79c-4ad4-95cf-a88d714500a6">

After:

<img width="261" alt="Screenshot 2023-12-15 at 18 33 59" src="https://github.com/zer0-os/zOS/assets/39112648/41fe99e9-69e5-47b6-b090-c48b91c89741">
<img width="261" alt="Screenshot 2023-12-15 at 18 34 39" src="https://github.com/zer0-os/zOS/assets/39112648/a5479d2c-c8d0-48c8-959a-89b031483ca8">
