### PR TITLE
feat: apply raised styles to conversation list avatars

### DIFF
--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -66,6 +66,7 @@ export class ConversationItem extends React.Component<Properties> {
           imageURL={this.props.conversation.otherMembers[0].profileImage}
           statusType={this.conversationStatus}
           tabIndex={-1}
+          isRaised
         />
       );
     } else if (isCustomIcon(this.props.conversation.icon)) {
@@ -76,6 +77,7 @@ export class ConversationItem extends React.Component<Properties> {
           imageURL={this.props.conversation.icon}
           statusType={this.conversationStatus}
           tabIndex={-1}
+          isRaised
         />
       );
     } else if (!this.props.conversation.isOneOnOne) {
@@ -87,7 +89,7 @@ export class ConversationItem extends React.Component<Properties> {
       );
     }
 
-    return <Avatar size={'regular'} type={'circle'} statusType={this.conversationStatus} tabIndex={-1} />;
+    return <Avatar size={'regular'} type={'circle'} statusType={this.conversationStatus} tabIndex={-1} isRaised />;
   }
 
   render() {


### PR DESCRIPTION
### What does this do?
- applies `isRaised` property to `Avatar`'s used in the `ConversationList`.

### Why are we making this change?
- as per figma designs (re-design)

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="238" alt="Screenshot 2023-12-19 at 11 22 41" src="https://github.com/zer0-os/zOS/assets/39112648/c0c1b856-e484-4bde-894e-f41b35cd29ec">