### PR TITLE
Remove old polling for channels

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -6,8 +6,6 @@ import { ParentMessage, User } from './types';
 import { MemberNetworks } from '../../store/users/types';
 
 export interface RealtimeChatEvents {
-  reconnectStart: () => void;
-  reconnectStop: () => void;
   receiveNewMessage: (channelId: string, message: Message) => void;
   receiveDeleteMessage: (roomId: string, messageId: string) => void;
   onMessageUpdated: (channelId: string, message: Message) => void;

--- a/src/store/channels-list/index.ts
+++ b/src/store/channels-list/index.ts
@@ -1,14 +1,6 @@
-import { createAction } from '@reduxjs/toolkit';
 import { createNormalizedListSlice } from '../normalized';
 
 import { schema } from '../channels';
-
-export enum SagaActionTypes {
-  StartChannelsAndConversationsAutoRefresh = 'channelsList/saga/startChannelsAndConversationsAutoRefresh',
-  StopChannelsAndConversationsAutoRefresh = 'channelsList/saga/stopChannelsAndConversationsAutoRefresh',
-}
-
-const startChannelsAndConversationsAutoRefresh = createAction(SagaActionTypes.StartChannelsAndConversationsAutoRefresh);
 
 const slice = createNormalizedListSlice({
   name: 'channelsList',
@@ -17,7 +9,6 @@ const slice = createNormalizedListSlice({
 
 export const { receiveNormalized, setStatus, receive } = slice.actions;
 export const { reducer, normalize, denormalize } = slice;
-export { startChannelsAndConversationsAutoRefresh };
 
 export function denormalizeConversations(state) {
   return denormalize(state.channelsList.value, state).filter((c) => !c.isChannel);

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -1,13 +1,11 @@
 import { testSaga } from 'redux-saga-test-plan';
-import { call, race, take } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { chat } from '../../lib/chat';
 import { receive as receiveUser } from '../users';
 
 import {
   fetchConversations,
-  fetchChannelsAndConversations,
-  startChannelsAndConversationsRefresh,
   clearChannelsAndConversations,
   userLeftChannel,
   addChannel,
@@ -17,7 +15,6 @@ import {
   fetchUserPresence,
 } from './saga';
 
-import { SagaActionTypes } from '.';
 import { RootState, rootReducer } from '../reducer';
 import { ConversationEvents, getConversationsBus } from './channels';
 import { multicastChannel } from 'redux-saga';

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -209,27 +209,6 @@ describe('channels list saga', () => {
     });
   });
 
-  it('verify startChannelsAndConversationsRefresh', () => {
-    testSaga(startChannelsAndConversationsRefresh)
-      .next({ abort: undefined, success: true })
-      .inspect((raceValue) => {
-        expect(raceValue).toStrictEqual(
-          race({
-            abort: take(SagaActionTypes.StopChannelsAndConversationsAutoRefresh),
-            success: call(fetchChannelsAndConversations),
-          })
-        );
-      })
-
-      .next({ abort: true, success: undefined })
-      .inspect((returnValue) => {
-        expect(returnValue).toBeFalse();
-      })
-
-      .next()
-      .isDone();
-  });
-
   it('removes the channels list and channels', async () => {
     const channelsList = { value: ['id-one'] };
     const channels = { 'id-one': { id: 'id-one', name: 'this should be removed' } };

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -2,8 +2,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { ChannelType } from './types';
 import getDeepProperty from 'lodash.get';
 import uniqBy from 'lodash.uniqby';
-import { fork, takeLatest, put, call, take, race, all, select, spawn } from 'redux-saga/effects';
-import { SagaActionTypes, receive, denormalizeConversations } from '.';
+import { fork, put, call, take, all, select, spawn } from 'redux-saga/effects';
+import { receive, denormalizeConversations } from '.';
 import { chat } from '../../lib/chat';
 import { receive as receiveUser } from '../users';
 
@@ -224,17 +224,6 @@ export function* fetchChannelsAndConversations() {
   }
 }
 
-export function* startChannelsAndConversationsRefresh() {
-  while (true) {
-    const { abort, _success } = yield race({
-      abort: take(SagaActionTypes.StopChannelsAndConversationsAutoRefresh),
-      success: call(fetchChannelsAndConversations),
-    });
-
-    if (abort) return false;
-  }
-}
-
 export function* channelsReceived(action) {
   const { channels } = action.payload;
 
@@ -264,14 +253,6 @@ function* listenForUserLogin() {
   }
 }
 
-function* listenForUserLogout() {
-  const userChannel = yield call(getAuthChannel);
-  while (true) {
-    yield take(userChannel, Events.UserLogout);
-    yield put({ type: SagaActionTypes.StopChannelsAndConversationsAutoRefresh });
-  }
-}
-
 export function* currentUserAddedToChannel(_action) {
   // For now, just force a fetch of conversations to refresh the list.
   yield fetchConversations();
@@ -298,8 +279,6 @@ function* currentUserLeftChannel(channelId) {
 
 export function* saga() {
   yield spawn(listenForUserLogin);
-  yield spawn(listenForUserLogout);
-  yield takeLatest(SagaActionTypes.StartChannelsAndConversationsAutoRefresh, startChannelsAndConversationsRefresh);
 
   const chatBus = yield call(getChatBus);
   yield takeEveryFromBus(chatBus, ChatEvents.ChannelInvitationReceived, currentUserAddedToChannel);

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -7,8 +7,6 @@ export enum Events {
   MessageUpdated = 'chat/message/updated',
   MessageDeleted = 'chat/message/deleted',
   UnreadCountChanged = 'chat/message/unreadCountChanged',
-  ReconnectStart = 'chat/reconnectStart',
-  ReconnectStop = 'chat/reconnectStop',
   InvalidToken = 'chat/invalidToken',
   ChannelInvitationReceived = 'chat/channel/invitationReceived',
   UserLeftChannel = 'chat/channel/userLeft',
@@ -54,8 +52,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       emit({ type: Events.MessageDeleted, payload: { channelId, messageId } });
     const receiveUnreadCount = (channelId, unreadCount) =>
       emit({ type: Events.UnreadCountChanged, payload: { channelId, unreadCount } });
-    const reconnectStart = () => emit({ type: Events.ReconnectStart, payload: {} });
-    const reconnectStop = () => emit({ type: Events.ReconnectStop, payload: {} });
     const invalidChatAccessToken = () => emit({ type: Events.InvalidToken, payload: {} });
     const onUserReceivedInvitation = (channelId) =>
       emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
@@ -72,8 +68,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
 
     chatClient.initChat({
-      reconnectStart,
-      reconnectStop,
       receiveNewMessage,
       onMessageUpdated,
       receiveDeleteMessage,

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -6,7 +6,6 @@ const initialState: ChatState = {
     isLoading: false,
     value: null,
   },
-  isReconnecting: false,
   activeConversationId: null,
 };
 
@@ -14,9 +13,6 @@ const slice = createSlice({
   name: 'chat',
   initialState,
   reducers: {
-    setReconnecting: (state, action: PayloadAction<ChatState['isReconnecting']>) => {
-      state.isReconnecting = action.payload;
-    },
     setChatAccessToken: (state, action: PayloadAction<ChatState['chatAccessToken']>) => {
       state.chatAccessToken = action.payload;
     },
@@ -26,5 +22,5 @@ const slice = createSlice({
   },
 });
 
-export const { setChatAccessToken, setReconnecting, setActiveConversationId } = slice.actions;
+export const { setChatAccessToken, setActiveConversationId } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -1,5 +1,4 @@
 export interface ChatState {
-  isReconnecting: boolean;
   chatAccessToken: {
     value: string;
     isLoading: boolean;


### PR DESCRIPTION
### What does this do?

We used to poll for channel information in the case of public zOS. That's no longer a thing so this removes it.

