### PR TITLE
chore: bump zui version (`1.6.0`) -> (`1.7.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@web3-react/walletconnect-connector": "^6.2.13",
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
-        "@zero-tech/zui": "^1.6.0",
+        "@zero-tech/zui": "^1.7.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8389,9 +8389,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.6.0.tgz",
-      "integrity": "sha512-0atOoPvHIGIG6cW9YlLaJXCHQM4x1LBM2yJCmAw9391xA+ooMXxdbwd8khRsyuSXliBWFNnCHsgBAA3LDiOlNQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.7.0.tgz",
+      "integrity": "sha512-B0zPzpHaEJDMwlDAvpbkfK0Vclsp5lN/TC79/KQCs5eZffthfr0kgZYyH6lnCsoUPUSmMLW8Aj6LmqejhRglag==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -37616,9 +37616,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.6.0.tgz",
-      "integrity": "sha512-0atOoPvHIGIG6cW9YlLaJXCHQM4x1LBM2yJCmAw9391xA+ooMXxdbwd8khRsyuSXliBWFNnCHsgBAA3LDiOlNQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.7.0.tgz",
+      "integrity": "sha512-B0zPzpHaEJDMwlDAvpbkfK0Vclsp5lN/TC79/KQCs5eZffthfr0kgZYyH6lnCsoUPUSmMLW8Aj6LmqejhRglag==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@web3-react/walletconnect-connector": "^6.2.13",
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
-    "@zero-tech/zui": "^1.6.0",
+    "@zero-tech/zui": "^1.7.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
- chore: bump zui version (`1.6.0`) -> (`1.7.0`)

Updates `IconInfoCircle` icon stroke width