### PR TITLE
feat: apply height and width to group management trigger

### DIFF
--- a/src/components/group-management-menu/styles.scss
+++ b/src/components/group-management-menu/styles.scss
@@ -14,6 +14,8 @@
 .group-management-trigger {
   padding: 4px;
   border-radius: 50%;
+  width: 32px;
+  height: 32px;
 
   &:hover {
     background-color: theme.$color-greyscale-transparency-3;


### PR DESCRIPTION
### What does this do?
- applies height and width to group management trigger.

### Why are we making this change?
- as per figma, adds the width and height to the trigger to ensure correct hover radius.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="94" alt="Screenshot 2024-01-04 at 09 50 20" src="https://github.com/zer0-os/zOS/assets/39112648/0ec879f2-69f7-457e-b709-200f0434bda0">

After:
<img width="94" alt="Screenshot 2024-01-04 at 09 50 01" src="https://github.com/zer0-os/zOS/assets/39112648/187d38ef-bc77-4d4a-8ac4-2cb641292ace">
