### PR TITLE
feat: update group management dropdown menu items for re-design

### DIFF
--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -42,7 +42,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
     if (this.props.canAddMembers) {
       menuItems.push({
         id: 'add-member',
-        label: this.renderMenuItem(<IconPlus />, 'Add Member'),
+        label: this.renderMenuItem(<IconPlus size={20} />, 'Add Member'),
         onSelect: this.startAddMember as any,
       });
     }
@@ -51,7 +51,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
       menuItems.push({
         id: 'leave_group',
         className: 'leave-group',
-        label: this.renderMenuItem(<IconUserRight1 />, 'Leave Group'),
+        label: this.renderMenuItem(<IconUserRight1 size={20} />, 'Leave Group'),
         onSelect: () => {
           this.props.onLeave();
         },
@@ -61,7 +61,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
     if (this.props.canEdit) {
       menuItems.push({
         id: 'edit_group',
-        label: this.renderMenuItem(<IconEdit5 />, 'Edit'),
+        label: this.renderMenuItem(<IconEdit5 size={20} />, 'Edit Group'),
         onSelect: this.props.onEdit,
       });
     }

--- a/src/components/group-management-menu/styles.scss
+++ b/src/components/group-management-menu/styles.scss
@@ -1,19 +1,12 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .group-management-menu {
-  width: 232px;
-  padding: 8px;
-
   .leave-group {
     color: theme.$color-failure-11;
   }
 
   .menu-item {
     display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 10px;
-    font-size: 16px;
-    line-height: 24px;
+    gap: 8px;
   }
 }

--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -39,11 +39,7 @@
   }
 
   .option {
-    display: flex;
-    align-items: center;
     gap: 10px;
-    font-size: 16px;
-    line-height: 24px;
   }
 
   .zui-dropdown-item.divider {


### PR DESCRIPTION
### What does this do?
- updates group management dropdown menu items

### Why are we making this change?
- align with figma designs (re-design)

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="501" alt="Screenshot 2023-12-19 at 14 24 32" src="https://github.com/zer0-os/zOS/assets/39112648/d94fb8e4-2011-4626-9072-6ed67924c5e5">
<img width="501" alt="Screenshot 2023-12-19 at 14 24 47" src="https://github.com/zer0-os/zOS/assets/39112648/6db0af75-1983-472e-ad41-93dcd56b3535">

After:
<img width="313" alt="Screenshot 2023-12-19 at 14 25 20" src="https://github.com/zer0-os/zOS/assets/39112648/a0d3b10b-0076-464c-8ccb-cfc97ee17dce">
<img width="313" alt="Screenshot 2023-12-19 at 14 25 16" src="https://github.com/zer0-os/zOS/assets/39112648/cddbdae0-88bc-4354-89f4-bdc5bcde1065">

