### PR TITLE
feat: update message dropdown menu items for redesign

### DIFF
--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -34,7 +34,7 @@ export class MessageMenu extends React.Component<Properties, State> {
   renderMenuOption(icon, label) {
     return (
       <div className={'option'}>
-        {label} {icon}
+        {icon} {label}
       </div>
     );
   }
@@ -51,21 +51,21 @@ export class MessageMenu extends React.Component<Properties, State> {
     if (this.props.onEdit && this.props.canEdit && !this.props.isMediaMessage) {
       menuItems.push({
         id: 'edit',
-        label: this.renderMenuOption(<IconEdit5 />, 'Edit'),
+        label: this.renderMenuOption(<IconEdit5 size={20} />, 'Edit'),
         onSelect: this.onEdit,
       });
     }
     if (this.props.onReply && this.props.canReply && !this.props.isMediaMessage) {
       menuItems.push({
         id: 'reply',
-        label: this.renderMenuOption(<IconFlipBackward />, 'Reply'),
+        label: this.renderMenuOption(<IconFlipBackward size={20} />, 'Reply'),
         onSelect: this.onReply,
       });
     }
     if (this.props.onDelete && this.props.canDelete) {
       menuItems.push({
         id: 'delete',
-        label: this.renderMenuOption(<IconTrash4 />, 'Delete'),
+        label: this.renderMenuOption(<IconTrash4 size={20} />, 'Delete'),
         onSelect: this.toggleDeleteDialog,
       });
     }

--- a/src/platform-apps/channels/messages-menu/styles.scss
+++ b/src/platform-apps/channels/messages-menu/styles.scss
@@ -34,16 +34,12 @@
 }
 
 .dropdown-menu {
-  width: 240px;
-  padding: 8px;
+  min-width: 128px;
 }
 
 .option {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 16px;
-  line-height: 24px;
+  gap: 8px;
 }
 
 .delete-message-modal {

--- a/src/platform-apps/channels/messages-menu/styles.scss
+++ b/src/platform-apps/channels/messages-menu/styles.scss
@@ -33,10 +33,6 @@
   pointer-events: auto;
 }
 
-.dropdown-menu {
-  min-width: 128px;
-}
-
 .option {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
### What does this do?
- updates the three dot message dropdown menu items.

### Why are we making this change?
- as per figma designs (re-design)

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="313" alt="Screenshot 2023-12-19 at 14 42 25" src="https://github.com/zer0-os/zOS/assets/39112648/2be48f1f-086c-4055-9bb9-53cc3a7b6468">


After:
<img width="313" alt="Screenshot 2023-12-19 at 14 42 12" src="https://github.com/zer0-os/zOS/assets/39112648/d3d18a60-3b27-49d8-b35a-6e67fc556c86">
