### PR TITLE
Manage the open conversation via the URL

### DIFF
--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -40,4 +40,30 @@ describe('MessengerMain', () => {
 
     expect(setActiveConversationId).toHaveBeenCalledWith('123');
   });
+
+  it('updates the conversation id when the route changes', () => {
+    const setActiveConversationId = jest.fn();
+    const wrapper = subject({ setActiveConversationId, match: { params: { conversationId: '123' } } });
+
+    expect(setActiveConversationId).toHaveBeenCalledWith('123');
+    jest.clearAllMocks();
+
+    wrapper.setProps({ match: { params: { conversationId: '456' } } });
+    expect(setActiveConversationId).toHaveBeenCalledWith('456');
+  });
+
+  it('does not update the conversation id when the route does not change', () => {
+    const setActiveConversationId = jest.fn();
+    const wrapper = subject({
+      setActiveConversationId,
+      match: { params: { conversationId: '123' } },
+      isAuthenticated: true, // To allow us to force a property change
+    });
+
+    expect(setActiveConversationId).toHaveBeenCalledWith('123');
+    jest.clearAllMocks();
+
+    wrapper.setProps({ isAuthenticated: false }); // force prop change without changing `match`
+    expect(setActiveConversationId).not.toHaveBeenCalled();
+  });
 });

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -31,6 +31,12 @@ export class Container extends React.Component<Properties> {
     this.props.setActiveConversationId(this.conversationId);
   }
 
+  componentDidUpdate(prevProps: Properties): void {
+    if (this.idChanged(prevProps)) {
+      this.props.setActiveConversationId(this.conversationId);
+    }
+  }
+
   get authenticationContext() {
     const { isAuthenticated } = this.props;
     return {
@@ -39,7 +45,15 @@ export class Container extends React.Component<Properties> {
   }
 
   get conversationId() {
-    return this.props.match?.params?.conversationId || '';
+    return this.idFrom(this.props);
+  }
+
+  idChanged(prevProps: Properties) {
+    return this.idFrom(prevProps) !== this.conversationId;
+  }
+
+  idFrom(props: Properties) {
+    return props.match?.params?.conversationId || '';
   }
 
   render() {

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -26,6 +26,7 @@ import { StoreBuilder } from '../test/store';
 import { expectSaga } from '../../test/saga';
 import { getZEROUsers } from './api';
 import { mapAdminUserIdToZeroUserId, mapChannelMembers } from './utils';
+import { openFirstConversation } from '../channels/saga';
 
 const mockChannel = (id: string) => ({
   id: `channel_${id}`,
@@ -200,11 +201,11 @@ describe('channels list saga', () => {
         .withActiveConversation({ id: channelId })
         .build();
 
-      const { storeState } = await expectSaga(userLeftChannel, channelId, 'matrix-id')
+      await expectSaga(userLeftChannel, channelId, 'matrix-id')
+        .provide([[matchers.call.fn(openFirstConversation), null]])
         .withReducer(rootReducer, initialState)
+        .call(openFirstConversation)
         .run();
-
-      expect(storeState.chat.activeConversationId).toEqual('conversation-2');
     });
   });
 

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -80,6 +80,7 @@ export function* openFirstConversation() {
   if (conversation) {
     yield call(openConversation, conversation.id);
   } else {
+    // Not sure this is the right choice. Maybe there's a redirectToRoot at some point.
     yield call(setActiveConversation, '');
   }
 }

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -11,6 +11,7 @@ import { saveUserMatrixCredentials } from '../edit-profile/saga';
 import { receive } from '../users';
 import { chat } from '../../lib/chat';
 import { ConversationEvents, getConversationsBus } from '../channels-list/channels';
+import { getHistory } from '../../lib/browser';
 
 function* listenForReconnectStart(_action) {
   yield put(setReconnecting(true));
@@ -76,8 +77,10 @@ function* addAdminUser() {
   yield put(receive({ userId: 'admin', firstName: 'Admin', profileImage: null, matrixId: 'admin' }));
 }
 
+// The selected conversation is managed via the URL
 export function* setActiveConversation(id: string) {
-  yield put(setActiveConversationId(id));
+  const history = yield call(getHistory);
+  history.push({ pathname: `/conversation/${id}` });
 }
 
 export function* saga() {

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -15,6 +15,7 @@ import { channelsReceived, createConversation as performCreateConversation } fro
 import { rootReducer } from '../reducer';
 import { StoreBuilder } from '../test/store';
 import { chat } from '../../lib/chat';
+import { openConversation } from '../channels/saga';
 
 describe('create conversation saga', () => {
   describe('startConversation', () => {
@@ -87,6 +88,7 @@ describe('create conversation saga', () => {
           [matchers.call.fn(channelsReceived), null],
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.fetchConversationsWithUsers), []],
+          [matchers.call.fn(openConversation), null],
         ])
         .withReducer(rootReducer, defaultState());
     }
@@ -114,11 +116,10 @@ describe('create conversation saga', () => {
     });
 
     it('opens the existing conversation', async () => {
-      const { storeState } = await subject(performGroupMembersSelected, [])
+      await subject(performGroupMembersSelected, [])
         .provide([[matchers.call.fn(chatClient.fetchConversationsWithUsers), [{ id: 'convo-1' }]]])
+        .call(openConversation, 'convo-1')
         .run();
-
-      expect(storeState.chat.activeConversationId).toBe('convo-1');
     });
 
     it('returns to initial state when existing conversation selected', async () => {


### PR DESCRIPTION
### What does this do?

This manages the open conversation via the URL.

### Why are we making this change?

Makes routable conversations a more complete user experience. The user can now use the back/forward button, bookmark pages, link to conversations (the key piece for token-gated access)

