### PR TITLE
Update zOS background image, change fill opacity

### DIFF
--- a/src/_glass.scss
+++ b/src/_glass.scss
@@ -70,7 +70,7 @@
   border-radius: 16px;
   overflow: hidden;
   background: radial-gradient(273.54% 141.42% at 0% 0%, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0) 100%),
-    rgba(10, 10, 10, 0.75);
+    rgba(10, 10, 10, 0.5);
 }
 
 // "flat" style mixin

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -370,13 +370,13 @@ describe('ChatView', () => {
     });
 
     it('returns the formatted date for the same year', () => {
-      const currentYearDate = moment('2023-06-11'); // Example date within the same year
+      const currentYearDate = moment('2024-06-11'); // Example date within the same year
       const messages = [
         { id: 111, message: 'what', createdAt: currentYearDate.valueOf() } as MessageModel,
       ];
 
       const wrapper = subject({ messages });
-      expect(wrapper.find('.message__header-date').text()).toEqual('Sun, Jun 11');
+      expect(wrapper.find('.message__header-date').text()).toEqual('Tue, Jun 11');
     });
 
     it('returns the formatted date for previous years', () => {

--- a/src/index.scss
+++ b/src/index.scss
@@ -21,7 +21,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  background-image: url(cloudAsset('messenger_background.png'));
+  background-image: url(cloudAsset('Messenger-BG-02.png'));
   background-size: cover;
   background-repeat: no-repeat;
 

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -246,9 +246,10 @@ describe(previewDisplayDate, () => {
   });
 
   it('displays the three-letter month abbreviation and day of the month for messages sent in the same calendar year prior to the last 7 days', () => {
-    const withinCalendarYear = moment().subtract(10, 'days');
+    const currentDate = moment('2024-01-20');
+    const withinCalendarYear = moment(currentDate).subtract(10, 'days');
 
-    expect(previewDisplayDate(withinCalendarYear.valueOf())).toEqual(withinCalendarYear.format('MMM D'));
+    expect(previewDisplayDate(withinCalendarYear.valueOf(), currentDate)).toEqual(withinCalendarYear.format('MMM D'));
   });
 
   it('displays the three-letter month abbreviation, day of the month, and the year for messages sent before the current calendar year', () => {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -4,13 +4,12 @@ import { denormalize as denormalizeUser } from '../../store/users';
 import { currentUserSelector } from '../../store/authentication/saga';
 import moment from 'moment';
 
-export function previewDisplayDate(timestamp: number) {
+export function previewDisplayDate(timestamp: number, currentDate = moment()) {
   if (!timestamp) {
     return '';
   }
 
   const messageDate = moment(timestamp);
-  const currentDate = moment();
 
   if (messageDate.isSame(currentDate, 'day')) {
     return messageDate.format('h:mm A');


### PR DESCRIPTION
### What does this do?

- changes the "fill" as per Ethan (change the opacity to 50%)
- change the background image

<img width="1491" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/4673a574-ca95-4770-a5dc-be715ac2e06d">