### PR TITLE
fix(grp-mgmt-menu): non-serializable value detected console error

### DIFF
--- a/src/components/group-management-menu/index.tsx
+++ b/src/components/group-management-menu/index.tsx
@@ -30,6 +30,10 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
     this.props.onStartAddMember();
   };
 
+  editGroup = () => {
+    this.props.onEdit();
+  };
+
   renderMenuItem(icon, label) {
     return (
       <div className={'menu-item'}>
@@ -61,7 +65,7 @@ export class GroupManagementMenu extends React.Component<Properties, State> {
       menuItems.push({
         id: 'edit_group',
         label: this.renderMenuItem(<IconEdit5 size={20} />, 'Edit Group'),
-        onSelect: this.props.onEdit,
+        onSelect: this.editGroup,
       });
     }
 


### PR DESCRIPTION
### What does this do?
- fixes a non-serializable value detected console error.

### Why are we making this change?
- fixes the error shown below caused when clicking the `Edit Group` menu item.

### How do I test this?
- Click `Edit Group` menu item and check console for errors.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Error:
<img width="434" alt="Screenshot 2024-01-12 at 02 36 14" src="https://github.com/zer0-os/zOS/assets/39112648/2fb5d03f-b6c5-4279-839d-2645c5137114">
