### PR TITLE
chore: bump zui version (`1.4.0`) -> (`1.5.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
         "@zer0-os/zos-zns": "2.3.3",
-        "@zero-tech/zui": "^1.4.0",
+        "@zero-tech/zui": "^1.5.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8761,9 +8761,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.4.0.tgz",
-      "integrity": "sha512-ROUXOb3k8QZJXuBXNmPOpDqI5IVd0Fx+U1NKueVFHinrT/px5fuuW/a46BfLpL0d704zN+MfTKFvmO0ye7CR6Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.5.0.tgz",
+      "integrity": "sha512-M5ww84k6rLsMyxZNob8bXB8cmKFj0dyxhZdn7KAT3GlFNqhpfsb9DAVGpntE6flLV1kyxsApOIJfHRjAvOFssA==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -38333,9 +38333,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.4.0.tgz",
-      "integrity": "sha512-ROUXOb3k8QZJXuBXNmPOpDqI5IVd0Fx+U1NKueVFHinrT/px5fuuW/a46BfLpL0d704zN+MfTKFvmO0ye7CR6Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.5.0.tgz",
+      "integrity": "sha512-M5ww84k6rLsMyxZNob8bXB8cmKFj0dyxhZdn7KAT3GlFNqhpfsb9DAVGpntE6flLV1kyxsApOIJfHRjAvOFssA==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
     "@zer0-os/zos-zns": "2.3.3",
-    "@zero-tech/zui": "^1.4.0",
+    "@zero-tech/zui": "^1.5.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
chore: bump zui version (`1.4.0`) -> (`1.5.0`)