### PR TITLE
Fix creating a new conversation

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -137,7 +137,7 @@ export class Container extends React.Component<Properties, State> {
   };
 
   isUserAlreadyInConversation = (userId: string) => {
-    return this.props.conversations.filter((c) => c.isOneOnOne).find((c) => c.otherMembers[0].userId === userId);
+    return this.props.conversations.filter((c) => c.isOneOnOne).find((c) => c.otherMembers[0]?.userId === userId);
   };
 
   createOneOnOneConversation = (id: string) => {


### PR DESCRIPTION
### What does this do?

Could be a conversation on my list where the "otherMember" had not accepted the invite. I was getting this on my local & development accounts.

<img width="1496" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/a19aec9e-1075-49f6-b36b-5f54351afa06">

