### PR TITLE
feat: replace `group` with `conversation` (admin messages)

### DIFF
--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -132,7 +132,7 @@ describe(adminMessageText, () => {
 
       const adminText = adminMessageText(message, state);
 
-      expect(adminText).toEqual('Courtney left the group');
+      expect(adminText).toEqual('Courtney left the conversation');
     });
   });
 

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -161,7 +161,7 @@ describe(adminMessageText, () => {
 
       const adminText = adminMessageText(message, state);
 
-      expect(adminText).toEqual('Courtney was added to the group');
+      expect(adminText).toEqual('Courtney was added to the conversation');
     });
   });
 });

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -104,7 +104,7 @@ function translateConversationStarted(admin: { userId?: string }, currentUser, s
 
 function translateMemberLeftGroup(admin: { userId?: string }, state: RootState) {
   const user = denormalizeUser(admin.userId, state);
-  return user?.firstName ? `${user.firstName} left the group` : null;
+  return user?.firstName ? `${user.firstName} left the conversation` : null;
 }
 
 function translateMemberAddedToGroup(admin: { userId?: string }, state: RootState) {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -109,5 +109,5 @@ function translateMemberLeftGroup(admin: { userId?: string }, state: RootState) 
 
 function translateMemberAddedToGroup(admin: { userId?: string }, state: RootState) {
   const user = denormalizeUser(admin.userId, state);
-  return user?.firstName ? `${user.firstName} was added to the group` : null;
+  return user?.firstName ? `${user.firstName} was added to the conversation` : null;
 }


### PR DESCRIPTION
### What does this do?
- replaces `group` with `conversation` (admin messages)

### Why are we making this change?
- for a one on one conversation the word `group` doesn't make too much sense `xyz was added to the group`.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
