### PR TITLE
ZOS Redesign: Replies

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -105,3 +105,7 @@
   box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.25), 1px 1px 1px 0px rgba(0, 0, 0, 0.21),
     2px 2px 2px 0px rgba(0, 0, 0, 0.13), 4px 4px 2px 0px rgba(0, 0, 0, 0.04), 6px 6px 2px 0px rgba(0, 0, 0, 0);
 }
+
+@mixin glass-state-active-stroke {
+  border-bottom: 1px solid rgba(163, 162, 163, 0.1);
+}

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -48,7 +48,7 @@
   }
 
   &__addon-row {
-    margin-bottom: 8px;
+    margin-bottom: 16px;
 
     &:empty {
       display: none;

--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -1,11 +1,10 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../glass';
 
 .parent-message {
   display: flex;
   align-items: center;
-  padding: 8px;
-  background-color: theme.$color-greyscale-transparency-2;
-  color: theme.$color-greyscale-11;
+  padding: 8px 8px 8px 16px;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
 
@@ -14,16 +13,17 @@
   font-style: normal;
   line-height: 15px;
 
+  @include glass-text-secondary-color;
+  @include glass-state-active-stroke;
+
   &__content {
-    padding-left: 8px;
+    padding-left: 16px;
     flex-grow: 1;
     overflow: hidden;
     white-space: nowrap;
   }
 
   &__header {
-    color: theme.$color-greyscale-12;
-    font-weight: 700;
     margin-bottom: 4px;
   }
 }

--- a/src/components/reply-card/styles.scss
+++ b/src/components/reply-card/styles.scss
@@ -4,21 +4,23 @@
 
 @import '../../variables';
 @import '../../animation';
+@import '../../glass';
 
 .reply-card {
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px;
-  background-color: theme.$color-greyscale-transparency-2;
-  color: theme.$color-greyscale-11;
+  gap: 16px;
+  padding: 8px 8px 8px 16px;
   border-radius: 4px;
 
   font-weight: 400;
   font-size: 12px;
   font-style: normal;
   line-height: 15px;
+
+  @include glass-text-secondary-color;
+  @include glass-state-active-stroke;
 
   &__content {
     flex-grow: 1;
@@ -27,8 +29,6 @@
   }
 
   &__header {
-    color: theme.$color-greyscale-12;
-    font-weight: 700;
     margin-bottom: 4px;
   }
 }


### PR DESCRIPTION
### What does this do?

Updates the styles for replies (inside message-input, and the parent message rendered)

Message Input
![image](https://github.com/zer0-os/zOS/assets/33264364/cfab5f03-6939-4d84-a333-9d04ab5343b2)

![image](https://github.com/zer0-os/zOS/assets/33264364/cd1fd074-4bb1-4f9a-8a8c-085c2c75d98b)

Parent Message:

![image](https://github.com/zer0-os/zOS/assets/33264364/4c816837-7fab-4225-bef9-f6afd74d52f7)

![image](https://github.com/zer0-os/zOS/assets/33264364/04fd4a44-fa0d-4b3d-8c98-3bda99957bcf)

