### PR TITLE
chore: bump zOS version (`1.3.0`) -> (`1.4.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zOS",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zOS",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@craco/craco": "^6.4.3",
         "@giphy/js-fetch-api": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zOS",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "main": "./public/electron.js",
   "engines": {


### PR DESCRIPTION
chore: bump version (`1.3.0`) -> (`1.4.0`)