### PR TITLE
Revert "Call setActiveConversationId on componentDidUpdate in messenger-main.tsx (#1412)"

### DIFF
--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -10,6 +10,7 @@ describe('MessengerMain', () => {
     const allProps = {
       isAuthenticated: false,
       match: { params: { conversationId: '' } },
+      rawSetActiveConversationId: () => null,
       setActiveConversationId: () => null,
       ...props,
     };
@@ -52,8 +53,10 @@ describe('MessengerMain', () => {
   });
 
   it('updates the conversation id when the route changes', () => {
+    const rawSetActiveConversationId = jest.fn();
     const setActiveConversationId = jest.fn();
     const wrapper = subject({
+      rawSetActiveConversationId,
       setActiveConversationId,
       match: { params: { conversationId: '123' } },
     });
@@ -62,12 +65,14 @@ describe('MessengerMain', () => {
     jest.clearAllMocks();
 
     wrapper.setProps({ match: { params: { conversationId: '456' } } });
-    expect(setActiveConversationId).toHaveBeenCalledWith({ id: '456' });
+    expect(rawSetActiveConversationId).toHaveBeenCalledWith('456');
   });
 
   it('does not update the conversation id when the route does not change', () => {
+    const rawSetActiveConversationId = jest.fn();
     const setActiveConversationId = jest.fn();
     const wrapper = subject({
+      rawSetActiveConversationId,
       setActiveConversationId,
       match: { params: { conversationId: '123' } },
       isAuthenticated: true, // To allow us to force a property change
@@ -77,6 +82,6 @@ describe('MessengerMain', () => {
     jest.clearAllMocks();
 
     wrapper.setProps({ isAuthenticated: false }); // force prop change without changing `match`
-    expect(setActiveConversationId).not.toHaveBeenCalled();
+    expect(rawSetActiveConversationId).not.toHaveBeenCalled();
   });
 });

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -5,12 +5,13 @@ import { connectContainer } from './store/redux-container';
 import { Main } from './Main';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { setActiveConversationId } from './store/chat';
+import { rawSetActiveConversationId, setActiveConversationId } from './store/chat';
 
 export interface Properties {
   isAuthenticated: boolean;
 
   match: { params: { conversationId: string } };
+  rawSetActiveConversationId: (id: string) => void;
   setActiveConversationId: ({ id }: { id: string }) => void;
 }
 
@@ -23,6 +24,7 @@ export class Container extends React.Component<Properties> {
 
   static mapActions() {
     return {
+      rawSetActiveConversationId,
       setActiveConversationId,
     };
   }
@@ -33,7 +35,7 @@ export class Container extends React.Component<Properties> {
 
   componentDidUpdate(prevProps: Properties): void {
     if (this.idChanged(prevProps)) {
-      this.props.setActiveConversationId({ id: this.conversationId });
+      this.props.rawSetActiveConversationId(this.conversationId);
     }
   }
 


### PR DESCRIPTION
This reverts commit 2fce711ec070f4f19d2607482d393509f59762d3. 

PR - [https://github.com/zer0-os/zOS/pull/1412](https://github.com/zer0-os/zOS/pull/1412)
### What does this do?

This was causing issues with the initial load after logging in. Looking into it, but meanwhile reverting this change.