### PR TITLE
Redirect to the initial entry path when user logs in or creates new account

### DIFF
--- a/src/pages/login/login-component.tsx
+++ b/src/pages/login/login-component.tsx
@@ -28,6 +28,8 @@ export class LoginComponent extends React.Component<LoginComponentProperties> {
       case LoginStage.Web3Login:
         return <Web3LoginContainer />;
       case LoginStage.Done:
+        // This case may not be needed any more now that the sagas are redirecting
+        // on login
         return <Redirect to='/' />;
       default:
         return <EmailLoginContainer />;

--- a/src/store/page-load/index.ts
+++ b/src/store/page-load/index.ts
@@ -2,11 +2,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export type PageloadState = {
   isComplete: boolean;
+  entryPath: string;
 };
 
 export const initialState = {
   isComplete: false,
   showAndroidDownload: false,
+  entryPath: '',
 };
 
 const slice = createSlice({
@@ -19,8 +21,11 @@ const slice = createSlice({
     setShowAndroidDownload: (state, action: PayloadAction<boolean>) => {
       state.showAndroidDownload = action.payload;
     },
+    setEntryPath: (state, action: PayloadAction<PageloadState['entryPath']>) => {
+      state.entryPath = action.payload;
+    },
   },
 });
 
-export const { setIsComplete, setShowAndroidDownload } = slice.actions;
+export const { setIsComplete, setShowAndroidDownload, setEntryPath } = slice.actions;
 export const { reducer } = slice;


### PR DESCRIPTION
### What does this do?

If a user opens the app to a specific path but is not logged in the app will redirect back to that page once login is completed successfully.

### How do I test this?

Hit a known url within the app such as /conversation/<id> when the user is logged out. Log in. Verify that the correct conversation is open when the login completes and the app is fully loaded.

