### PR TITLE
Call openConversation rather than just setting state

### DIFF
--- a/src/store/channels-list/saga.createConversation.test.ts
+++ b/src/store/channels-list/saga.createConversation.test.ts
@@ -15,10 +15,10 @@ import {
   MessagesFetchState,
   denormalize as denormalizeChannel,
 } from '../channels';
-import { setactiveConversationId } from '../chat';
 import { StoreBuilder } from '../test/store';
 import { AdminMessageType } from '../messages';
 import { chat } from '../../lib/chat';
+import { openConversation } from '../channels/saga';
 
 describe(createConversation, () => {
   it('creates the conversation - full success flow', async () => {
@@ -42,7 +42,7 @@ describe(createConversation, () => {
       .next(true)
       .call(createOptimisticConversation, otherUserIds, name, image)
       .next(stubOptimisticConversation)
-      .put(setactiveConversationId(stubOptimisticConversation.id))
+      .call(openConversation, stubOptimisticConversation.id)
       .next()
       .select(userSelector, otherUserIds)
       .next([{ userId: 'user-1' }])

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -7,6 +7,7 @@ import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
 import { setActiveChannelId, setactiveConversationId } from '../chat';
 import { chat } from '../../lib/chat';
+import { mostRecentConversation } from '../channels-list/selectors';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -71,6 +72,15 @@ export function* openChannel(channelId) {
 
   yield put(setActiveChannelId(channelId));
   yield spawn(markChannelAsRead, channelId);
+}
+
+export function* openFirstConversation() {
+  const conversation = yield select(mostRecentConversation);
+  if (conversation) {
+    yield call(openConversation, conversation.id);
+  } else {
+    yield put(setactiveConversationId(''));
+  }
 }
 
 export function* openConversation(conversationId) {

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,7 +1,6 @@
 import { put, call, select, race, take, fork, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, setGroupUsers, setStage } from '.';
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
-import { setactiveConversationId } from '../chat';
 import { Events, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/selectors';
 import { Chat, chat } from '../../lib/chat';
@@ -44,7 +43,7 @@ export function* performGroupMembersSelected(userSelections: { value: string; la
   } else {
     const selectedConversation = existingConversations[0];
     yield call(channelsReceived, { payload: { channels: [selectedConversation] } });
-    yield put(setactiveConversationId(selectedConversation.id));
+    yield call(openConversation, selectedConversation.id);
     return Stage.None;
   }
 }

--- a/src/store/login/saga.test.ts
+++ b/src/store/login/saga.test.ts
@@ -1,6 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan';
 
-import { emailLogin, openFirstConversation, validateEmailLogin } from './saga';
+import { emailLogin, validateEmailLogin } from './saga';
 
 import { call } from 'redux-saga/effects';
 
@@ -8,9 +8,7 @@ import { EmailLoginErrors, LoginStage, LoginState, initialState as initialRegist
 
 import { rootReducer } from '../reducer';
 import { throwError } from 'redux-saga-test-plan/providers';
-import { setactiveConversationId } from '../chat';
 import { authenticateByEmail } from '../authentication/saga';
-import { StoreBuilder } from '../test/store';
 
 describe('emailLogin', () => {
   it('logs the user in', async () => {
@@ -134,17 +132,6 @@ describe('validateEmailLogin', () => {
     const errors = validateEmailLogin({ email, password });
 
     expect(errors).toEqual([EmailLoginErrors.PASSWORD_REQUIRED]);
-  });
-});
-
-describe(openFirstConversation, () => {
-  it('opens the first conversation', async () => {
-    const initialState = new StoreBuilder().withConversationList({ id: '1234' });
-
-    await expectSaga(openFirstConversation)
-      .withReducer(rootReducer, initialState.build())
-      .put(setactiveConversationId('1234'))
-      .run();
   });
 });
 

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -17,8 +17,7 @@ import { setWalletModalOpen } from '../web3';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { Web3Events, getWeb3Channel } from '../web3/channels';
 import { ConversationEvents, getConversationsBus } from '../channels-list/channels';
-import { openConversation } from '../channels/saga';
-import { mostRecentConversation } from '../channels-list/selectors';
+import { openFirstConversation } from '../channels/saga';
 
 export function* emailLogin(action) {
   const { email, password } = action.payload;
@@ -150,13 +149,6 @@ function* listenForUserLogin() {
     if (yield call(isWeb3AccountConnected)) {
       yield spawn(listenForWeb3AccountChanges);
     }
-  }
-}
-
-export function* openFirstConversation() {
-  const conversation = yield select(mostRecentConversation);
-  if (conversation) {
-    yield call(openConversation, conversation.id);
   }
 }
 


### PR DESCRIPTION
### What does this do?

Refactors sagas to call `openConversation` when that's what they mean rather than old direct data setting `setactiveConversationId`. This helps readability as the sagas now show the intention better but also allows us to modify what it means to open a conversation more easily.

