### PR TITLE
chore: bump zui version `(1.2.0)` -> `(1.3.0)`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^1.2.0",
+        "@zero-tech/zui": "^1.3.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8796,9 +8796,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.2.0.tgz",
-      "integrity": "sha512-RFEtsNmA01aGbBbpLcDyZHW38rmDDot0m7NIy4x/P2f23TOqlDE9LjU26I7nl26m/crjFbr6IkkFW5Uejn5KYg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.3.0.tgz",
+      "integrity": "sha512-/te/3j2NSZt7e9YruIQzVvlEk4bc+/QLttYS63+2r7/mY0vP7AF8N29TrhZpMJAG5XvV2OMsLy8yq6ntS5yr0Q==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -38414,9 +38414,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.2.0.tgz",
-      "integrity": "sha512-RFEtsNmA01aGbBbpLcDyZHW38rmDDot0m7NIy4x/P2f23TOqlDE9LjU26I7nl26m/crjFbr6IkkFW5Uejn5KYg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.3.0.tgz",
+      "integrity": "sha512-/te/3j2NSZt7e9YruIQzVvlEk4bc+/QLttYS63+2r7/mY0vP7AF8N29TrhZpMJAG5XvV2OMsLy8yq6ntS5yr0Q==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^1.2.0",
+    "@zero-tech/zui": "^1.3.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
- bumps zui version `(1.2.0)` -> `(1.3.0)`

*pulls in latest dropdown menu item size styles