### PR TITLE
feat(group-management): get current users online presence

### DIFF
--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -63,6 +63,7 @@ export class Container extends React.Component<Properties> {
         firstName: currentUser?.profileSummary.firstName,
         lastName: currentUser?.profileSummary.lastName,
         profileImage: currentUser?.profileSummary.profileImage,
+        isOnline: currentUser?.isOnline,
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,


### PR DESCRIPTION
### What does this do?
- gets current users online presence.

### Why are we making this change?
- to have an accurate users status/presence in the group management panels

### How do I test this?
- open a group management panel that contains members avatars and check current users presence status (should be green/online, not grey/offline)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="295" alt="Screenshot 2024-01-11 at 10 45 47" src="https://github.com/zer0-os/zOS/assets/39112648/fbcfb868-37a8-4fd4-9dbf-63d924fe5932">
