### PR TITLE
feat: add sort members and is user admin util functions to messenger/list/utils

### DIFF
--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -2,20 +2,23 @@ import { isUserAdmin, sortMembers } from './utils';
 import { User } from '../../../../store/channels';
 
 describe('sortMembers', () => {
-  it('sorts members with admins first and others alphabetically', () => {
-    const members = [
-      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
-      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
-      { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda' },
-    ] as User[];
-    const adminIds = ['matrix-id-2'];
+  it('sorts members correctly with current user first, admins next, then online status and alphabetically', () => {
+    const members: Partial<User>[] = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam', isOnline: false },
+      { userId: 'currentUser', matrixId: 'matrix-id-current', firstName: 'Zara', isOnline: true },
+      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie', isOnline: true },
+      { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda', isOnline: true },
+    ];
+    const adminIds = ['matrix-id-2', 'matrix-id-3'];
+    const currentUserId = 'currentUser';
 
-    const sortedMembers = sortMembers(members, adminIds);
+    const sortedMembers = sortMembers(members, adminIds, currentUserId);
 
-    const expectedOrder = [
-      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
-      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
-      { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda' },
+    const expectedOrder: Partial<User>[] = [
+      { userId: 'currentUser', matrixId: 'matrix-id-current', firstName: 'Zara', isOnline: true },
+      { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda', isOnline: true },
+      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie', isOnline: true },
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam', isOnline: false },
     ];
 
     expect(sortedMembers).toEqual(expectedOrder);

--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -3,18 +3,18 @@ import { User } from '../../../../store/channels';
 
 describe('sortMembers', () => {
   it('sorts members correctly with current user first, admins next, then online status and alphabetically', () => {
-    const members: Partial<User>[] = [
+    const members = [
       { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam', isOnline: false },
       { userId: 'currentUser', matrixId: 'matrix-id-current', firstName: 'Zara', isOnline: true },
       { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie', isOnline: true },
       { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda', isOnline: true },
-    ];
+    ] as any;
     const adminIds = ['matrix-id-2', 'matrix-id-3'];
     const currentUserId = 'currentUser';
 
     const sortedMembers = sortMembers(members, adminIds, currentUserId);
 
-    const expectedOrder: Partial<User>[] = [
+    const expectedOrder = [
       { userId: 'currentUser', matrixId: 'matrix-id-current', firstName: 'Zara', isOnline: true },
       { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda', isOnline: true },
       { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie', isOnline: true },

--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -1,0 +1,46 @@
+import { isUserAdmin, sortMembers } from './utils';
+import { User } from '../../../../store/channels';
+
+describe('sortMembers', () => {
+  it('sorts members with admins first and others alphabetically', () => {
+    const members = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+      { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda' },
+    ] as User[];
+    const adminIds = ['matrix-id-2'];
+
+    const sortedMembers = sortMembers(members, adminIds);
+
+    const expectedOrder = [
+      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+      { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda' },
+    ];
+
+    expect(sortedMembers).toEqual(expectedOrder);
+  });
+});
+
+describe('isUserAdmin', () => {
+  it('returns true if the user is an admin', () => {
+    const user = { userId: 'user1', matrixId: 'matrix-id-1' } as User;
+    const adminIds = ['matrix-id-1', 'matrix-id-2'];
+
+    expect(isUserAdmin(user, adminIds)).toBe(true);
+  });
+
+  it('returns false if the user is not an admin', () => {
+    const user = { userId: 'user2', matrixId: 'matrix-id-3' } as User;
+    const adminIds = ['matrix-id-1', 'matrix-id-2'];
+
+    expect(isUserAdmin(user, adminIds)).toBe(false);
+  });
+
+  it('handles empty adminIds array', () => {
+    const user = { userId: 'user1', matrixId: 'matrix-id-1' } as User;
+    const adminIds: string[] = [];
+
+    expect(isUserAdmin(user, adminIds)).toBe(false);
+  });
+});

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -20,18 +20,28 @@ export function isCustomIcon(url?: string) {
   return !url.startsWith('https://static.sendbird.com/sample');
 }
 
-export function isUserAdmin(user: User, adminIds: string[]) {
-  return adminIds.includes(user.matrixId);
+export function isUserAdmin(user: Partial<User>, adminIds: string[]) {
+  return adminIds.includes(user.matrixId!);
 }
 
-export function sortMembers(members: User[], adminIds?: string[]) {
+export function sortMembers(members: Partial<User>[], adminIds?: string[], currentUserId?: string) {
   return members.sort((a, b) => {
     const aIsAdmin = adminIds ? isUserAdmin(a, adminIds) : false;
     const bIsAdmin = adminIds ? isUserAdmin(b, adminIds) : false;
 
+    // Sort current user to the top
+    if (a.userId === currentUserId) return -1;
+    if (b.userId === currentUserId) return 1;
+
+    // Sort admins next
     if (aIsAdmin && !bIsAdmin) return -1;
     if (!aIsAdmin && bIsAdmin) return 1;
 
-    return a.firstName.localeCompare(b.firstName);
+    // Then sort by online status
+    if (a.isOnline && !b.isOnline) return -1;
+    if (!a.isOnline && b.isOnline) return 1;
+
+    // Finally sort alphabetically by firstName
+    return a.firstName!.localeCompare(b.firstName!);
   });
 }

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -1,4 +1,5 @@
 import { monthsSince, fromNow } from '../../../../lib/date';
+import { User } from '../../../../store/channels';
 
 export function lastSeenText(user): string {
   if (user.isOnline) {
@@ -17,4 +18,20 @@ export function isCustomIcon(url?: string) {
 
   // Sendbird sets a custom icon by default. 🤞 that it's a good enough filter for now.
   return !url.startsWith('https://static.sendbird.com/sample');
+}
+
+export function isUserAdmin(user: User, adminIds: string[]) {
+  return adminIds.includes(user.matrixId);
+}
+
+export function sortMembers(members: User[], adminIds?: string[]) {
+  return members.sort((a, b) => {
+    const aIsAdmin = adminIds ? isUserAdmin(a, adminIds) : false;
+    const bIsAdmin = adminIds ? isUserAdmin(b, adminIds) : false;
+
+    if (aIsAdmin && !bIsAdmin) return -1;
+    if (!aIsAdmin && bIsAdmin) return 1;
+
+    return a.firstName.localeCompare(b.firstName);
+  });
 }

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -20,8 +20,8 @@ export function isCustomIcon(url?: string) {
   return !url.startsWith('https://static.sendbird.com/sample');
 }
 
-export function isUserAdmin(user: Partial<User>, adminIds: string[]) {
-  return adminIds.includes(user.matrixId!);
+export function isUserAdmin(user: User, adminIds: string[]) {
+  return adminIds.includes(user.matrixId);
 }
 
 export function sortMembers(members: User[], adminIds?: string[], currentUserId?: string) {
@@ -42,6 +42,6 @@ export function sortMembers(members: User[], adminIds?: string[], currentUserId?
     if (!a.isOnline && b.isOnline) return 1;
 
     // Finally sort alphabetically by firstName
-    return a.firstName!.localeCompare(b.firstName!);
+    return a.firstName!.localeCompare(b.firstName);
   });
 }

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -24,7 +24,7 @@ export function isUserAdmin(user: Partial<User>, adminIds: string[]) {
   return adminIds.includes(user.matrixId!);
 }
 
-export function sortMembers(members: Partial<User>[], adminIds?: string[], currentUserId?: string) {
+export function sortMembers(members: User[], adminIds?: string[], currentUserId?: string) {
   return members.sort((a, b) => {
     const aIsAdmin = adminIds ? isUserAdmin(a, adminIds) : false;
     const bIsAdmin = adminIds ? isUserAdmin(b, adminIds) : false;


### PR DESCRIPTION
### What does this do?
- adds helper functions (utils) to sort members for view group info panel and edit group info panel.

In the `sortMembers` function, the order is:

1. The current user is sorted to the top.
2. Admins are sorted next.
3. Users are then sorted based on their online status, with online users appearing before offline users.
4. Lastly, users are sorted alphabetically by their first name.