### PR TITLE
Move some channel styles closer to the appropriate sub-components

### DIFF
--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -110,3 +110,46 @@
     }
   }
 }
+
+.messages__container {
+  animation: fadein 200ms ease-out forwards;
+  padding-right: 16px;
+  padding-top: 100px;
+
+  .message__header {
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin: 8px 16px;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+
+    &-date {
+      width: 100%;
+      text-align: center;
+      @include glass-text-primary-color;
+    }
+  }
+
+  .messages__message-row {
+    display: flex;
+    margin: 4px 16px;
+
+    &--owner {
+      justify-content: flex-end;
+    }
+
+    &:hover {
+      .message__menu {
+        transform: translateX(0);
+        transition: transform 0.1s ease-in-out, opacity 0s ease-in-out;
+        opacity: 1;
+      }
+    }
+  }
+}
+
+.channel-view__inverted-scroll {
+  flex-grow: 99;
+}

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -204,3 +204,15 @@ $recent-indicator-size: 8px;
     bottom: calc($title-bar-height + $header-height - $window-height);
   }
 }
+
+// Message sizing
+.direct-message-chat--full-screen {
+  .messages__message {
+    box-sizing: border-box;
+    max-width: 100%;
+  }
+
+  .messages__message {
+    max-width: 560px;
+  }
+}

--- a/src/platform-apps/channels/styles.scss
+++ b/src/platform-apps/channels/styles.scss
@@ -76,10 +76,6 @@ $scrollbar-width: 5px;
   }
 }
 
-.channel-view__inverted-scroll {
-  flex-grow: 99;
-}
-
 .channel {
   &-list {
     width: 100%;
@@ -235,66 +231,5 @@ $scrollbar-width: 5px;
         height: 20px;
       }
     }
-  }
-}
-
-.messages__container {
-  animation: fadein 200ms ease-out forwards;
-  padding-right: 16px;
-  padding-top: 100px;
-
-  .message__header {
-    display: flex;
-    align-items: center;
-    position: relative;
-    margin: 8px 16px;
-    font-weight: 400;
-    font-size: 12px;
-    line-height: 15px;
-
-    &-date {
-      width: 100%;
-      text-align: center;
-      @include glass-text-primary-color;
-    }
-  }
-
-  .messages__message-row {
-    display: flex;
-    margin: 4px 16px;
-
-    &--owner {
-      justify-content: flex-end;
-    }
-  }
-}
-
-@keyframes fade-background-in {
-  from {
-    background-color: rgba(0, 0, 0, 0);
-  }
-
-  to {
-    background-color: themeDeprecated.$accent-color;
-  }
-}
-
-.messages__container .messages__message-row:hover {
-  .message__menu {
-    transform: translateX(0);
-    transition: transform 0.1s ease-in-out, opacity 0s ease-in-out;
-    opacity: 1;
-  }
-}
-
-// Message sizing
-.direct-message-chat--full-screen {
-  .messages__message {
-    box-sizing: border-box;
-    max-width: 100%;
-  }
-
-  .messages__message {
-    max-width: 560px;
   }
 }


### PR DESCRIPTION
### What does this do?

We had some styles that were still included in the higher Channels app that applied to the lower components. This is just a consequence of extracting subcomponents and not getting all the styles moved down. This PR moves the ones that appear to impact Messenger.

### Why are we making this change?

To allow future deletion of the Channels app

