### PR TITLE
Make conversations routable

### DIFF
--- a/src/components/dev-panel/container.tsx
+++ b/src/components/dev-panel/container.tsx
@@ -38,7 +38,7 @@ export class Container extends React.Component<Properties, State> {
 
     let messages = [];
     if (activeConversationId) {
-      const channel = denormalizeChannel(activeConversationId, state) || null;
+      const channel = denormalizeChannel(activeConversationId, state) || {};
       messages = channel.messages || [];
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import { store, runSagas } from './store';
 import { Provider } from 'react-redux';
 import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
-import { Router, Redirect, Route } from 'react-router-dom';
+import { Router, Redirect, Route, Switch } from 'react-router-dom';
 import { ContextProvider as Web3ReactContextProvider } from './lib/web3/web3-react';
 import { showReleaseVersionInConsole, initializeErrorBoundary } from './utils';
 import { ErrorBoundary } from './components/error-boundary/';
@@ -27,14 +27,7 @@ showReleaseVersionInConsole();
 
 export const history = getHistory();
 
-const redirectToDefaults = ({ match: { params } }) => {
-  const route = params.znsRoute;
-  if (route === 'get-access') return <Redirect to={'/get-access'} />;
-  if (route === 'login') return <Redirect to={'/login'} />;
-  if (route === 'reset-password') return <ResetPassword />;
-
-  return <Redirect to={'/'} />;
-};
+const redirectToRoot = () => <Redirect to={'/'} />;
 
 ReactDOM.render(
   <React.StrictMode>
@@ -44,11 +37,14 @@ ReactDOM.render(
           <Router history={history}>
             <Web3ReactContextProvider>
               <Web3Connect>
-                <Route path='/get-access' exact component={Invite} />
-                <Route path='/login' exact component={LoginPage} />
-                <Route path='/reset-password' exact component={ResetPassword} />
-                <Route path='/' exact component={MessengerMain} />
-                <Route path='/:znsRoute' render={redirectToDefaults} />
+                <Switch>
+                  <Route path='/get-access' exact component={Invite} />
+                  <Route path='/login' exact component={LoginPage} />
+                  <Route path='/reset-password' exact component={ResetPassword} />
+                  <Route path='/conversation/:conversationId' exact component={MessengerMain} />
+                  <Route path='/' exact component={MessengerMain} />
+                  <Route component={redirectToRoot} />
+                </Switch>
               </Web3Connect>
             </Web3ReactContextProvider>
           </Router>

--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -1,28 +1,27 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Container } from './messenger-main';
+import { Container, Properties } from './messenger-main';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Main } from './Main';
 
 describe('MessengerMain', () => {
-  const mockIsAuthenticated = true;
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps = {
+      isAuthenticated: false,
+      match: { params: { conversationId: '' } },
+      setActiveConversationId: () => null,
+      ...props,
+    };
 
-  const subject = (isAuthenticated = mockIsAuthenticated) => {
-    return shallow(
-      <Container
-        isAuthenticated={isAuthenticated}
-        match={{ params: { conversationId: '' } }}
-        setActiveConversationId={() => null}
-      />
-    );
+    return shallow(<Container {...allProps} />);
   };
 
   it('contains AuthenticationContextProvider with the correct context', () => {
-    const wrapper = subject();
+    const wrapper = subject({ isAuthenticated: true });
     const provider = wrapper.find(AuthenticationContextProvider);
     expect(provider).toHaveLength(1);
-    expect(provider.prop('value')).toEqual({ isAuthenticated: mockIsAuthenticated });
+    expect(provider.prop('value')).toEqual({ isAuthenticated: true });
   });
 
   it('contains the ZUIProvider', () => {
@@ -33,5 +32,12 @@ describe('MessengerMain', () => {
   it('renders the Main component', () => {
     const wrapper = subject();
     expect(wrapper.find(Main)).toHaveLength(1);
+  });
+
+  it('parses the conversationId from the url on mount', () => {
+    const setActiveConversationId = jest.fn();
+    subject({ setActiveConversationId, match: { params: { conversationId: '123' } } });
+
+    expect(setActiveConversationId).toHaveBeenCalledWith('123');
   });
 });

--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -9,7 +9,13 @@ describe('MessengerMain', () => {
   const mockIsAuthenticated = true;
 
   const subject = (isAuthenticated = mockIsAuthenticated) => {
-    return shallow(<Container isAuthenticated={isAuthenticated} />);
+    return shallow(
+      <Container
+        isAuthenticated={isAuthenticated}
+        match={{ params: { conversationId: '' } }}
+        setActiveConversationId={() => null}
+      />
+    );
   };
 
   it('contains AuthenticationContextProvider with the correct context', () => {

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -5,9 +5,13 @@ import { connectContainer } from './store/redux-container';
 import { Main } from './Main';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
+import { setactiveConversationId } from './store/chat';
 
 export interface Properties {
   isAuthenticated: boolean;
+
+  match: { params: { conversationId: string } };
+  setactiveConversationId: (id: string) => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -18,7 +22,13 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions() {
-    return {};
+    return {
+      setactiveConversationId,
+    };
+  }
+
+  componentDidMount(): void {
+    this.props.setactiveConversationId(this.conversationId);
   }
 
   get authenticationContext() {
@@ -26,6 +36,10 @@ export class Container extends React.Component<Properties> {
     return {
       isAuthenticated,
     };
+  }
+
+  get conversationId() {
+    return this.props.match?.params?.conversationId || '';
   }
 
   render() {

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -5,13 +5,13 @@ import { connectContainer } from './store/redux-container';
 import { Main } from './Main';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { setactiveConversationId } from './store/chat';
+import { setActiveConversationId } from './store/chat';
 
 export interface Properties {
   isAuthenticated: boolean;
 
   match: { params: { conversationId: string } };
-  setactiveConversationId: (id: string) => void;
+  setActiveConversationId: (id: string) => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -23,12 +23,12 @@ export class Container extends React.Component<Properties> {
 
   static mapActions() {
     return {
-      setactiveConversationId,
+      setActiveConversationId,
     };
   }
 
   componentDidMount(): void {
-    this.props.setactiveConversationId(this.conversationId);
+    this.props.setActiveConversationId(this.conversationId);
   }
 
   get authenticationContext() {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -5,9 +5,10 @@ import { joinChannel as joinChannelAPI } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
-import { setActiveChannelId, setactiveConversationId } from '../chat';
+import { setActiveChannelId } from '../chat';
 import { chat } from '../../lib/chat';
 import { mostRecentConversation } from '../channels-list/selectors';
+import { setActiveConversation } from '../chat/saga';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -79,7 +80,7 @@ export function* openFirstConversation() {
   if (conversation) {
     yield call(openConversation, conversation.id);
   } else {
-    yield put(setactiveConversationId(''));
+    yield call(setActiveConversation, '');
   }
 }
 
@@ -88,7 +89,7 @@ export function* openConversation(conversationId) {
     return;
   }
 
-  yield put(setactiveConversationId(conversationId));
+  yield call(setActiveConversation, conversationId);
   yield spawn(markConversationAsRead, conversationId);
 }
 

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -21,7 +21,7 @@ const slice = createSlice({
     setChatAccessToken: (state, action: PayloadAction<ChatState['chatAccessToken']>) => {
       state.chatAccessToken = action.payload;
     },
-    setactiveConversationId: (state, action: PayloadAction<ChatState['activeConversationId']>) => {
+    setActiveConversationId: (state, action: PayloadAction<ChatState['activeConversationId']>) => {
       state.activeConversationId = action.payload;
     },
     setActiveChannelId: (state, action: PayloadAction<ChatState['activeChannelId']>) => {
@@ -30,5 +30,5 @@ const slice = createSlice({
   },
 });
 
-export const { setChatAccessToken, setReconnecting, setactiveConversationId, setActiveChannelId } = slice.actions;
+export const { setChatAccessToken, setReconnecting, setActiveConversationId, setActiveChannelId } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -1,7 +1,7 @@
 import { put, select, call, take, takeEvery, spawn, race } from 'redux-saga/effects';
 import { takeEveryFromBus } from '../../lib/saga';
 
-import { setActiveChannelId, setReconnecting, setactiveConversationId } from '.';
+import { setActiveChannelId, setReconnecting, setActiveConversationId } from '.';
 import { startChannelsAndConversationsAutoRefresh } from '../channels-list';
 import { Events, createChatConnection, getChatBus } from './bus';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
@@ -69,7 +69,7 @@ function* activateWhenConversationsLoaded(activate) {
 
 function* clearOnLogout() {
   yield put(setActiveChannelId(null));
-  yield put(setactiveConversationId(null));
+  yield put(setActiveConversationId(null));
 }
 
 function* addAdminUser() {
@@ -77,7 +77,7 @@ function* addAdminUser() {
 }
 
 export function* setActiveConversation(id: string) {
-  yield put(setactiveConversationId(id));
+  yield put(setActiveConversationId(id));
 }
 
 export function* saga() {

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -76,8 +76,13 @@ function* addAdminUser() {
   yield put(receive({ userId: 'admin', firstName: 'Admin', profileImage: null, matrixId: 'admin' }));
 }
 
+export function* setActiveConversation(id: string) {
+  yield put(setactiveConversationId(id));
+}
+
 export function* saga() {
   yield spawn(connectOnLogin);
+
   const authBus = yield call(getAuthChannel);
   yield takeEveryFromBus(authBus, AuthEvents.UserLogout, clearOnLogout);
   yield takeEveryFromBus(authBus, AuthEvents.UserLogin, addAdminUser);

--- a/src/store/chat/selectors.ts
+++ b/src/store/chat/selectors.ts
@@ -3,3 +3,7 @@ import { RootState } from '../reducer';
 export function activeChannelIdSelector(state: RootState) {
   return state.chat.activeChannelId;
 }
+
+export function activeConversationIdSelector(state: RootState) {
+  return state.chat.activeConversationId;
+}

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -18,6 +18,7 @@ import { Events as AuthEvents, getAuthChannel } from '../authentication/channels
 import { Web3Events, getWeb3Channel } from '../web3/channels';
 import { ConversationEvents, getConversationsBus } from '../channels-list/channels';
 import { openFirstConversation } from '../channels/saga';
+import { activeConversationIdSelector } from '../chat/selectors';
 
 export function* emailLogin(action) {
   const { email, password } = action.payload;
@@ -155,9 +156,8 @@ function* listenForUserLogin() {
 export function* openFirstConversationAfterChannelsLoaded() {
   const channel = yield call(getConversationsBus);
   yield take(channel, ConversationEvents.ConversationsLoaded);
-
-  const isMessengerFullScreen = yield select((state) => getDeepProperty(state, 'layout.value.isMessengerFullScreen'));
-  if (isMessengerFullScreen) {
+  const activeConversationId = yield select(activeConversationIdSelector);
+  if (!activeConversationId) {
     yield call(openFirstConversation);
   }
 }

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -1,4 +1,3 @@
-import getDeepProperty from 'lodash.get';
 import { call, put, race, select, spawn, take, takeLatest } from 'redux-saga/effects';
 
 import {


### PR DESCRIPTION
### What does this do?

1. Adds route parsing for conversations
1. When loading the url, parses the id and opens it rather than the top conversation

Eg: http://example.com/conversation/!URmXfWMRTpYQZBXEzV:zero-synapse-development.zer0.io

Still to come:
* Change the url when opening a conversation