### PR TITLE
Fix emoji picker not appearing on click

### DIFF
--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -135,7 +135,6 @@ $recent-indicator-size: 8px;
   // message-input
   &__footer {
     border-radius: 16px;
-    overflow: hidden;
     flex-shrink: 0;
 
     @include flat-thick;


### PR DESCRIPTION
### What does this do?

Removes `overflow: hidden` prop which was hiding the emoji picker.

Before:
![image](https://github.com/zer0-os/zOS/assets/33264364/c63f9326-1667-4451-adad-7f5cf367d3e0)

After:
![image](https://github.com/zer0-os/zOS/assets/33264364/d973a8fc-d593-49be-8d2b-b3b2a3a6d672)

