### PR TITLE
Add allowJoinRoom feature flag

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -81,6 +81,14 @@ export class FeatureFlags {
   set internalUsage(value: boolean) {
     this._setBoolean('internalUsage', value);
   }
+
+  get allowJoinRoom() {
+    return this._getBoolean('allowJoinRoom', false);
+  }
+
+  set allowJoinRoom(value: boolean) {
+    this._setBoolean('allowJoinRoom', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?

Add `allowJoinRoom`, if set `true` then user can be a part of a room that doesn't exist, or he hasn't joined yet.
