### PR TITLE
feat: remove group information feature flag

### DIFF
--- a/src/components/group-management-menu/index.test.tsx
+++ b/src/components/group-management-menu/index.test.tsx
@@ -3,11 +3,6 @@ import { shallow } from 'enzyme';
 import { Properties, GroupManagementMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
-const featureFlags = { enableGroupInformation: false };
-jest.mock('../../lib/feature-flags', () => ({
-  featureFlags: featureFlags,
-}));
-
 describe(GroupManagementMenu, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
@@ -30,6 +25,7 @@ describe(GroupManagementMenu, () => {
       canAddMembers: false,
       canLeaveRoom: false,
       canEdit: false,
+      canViewGroupInformation: false,
     });
 
     expect(wrapper).not.toHaveElement(DropdownMenu);
@@ -84,7 +80,6 @@ describe(GroupManagementMenu, () => {
 
   describe('View Group Information', () => {
     it('calls onViewGroupInformation when the group info menu item is selected', () => {
-      featureFlags.enableGroupInformation = true;
       const onViewGroupInformation = jest.fn();
       const wrapper = subject({ onViewGroupInformation });
 

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import { IconDotsHorizontal, IconEdit5, IconInfoCircle, IconPlus, IconUserRight1 } from '@zero-tech/zui/icons';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
-import { featureFlags } from '../../lib/feature-flags';
-
 import './styles.scss';
 
 export interface Properties {
@@ -62,7 +60,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
       });
     }
 
-    if (featureFlags.enableGroupInformation && this.props.canViewGroupInformation) {
+    if (this.props.canViewGroupInformation) {
       menuItems.push({
         id: 'group_information',
         label: this.renderMenuItem(<IconInfoCircle size={20} />, 'Group Info'),

--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -49,7 +49,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
       });
     }
 
-    if (featureFlags.enableGroupInformation && this.props.canViewGroupInformation) {
+    if (this.props.canViewGroupInformation) {
       menuItems.push({
         id: 'group_information',
         label: this.renderMenuItem(<IconInfoCircle size={20} />, 'Group Info'),

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -81,14 +81,6 @@ export class FeatureFlags {
   set internalUsage(value: boolean) {
     this._setBoolean('internalUsage', value);
   }
-
-  get enableGroupInformation() {
-    return this._getBoolean('enableGroupInformation', false);
-  }
-
-  set enableGroupInformation(value: boolean) {
-    this._setBoolean('enableGroupInformation', value);
-  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?
- removes group info feature flag

### Why are we making this change?
- to enable view group information flow.

### How do I test this?
- open a group conversation and check if the `Group Info` menu item is displayed and initiates the flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
