### PR TITLE
fix(view-group-information): admin tag should be assigned to conversation admin

### DIFF
--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -95,10 +95,6 @@ export class Container extends React.Component<Properties> {
     this.props.editConversationNameAndIcon({ roomId: this.props.activeConversationId, name, image });
   };
 
-  isUserAdmin = (userMatrixId: string, adminMatrixIds: string) => {
-    return adminMatrixIds.includes(userMatrixId);
-  };
-
   render() {
     return (
       <>

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -34,6 +34,7 @@ export interface Properties extends PublicProperties {
   name: string;
   conversationIcon: string;
   editConversationState: EditConversationState;
+  conversationAdminIds: string[];
 
   back: () => void;
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
@@ -50,6 +51,7 @@ export class Container extends React.Component<Properties> {
 
     const conversation = denormalizeChannel(activeConversationId, state);
     const currentUser = currentUserSelector(state);
+    const conversationAdminIds = conversation?.adminMatrixIds;
 
     return {
       activeConversationId,
@@ -63,10 +65,12 @@ export class Container extends React.Component<Properties> {
         firstName: currentUser?.profileSummary.firstName,
         lastName: currentUser?.profileSummary.lastName,
         profileImage: currentUser?.profileSummary.profileImage,
+        matrixId: currentUser?.matrixId,
         isOnline: currentUser?.isOnline,
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,
+      conversationAdminIds,
     };
   }
 
@@ -91,6 +95,10 @@ export class Container extends React.Component<Properties> {
     this.props.editConversationNameAndIcon({ roomId: this.props.activeConversationId, name, image });
   };
 
+  isUserAdmin = (userMatrixId: string, adminMatrixIds: string) => {
+    return adminMatrixIds.includes(userMatrixId);
+  };
+
   render() {
     return (
       <>
@@ -109,6 +117,7 @@ export class Container extends React.Component<Properties> {
           onEditConversation={this.onEditConversation}
           editConversationState={this.props.editConversationState}
           onRemoveMember={this.openRemoveMember}
+          conversationAdminIds={this.props.conversationAdminIds}
         />
         <RemoveMemberDialogContainer />
       </>

--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -19,6 +19,7 @@ describe(GroupManagement, () => {
       icon: '',
       errors: {},
       editConversationState: EditConversationState.NONE,
+      conversationAdminIds: [],
       onBack: () => null,
       searchUsers: () => null,
       onAddMembers: () => null,

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -18,6 +18,7 @@ export interface Properties {
   currentUser: User;
   otherMembers: User[];
   editConversationState: EditConversationState;
+  conversationAdminIds: string[];
 
   onBack: () => void;
   onAddMembers: (options: Option[]) => void;
@@ -58,6 +59,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             icon={this.props.icon}
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
+            conversationAdminIds={this.props.conversationAdminIds}
             onBack={this.props.onBack}
           />
         )}

--- a/src/components/messenger/list/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.test.tsx
@@ -17,6 +17,7 @@ describe(ViewGroupInformationPanel, () => {
       icon: '',
       currentUser: { userId: 'current-user' } as User,
       otherMembers: [],
+      conversationAdminIds: [],
 
       onBack: () => null,
       ...props,
@@ -73,5 +74,20 @@ describe(ViewGroupInformationPanel, () => {
       { userId: '2' },
       { userId: '3' },
     ]);
+  });
+
+  it('assigns admin tag to the user that is the conversation admin', () => {
+    const wrapper = subject({
+      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-current' } as User,
+      otherMembers: [
+        { userId: 'otherUser1', matrixId: 'matrix-id-1' },
+        { userId: 'otherUser2', matrixId: 'matrix-id-2' },
+      ] as User[],
+      conversationAdminIds: ['matrix-id-1'],
+    });
+
+    expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null);
+    expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Admin');
+    expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
   });
 });

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -18,11 +18,20 @@ export interface Properties {
   icon: string;
   currentUser: User;
   otherMembers: User[];
+  conversationAdminIds: string[];
 
   onBack: () => void;
 }
 
 export class ViewGroupInformationPanel extends React.Component<Properties> {
+  isUserAdmin(user: User) {
+    return this.props.conversationAdminIds.includes(user.matrixId);
+  }
+
+  getTagForUser(user: User) {
+    return this.isUserAdmin(user) ? 'Admin' : null;
+  }
+
   renderImage = () => {
     return (
       <div {...cn('details')}>
@@ -50,9 +59,12 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         </div>
         <div {...cn('member-list')}>
           <ScrollbarContainer>
-            <CitizenListItem user={this.props.currentUser} tag='admin'></CitizenListItem>
+            <CitizenListItem
+              user={this.props.currentUser}
+              tag={this.getTagForUser(this.props.currentUser)}
+            ></CitizenListItem>
             {otherMembers.map((u) => (
-              <CitizenListItem key={u.userId} user={u}></CitizenListItem>
+              <CitizenListItem key={u.userId} user={u} tag={this.getTagForUser(u)}></CitizenListItem>
             ))}
           </ScrollbarContainer>
         </div>


### PR DESCRIPTION
### What does this do?
- correctly assigns the `Admin` tag to the conversation admin.

### Why are we making this change?
- `Admin` tag was being assigned to current user for each group conversation.

### How do I test this?
- open group information panel and check the admin tag is next to the correct conversation admin user.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Note: this image contains changes to the Admin tag styles, which will be pushed in a follow up PR
<img width="345" alt="Screenshot 2024-01-11 at 17 06 05" src="https://github.com/zer0-os/zOS/assets/39112648/896c43a9-27ef-437e-aded-0ef41c9b9414">
