### PR TITLE
feat: navigate to edit group flow from view group information panel

### DIFF
--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -9,6 +9,7 @@ import {
   editConversationNameAndIcon,
   EditConversationPayload,
   openRemoveMember,
+  startEditConversation,
 } from '../../../../store/group-management';
 import { Option } from '../../lib/types';
 
@@ -40,6 +41,7 @@ export interface Properties extends PublicProperties {
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
   editConversationNameAndIcon: (payload: EditConversationPayload) => void;
   openRemoveMember: (params: { roomId: string; userId: string }) => void;
+  startEditConversation: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -79,6 +81,7 @@ export class Container extends React.Component<Properties> {
       addSelectedMembers,
       editConversationNameAndIcon,
       openRemoveMember,
+      startEditConversation,
     };
   }
 
@@ -113,6 +116,7 @@ export class Container extends React.Component<Properties> {
           editConversationState={this.props.editConversationState}
           onRemoveMember={this.openRemoveMember}
           isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
+          startEditConversation={this.props.startEditConversation}
         />
         <RemoveMemberDialogContainer />
       </>

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -34,6 +34,7 @@ export interface Properties extends PublicProperties {
   name: string;
   conversationIcon: string;
   editConversationState: EditConversationState;
+  isCurrentUserRoomAdmin: boolean;
 
   back: () => void;
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
@@ -50,6 +51,7 @@ export class Container extends React.Component<Properties> {
 
     const conversation = denormalizeChannel(activeConversationId, state);
     const currentUser = currentUserSelector(state);
+    const isCurrentUserRoomAdmin = conversation?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
 
     return {
       activeConversationId,
@@ -67,6 +69,7 @@ export class Container extends React.Component<Properties> {
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,
+      isCurrentUserRoomAdmin,
     };
   }
 
@@ -109,6 +112,7 @@ export class Container extends React.Component<Properties> {
           onEditConversation={this.onEditConversation}
           editConversationState={this.props.editConversationState}
           onRemoveMember={this.openRemoveMember}
+          isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
         />
         <RemoveMemberDialogContainer />
       </>

--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -20,11 +20,13 @@ describe(GroupManagement, () => {
       errors: {},
       editConversationState: EditConversationState.NONE,
       conversationAdminIds: [],
+      isCurrentUserRoomAdmin: false,
       onBack: () => null,
       searchUsers: () => null,
       onAddMembers: () => null,
       onRemoveMember: () => null,
       onEditConversation: () => null,
+      startEditConversation: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -18,6 +18,7 @@ export interface Properties {
   currentUser: User;
   otherMembers: User[];
   editConversationState: EditConversationState;
+  isCurrentUserRoomAdmin: boolean;
 
   onBack: () => void;
   onAddMembers: (options: Option[]) => void;
@@ -58,6 +59,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             icon={this.props.icon}
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
+            isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
             onBack={this.props.onBack}
           />
         )}

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -25,6 +25,7 @@ export interface Properties {
   onEditConversation: (name: string, image: File | null) => void;
   searchUsers: (search: string) => Promise<any>;
   onRemoveMember: (userId: string) => void;
+  startEditConversation: () => void;
 }
 
 export class GroupManagement extends React.PureComponent<Properties> {
@@ -60,6 +61,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
             isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
+            onEdit={this.props.startEditConversation}
             onBack={this.props.onBack}
           />
         )}

--- a/src/components/messenger/list/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.test.tsx
@@ -4,7 +4,7 @@ import { ViewGroupInformationPanel, Properties } from '.';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { User } from '../../../../store/channels';
 import { PanelHeader } from '../panel-header';
-import { Image } from '@zero-tech/zui/components';
+import { Button, Image } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bem } from '../../../../lib/bem';
 
@@ -18,7 +18,9 @@ describe(ViewGroupInformationPanel, () => {
       currentUser: { userId: 'current-user' } as User,
       otherMembers: [],
       conversationAdminIds: [],
+      isCurrentUserRoomAdmin: false,
 
+      onEdit: () => null,
       onBack: () => null,
       ...props,
     };
@@ -35,6 +37,15 @@ describe(ViewGroupInformationPanel, () => {
     expect(onBack).toHaveBeenCalled();
   });
 
+  it('publishes onEdit event', () => {
+    const onEdit = jest.fn();
+    const wrapper = subject({ onEdit, isCurrentUserRoomAdmin: true });
+
+    wrapper.find(Button).simulate('press');
+
+    expect(onEdit).toHaveBeenCalled();
+  });
+
   it('renders group name when name prop is provided', () => {
     const wrapper = subject({ name: 'test-group-name' });
     expect(wrapper.find(c('group-name'))).toHaveText('test-group-name');
@@ -49,6 +60,11 @@ describe(ViewGroupInformationPanel, () => {
   it('renders default group icon when icon prop is not provided', () => {
     const wrapper = subject({ icon: '' });
     expect(wrapper).toHaveElement(IconUsers1);
+  });
+
+  it('renders edit button when current user is admin', () => {
+    const wrapper = subject({ isCurrentUserRoomAdmin: true });
+    expect(wrapper).toHaveElement(Button);
   });
 
   it('renders member header with correct count', () => {

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -34,7 +34,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     return this.isUserAdmin(user) ? 'Admin' : null;
   }
 
-  navigateToEditPanel = () => {
+  editGroup = () => {
     this.props.onEdit();
   };
 
@@ -54,7 +54,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         {this.props.name && <div {...cn('group-name')}>{this.props.name}</div>}
 
         {this.props.isCurrentUserRoomAdmin && (
-          <Button {...cn('edit-group-button')} onPress={this.navigateToEditPanel} variant='text'>
+          <Button {...cn('edit-group-button')} onPress={this.editGroup} variant='text'>
             Edit
           </Button>
         )}

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -20,7 +20,7 @@ export interface Properties {
   otherMembers: User[];
   isCurrentUserRoomAdmin: boolean;
 
-  onEdit?: () => void;
+  onEdit: () => void;
   onBack: () => void;
 }
 

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Image } from '@zero-tech/zui/components';
+import { Button, Image } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 
 import { PanelHeader } from '../panel-header';
@@ -18,7 +18,9 @@ export interface Properties {
   icon: string;
   currentUser: User;
   otherMembers: User[];
+  isCurrentUserRoomAdmin: boolean;
 
+  onEdit?: () => void;
   onBack: () => void;
 }
 
@@ -37,6 +39,12 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         </div>
 
         {this.props.name && <div {...cn('group-name')}>{this.props.name}</div>}
+
+        {this.props.isCurrentUserRoomAdmin && (
+          <Button {...cn('edit-group-button')} onPress={this.props.onEdit} variant='text'>
+            Edit
+          </Button>
+        )}
       </div>
     );
   };

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -34,6 +34,10 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     return this.isUserAdmin(user) ? 'Admin' : null;
   }
 
+  navigateToEditPanel = () => {
+    this.props.onEdit();
+  };
+
   renderImage = () => {
     return (
       <div {...cn('details')}>
@@ -50,7 +54,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         {this.props.name && <div {...cn('group-name')}>{this.props.name}</div>}
 
         {this.props.isCurrentUserRoomAdmin && (
-          <Button {...cn('edit-group-button')} onPress={this.props.onEdit} variant='text'>
+          <Button {...cn('edit-group-button')} onPress={this.navigateToEditPanel} variant='text'>
             Edit
           </Button>
         )}

--- a/src/components/messenger/list/view-group-information-panel/styles.scss
+++ b/src/components/messenger/list/view-group-information-panel/styles.scss
@@ -51,6 +51,11 @@
     padding-bottom: 24px;
   }
 
+  &__edit-group-button {
+    width: fit-content;
+    align-self: center;
+  }
+
   &__members {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### What does this do?
- adds edit button to view group information panel to navigate to the edit group panel.

### Why are we making this change?
- as per design - so the user can access the edit group panel from the view group information panel.

### How do I test this?
- if you are admin of a group, navigate to the group information panel > click `Edit` button > check edit group panel is displayed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Navigate to Edit Group Panel from View Group Information Panel.
Note :: we may choose to improve/adjust back navigation at a later date.

https://github.com/zer0-os/zOS/assets/39112648/8337f1c9-c9a9-4d97-bb1e-c056a2aa300e

