### PR TITLE
(Bug)  `+` icon not responding after you open a conversation with someone already on your list

### DIFF
--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -1,7 +1,7 @@
 import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, select, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, receive, schema, removeAll } from '.';
-
+import { SagaActionTypes as CreateConversationSagaActionTypes } from '../create-conversation';
 import { joinChannel as joinChannelAPI } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
@@ -81,6 +81,8 @@ export function* openConversation(conversationId) {
   }
 
   yield call(reset);
+  // cancel start of create conversation flow if it's in progress (resolves the race condition)
+  yield put({ type: CreateConversationSagaActionTypes.Cancel });
   yield put(setactiveConversationId(conversationId));
   yield spawn(markConversationAsRead, conversationId);
 }


### PR DESCRIPTION
### What does this do?

The issue was with the race condition during create conversation's `startEvent` saga. It sets up a few race conditions, but if we "don't create a conversation", & just open an already existing one, the race condition isn't resolved and hence the `+` icon does not respond afterwards.

Before:

https://github.com/zer0-os/zOS/assets/33264364/5823c8e7-1233-40bd-aeb7-b4c59e039bd5

After:


https://github.com/zer0-os/zOS/assets/33264364/07580419-aa02-4d75-958d-e3913457d0fc

