### PR TITLE
feat(group-management): add group info menu item

### DIFF
--- a/src/components/group-management-menu/index.test.tsx
+++ b/src/components/group-management-menu/index.test.tsx
@@ -3,6 +3,11 @@ import { shallow } from 'enzyme';
 import { Properties, GroupManagementMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
+const featureFlags = { enableGroupInformation: false };
+jest.mock('../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
+
 describe(GroupManagementMenu, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
@@ -12,6 +17,7 @@ describe(GroupManagementMenu, () => {
       onStartAddMember: () => {},
       onLeave: () => {},
       onEdit: () => {},
+      onViewGroupInformation: () => {},
       ...props,
     };
 
@@ -72,6 +78,18 @@ describe(GroupManagementMenu, () => {
     it('does not render item when canEditRoom is false', function () {
       const wrapper = subject({ canEdit: false });
       expect(menuItem(wrapper, 'edit_group')).toBeFalsy();
+    });
+  });
+
+  describe('Group Info', () => {
+    it('calls onViewGroupInformation when the group info menu item is selected', () => {
+      featureFlags.enableGroupInformation = true;
+      const onViewGroupInformation = jest.fn();
+      const wrapper = subject({ onViewGroupInformation });
+
+      selectItem(wrapper, 'group_information');
+
+      expect(onViewGroupInformation).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
-import { IconDotsHorizontal, IconEdit5, IconPlus, IconUserRight1 } from '@zero-tech/zui/icons';
+import { IconDotsHorizontal, IconEdit5, IconInfoCircle, IconPlus, IconUserRight1 } from '@zero-tech/zui/icons';
 import { DropdownMenu } from '@zero-tech/zui/components';
+
+import { featureFlags } from '../../lib/feature-flags';
 
 import './styles.scss';
 
@@ -12,6 +14,7 @@ export interface Properties {
   onStartAddMember: () => void;
   onLeave: () => void;
   onEdit: () => void;
+  onViewGroupInformation: () => void;
 }
 
 interface State {}
@@ -55,6 +58,14 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
         onSelect: () => {
           this.props.onLeave();
         },
+      });
+    }
+
+    if (featureFlags.enableGroupInformation) {
+      menuItems.push({
+        id: 'group_information',
+        label: this.renderMenuItem(<IconInfoCircle size={20} />, 'Group Info'),
+        onSelect: this.props.onViewGroupInformation,
       });
     }
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -236,6 +236,7 @@ export class Container extends React.Component<Properties> {
                   }
                   canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                   onEdit={this.props.startEditConversation}
+                  onViewGroupInformation={() => console.log('View group information selected')}
                 />
               </div>
             </div>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -73,6 +73,14 @@ export class FeatureFlags {
   set internalUsage(value: boolean) {
     this._setBoolean('internalUsage', value);
   }
+
+  get enableGroupInformation() {
+    return this._getBoolean('enableGroupInformation', false);
+  }
+
+  set enableGroupInformation(value: boolean) {
+    this._setBoolean('enableGroupInformation', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?
- adds group info menu item to dropdown menu (group management)

### Why are we making this change?
- to have a menu item to open the group information panel (when implemented)

### How do I test this?
- In the console enter `window.FEATURE_FLAGS.enableGroupInformation = true;` > refresh > In a group conversation click the three dot group management menu > check group info menu item is displayed > click and check console logs.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="997" alt="Screenshot 2024-01-10 at 13 52 34" src="https://github.com/zer0-os/zOS/assets/39112648/fcf01821-101d-4db4-9b29-c8c122bd07ac">
