### PR TITLE
feat: unread count redesign

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -13,9 +13,19 @@
   color: rgba(238, 236, 255, 0.42);
 }
 
+// D/Glass/Ui State/Default
+@mixin glass-state-default-color {
+  background-color: rgba(167, 163, 163, 0.05);
+}
+
 // D/Glass/Ui State/Hover
 @mixin glass-state-hover-color {
   background-color: rgba(253, 252, 253, 0.05);
+}
+
+// D/Glows/Highlight/Small (4px)
+@mixin glass-glow-highlight-small {
+  text-shadow: 0px 0px 4px rgba(1, 250, 195, 0.75);
 }
 
 @mixin glass-outer {
@@ -85,14 +95,15 @@
 }
 
 // D/Glass/Materials/Raised
-@mixin glass-materials-raised {
+@mixin glass-materials-raised($startColor: rgba(167, 163, 163, 0.05), $endColor: rgba(167, 163, 163, 0.05)) {
   background: linear-gradient(
-    153.33deg,
-    rgba(255, 255, 255, 0.55) 0%,
-    rgba(255, 255, 255, 0) 24.43%,
-    rgba(255, 255, 255, 0.01) 79.12%,
-    rgba(255, 255, 255, 0.75) 100%
-  );
+      153.33deg,
+      rgba(255, 255, 255, 0.25) 0%,
+      rgba(255, 255, 255, 0) 24.43%,
+      rgba(255, 255, 255, 0.01) 79.12%,
+      rgba(255, 255, 255, 0.05) 100%
+    ),
+    linear-gradient(0deg, $startColor, $endColor);
 }
 
 // L/Glass/Separator/Primary

--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -95,13 +95,16 @@
   }
 
   &__unread-count {
+    @include glass-state-default-color;
+    @include glass-glow-highlight-small;
+    @include glass-materials-raised();
+
     display: flex;
     justify-content: center;
     align-items: center;
     flex-grow: 0;
     flex-shrink: 0;
-    background-color: theme.$color-primary-8;
-    color: theme.$color-primary-transparency-12;
+    color: theme.$color-secondary-transparency-11;
     border-radius: 50%;
     width: 16px;
     height: 16px;
@@ -110,6 +113,7 @@
     font-weight: 700;
     line-height: 11px;
     margin-left: 3px;
+    letter-spacing: 0.32px;
   }
 
   &__content {
@@ -141,7 +145,14 @@
       border-radius: inherit;
       z-index: -1;
 
-      @include glass-materials-raised;
+      // custom raised background for group icon
+      background: linear-gradient(
+        153.33deg,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0) 24.43%,
+        rgba(255, 255, 255, 0.01) 79.12%,
+        rgba(255, 255, 255, 0.75) 100%
+      );
     }
 
     & > * {


### PR DESCRIPTION
### What does this do?
- implements the redesign for the unread message count

### Why are we making this change?
- as per figma designs

<img width="290" alt="Screenshot 2023-12-18 at 18 33 03" src="https://github.com/zer0-os/zOS/assets/39112648/c01814a4-4f2d-41c1-9f89-320ea8b21e54">
<img width="290" alt="Screenshot 2023-12-18 at 18 32 59" src="https://github.com/zer0-os/zOS/assets/39112648/f63adeac-7e63-4d6c-a9f5-d8b82df9dd2d">
