### PR TITLE
Add feature flag for email login defaulted to enabled

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -66,6 +66,14 @@ export class FeatureFlags {
     this._setBoolean('enableMatrix', value);
   }
 
+  get allowEmailLogin() {
+    return this._getBoolean('allowEmailLogin', true);
+  }
+
+  set allowEmailLogin(value: boolean) {
+    this._setBoolean('allowEmailLogin', value);
+  }
+
   get internalUsage() {
     return this._getBoolean('internalUsage', false);
   }


### PR DESCRIPTION
### What does this do?

Adds a feature flag for toggling email registration/login

