### PR TITLE
ZOS Redesign: Message Bubbles

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -39,13 +39,11 @@
     // Our solution is to use a div with a full background and then mask out the inside
     // of it so that you only see approximately 1 px of it
     //
-    background-image: linear-gradient(
-      153.33deg,
-      rgba(255, 255, 255, 0.25) 0%,
-      rgba(255, 255, 255, 0) 24.43%,
-      rgba(255, 255, 255, 0.01) 79.12%,
-      rgba(255, 255, 255, 0.05) 100%
-    );
+    background-image: linear-gradient(153.33deg,
+        rgba(255, 255, 255, 0.25) 0%,
+        rgba(255, 255, 255, 0) 24.43%,
+        rgba(255, 255, 255, 0.01) 79.12%,
+        rgba(255, 255, 255, 0.05) 100%);
     mask: linear-gradient(black, black) center / 100% 100% no-repeat exclude,
       radial-gradient(circle 16px at 17px 17px, black 99%, transparent),
       radial-gradient(circle 16px at 17px calc(100% - 17px), black 99%, transparent),
@@ -69,6 +67,11 @@
   backdrop-filter: blur(64px);
 }
 
+@mixin flat-thin {
+  background: rgba(10, 10, 10, 0.5);
+  backdrop-filter: blur(64px);
+}
+
 @mixin text-input-default {
   background: rgba(167, 163, 163, 0.05);
   box-shadow: -2px -2px 4px 0px rgba(246, 244, 246, 0.05) inset, 2px 2px 4px -1px rgba(10, 10, 10, 0.4) inset;
@@ -80,13 +83,11 @@
 
 // D/Glass/Materials/Raised
 @mixin glass-materials-raised {
-  background: linear-gradient(
-    153.33deg,
-    rgba(255, 255, 255, 0.55) 0%,
-    rgba(255, 255, 255, 0) 24.43%,
-    rgba(255, 255, 255, 0.01) 79.12%,
-    rgba(255, 255, 255, 0.75) 100%
-  );
+  background: linear-gradient(153.33deg,
+      rgba(255, 255, 255, 0.55) 0%,
+      rgba(255, 255, 255, 0) 24.43%,
+      rgba(255, 255, 255, 0.01) 79.12%,
+      rgba(255, 255, 255, 0.75) 100%);
 }
 
 // L/Glass/Separator/Primary

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -33,7 +33,7 @@
     }
 
     .message__block {
-      @include flat-thick;
+      @include flat-thin;
       border-radius: var(--border-owner-radius); // set in message__message-row
 
       &--edit {
@@ -54,7 +54,7 @@
     z-index: 1;
 
     border-radius: var(--border-radius); // set in message__message-row
-    @include flat-thin;
+    @include flat-thick;
 
     &--edit {
       width: 100%;
@@ -63,15 +63,16 @@
 
   &__block-body {
     font-weight: 400;
-    font-size: 14px;
-    line-height: 20px;
-    color: theme.$color-greyscale-12;
+    font-size: 16px;
+    line-height: 23px;
     display: flex;
     flex-direction: column;
     gap: 4px;
 
-    margin: 8px 0 0px 0;
-    padding: 0px 8px 8px 8px;
+    margin: 16px 0px 0px 0px;
+    padding: 0px 16px 16px 16px;
+
+    @include glass-text-primary-color;
 
     white-space: pre-wrap;
     word-break: break-word;
@@ -127,6 +128,7 @@
 
   &__time {
     display: flex;
+    @include glass-text-secondary-color;
   }
 
   &__failure-message {
@@ -169,12 +171,12 @@
 
   &__author-name {
     display: flex;
-    font-weight: 700;
+    font-weight: 600;
     font-size: 12px;
     line-height: 15px;
-    color: theme.$color-greyscale-12;
     margin: 0 0 8px 0;
-    padding: 8px 8px 0px 8px;
+    padding: 8px 16px 0px 16px;
+    @include glass-text-primary-color;
   }
 
   &.messages__message--last-in-group {

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -1,5 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @use '../../shared-components/theme-engine/theme' as themeDeprecated;
+@import '../../glass';
 
 .message {
   display: flex;
@@ -32,7 +33,7 @@
     }
 
     .message__block {
-      background-color: theme.$color-secondary-3;
+      @include flat-thick;
       border-radius: var(--border-owner-radius); // set in message__message-row
 
       &--edit {
@@ -46,7 +47,6 @@
   }
 
   &__block {
-    background-color: theme.$color-primary-3;
     position: relative;
     padding: 0px;
     color: themeDeprecated.$card-text-color;
@@ -54,6 +54,7 @@
     z-index: 1;
 
     border-radius: var(--border-radius); // set in message__message-row
+    @include flat-thin;
 
     &--edit {
       width: 100%;


### PR DESCRIPTION
### What does this do?
Updates the message bubble as per the new design

<img width="1496" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/d12337b5-cc86-4ea5-8cb9-0d1e07324d8c">



Messages Sent (flat/thin)

<img width="661" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/f04c7d7f-9541-46c8-97a2-75af4a0970a6">

<img width="541" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6109e0d6-e05c-49b4-8b5a-b1080e90fdeb">


Messages Received (flat/thick)

<img width="316" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/96b7bd69-5862-4f80-b8ff-8b22eb0af526">
<img width="340" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/e3ec9181-fae3-4395-8d71-ed3df0015715">
<img width="693" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2fc2cc10-eb8d-41e4-88fe-f3d2429b748c">

