### PR TITLE
Hide the chatClient abstraction from the sagas

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -263,3 +263,7 @@ export const chat = {
     return chatClient;
   },
 };
+
+export async function fetchConversationsWithUsers(users: User[]) {
+  return chat.get().fetchConversationsWithUsers(users);
+}

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -3,7 +3,7 @@ import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, set
 import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
 import { Events, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/selectors';
-import { Chat, chat } from '../../lib/chat';
+import { fetchConversationsWithUsers } from '../../lib/chat';
 import { denormalize as denormalizeUsers } from '../users';
 import { denormalizeConversations } from '../channels-list';
 import { openConversation } from '../channels/saga';
@@ -34,8 +34,7 @@ export function* performGroupMembersSelected(userSelections: { value: string; la
   ];
   const users = yield select((state) => denormalizeUsers(userIds, state));
 
-  const chatClient: Chat = yield call(chat.get);
-  const existingConversations = yield call([chatClient, chatClient.fetchConversationsWithUsers], users);
+  const existingConversations = yield call(fetchConversationsWithUsers, users);
 
   if (existingConversations.length === 0) {
     yield put(setGroupUsers(userSelections));


### PR DESCRIPTION
### What does this do?

Hides the chatClient abstraction from the sagas. This makes the tests a little tidier as it's simpler to mock a chat call.

