### PR TITLE
Refactor `<MessageInput /> component, update styles (bottom gradient, scrollbar)

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -5,7 +5,6 @@ import { shallow } from 'enzyme';
 import { Container } from './chat-view-container';
 import { ChatView } from './chat-view';
 import { Message } from '../../store/messages';
-import { Media } from '../message-input/utils';
 import { ConversationStatus } from '../../store/channels';
 
 describe('ChannelViewContainer', () => {
@@ -185,55 +184,6 @@ describe('ChannelViewContainer', () => {
     });
   });
 
-  it('should not send message if there is no channel id', () => {
-    const sendMessage = jest.fn();
-    const message = 'test message';
-
-    const wrapper = subject({ sendMessage, channel: {} });
-
-    wrapper.find(ChatView).first().prop('sendMessage')(message, [], []);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('calls sendMessage when chat view publishes message', () => {
-    const sendMessage = jest.fn();
-    const message = 'test message';
-    const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
-    const channelId = 'the-channel-id';
-
-    const wrapper = subject({ sendMessage, channelId, channel: {} });
-
-    wrapper.find(ChatView).first().prop('sendMessage')(message, mentionedUserIds, []);
-
-    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ channelId, message, mentionedUserIds }));
-  });
-
-  it('calls sendMessage with parent message a reply is included', () => {
-    const sendMessage = jest.fn();
-    const channelId = 'the-channel-id';
-
-    const wrapper = subject({ sendMessage, channelId, channel: {} });
-
-    wrapper.find(ChatView).simulate('reply', { id: 'parent' });
-    wrapper.find(ChatView).first().prop('sendMessage')('message', [], []);
-
-    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ channelId, parentMessage: { id: 'parent' } }));
-  });
-
-  it('calls sendMessage with files', () => {
-    const sendMessage = jest.fn();
-    const channelId = 'the-channel-id';
-
-    const wrapper = subject({ sendMessage, channelId, channel: {} });
-
-    wrapper.find(ChatView).first().prop('sendMessage')('', [], [{ id: 'file-id', name: 'file-name' } as Media]);
-
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ channelId, files: [{ id: 'file-id', name: 'file-name' }] })
-    );
-  });
-
   it('should call joinChannel when join button is clicked', () => {
     const joinChannel = jest.fn();
 
@@ -301,91 +251,6 @@ describe('ChannelViewContainer', () => {
       filter: {
         lastCreatedAt: 1658776625730,
       },
-    });
-  });
-
-  it('should call focus on message input render', () => {
-    const textareaRef = {
-      current: {
-        focus: jest.fn(),
-      },
-    };
-
-    const wrapper = subject();
-
-    (wrapper.instance() as any).onMessageInputRendered(textareaRef);
-
-    expect(textareaRef.current.focus).toHaveBeenCalled();
-  });
-
-  it('should not call focus on message input render if activeConversationId not equal the id of textareaRef', () => {
-    const activeConversationId = '1';
-    const textareaRef = {
-      current: {
-        focus: jest.fn(),
-        id: '3',
-      },
-    };
-
-    const wrapper = subject({ activeConversationId });
-
-    (wrapper.instance() as any).onMessageInputRendered(textareaRef);
-
-    expect(textareaRef.current.focus).not.toHaveBeenCalled();
-  });
-
-  it('should call focus on message input render if activeConversationId equal the id of textareaRef', () => {
-    const activeConversationId = '1';
-    const textareaRef = {
-      current: {
-        focus: jest.fn(),
-        id: activeConversationId,
-      },
-    };
-
-    const wrapper = subject({ activeConversationId });
-
-    (wrapper.instance() as any).onMessageInputRendered(textareaRef);
-
-    expect(textareaRef.current.focus).toHaveBeenCalled();
-  });
-
-  describe('sendDisabledMessage', () => {
-    it('is empty if the channel is created', () => {
-      const wrapper = subject({ channel: { conversationStatus: ConversationStatus.CREATED } });
-
-      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual('');
-    });
-
-    it('includes user name if one on one', () => {
-      const otherMembers = [{ userId: '1', firstName: 'Jack', lastName: 'Black' }];
-      const wrapper = subject({
-        channel: { isOneOnOne: true, otherMembers, conversationStatus: ConversationStatus.CREATING },
-      });
-
-      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
-        "We're connecting you with Jack Black. Try again in a few seconds."
-      );
-    });
-
-    it('includes conversation name if exists', () => {
-      const wrapper = subject({ channel: { name: 'NamedGroup', conversationStatus: ConversationStatus.CREATING } });
-
-      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
-        "We're connecting you with NamedGroup. Try again in a few seconds."
-      );
-    });
-
-    it('references group if more than one member', () => {
-      const otherMembers = [
-        { userId: '1' },
-        { userId: '2' },
-      ];
-      const wrapper = subject({ channel: { otherMembers, conversationStatus: ConversationStatus.CREATING } });
-
-      expect(wrapper.find('ChatView').prop('sendDisabledMessage')).toEqual(
-        "We're connecting you with the group. Try again in a few seconds."
-      );
     });
   });
 

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { RootState } from '../../store/reducer';
 
@@ -9,7 +9,6 @@ import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
 import { EditPayload, Payload as PayloadFetchMessages } from '../../store/messages/saga';
 import { Payload as PayloadJoinChannel } from '../../store/channels/types';
-import { withContext as withAuthenticationContext } from '../authentication/context';
 import { ParentMessage } from '../../lib/chat/types';
 import { compareDatesAsc } from '../../lib/date';
 
@@ -34,10 +33,16 @@ interface PublicProperties {
   className?: string;
   isDirectMessage?: boolean;
   showSenderAvatar?: boolean;
+  ref?: any;
 }
 
 export class Container extends React.Component<Properties> {
-  private textareaRef: RefObject<HTMLTextAreaElement>;
+  chatViewRef: React.RefObject<any>;
+
+  constructor(props) {
+    super(props);
+    this.chatViewRef = React.createRef();
+  }
 
   static mapState(state: RootState, props: PublicProperties): Partial<Properties> {
     const channel = denormalize(props.channelId, state) || null;
@@ -84,6 +89,12 @@ export class Container extends React.Component<Properties> {
       this.props.fetchMessages({ channelId });
     }
   }
+
+  scrollToBottom = (): void => {
+    if (this.chatViewRef?.current) {
+      this.chatViewRef.current.scrollToBottom();
+    }
+  };
 
   getOldestTimestamp(messages: Message[] = []): number {
     return messages.reduce((previousTimestamp, message: any) => {
@@ -214,12 +225,11 @@ export class Container extends React.Component<Properties> {
           isOneOnOne={this.isOneOnOne}
           onReply={this.props.onReply}
           conversationErrorMessage={this.conversationErrorMessage}
+          ref={this.chatViewRef}
         />
       </>
     );
   }
 }
 
-export const ChatViewContainer = withAuthenticationContext<PublicProperties>(
-  connectContainer<PublicProperties>(Container)
-);
+export const ChatViewContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -128,24 +128,6 @@ describe('ChatView', () => {
     expect(wrapper.find(InvertedScroll).hasClass('channel-view__inverted-scroll')).toBe(true);
   });
 
-  /*
-  it('scrollToBottom is called when a message is sent', async function () {
-    const sendMessageMock = jest.fn().mockResolvedValue({});
-    const wrapper: any = subject({ sendMessage: sendMessageMock });
-
-    wrapper.instance().scrollContainerRef = {
-      current: {
-        scrollToBottom: jest.fn(),
-      },
-    } as any;
-
-    await wrapper.instance().handleSendMessage('Hello', [], []);
-
-    const scrollContainerRef = wrapper.instance().scrollContainerRef;
-    expect(scrollContainerRef.current.scrollToBottom).toHaveBeenCalled();
-  });
-  */
-
   it('should not render MessageInput if user not a member', () => {
     const wrapper = subject({ messages: MESSAGES_TEST, user: { id: 'userId-test' } as User });
 

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -14,15 +14,6 @@ import { User } from '../../store/authentication/types';
 import moment from 'moment';
 import { MessagesFetchState } from '../../store/channels';
 
-const mockSearchMentionableUsersForChannel = jest.fn();
-jest.mock('../../platform-apps/channels/util/api', () => {
-  return {
-    searchMentionableUsersForChannel: (...args) => {
-      mockSearchMentionableUsersForChannel(...args);
-    },
-  };
-});
-
 describe('ChatView', () => {
   const MESSAGES_TEST = [
     { id: 1111, message: 'what', sender: { userId: '1' }, createdAt: 1658776625730 },
@@ -40,7 +31,6 @@ describe('ChatView', () => {
       user: null,
       joinChannel: () => null,
       onFetchMore: () => null,
-      sendMessage: () => null,
       deleteMessage: () => null,
       editMessage: () => null,
       onRemove: () => null,
@@ -138,6 +128,7 @@ describe('ChatView', () => {
     expect(wrapper.find(InvertedScroll).hasClass('channel-view__inverted-scroll')).toBe(true);
   });
 
+  /*
   it('scrollToBottom is called when a message is sent', async function () {
     const sendMessageMock = jest.fn().mockResolvedValue({});
     const wrapper: any = subject({ sendMessage: sendMessageMock });
@@ -153,14 +144,7 @@ describe('ChatView', () => {
     const scrollContainerRef = wrapper.instance().scrollContainerRef;
     expect(scrollContainerRef.current.scrollToBottom).toHaveBeenCalled();
   });
-
-  it('render MessageInput', () => {
-    const wrapper = subject({ messages: MESSAGES_TEST, hasJoined: true });
-
-    const ifAuthenticated = wrapper.find(IfAuthenticated).find({ showChildren: true });
-
-    expect(ifAuthenticated.find(MessageInput).exists()).toBe(true);
-  });
+  */
 
   it('should not render MessageInput if user not a member', () => {
     const wrapper = subject({ messages: MESSAGES_TEST, user: { id: 'userId-test' } as User });
@@ -335,15 +319,6 @@ describe('ChatView', () => {
     const wrapper = subject({ messages: [], isDirectMessage: true });
 
     expect(wrapper.find('.channel-view__name').exists()).toBeFalsy();
-  });
-
-  it('searches for user mentions', async () => {
-    const wrapper = subject({ messages: MESSAGES_TEST, hasJoined: true, id: '5' });
-    const input = wrapper.find(IfAuthenticated).find(MessageInput);
-
-    await input.prop('getUsersForMentions')('bob');
-
-    expect(mockSearchMentionableUsersForChannel).toHaveBeenCalledWith('5', 'bob', []);
   });
 
   describe('formatDayHeader', () => {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, RefObject } from 'react';
+import React, { Fragment } from 'react';
 import { Waypoint } from 'react-waypoint';
 import classNames from 'classnames';
 import moment from 'moment';
@@ -7,11 +7,9 @@ import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
 import { User as ChannelMember } from '../../store/channels';
-import { MessageInput } from '../message-input/container';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { Button as ConnectButton } from '../authentication/button';
 import { Button as ComponentButton } from '@zer0-os/zos-component-library';
-import { Media } from '../message-input/utils';
 import { ParentMessage } from '../../lib/chat/types';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
 import { Message } from '../message';
@@ -42,7 +40,6 @@ export interface Properties {
   fetchMessages: (payload: PayloadFetchMessages) => void;
   user: User;
   hasJoined: boolean;
-  sendMessage: (message: string, mentionedUserIds: string[], media: Media[]) => void;
   deleteMessage: (messageId: number) => void;
   editMessage: (
     messageId: number,
@@ -50,17 +47,13 @@ export interface Properties {
     mentionedUserIds: string[],
     data?: Partial<EditMessageOptions>
   ) => void;
-  onRemove?: () => void;
-  onReply: (reply: ParentMessage) => void;
+  onReply: ({ reply }: { reply: ParentMessage }) => void;
   joinChannel: () => void;
   className?: string;
-  reply?: null | ParentMessage;
-  onMessageInputRendered: (ref: RefObject<HTMLTextAreaElement>) => void;
   isDirectMessage: boolean;
   showSenderAvatar?: boolean;
   isMessengerFullScreen: boolean;
   isOneOnOne: boolean;
-  sendDisabledMessage: string;
   conversationErrorMessage: string;
 }
 
@@ -83,11 +76,6 @@ export class ChatView extends React.Component<Properties, State> {
     if (this.scrollContainerRef.current) {
       this.scrollContainerRef.current.scrollToBottom();
     }
-  };
-
-  handleSendMessage = (message: string, mentionedUserIds: string[], media: Media[]) => {
-    this.scrollToBottom();
-    this.props.sendMessage(message, mentionedUserIds, media);
   };
 
   getMessagesByDay() {
@@ -301,21 +289,11 @@ export class ChatView extends React.Component<Properties, State> {
           </div>
         )}
 
+        {/* i think we can remove the entire code below */}
         <IfAuthenticated showChildren>
           {isMemberOfChannel && (
             <>
               {this.props.conversationErrorMessage && <div {...cn('error')}>{this.props.conversationErrorMessage}</div>}
-              <div {...cn('message-input-container')}>
-                <MessageInput
-                  onMessageInputRendered={this.props.onMessageInputRendered}
-                  id={this.props.id}
-                  onSubmit={this.handleSendMessage}
-                  getUsersForMentions={this.searchMentionableUsers}
-                  reply={this.props.reply}
-                  onRemoveReply={this.props.onRemove}
-                  sendDisabledMessage={this.props.sendDisabledMessage}
-                />
-              </div>
             </>
           )}
           {!isMemberOfChannel && this.renderJoinButton()}

--- a/src/components/message-input/container.test.tsx
+++ b/src/components/message-input/container.test.tsx
@@ -1,0 +1,68 @@
+import { shallow } from 'enzyme';
+
+import { Container } from './container';
+
+describe('MessageInputContainer', () => {
+  const subject = (props: any = {}) => {
+    const allProps = {
+      onsubmit: jest.fn(),
+      initialValue: '12',
+      getUsersForMentions: jest.fn(),
+      renderAfterInput: jest.fn(),
+      onMessageInputRendered: jest.fn(),
+      id: '123',
+      reply: null,
+      currentUserId: '11',
+      onRemoveReply: jest.fn(),
+      isEditing: false,
+      ...props,
+    };
+
+    return shallow(<Container {...allProps} />);
+  };
+
+  it('should call focus on message input render', () => {
+    const textareaRef = {
+      current: {
+        focus: jest.fn(),
+      },
+    };
+
+    const wrapper = subject({ id: null });
+    (wrapper.instance() as any).onMessageInputRendered(textareaRef);
+
+    expect(textareaRef.current.focus).toHaveBeenCalled();
+  });
+
+  it('should not call focus on message input render if activeConversationId not equal the id of textareaRef', () => {
+    const activeConversationId = '1';
+    const textareaRef = {
+      current: {
+        focus: jest.fn(),
+        id: 'some-other-id',
+      },
+    };
+
+    const wrapper = subject({ activeConversationId });
+
+    (wrapper.instance() as any).onMessageInputRendered(textareaRef);
+
+    expect(textareaRef.current.focus).not.toHaveBeenCalled();
+  });
+
+  it('should call focus on message input render if activeConversationId equal the id of textareaRef', () => {
+    const activeConversationId = '123';
+    const textareaRef = {
+      current: {
+        focus: jest.fn(),
+        id: activeConversationId,
+      },
+    };
+
+    const wrapper = subject({ activeConversationId });
+
+    (wrapper.instance() as any).onMessageInputRendered(textareaRef);
+
+    expect(textareaRef.current.focus).toHaveBeenCalled();
+  });
+});

--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -49,8 +49,17 @@ export class Container extends React.Component<Properties> {
     return {};
   }
 
+  onMessageInputRendered = (textareaRef: RefObject<HTMLTextAreaElement>) => {
+    const activeConversationId = this.props.id;
+    if (textareaRef && textareaRef.current) {
+      if ((activeConversationId && activeConversationId === textareaRef.current.id) || !activeConversationId) {
+        textareaRef.current.focus();
+      }
+    }
+  };
+
   render() {
-    const { reply, currentUserId } = this.props;
+    const { currentUserId, reply } = this.props;
     const replyIsCurrentUser = currentUserId && reply?.sender && currentUserId === reply.sender.userId;
 
     return (
@@ -61,7 +70,7 @@ export class Container extends React.Component<Properties> {
         onSubmit={this.props.onSubmit}
         getUsersForMentions={this.props.getUsersForMentions}
         renderAfterInput={this.props.renderAfterInput}
-        onMessageInputRendered={this.props.onMessageInputRendered}
+        onMessageInputRendered={this.onMessageInputRendered}
         onRemoveReply={this.props.onRemoveReply}
         viewMode={this.props.viewMode}
         reply={this.props.reply}

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -252,11 +252,6 @@ export class MessageInput extends React.Component<Properties, State> {
     return mentions;
   }
 
-  removeReply = (): void => {
-    this.props.onRemoveReply();
-    this.props.onMessageInputRendered(this.textareaRef);
-  };
-
   mediaSelected = (newMedia: Media[]): void => {
     this.setState({
       media: [
@@ -382,7 +377,7 @@ export class MessageInput extends React.Component<Properties, State> {
               senderIsCurrentUser={this.props.replyIsCurrentUser}
               senderFirstName={reply?.sender?.firstName}
               senderLastName={reply?.sender?.lastName}
-              onRemove={this.removeReply}
+              onRemove={this.props.onRemoveReply}
             />
           )}
         </div>

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -240,7 +240,7 @@ describe('message', () => {
 
     wrapper.find(MessageMenu).simulate('reply');
 
-    expect(onReply).toHaveBeenCalledWith(replyMessage);
+    expect(onReply).toHaveBeenCalledWith({ reply: replyMessage });
   });
 
   it('should not renders edited indicator', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -32,7 +32,7 @@ interface Properties extends MessageModel {
     mentionedUserIds: User['userId'][],
     data?: Partial<EditMessageOptions>
   ) => void;
-  onReply: (reply: ParentMessageType) => void;
+  onReply: ({ reply }: { reply: ParentMessageType }) => void;
   isOwner?: boolean;
   messageId?: number;
   updatedAt: number;
@@ -191,7 +191,7 @@ export class Message extends React.Component<Properties, State> {
   };
 
   onReply = (): void => {
-    this.props.onReply({
+    const reply = {
       messageId: this.props.messageId,
       userId: this.props.sender.userId,
       message: this.props.message,
@@ -202,7 +202,9 @@ export class Message extends React.Component<Properties, State> {
       admin: this.props.admin,
       optimisticId: this.props.optimisticId,
       rootMessageId: this.props.rootMessageId,
-    });
+    };
+
+    this.props.onReply({ reply });
   };
 
   editActions = (value: string, mentionedUserIds: string[]) => {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -27,7 +27,7 @@ import { MessageInput } from '../../message-input/container';
 import { searchMentionableUsersForChannel } from '../../../platform-apps/channels/util/api';
 import { Media } from '../../message-input/utils';
 
-export interface PublicProperties {}
+export interface PublicProperties { }
 
 export interface Properties extends PublicProperties {
   activeConversationId: string;
@@ -42,6 +42,13 @@ export interface Properties extends PublicProperties {
 }
 
 export class Container extends React.Component<Properties> {
+  chatViewContainerRef = null;
+
+  constructor(props: Properties) {
+    super(props);
+    this.chatViewContainerRef = React.createRef();
+  }
+
   static mapState(state: RootState): Partial<Properties> {
     const {
       chat: { activeConversationId },
@@ -185,6 +192,10 @@ export class Container extends React.Component<Properties> {
     if (this.isNotEmpty(message)) {
       this.props.onRemoveReply();
     }
+
+    if (this.chatViewContainerRef?.current) {
+      this.chatViewContainerRef.current.scrollToBottom();
+    }
   };
 
   render() {
@@ -236,17 +247,21 @@ export class Container extends React.Component<Properties> {
             className='direct-message-chat__channel'
             isDirectMessage
             showSenderAvatar={!this.isOneOnOne()}
+            ref={this.chatViewContainerRef}
           />
 
-          <div className='direct-message-chat__footer'>
-            <MessageInput
-              id={this.props.activeConversationId}
-              onSubmit={this.handleSendMessage}
-              getUsersForMentions={this.searchMentionableUsers}
-              reply={this.props.directMessage.reply}
-              onRemoveReply={this.props.onRemoveReply}
-            />
+          <div className='direct-message-chat__footer-position'>
+            <div className='direct-message-chat__footer'>
+              <MessageInput
+                id={this.props.activeConversationId}
+                onSubmit={this.handleSendMessage}
+                getUsersForMentions={this.searchMentionableUsers}
+                reply={this.props.directMessage.reply}
+                onRemoveReply={this.props.onRemoveReply}
+              />
+            </div>
           </div>
+          <div className='direct-message-chat__footer-gradient'></div>
 
           {this.isLeaveGroupDialogOpen && this.renderLeaveGroupDialog()}
         </div>

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -27,16 +27,13 @@ $recent-indicator-size: 8px;
   &__channel {
     .channel-view__main {
       padding-right: 0;
+      margin-bottom: 96px;
     }
 
     &.channel-view {
-      height: calc(100% - $title-bar-height - $header-height);
+      height: 100%;
       display: flex;
       flex-direction: column;
-
-      &__fullscreen {
-        height: 100%;
-      }
     }
   }
 
@@ -82,7 +79,7 @@ $recent-indicator-size: 8px;
 
     @include flat-thick;
 
-    > div:last-child {
+    >div:last-child {
       flex-grow: 1;
       display: flex;
       justify-content: flex-end;
@@ -117,13 +114,42 @@ $recent-indicator-size: 8px;
         background-color: theme.$color-greyscale-9;
       }
 
-      & > * {
+      &>* {
         position: absolute;
         top: calc(50% - 8px);
         line-height: 0px;
         left: calc(50% - 8px);
       }
     }
+  }
+
+  &__footer-position {
+    position: absolute;
+    bottom: 0px;
+    width: 100%;
+    padding: 0px 16px 16px 16px;
+    box-sizing: border-box;
+    z-index: 3;
+  }
+
+  // message-input
+  &__footer {
+    border-radius: 16px;
+    overflow: hidden;
+    flex-shrink: 0;
+
+    @include flat-thick;
+
+    backdrop-filter: blur(32px);
+  }
+
+  &__footer-gradient {
+    position: absolute;
+    bottom: 0px;
+    width: 100%;
+    height: 64px;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.75) 0px, rgba(0, 0, 0, 0.492172) 22px, rgba(0, 0, 0, 0) 64px);
+    z-index: 2;
   }
 
   &__description {

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -9,7 +9,15 @@
   width: $width-sidekick + 32px;
   height: 100%;
   transition: margin animation.$animation-duration-double var(--sidekick-transition-easing-function);
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.492172) 22px, rgba(0, 0, 0, 0) 64px);
+  background: linear-gradient(
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0.492172) 22px,
+    rgba(0, 0, 0, 0) 64px,
+
+    rgba(0, 0, 0, 0) calc(100% - 64px),
+    rgba(0, 0, 0, 0.492172) calc(100% - 22px),
+    rgba(0, 0, 0, 0.75) 100%
+  );
 
   box-sizing: border-box;
   position: relative;

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -4,6 +4,7 @@ import { Message, schema as messageSchema } from '../messages';
 import { schema as userSchema } from '../users';
 import { createAction } from '@reduxjs/toolkit';
 import { Payload, UnreadCountUpdatedPayload } from './types';
+import { ParentMessage } from '../../lib/chat/types';
 
 export interface User {
   userId: string;
@@ -55,6 +56,7 @@ export interface Channel {
   conversationStatus: ConversationStatus;
   messagesFetchStatus: MessagesFetchState;
   adminMatrixIds: string[];
+  reply?: ParentMessage;
 }
 
 export enum SagaActionTypes {
@@ -62,12 +64,16 @@ export enum SagaActionTypes {
   UnreadCountUpdated = 'channels/saga/unreadCountUpdated',
   OpenChannel = 'channels/saga/openChannel',
   OpenConversation = 'channels/saga/openConversation',
+  OnReply = 'channels/saga/onReply',
+  OnRemoveReply = 'channels/saga/onRemoveReply',
 }
 
 const joinChannel = createAction<Payload>(SagaActionTypes.JoinChannel);
 const openChannel = createAction<Payload>(SagaActionTypes.OpenChannel);
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
+const onReply = createAction<{ reply: ParentMessage }>(SagaActionTypes.OnReply);
+const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -80,4 +86,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { joinChannel, unreadCountUpdated, removeAll, openChannel, openConversation };
+export { joinChannel, unreadCountUpdated, removeAll, openChannel, openConversation, onReply, onRemoveReply };

--- a/src/store/redux-container.ts
+++ b/src/store/redux-container.ts
@@ -36,5 +36,5 @@ export function connectContainer<TPublicProps>(
     return dispatchActions;
   }
 
-  return connect(mapStateToProps, mapDispatchToProps)(containerComponent);
+  return connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(containerComponent);
 }


### PR DESCRIPTION
### What does this do?

- refactored `<MessageInput>` component, moved it from `<ChatView>` (lower level) to `<MessengerChat>` (higher level in DOM).
- moved `reply` local state from container to global state in redux.
- added bottom gradient. 
- added background blur on composer
- messages can now be scrolled to the bottom of the composer.

<img width="1491" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/293cb344-b1e3-4855-9ee5-42c3f8430b4c">

<img width="749" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/a1f85d13-8dbb-4fd2-ad07-55ccc1ce1945">
