### PR TITLE
feat: clear invite when closing invite dialog

### DIFF
--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -16,6 +16,7 @@ describe('Container', () => {
       maxUses: 0,
       isLoading: false,
       fetchInvite: () => null,
+      clearInvite: () => null,
       ...props,
     };
 
@@ -27,6 +28,15 @@ describe('Container', () => {
     subject({ fetchInvite });
 
     expect(fetchInvite).toHaveBeenCalledOnce();
+  });
+
+  it('clears the invite code when unmounted', function () {
+    const clearInvite = jest.fn();
+    const wrapper = subject({ clearInvite });
+
+    wrapper.unmount();
+
+    expect(clearInvite).toHaveBeenCalled();
   });
 
   describe('mapState', () => {

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -24,7 +24,7 @@ export interface Properties extends PublicProperties {
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const { createInvitation } = state;
-    console.log('CREATE INVITATION', createInvitation);
+
     return {
       inviteCode: createInvitation.code,
       inviteUrl: createInvitation.url,

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RootState } from '../../store/reducer';
 import { InviteDialog } from '.';
 import { connectContainer } from '../../store/redux-container';
-import { fetchInvite } from '../../store/create-invitation';
+import { clearInvite, fetchInvite } from '../../store/create-invitation';
 import { config } from '../../config';
 
 export interface PublicProperties {
@@ -18,12 +18,13 @@ export interface Properties extends PublicProperties {
   isLoading: boolean;
 
   fetchInvite: () => void;
+  clearInvite: () => void;
 }
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const { createInvitation } = state;
-
+    console.log('CREATE INVITATION', createInvitation);
     return {
       inviteCode: createInvitation.code,
       inviteUrl: createInvitation.url,
@@ -35,11 +36,15 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { fetchInvite };
+    return { fetchInvite, clearInvite };
   }
 
   componentDidMount() {
     this.props.fetchInvite();
+  }
+
+  componentWillUnmount() {
+    this.props.clearInvite();
   }
 
   render() {

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { InviteDialog, Properties } from '.';
+import { Button } from '@zero-tech/zui/components';
 
 describe('InviteDialog', () => {
   const subject = (props: Partial<Properties>) => {
@@ -20,65 +21,39 @@ describe('InviteDialog', () => {
     return shallow(<InviteDialog {...allProps} />);
   };
 
-  it('renders the code', function () {
-    const wrapper = subject({ inviteCode: '23817' });
+  it('renders the code remaining number of invites', function () {
+    const wrapper = subject({ inviteCode: '23817', maxUses: 5, invitesUsed: 3 });
 
-    expect(wrapper.find('textarea').prop('value')).toContain('23817');
+    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
   });
 
   it('copies the invitation to the clipboard', function () {
     const clipboard = { write: jest.fn() };
     const wrapper = subject({ clipboard, inviteCode: '23817' });
 
-    wrapper.find('.invite-dialog__inline-button').simulate('click');
+    wrapper.find(Button).simulate('press');
 
-    expect(wrapper.find('.invite-dialog__inline-button').prop('disabled')).toBeFalse();
+    expect(wrapper.find(Button).prop('isDisabled')).toBeFalse();
     expect(clipboard.write).toHaveBeenCalledWith(expect.stringContaining('23817'));
   });
 
-  it('sets button text to copied for a few seconds after copying the text', async function () {
+  it('sets copy text to copied for a few seconds after copying the text', async function () {
     const clipboard = { write: jest.fn().mockResolvedValue(null) };
     jest.useFakeTimers();
     const wrapper = subject({ clipboard });
 
-    wrapper.find('.invite-dialog__inline-button').simulate('click');
+    wrapper.find(Button).simulate('press');
     await new Promise(setImmediate);
 
-    expect(wrapper.find('.invite-dialog__inline-button').text()).toEqual('COPIED');
+    expect(wrapper.state('copyText')).toEqual('Copied');
     jest.runAllTimers();
-    expect(wrapper.find('.invite-dialog__inline-button').text()).toEqual('COPY');
-  });
-
-  it('does not render the text content if no invite code', function () {
-    const wrapper = subject({ inviteCode: '' });
-
-    expect(wrapper.find('.invite-dialog__code-block').text()).not.toContain('Here is an invite');
-  });
-
-  it('does not render the text content if isLoading is true ', function () {
-    const wrapper = subject({ inviteCode: '12345', isLoading: true });
-
-    expect(wrapper.find('.invite-dialog__code-block').text()).not.toContain('Here is an invite');
+    expect(wrapper.state('copyText')).toEqual('Copy Invite Code');
   });
 
   it('disables copy button if code does not exist', function () {
     const wrapper = subject({ inviteCode: '' });
 
-    expect(wrapper.find('.invite-dialog__inline-button').prop('disabled')).toBeTrue();
-  });
-
-  describe('invite text', () => {
-    it('renders the invite code in a textarea', function () {
-      const wrapper = subject({ inviteCode: '23817' });
-
-      expect(wrapper.find('textarea').prop('value')).toContain('23817');
-    });
-
-    it('should not be editable', function () {
-      const wrapper = subject({ inviteCode: '23817' });
-
-      expect(wrapper.find('textarea').prop('readOnly')).toBeTrue();
-    });
+    expect(wrapper.find(Button).prop('isDisabled')).toBeTrue();
   });
 
   it('publishes close event.', function () {
@@ -88,15 +63,5 @@ describe('InviteDialog', () => {
     wrapper.find('IconButton').simulate('click');
 
     expect(onClose).toHaveBeenCalled();
-  });
-
-  it('displays text in green if invites remaining', function () {
-    // 2 invites left
-    let wrapper = subject({ inviteCode: '123456', invitesUsed: 3, maxUses: 5 });
-    expect(wrapper.find('.invite-dialog__invite-left').exists()).toBeTrue();
-
-    // no invite left
-    wrapper = subject({ inviteCode: '123456', invitesUsed: 5, maxUses: 5 });
-    expect(wrapper.find('.invite-dialog__invite-left').exists()).toBeFalse();
   });
 });

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
 
-import { Image, Skeleton, IconButton } from '@zero-tech/zui/components';
-import { IconXClose, IconGift1 } from '@zero-tech/zui/icons';
+import { Image, IconButton, Button } from '@zero-tech/zui/components';
+import { IconXClose } from '@zero-tech/zui/icons';
 
 import { clipboard } from '../../lib/clipboard';
+import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
 
-import { bem, bemClassName } from '../../lib/bem';
-import classNames from 'classnames';
-
-const c = bem('invite-dialog');
 const cn = bemClassName('invite-dialog');
 
 export interface Clipboard {
@@ -34,7 +31,7 @@ interface State {
 }
 
 export class InviteDialog extends React.Component<Properties, State> {
-  state = { copyText: 'COPY' };
+  state = { copyText: 'Copy Invite Code' };
   buttonTimeout = null;
 
   static defaultProps = { clipboard: clipboard };
@@ -48,20 +45,14 @@ export class InviteDialog extends React.Component<Properties, State> {
   }
 
   get inviteText() {
-    return (
-      // eslint-disable-next-line
-      "Here's your invite code for ZERO Messenger:\n" +
-      `${this.props.inviteCode}\n\n` +
-      'Join early, earn more:\n' +
-      `${this.props.inviteUrl}`
-    );
+    return this.props.inviteCode;
   }
 
   writeInviteToClipboard = async () => {
     try {
       await this.props.clipboard.write(this.inviteText);
-      this.setState({ copyText: 'COPIED' });
-      this.buttonTimeout = setTimeout(() => this.setState({ copyText: 'COPY' }), 3000);
+      this.setState({ copyText: 'Copied' });
+      this.buttonTimeout = setTimeout(() => this.setState({ copyText: 'Copy Invite Code' }), 3000);
     } catch (e) {
       // Assume copying succeeds. There's not much we can do if it fails.
     }
@@ -70,49 +61,27 @@ export class InviteDialog extends React.Component<Properties, State> {
   render() {
     return (
       <div {...cn('')}>
-        <div {...cn('title-bar')}>
-          <h3 {...cn('title')}>Invite to ZERO Messenger</h3>
-          <IconButton {...cn('close')} size={32} Icon={IconXClose} onClick={this.props.onClose} />
-        </div>
-        <div {...cn('content')}>
-          <Image
-            src={`${this.props.assetsPath}/InviteFriends.png`}
-            alt='Hands reaching out to connect'
-            {...cn('image')}
-          />
+        <IconButton {...cn('close')} size={40} Icon={IconXClose} onClick={this.props.onClose} />
 
-          <div {...cn('heading')}>Invite a friend. Chat on ZERO. Earn rewards.</div>
-          <div {...cn('byline')}>
-            The more active you are, the more you earn. Take back ownership of your content and get rewarded.
-            <br />
-          </div>
-          <div {...cn('code-block')}>
-            {this.props.inviteCode || !this.props.isLoading ? (
-              <textarea readOnly={true} value={this.inviteText} />
-            ) : (
-              <Skeleton width={'100%'} height={'100px'} />
+        <Image
+          {...cn('image')}
+          src={`${this.props.assetsPath}/InviteFriends.png`}
+          alt='Hands reaching out to connect'
+        />
+        <div {...cn('heading')}>Invite a friend. Earn rewards.</div>
+
+        <div>
+          <Button onPress={this.writeInviteToClipboard} isDisabled={!this.props.inviteCode}>
+            {this.state.copyText}
+          </Button>
+
+          <div {...cn('remaining-invite-container')}>
+            {!this.props.isLoading && (
+              <>
+                <div {...cn('remaining-invite')}>{this.getInvitesRemaining()}</div>
+                <>Remaining</>
+              </>
             )}
-            <button
-              {...cn('inline-button', 'right')}
-              onClick={this.writeInviteToClipboard}
-              disabled={!this.props.inviteCode}
-            >
-              {this.state.copyText}
-            </button>
-          </div>
-          <div
-            className={classNames(c('remaining-invite-container'), {
-              [c('invite-left')]: this.getInvitesRemaining() !== 0 && !this.props.isLoading,
-            })}
-          >
-            <IconGift1 />
-            <div {...cn(!this.props.isLoading && 'remaining-invite')}>
-              {!this.props.isLoading && (
-                <>
-                  <b>{this.getInvitesRemaining()}</b> of <b>{this.props.maxUses}</b> invites remaining
-                </>
-              )}
-            </div>
           </div>
         </div>
       </div>

--- a/src/components/invite-dialog/styles.scss
+++ b/src/components/invite-dialog/styles.scss
@@ -1,4 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../variables';
+@import '../../glass';
 
 @keyframes fadeIn {
   0% {
@@ -10,157 +12,59 @@
 }
 
 .invite-dialog {
-  width: 548px;
+  display: flex;
+  padding-bottom: 16px;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  align-self: stretch;
+  position: relative;
 
-  &__title-bar {
-    display: flex;
-    height: 53px;
-    border-bottom: 1px solid theme.$color-primary-4;
-    margin-left: 10px;
-
-    color: theme.$color-greyscale-12;
-
-    > *:first-child {
-      flex-grow: 1;
-    }
-
-    > *:last-child {
-      flex-grow: 0;
-    }
-  }
-
-  &__title {
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 29px;
-    margin: 0px;
-  }
+  width: 256px;
 
   &__close {
+    position: absolute;
+    right: -8px;
+    top: -8px;
+    z-index: 2;
+
     &:focus-visible {
       outline: none;
     }
   }
 
   &__image {
-    width: 100%;
-    height: 312px;
+    width: 248px;
+    height: 188px;
   }
 
   &__heading {
-    font-style: normal;
-    font-weight: 700;
+    @include glass-text-primary-color;
+
+    text-align: center;
+    font-weight: 600;
     font-size: 24px;
     line-height: 29px;
-
-    color: theme.$color-greyscale-12;
-  }
-
-  &__byline {
-    margin-top: 12px;
-    margin-bottom: 16px;
-    color: theme.$color-greyscale-11;
-    font-style: normal;
-    font-weight: 400;
-    font-size: 14px;
-  }
-
-  &__code-block {
-    border: 1px solid theme.$color-greyscale-6;
-    background: theme.$color-greyscale-2;
-    border-radius: 8px;
-
-    color: theme.$color-greyscale-11;
-    font-weight: 400;
-    font-size: 16px;
-
-    display: flex;
-
-    textarea {
-      background: none;
-      color: inherit;
-      font-size: inherit;
-      resize: none;
-      border-radius: inherit;
-      outline: none;
-      border: none;
-      animation: fadeIn 0.2s ease-in;
-
-      &::-webkit-scrollbar {
-        display: none;
-      }
-
-      height: 100px;
-    }
-
-    & > *:first-child {
-      flex-grow: 1;
-      padding: 9px;
-    }
-
-    & > *:last-child {
-      flex-grow: 0;
-      cursor: pointer;
-    }
-  }
-
-  &__inline-button--right {
-    padding: 8px;
-    margin: 0px;
-    border-width: 0px;
-    border-left: 1px solid theme.$color-secondary-6;
-    border-radius: 8px;
-    border-top-left-radius: 0px;
-    border-bottom-left-radius: 0px;
-    background-color: theme.$color-secondary-1;
-    color: theme.$color-secondary-11;
-    width: 70px;
-    font-weight: 700;
-    font-size: 14px;
-    line-height: 17px;
-
-    &:hover {
-      background-color: theme.$color-secondary-4;
-    }
-
-    &:active {
-      background-color: theme.$color-secondary-5;
-      box-shadow: 0px 0px 16px rgba(1, 250, 195, 0.75);
-    }
-
-    &:focus-visible {
-      outline: none;
-    }
-
-    &:disabled {
-      background-color: transparent;
-      cursor: not-allowed;
-      color: theme.$color-greyscale-11;
-      border-color: theme.$color-greyscale-6;
-
-      &:active {
-        box-shadow: none;
-      }
-    }
+    width: 171px;
   }
 
   &__remaining-invite-container {
+    @include glass-text-secondary-color;
+
     display: flex;
-    flex-direction: row;
-    padding: 12px;
-    gap: 10px;
+    justify-content: center;
     align-items: center;
+    font-size: $font-size-medium;
+    line-height: 17px;
+    gap: 4px;
+    height: 20px;
 
-    background: theme.$color-primary-3;
-    border-radius: 8px;
     margin-top: 16px;
-  }
-
-  &__remaining-invite {
     animation: fadeIn 0.2s ease-in;
   }
 
-  &__invite-left {
-    color: theme.$color-success-11;
+  &__remaining-invite {
+    font-weight: 600;
+    line-height: 20px;
   }
 }

--- a/src/store/create-invitation/index.ts
+++ b/src/store/create-invitation/index.ts
@@ -6,6 +6,7 @@ export enum SagaActionTypes {
 }
 
 export const fetchInvite = createAction(SagaActionTypes.GetCode);
+export const clearInvite = createAction(SagaActionTypes.Cancel);
 
 export type CreateInvitationState = {
   code: string;

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -35,7 +35,12 @@ function* clearOnLogout() {
   yield put(reset());
 }
 
+export function* clearInvite() {
+  yield put(reset());
+}
+
 export function* saga() {
   yield takeLeading(SagaActionTypes.GetCode, fetchInvite);
   yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
+  yield takeLeading(SagaActionTypes.Cancel, clearInvite);
 }


### PR DESCRIPTION
### What does this do?
- dispatch a `clearInvite` saga action to clear the invite when the invite dialog is closed.

### Why are we making this change?
Issue:
The InviteDialog component's button flickers between disabled and enabled states on subsequent openings. Initially, on first opening, the inviteCode is not present, so the button is correctly disabled. However, on closing and reopening the dialog, the button quickly toggles from enabled (as inviteCode is initially present) to disabled (as inviteCode is momentarily cleared due to a reset() in the fetch saga) and back to enabled (after inviteCode is refetched and set).

Root Cause:
The fetchInvite saga always resets the inviteCode state on each call, causing the inviteCode to be temporarily undefined even if it was previously fetched. This reset, followed by a refetch, leads to flickering behaviour of the button tied to the inviteCode's availability.


### How do I test this?
Open invite dialog on first load > check disabled state is as expected > close dialog and reopen > check disabled state of button again.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:


https://github.com/zer0-os/zOS/assets/39112648/118728b5-fe2d-420f-a024-c7bf5295ce61



After:


https://github.com/zer0-os/zOS/assets/39112648/c643d043-be0c-499f-9dea-6d1ff417711c

