### PR TITLE
Add default and active states for message input (composer)

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -69,11 +69,13 @@
   backdrop-filter: blur(64px);
 }
 
-@mixin text-input {
-  background: var(--D-Glass-Ui-State-Active, rgba(163, 162, 163, 0.1));
-
-  /* D/Glass/Inset/Shadows */
+@mixin text-input-default {
+  background: rgba(167, 163, 163, 0.05);
   box-shadow: -2px -2px 4px 0px rgba(246, 244, 246, 0.05) inset, 2px 2px 4px -1px rgba(10, 10, 10, 0.4) inset;
+}
+
+@mixin text-input-focus {
+  background: rgba(163, 162, 163, 0.1);
 }
 
 // D/Glass/Materials/Raised

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -103,10 +103,11 @@
     width: 100%;
     border-radius: 8px;
 
-    @include text-input;
+    @include text-input-default;
 
     &:focus-within {
       border-color: theme.$color-primary-7;
+      @include text-input-focus;
     }
   }
 


### PR DESCRIPTION
### What does this do?

Previously there was only a single state for message input background. The new design adds 2 - one for default, and another for active (i.e focused)

Default
![image](https://github.com/zer0-os/zOS/assets/33264364/03646013-4f77-48ca-9c15-3c19526d3367)

Active (when typing something)
![image](https://github.com/zer0-os/zOS/assets/33264364/5e155342-974e-498c-bbf5-8f733cb142ac)
