### PR TITLE
ZOS Redesign: Update conversation thread divider color text to primary

### DIFF
--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -2,6 +2,7 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @use '../../shared-components/theme-engine/theme' as themeDeprecated;
 @import '../../animation';
+@import '../../glass';
 
 @mixin actionable-color(
   $inactive-color: themeDeprecated.$actionable-inactive-color,
@@ -252,9 +253,9 @@ $scrollbar-width: 5px;
     line-height: 15px;
 
     &-date {
-      color: theme.$color-greyscale-transparency-11;
       width: 100%;
       text-align: center;
+      @include glass-text-primary-color;
     }
   }
 


### PR DESCRIPTION
### What does this do?

![image](https://github.com/zer0-os/zOS/assets/33264364/c6b0279c-c4aa-4a2c-b1d3-6c0fedaea146)


NOTE: Not sure if this should also be applies to the colors of admin messages as well. Will ask Ethan about it.