### PR TITLE
Hide the registration/login method toggle if email is disabled

### DIFF
--- a/src/authentication/create-account-method/index.tsx
+++ b/src/authentication/create-account-method/index.tsx
@@ -8,6 +8,7 @@ import { ToggleGroup } from '@zero-tech/zui/components';
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
+import { FeatureFlag } from '../../components/feature-flag';
 
 const cn = bemClassName('create-account-method');
 
@@ -31,18 +32,20 @@ export const CreateAccountMethod: React.FC<CreateAccountMethodProps> = ({ stage,
     <div {...cn('', isConnecting && isWalletAccountCreationStage && 'is-connecting')}>
       <h3 {...cn('heading')}>Create Account</h3>
 
-      {!isConnectingWithWallet && (
-        <ToggleGroup
-          {...cn('toggle-group')}
-          options={options}
-          variant='default'
-          onSelectionChange={onSelectionChange}
-          selection={selectedOption}
-          selectionType='single'
-          isRequired
-          isDisabled={isConnecting}
-        />
-      )}
+      <FeatureFlag featureFlag='allowEmailLogin'>
+        {!isConnectingWithWallet && (
+          <ToggleGroup
+            {...cn('toggle-group')}
+            options={options}
+            variant='default'
+            onSelectionChange={onSelectionChange}
+            selection={selectedOption}
+            selectionType='single'
+            isRequired
+            isDisabled={isConnecting}
+          />
+        )}
+      </FeatureFlag>
       {isWalletAccountCreationStage ? <CreateWalletAccountContainer /> : <CreateEmailAccountContainer />}
     </div>
   );

--- a/src/pages/login/login-component.tsx
+++ b/src/pages/login/login-component.tsx
@@ -90,7 +90,9 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
             </div>
             <div {...cn('inner-content-wrapper', isLoggingIn && isWeb3LoginStage && 'is-logging-in')}>
               <h3 {...cn('header')}>Log In</h3>
-              {this.renderToggleGroup(isLoggingIn, selectedOption, this.props.stage)}
+              <FeatureFlag featureFlag={'allowEmailLogin'}>
+                {this.renderToggleGroup(isLoggingIn, selectedOption, this.props.stage)}
+              </FeatureFlag>
               <div {...cn('login-option')}>{this.renderLoginOption()}</div>
             </div>
             {this.renderFooter(stage)}


### PR DESCRIPTION
### What does this do?

Hides the registration/login by email options based on the feature flag.

Registration enabled:
![image](https://github.com/zer0-os/zOS/assets/43770/dcf8dbb3-0bb7-4af7-b05e-10359cff4493)

Registration disabled:
![image](https://github.com/zer0-os/zOS/assets/43770/f131155a-43a9-43e3-8807-f596a57360c1)

Login enabled:
![image](https://github.com/zer0-os/zOS/assets/43770/5049c568-4294-4fd2-9859-34ae8fa12eb9)

Login disabled:
![image](https://github.com/zer0-os/zOS/assets/43770/ee5630a8-d074-4d2e-b66a-672fffc33880)
