### PR TITLE
Remove `rawSetActiveConversationId` from messenger-main.tsx

### DIFF
--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -10,7 +10,6 @@ describe('MessengerMain', () => {
     const allProps = {
       isAuthenticated: false,
       match: { params: { conversationId: '' } },
-      rawSetActiveConversationId: () => null,
       setActiveConversationId: () => null,
       ...props,
     };
@@ -53,10 +52,8 @@ describe('MessengerMain', () => {
   });
 
   it('updates the conversation id when the route changes', () => {
-    const rawSetActiveConversationId = jest.fn();
     const setActiveConversationId = jest.fn();
     const wrapper = subject({
-      rawSetActiveConversationId,
       setActiveConversationId,
       match: { params: { conversationId: '123' } },
     });
@@ -65,14 +62,12 @@ describe('MessengerMain', () => {
     jest.clearAllMocks();
 
     wrapper.setProps({ match: { params: { conversationId: '456' } } });
-    expect(rawSetActiveConversationId).toHaveBeenCalledWith('456');
+    expect(setActiveConversationId).toHaveBeenCalledWith({ id: '456' });
   });
 
   it('does not update the conversation id when the route does not change', () => {
-    const rawSetActiveConversationId = jest.fn();
     const setActiveConversationId = jest.fn();
     const wrapper = subject({
-      rawSetActiveConversationId,
       setActiveConversationId,
       match: { params: { conversationId: '123' } },
       isAuthenticated: true, // To allow us to force a property change
@@ -82,6 +77,6 @@ describe('MessengerMain', () => {
     jest.clearAllMocks();
 
     wrapper.setProps({ isAuthenticated: false }); // force prop change without changing `match`
-    expect(rawSetActiveConversationId).not.toHaveBeenCalled();
+    expect(setActiveConversationId).not.toHaveBeenCalled();
   });
 });

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -5,13 +5,12 @@ import { connectContainer } from './store/redux-container';
 import { Main } from './Main';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { rawSetActiveConversationId, setActiveConversationId } from './store/chat';
+import { setActiveConversationId } from './store/chat';
 
 export interface Properties {
   isAuthenticated: boolean;
 
   match: { params: { conversationId: string } };
-  rawSetActiveConversationId: (id: string) => void;
   setActiveConversationId: ({ id }: { id: string }) => void;
 }
 
@@ -24,7 +23,6 @@ export class Container extends React.Component<Properties> {
 
   static mapActions() {
     return {
-      rawSetActiveConversationId,
       setActiveConversationId,
     };
   }
@@ -35,7 +33,7 @@ export class Container extends React.Component<Properties> {
 
   componentDidUpdate(prevProps: Properties): void {
     if (this.idChanged(prevProps)) {
-      this.props.rawSetActiveConversationId(this.conversationId);
+      this.props.setActiveConversationId({ id: this.conversationId });
     }
   }
 

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -115,6 +115,9 @@ export function* performValidateActiveConversation(activeConversationId: string)
   if (!featureFlags.allowJoinRoom) {
     const isUserMemberOfActiveConversation = yield call(isMemberOfActiveConversation, activeConversationId);
     yield put(setIsConversationErrorDialogOpen(!isUserMemberOfActiveConversation));
+    if (isUserMemberOfActiveConversation) {
+      yield put(rawSetActiveConversationId(activeConversationId));
+    }
     return;
   }
 


### PR DESCRIPTION
### What does this do?

As per review feedback, we need to validate the active conversation when the user changes a url within the app as well (working now)