### PR TITLE
Move check for existing conversation into saga

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -167,51 +167,6 @@ describe('messenger-list', () => {
     expect(createConversation).toHaveBeenCalledWith({ userIds: ['selected-user-id'] });
   });
 
-  it('doest NOT create a one on one conversation if there is already a conversation with user', async function () {
-    const createConversation = jest.fn();
-    const wrapper = subject({
-      createConversation,
-      stage: Stage.CreateOneOnOne,
-      conversations: [{ id: 'convo-id', isOneOnOne: true, otherMembers: [{ userId: 'selected-user-id' }] }] as any,
-    });
-
-    wrapper.find(CreateConversationPanel).prop('onCreate')('selected-user-id');
-    expect(createConversation).not.toHaveBeenCalled();
-  });
-
-  it('opens the existing conversation if there is already a conversation with user', async function () {
-    const onConversationClick = jest.fn();
-    const wrapper = subject({
-      onConversationClick,
-      stage: Stage.CreateOneOnOne,
-      conversations: [{ id: 'convo-id', isOneOnOne: true, otherMembers: [{ userId: 'selected-user-id' }] }] as any,
-    });
-
-    wrapper.find(CreateConversationPanel).prop('onCreate')('selected-user-id');
-    expect(onConversationClick).toHaveBeenCalledWith({ conversationId: 'convo-id' });
-  });
-
-  it('does not open the existing conversation if there is already a conversation with user BUT the conversation is a group (and not one2one)', async function () {
-    const onConversationClick = jest.fn();
-    const wrapper = subject({
-      onConversationClick,
-      stage: Stage.CreateOneOnOne,
-      conversations: [
-        {
-          id: 'convo-id',
-          otherMembers: [
-            { userId: 'selected-user-id' },
-            { userId: 'another-user-id' },
-          ],
-          isOneOnOne: false,
-        },
-      ] as any,
-    });
-
-    wrapper.find(CreateConversationPanel).prop('onCreate')('selected-user-id');
-    expect(onConversationClick).not.toHaveBeenCalled();
-  });
-
   it('returns to conversation list if back button pressed', async function () {
     const back = jest.fn();
     const wrapper = subject({ stage: Stage.CreateOneOnOne, back });

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -133,16 +133,7 @@ export class Container extends React.Component<Properties, State> {
     return users.map((user) => ({ ...user, image: user.profileImage }));
   };
 
-  isUserAlreadyInConversation = (userId: string) => {
-    return this.props.conversations.filter((c) => c.isOneOnOne).find((c) => c.otherMembers[0]?.userId === userId);
-  };
-
   createOneOnOneConversation = (id: string) => {
-    if (this.isUserAlreadyInConversation(id)) {
-      this.props.onConversationClick({ conversationId: this.isUserAlreadyInConversation(id).id });
-      return;
-    }
-
     this.props.createConversation({ userIds: [id] });
   };
 

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -1,14 +1,12 @@
 import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, select, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, receive, schema, removeAll } from '.';
-import { SagaActionTypes as CreateConversationSagaActionTypes } from '../create-conversation';
 import { joinChannel as joinChannelAPI } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
 import { setActiveChannelId, setactiveConversationId } from '../chat';
 import { chat } from '../../lib/chat';
-import { reset } from '../create-conversation/saga';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -80,9 +78,6 @@ export function* openConversation(conversationId) {
     return;
   }
 
-  yield call(reset);
-  // cancel start of create conversation flow if it's in progress (resolves the race condition)
-  yield put({ type: CreateConversationSagaActionTypes.Cancel });
   yield put(setactiveConversationId(conversationId));
   yield spawn(markConversationAsRead, conversationId);
 }


### PR DESCRIPTION
### What does this do?

When in the create conversation flow we want to prevent creating duplicate 1 on 1s with the same user. This moves that protection logic out of the component and up to the appropriate saga

