### PR TITLE
refactor: re-order group management menu items

### DIFF
--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -51,17 +51,6 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
       });
     }
 
-    if (this.props.canLeaveRoom) {
-      menuItems.push({
-        id: 'leave_group',
-        className: 'leave-group',
-        label: this.renderMenuItem(<IconUserRight1 size={20} />, 'Leave Group'),
-        onSelect: () => {
-          this.props.onLeave();
-        },
-      });
-    }
-
     if (featureFlags.enableGroupInformation && this.props.canViewGroupInformation) {
       menuItems.push({
         id: 'group_information',
@@ -75,6 +64,17 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
         id: 'edit_group',
         label: this.renderMenuItem(<IconEdit5 size={20} />, 'Edit Group'),
         onSelect: this.props.onEdit,
+      });
+    }
+
+    if (this.props.canLeaveRoom) {
+      menuItems.push({
+        id: 'leave_group',
+        className: 'leave-group',
+        label: this.renderMenuItem(<IconUserRight1 size={20} />, 'Leave Group'),
+        onSelect: () => {
+          this.props.onLeave();
+        },
       });
     }
 


### PR DESCRIPTION
### What does this do?
- re-orders group management menu items as shown below.

### Why are we making this change?
- so `Leave Group` item is displayed last.

### How do I test this?
- open group management menu and check item order

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="295" alt="Screenshot 2024-01-11 at 15 13 10" src="https://github.com/zer0-os/zOS/assets/39112648/1fb06894-074a-493c-882b-6b753c916734">

After:
<img width="295" alt="Screenshot 2024-01-11 at 15 13 41" src="https://github.com/zer0-os/zOS/assets/39112648/27977972-e6d5-4d3b-a7d4-03ab1bbd24f1">
