### PR TITLE
feat: start add member flow from group info panel

### DIFF
--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -9,6 +9,7 @@ import {
   editConversationNameAndIcon,
   EditConversationPayload,
   openRemoveMember,
+  startEditConversation,
 } from '../../../../store/group-management';
 import { Option } from '../../lib/types';
 
@@ -40,6 +41,7 @@ export interface Properties extends PublicProperties {
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
   editConversationNameAndIcon: (payload: EditConversationPayload) => void;
   openRemoveMember: (params: { roomId: string; userId: string }) => void;
+  startEditConversation: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -79,6 +81,7 @@ export class Container extends React.Component<Properties> {
       addSelectedMembers,
       editConversationNameAndIcon,
       openRemoveMember,
+      startEditConversation,
     };
   }
 
@@ -113,6 +116,7 @@ export class Container extends React.Component<Properties> {
           editConversationState={this.props.editConversationState}
           onRemoveMember={this.openRemoveMember}
           isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
+          startEditConversation={this.props.startEditConversation}
         />
         <RemoveMemberDialogContainer />
       </>

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -10,6 +10,7 @@ import {
   EditConversationPayload,
   openRemoveMember,
   startEditConversation,
+  startAddGroupMember,
 } from '../../../../store/group-management';
 import { Option } from '../../lib/types';
 
@@ -43,6 +44,7 @@ export interface Properties extends PublicProperties {
   editConversationNameAndIcon: (payload: EditConversationPayload) => void;
   openRemoveMember: (params: { roomId: string; userId: string }) => void;
   startEditConversation: () => void;
+  startAddGroupMember: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -86,6 +88,7 @@ export class Container extends React.Component<Properties> {
       editConversationNameAndIcon,
       openRemoveMember,
       startEditConversation,
+      startAddGroupMember,
     };
   }
 
@@ -122,6 +125,7 @@ export class Container extends React.Component<Properties> {
           isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
           startEditConversation={this.props.startEditConversation}
           conversationAdminIds={this.props.conversationAdminIds}
+          startAddGroupMember={this.props.startAddGroupMember}
         />
         <RemoveMemberDialogContainer />
       </>

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -34,6 +34,7 @@ export interface Properties extends PublicProperties {
   name: string;
   conversationIcon: string;
   editConversationState: EditConversationState;
+  isCurrentUserRoomAdmin: boolean;
 
   back: () => void;
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
@@ -50,6 +51,7 @@ export class Container extends React.Component<Properties> {
 
     const conversation = denormalizeChannel(activeConversationId, state);
     const currentUser = currentUserSelector(state);
+    const isCurrentUserRoomAdmin = conversation?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
 
     return {
       activeConversationId,
@@ -67,6 +69,7 @@ export class Container extends React.Component<Properties> {
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,
+      isCurrentUserRoomAdmin,
     };
   }
 
@@ -109,6 +112,7 @@ export class Container extends React.Component<Properties> {
           onEditConversation={this.onEditConversation}
           editConversationState={this.props.editConversationState}
           onRemoveMember={this.openRemoveMember}
+          isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
         />
         <RemoveMemberDialogContainer />
       </>

--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -20,11 +20,13 @@ describe(GroupManagement, () => {
       errors: {},
       editConversationState: EditConversationState.NONE,
       conversationAdminIds: [],
+      isCurrentUserRoomAdmin: false,
       onBack: () => null,
       searchUsers: () => null,
       onAddMembers: () => null,
       onRemoveMember: () => null,
       onEditConversation: () => null,
+      startEditConversation: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/group-management/index.test.tsx
+++ b/src/components/messenger/list/group-management/index.test.tsx
@@ -27,6 +27,7 @@ describe(GroupManagement, () => {
       onRemoveMember: () => null,
       onEditConversation: () => null,
       startEditConversation: () => null,
+      startAddGroupMember: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -18,6 +18,7 @@ export interface Properties {
   currentUser: User;
   otherMembers: User[];
   editConversationState: EditConversationState;
+  isCurrentUserRoomAdmin: boolean;
 
   onBack: () => void;
   onAddMembers: (options: Option[]) => void;
@@ -58,6 +59,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             icon={this.props.icon}
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
+            isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
             onBack={this.props.onBack}
           />
         )}

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -63,7 +63,6 @@ export class GroupManagement extends React.PureComponent<Properties> {
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
             isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
-            onEdit={this.props.startEditConversation}
             conversationAdminIds={this.props.conversationAdminIds}
             onAdd={this.props.startAddGroupMember}
             onEdit={this.props.startEditConversation}

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -27,6 +27,7 @@ export interface Properties {
   searchUsers: (search: string) => Promise<any>;
   onRemoveMember: (userId: string) => void;
   startEditConversation: () => void;
+  startAddGroupMember: () => void;
 }
 
 export class GroupManagement extends React.PureComponent<Properties> {
@@ -62,8 +63,9 @@ export class GroupManagement extends React.PureComponent<Properties> {
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
             isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
-            onEdit={this.props.startEditConversation}
             conversationAdminIds={this.props.conversationAdminIds}
+            onAdd={this.props.startAddGroupMember}
+            onEdit={this.props.startEditConversation}
             onBack={this.props.onBack}
           />
         )}

--- a/src/components/messenger/list/group-management/index.tsx
+++ b/src/components/messenger/list/group-management/index.tsx
@@ -25,6 +25,7 @@ export interface Properties {
   onEditConversation: (name: string, image: File | null) => void;
   searchUsers: (search: string) => Promise<any>;
   onRemoveMember: (userId: string) => void;
+  startEditConversation: () => void;
 }
 
 export class GroupManagement extends React.PureComponent<Properties> {
@@ -60,6 +61,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
             isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
+            onEdit={this.props.startEditConversation}
             onBack={this.props.onBack}
           />
         )}

--- a/src/components/messenger/list/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.test.tsx
@@ -3,8 +3,7 @@ import { shallow } from 'enzyme';
 import { ViewGroupInformationPanel, Properties } from '.';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { User } from '../../../../store/channels';
-import { PanelHeader } from '../panel-header';
-import { Button, Image } from '@zero-tech/zui/components';
+import { Button, IconButton, Image } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bem } from '../../../../lib/bem';
 
@@ -32,7 +31,7 @@ describe(ViewGroupInformationPanel, () => {
     const onBack = jest.fn();
     const wrapper = subject({ onBack });
 
-    wrapper.find(PanelHeader).simulate('back');
+    wrapper.find(IconButton).simulate('click');
 
     expect(onBack).toHaveBeenCalled();
   });

--- a/src/components/messenger/list/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { ViewGroupInformationPanel, Properties } from '.';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { User } from '../../../../store/channels';
-import { Button, IconButton, Image } from '@zero-tech/zui/components';
+import { Button, Image } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bem } from '../../../../lib/bem';
 
@@ -19,6 +19,7 @@ describe(ViewGroupInformationPanel, () => {
       conversationAdminIds: [],
       isCurrentUserRoomAdmin: false,
 
+      onAdd: () => null,
       onEdit: () => null,
       onBack: () => null,
       ...props,
@@ -31,7 +32,7 @@ describe(ViewGroupInformationPanel, () => {
     const onBack = jest.fn();
     const wrapper = subject({ onBack });
 
-    wrapper.find(IconButton).simulate('click');
+    wrapper.find(c('back-icon')).simulate('click');
 
     expect(onBack).toHaveBeenCalled();
   });
@@ -43,6 +44,15 @@ describe(ViewGroupInformationPanel, () => {
     wrapper.find(Button).simulate('press');
 
     expect(onEdit).toHaveBeenCalled();
+  });
+
+  it('publishes onAdd event', () => {
+    const onAdd = jest.fn();
+    const wrapper = subject({ onAdd, isCurrentUserRoomAdmin: true });
+
+    wrapper.find(c('add-icon')).simulate('click');
+
+    expect(onAdd).toHaveBeenCalled();
   });
 
   it('renders group name when name prop is provided', () => {
@@ -64,6 +74,11 @@ describe(ViewGroupInformationPanel, () => {
   it('renders edit button when current user is admin', () => {
     const wrapper = subject({ isCurrentUserRoomAdmin: true });
     expect(wrapper).toHaveElement(Button);
+  });
+
+  it('renders add icon button when current user is admin', () => {
+    const wrapper = subject({ isCurrentUserRoomAdmin: true });
+    expect(wrapper).toHaveElement(c('add-icon'));
   });
 
   it('renders member header with correct count', () => {

--- a/src/components/messenger/list/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.test.tsx
@@ -4,7 +4,7 @@ import { ViewGroupInformationPanel, Properties } from '.';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { User } from '../../../../store/channels';
 import { PanelHeader } from '../panel-header';
-import { Image } from '@zero-tech/zui/components';
+import { Button, Image } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bem } from '../../../../lib/bem';
 
@@ -18,7 +18,9 @@ describe(ViewGroupInformationPanel, () => {
       currentUser: { userId: 'current-user' } as User,
       otherMembers: [],
       conversationAdminIds: [],
+      isCurrentUserRoomAdmin: false,
 
+      onEdit: () => null,
       onBack: () => null,
       ...props,
     };
@@ -35,6 +37,15 @@ describe(ViewGroupInformationPanel, () => {
     expect(onBack).toHaveBeenCalled();
   });
 
+  it('publishes onEdit event', () => {
+    const onEdit = jest.fn();
+    const wrapper = subject({ onEdit, isCurrentUserRoomAdmin: true });
+
+    wrapper.find(Button).simulate('press');
+
+    expect(onEdit).toHaveBeenCalled();
+  });
+
   it('renders group name when name prop is provided', () => {
     const wrapper = subject({ name: 'test-group-name' });
     expect(wrapper.find(c('group-name'))).toHaveText('test-group-name');
@@ -49,6 +60,11 @@ describe(ViewGroupInformationPanel, () => {
   it('renders default group icon when icon prop is not provided', () => {
     const wrapper = subject({ icon: '' });
     expect(wrapper).toHaveElement(IconUsers1);
+  });
+
+  it('renders edit button when current user is admin', () => {
+    const wrapper = subject({ isCurrentUserRoomAdmin: true });
+    expect(wrapper).toHaveElement(Button);
   });
 
   it('renders member header with correct count', () => {

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Button, IconButton, Image } from '@zero-tech/zui/components';
-import { IconArrowNarrowLeft, IconUsers1 } from '@zero-tech/zui/icons';
+import { IconArrowNarrowLeft, IconPlus, IconUsers1 } from '@zero-tech/zui/icons';
 
 import { User } from '../../../../store/channels';
 import { bemClassName } from '../../../../lib/bem';
@@ -20,6 +20,7 @@ export interface Properties {
   isCurrentUserRoomAdmin: boolean;
   conversationAdminIds: string[];
 
+  onAdd: () => void;
   onEdit: () => void;
   onBack: () => void;
 }
@@ -39,6 +40,10 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
 
   editGroup = () => {
     this.props.onEdit();
+  };
+
+  addMember = () => {
+    this.props.onAdd();
   };
 
   renderDetails = () => {
@@ -70,8 +75,14 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     return (
       <div {...cn('members')}>
         <div {...cn('member-header')}>
-          <span>{otherMembers.length + 1}</span> member{otherMembers.length + 1 === 1 ? '' : 's'}
+          <div {...cn('member-total')}>
+            <span>{otherMembers.length + 1}</span> member{otherMembers.length + 1 === 1 ? '' : 's'}
+          </div>
+          {this.props.isCurrentUserRoomAdmin && (
+            <IconButton {...cn('add-icon')} Icon={IconPlus} onClick={this.addMember} size={32} />
+          )}
         </div>
+
         <div {...cn('member-list')}>
           <ScrollbarContainer>
             <CitizenListItem

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -34,7 +34,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     return this.isUserAdmin(user) ? 'Admin' : null;
   }
 
-  navigateToEditPanel = () => {
+  editGroup = () => {
     this.props.onEdit();
   };
 
@@ -54,7 +54,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         {this.props.name && <div {...cn('group-name')}>{this.props.name}</div>}
 
         {this.props.isCurrentUserRoomAdmin && (
-          <Button {...cn('edit-group-button')} onPress={this.navigateToEditPanel} variant='text'>
+          <Button {...cn('edit-group-button')} onPress={this.editGroup} variant='text'>
             Edit
           </Button>
         )}

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -98,7 +98,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
   renderBackIcon = () => {
     return (
       <div {...cn('back-icon-container')}>
-        <IconButton {...cn('back-icon')} size={32} onClick={this.navigateBack} Icon={IconArrowNarrowLeft} isFilled />
+        <IconButton {...cn('back-icon')} Icon={IconArrowNarrowLeft} onClick={this.navigateBack} isFilled size={32} />
       </div>
     );
   };

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 
-import { Button, Image } from '@zero-tech/zui/components';
-import { IconUsers1 } from '@zero-tech/zui/icons';
+import { Button, IconButton, Image } from '@zero-tech/zui/components';
+import { IconArrowNarrowLeft, IconUsers1 } from '@zero-tech/zui/icons';
 
-import { PanelHeader } from '../panel-header';
 import { User } from '../../../../store/channels';
 import { bemClassName } from '../../../../lib/bem';
 import { CitizenListItem } from '../../../citizen-list-item';
@@ -34,18 +33,22 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     return this.isUserAdmin(user) ? 'Admin' : null;
   }
 
+  navigateBack = () => {
+    this.props.onBack();
+  };
+
   editGroup = () => {
     this.props.onEdit();
   };
 
-  renderImage = () => {
+  renderDetails = () => {
     return (
       <div {...cn('details')}>
-        <div {...cn('image')}>
+        <div {...cn('group-icon-conatiner')}>
           {this.props.icon ? (
-            <Image {...cn('custom-group-icon')} src={this.props.icon} alt='Custom Group Icon' />
+            <Image {...cn('group-icon')} src={this.props.icon} alt='Custom Group Icon' />
           ) : (
-            <div {...cn('default-group-icon')}>
+            <div {...cn('group-icon')}>
               <IconUsers1 size={60} />
             </div>
           )}
@@ -84,12 +87,29 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     );
   };
 
+  renderBanner = () => {
+    return (
+      <div {...cn('banner-container')}>
+        <div {...cn('banner')} />
+      </div>
+    );
+  };
+
+  renderBackIcon = () => {
+    return (
+      <div {...cn('back-icon-container')}>
+        <IconButton {...cn('back-icon')} size={32} onClick={this.navigateBack} Icon={IconArrowNarrowLeft} isFilled />
+      </div>
+    );
+  };
+
   render() {
     return (
       <div {...cn()}>
-        <PanelHeader title={'Group Info'} onBack={this.props.onBack} />
+        {this.renderBanner()}
+        {this.renderBackIcon()}
         <div {...cn('body')}>
-          {this.renderImage()}
+          {this.renderDetails()}
           {this.renderMembers()}
         </div>
       </div>

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -20,7 +20,7 @@ export interface Properties {
   otherMembers: User[];
   isCurrentUserRoomAdmin: boolean;
 
-  onEdit?: () => void;
+  onEdit: () => void;
   onBack: () => void;
 }
 

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Image } from '@zero-tech/zui/components';
+import { Button, Image } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 
 import { PanelHeader } from '../panel-header';
@@ -18,7 +18,9 @@ export interface Properties {
   icon: string;
   currentUser: User;
   otherMembers: User[];
+  isCurrentUserRoomAdmin: boolean;
 
+  onEdit?: () => void;
   onBack: () => void;
 }
 
@@ -37,6 +39,12 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         </div>
 
         {this.props.name && <div {...cn('group-name')}>{this.props.name}</div>}
+
+        {this.props.isCurrentUserRoomAdmin && (
+          <Button {...cn('edit-group-button')} onPress={this.props.onEdit} variant='text'>
+            Edit
+          </Button>
+        )}
       </div>
     );
   };

--- a/src/components/messenger/list/view-group-information-panel/index.tsx
+++ b/src/components/messenger/list/view-group-information-panel/index.tsx
@@ -34,6 +34,10 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     return this.isUserAdmin(user) ? 'Admin' : null;
   }
 
+  navigateToEditPanel = () => {
+    this.props.onEdit();
+  };
+
   renderImage = () => {
     return (
       <div {...cn('details')}>
@@ -50,7 +54,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
         {this.props.name && <div {...cn('group-name')}>{this.props.name}</div>}
 
         {this.props.isCurrentUserRoomAdmin && (
-          <Button {...cn('edit-group-button')} onPress={this.props.onEdit} variant='text'>
+          <Button {...cn('edit-group-button')} onPress={this.navigateToEditPanel} variant='text'>
             Edit
           </Button>
         )}

--- a/src/components/messenger/list/view-group-information-panel/styles.scss
+++ b/src/components/messenger/list/view-group-information-panel/styles.scss
@@ -16,20 +16,15 @@
     z-index: 1;
   }
 
-  &__back-icon {
-    height: 32px;
-    width: 32px;
-    cursor: pointer;
-    border-radius: 50%;
-    // TODO: uncomment when we have banner image path
-    // background-color: theme.$color-greyscale-4;
+  //   TODO: uncomment when we have banner image path
 
-    &:hover {
-      // TODO: uncomment and replace when we have banner image path
-      // background-color: theme.$color-greyscale-7;
-      background-color: theme.$color-greyscale-transparency-3;
-    }
-  }
+  // &__back-icon {
+  //   background-color: theme.$color-greyscale-4;
+
+  //   &:hover {
+  //   background-color: theme.$color-greyscale-7;
+  //   }
+  // }
 
   &__body {
     margin: 0px 16px;

--- a/src/components/messenger/list/view-group-information-panel/styles.scss
+++ b/src/components/messenger/list/view-group-information-panel/styles.scss
@@ -1,36 +1,60 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../../../variables';
+@import '../../../../glass';
 
 .view-group-information-panel {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  gap: 24px;
+
+  &__back-icon-container {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 16px 0 0 16px;
+    z-index: 1;
+  }
+
+  &__back-icon {
+    height: 32px;
+    width: 32px;
+    cursor: pointer;
+    border-radius: 50%;
+    background-color: theme.$color-greyscale-4;
+
+    &:hover {
+      background-color: theme.$color-greyscale-7;
+    }
+  }
 
   &__body {
     margin: 0px 16px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    gap: 24px;
   }
 
   &__details {
     display: flex;
     flex-direction: column;
+    gap: 16px;
+    z-index: 1;
   }
 
-  &__image {
-    margin: 8px 0px 24px 0px;
+  &__group-icon-conatiner {
     align-self: center;
   }
 
-  &__custom-group-icon {
+  &__group-icon {
+    @include flat-thick;
+
     width: 120px;
     height: 120px;
     border-radius: 9999px;
     overflow: hidden;
-  }
 
-  &__default-group-icon {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -47,8 +71,6 @@
     font-weight: 600;
     font-size: 18px;
     line-height: 21px;
-
-    padding-bottom: 24px;
   }
 
   &__edit-group-button {
@@ -63,9 +85,12 @@
   }
 
   &__member-header {
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 24px;
+    @include glass-text-secondary-color;
+
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 14px;
+    text-transform: uppercase;
   }
 
   &__member-list {
@@ -73,5 +98,24 @@
     flex-grow: 1;
     // Forcing a height here allows the flex-grow to fill the size without growing too big
     height: 1px;
+  }
+
+  &__banner-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    border-radius: 16px 16px 0 0;
+  }
+
+  &__banner {
+    display: flex;
+    height: 136px;
+    flex-direction: column;
+    align-items: flex-start;
+    flex-shrink: 0;
+    // replace with cloudinary path
+    // background: url('./assets/banner.png'), lightgray 50% / cover no-repeat;
+    border-radius: 16px 16px 0px 0px;
   }
 }

--- a/src/components/messenger/list/view-group-information-panel/styles.scss
+++ b/src/components/messenger/list/view-group-information-panel/styles.scss
@@ -21,10 +21,13 @@
     width: 32px;
     cursor: pointer;
     border-radius: 50%;
-    background-color: theme.$color-greyscale-4;
+    // TODO: uncomment when we have banner image path
+    // background-color: theme.$color-greyscale-4;
 
     &:hover {
-      background-color: theme.$color-greyscale-7;
+      // TODO: uncomment and replace when we have banner image path
+      // background-color: theme.$color-greyscale-7;
+      background-color: theme.$color-greyscale-transparency-3;
     }
   }
 
@@ -114,8 +117,9 @@
     flex-direction: column;
     align-items: flex-start;
     flex-shrink: 0;
-    // replace with cloudinary path
-    // background: url('./assets/banner.png'), lightgray 50% / cover no-repeat;
     border-radius: 16px 16px 0px 0px;
+
+    // TODO: replace with cloudinary path
+    // background: url('./assets/banner.png'), lightgray 50% / cover no-repeat;
   }
 }

--- a/src/components/messenger/list/view-group-information-panel/styles.scss
+++ b/src/components/messenger/list/view-group-information-panel/styles.scss
@@ -26,6 +26,10 @@
   //   }
   // }
 
+  &__add-icon {
+    margin-right: 8px;
+  }
+
   &__body {
     margin: 0px 16px;
     flex-grow: 1;
@@ -83,6 +87,12 @@
   }
 
   &__member-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__member-total {
     @include glass-text-secondary-color;
 
     font-weight: 600;

--- a/src/components/messenger/list/view-group-information-panel/styles.scss
+++ b/src/components/messenger/list/view-group-information-panel/styles.scss
@@ -51,6 +51,11 @@
     padding-bottom: 24px;
   }
 
+  &__edit-group-button {
+    width: fit-content;
+    align-self: center;
+  }
+
   &__members {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### What does this do?
- starts the add member flow from group info panel when clicking the '+' icon.

### Why are we making this change?
- as per designs.

### How do I test this?
- open the group info panel on a group you are the admin of > click the '+' icon > check the add member flow is displayed.

Note : Back navigation will likely be improved at a future date in a separate task.


https://github.com/zer0-os/zOS/assets/39112648/c5a82c6f-7039-48df-aee6-1d01667f8778

