### PR TITLE
fix: resolve group management menu nested button console error

### DIFF
--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -82,11 +82,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
         alignMenu='end'
         onOpenChange={this.handleOpenChange}
         className={'group-management-trigger'}
-        trigger={
-          <div>
-            <IconDotsHorizontal size={24} isFilled />
-          </div>
-        }
+        trigger={<IconDotsHorizontal size={24} isFilled />}
       />
     );
   }

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import { IconDotsHorizontal, IconEdit5, IconPlus, IconUserRight1 } from '@zero-tech/zui/icons';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
-import { bemClassName } from '../../lib/bem';
 import './styles.scss';
-
-const cn = bemClassName('group-management-menu');
 
 export interface Properties {
   canAddMembers: boolean;
@@ -33,7 +30,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
 
   renderMenuItem(icon, label) {
     return (
-      <div {...cn('menu-item')}>
+      <div className={'menu-item'}>
         {icon} {label}
       </div>
     );
@@ -84,8 +81,9 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
         side='bottom'
         alignMenu='end'
         onOpenChange={this.handleOpenChange}
+        className={'group-management-trigger'}
         trigger={
-          <div {...cn('trigger')}>
+          <div>
             <IconDotsHorizontal size={24} isFilled />
           </div>
         }

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 
 import { IconDotsHorizontal, IconEdit5, IconPlus, IconUserRight1 } from '@zero-tech/zui/icons';
-import { DropdownMenu, IconButton } from '@zero-tech/zui/components';
+import { DropdownMenu } from '@zero-tech/zui/components';
 
+import { bemClassName } from '../../lib/bem';
 import './styles.scss';
+
+const cn = bemClassName('group-management-menu');
 
 export interface Properties {
   canAddMembers: boolean;
@@ -30,7 +33,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
 
   renderMenuItem(icon, label) {
     return (
-      <div className={'menu-item'}>
+      <div {...cn('menu-item')}>
         {icon} {label}
       </div>
     );
@@ -81,7 +84,11 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
         side='bottom'
         alignMenu='end'
         onOpenChange={this.handleOpenChange}
-        trigger={<IconButton Icon={IconDotsHorizontal} size={32} isFilled onClick={() => {}} />}
+        trigger={
+          <div {...cn('trigger')}>
+            <IconDotsHorizontal size={24} isFilled />
+          </div>
+        }
       />
     );
   }

--- a/src/components/group-management-menu/styles.scss
+++ b/src/components/group-management-menu/styles.scss
@@ -5,17 +5,17 @@
     color: theme.$color-failure-11;
   }
 
-  &__menu-item {
+  .menu-item {
     display: flex;
     gap: 8px;
   }
+}
 
-  &__trigger {
-    padding: 4px;
-    border-radius: 50%;
+.group-management-trigger {
+  padding: 4px;
+  border-radius: 50%;
 
-    &:hover {
-      background-color: theme.$color-greyscale-transparency-3;
-    }
+  &:hover {
+    background-color: theme.$color-greyscale-transparency-3;
   }
 }

--- a/src/components/group-management-menu/styles.scss
+++ b/src/components/group-management-menu/styles.scss
@@ -5,8 +5,17 @@
     color: theme.$color-failure-11;
   }
 
-  .menu-item {
+  &__menu-item {
     display: flex;
     gap: 8px;
+  }
+
+  &__trigger {
+    padding: 4px;
+    border-radius: 50%;
+
+    &:hover {
+      background-color: theme.$color-greyscale-transparency-3;
+    }
   }
 }


### PR DESCRIPTION
### What does this do?
- removes the use of `IconButton`.
- adds `IconDotsHorizontal` in place of the button.
- makes use of the `className` attribute on the dropdown. This is the className for the trigger.
- added trigger styles to stylesheet.

### Why are we making this change?
- prevent the console error.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="1111" alt="Screenshot 2024-01-04 at 09 31 22" src="https://github.com/zer0-os/zOS/assets/39112648/d46d336a-7e13-48a3-828c-51cad096dbe9">

