### PR TITLE
feat: apply spacious sizing to settings menu dropdown menu

### DIFF
--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -127,10 +127,16 @@ export class SettingsMenu extends React.Component<Properties, State> {
         label: this.renderSettingsHeader(),
         onSelect: () => {},
       },
+      {
+        className: 'divider',
+        id: 'header-divider',
+        label: <div />,
+        onSelect: () => {},
+      },
       ...options,
       {
         className: 'divider',
-        id: 'divider',
+        id: 'footer-divider',
         label: <div />,
         onSelect: () => {},
       },
@@ -161,6 +167,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
               statusType={this.props.userStatus}
             />
           }
+          itemSize='spacious'
         />
         {this.renderEditProfileDialog()}
         {this.renderBackupDialog()}

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -50,7 +50,7 @@
   }
 
   .zui-dropdown-item.divider {
-    border-bottom: 1px solid theme.$color-primary-5;
+    border-bottom: 1px solid rgba(163, 162, 163, 0.1);
     margin: 8px 0px;
     padding: 0;
   }

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -1,9 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .settings-menu {
-  width: 256px;
-  padding: 8px;
-
   > *:first-child {
     &:hover {
       background: none;

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -48,7 +48,7 @@
 
   .zui-dropdown-item.divider {
     border-bottom: 1px solid rgba(163, 162, 163, 0.1);
-    margin: 8px 0px;
+    margin: 0;
     padding: 0;
   }
 


### PR DESCRIPTION
### What does this do?
- applies the `spacious` sizing to the settings menu dropdown menu items.

### Why are we making this change?
- as per figma designs (re-design)

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="445" alt="Screenshot 2023-12-19 at 13 47 30" src="https://github.com/zer0-os/zOS/assets/39112648/d0ff0fbe-02ce-45bf-9bf5-76bcbfbcafd7">

After:
<img width="270" alt="Screenshot 2023-12-19 at 13 56 11" src="https://github.com/zer0-os/zOS/assets/39112648/aab226ff-d292-47b0-b1e7-4a015c343817">


