### PR TITLE
feat: update conversation list avatar logic

### DIFF
--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -78,14 +78,16 @@ export class ConversationItem extends React.Component<Properties> {
           tabIndex={-1}
         />
       );
+    } else if (!this.props.conversation.isOneOnOne) {
+      return (
+        <div {...cn('group-icon')}>
+          <IconUsers1 size={25} />
+          <Status {...cn('group-status')} type={this.conversationStatus} />
+        </div>
+      );
     }
 
-    return (
-      <div {...cn('group-icon')}>
-        <IconUsers1 size={25} />
-        <Status {...cn('group-status')} type={this.conversationStatus} />
-      </div>
-    );
+    return <Avatar size={'regular'} type={'circle'} statusType={this.conversationStatus} tabIndex={-1} />;
   }
 
   render() {

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -16,7 +16,7 @@ $side-padding: 16px;
 }
 
 .highlighted-text {
-  color: theme.$color-primary-11;
+  color: theme.$color-secondary-11;
 }
 
 .invite-toast-notification {


### PR DESCRIPTION
### What does this do?
- updates the handling of which Avatar Icons to display.

### Why are we making this change?
- to display the correct Avatars in the conversation list.


<img width="257" alt="Screenshot 2023-12-18 at 13 22 54" src="https://github.com/zer0-os/zOS/assets/39112648/397245ec-e37b-4e71-8af0-b148624f2b50">
