### PR TITLE
Remove `openFirstConversationAfterChannelsLoaded` from `store/login/saga.ts`

### DIFF
--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -10,7 +10,6 @@ describe('MessengerMain', () => {
     const allProps = {
       isAuthenticated: false,
       match: { params: { conversationId: '' } },
-      rawSetActiveConversationId: () => null,
       setActiveConversationId: () => null,
       ...props,
     };
@@ -53,10 +52,8 @@ describe('MessengerMain', () => {
   });
 
   it('updates the conversation id when the route changes', () => {
-    const rawSetActiveConversationId = jest.fn();
     const setActiveConversationId = jest.fn();
     const wrapper = subject({
-      rawSetActiveConversationId,
       setActiveConversationId,
       match: { params: { conversationId: '123' } },
     });
@@ -65,14 +62,12 @@ describe('MessengerMain', () => {
     jest.clearAllMocks();
 
     wrapper.setProps({ match: { params: { conversationId: '456' } } });
-    expect(rawSetActiveConversationId).toHaveBeenCalledWith('456');
+    expect(setActiveConversationId).toHaveBeenCalledWith({ id: '456' });
   });
 
   it('does not update the conversation id when the route does not change', () => {
-    const rawSetActiveConversationId = jest.fn();
     const setActiveConversationId = jest.fn();
     const wrapper = subject({
-      rawSetActiveConversationId,
       setActiveConversationId,
       match: { params: { conversationId: '123' } },
       isAuthenticated: true, // To allow us to force a property change
@@ -82,6 +77,6 @@ describe('MessengerMain', () => {
     jest.clearAllMocks();
 
     wrapper.setProps({ isAuthenticated: false }); // force prop change without changing `match`
-    expect(rawSetActiveConversationId).not.toHaveBeenCalled();
+    expect(setActiveConversationId).not.toHaveBeenCalled();
   });
 });

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -5,13 +5,12 @@ import { connectContainer } from './store/redux-container';
 import { Main } from './Main';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { rawSetActiveConversationId, setActiveConversationId } from './store/chat';
+import { setActiveConversationId } from './store/chat';
 
 export interface Properties {
   isAuthenticated: boolean;
 
   match: { params: { conversationId: string } };
-  rawSetActiveConversationId: (id: string) => void;
   setActiveConversationId: ({ id }: { id: string }) => void;
 }
 
@@ -24,7 +23,6 @@ export class Container extends React.Component<Properties> {
 
   static mapActions() {
     return {
-      rawSetActiveConversationId,
       setActiveConversationId,
     };
   }
@@ -35,7 +33,7 @@ export class Container extends React.Component<Properties> {
 
   componentDidUpdate(prevProps: Properties): void {
     if (this.idChanged(prevProps)) {
-      this.props.rawSetActiveConversationId(this.conversationId);
+      this.props.setActiveConversationId({ id: this.conversationId });
     }
   }
 

--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -9,7 +9,7 @@ import { User } from '../channels';
 import { testSaga } from 'redux-saga-test-plan';
 import { waitForChannelListLoad } from '../channels-list/saga';
 import { getRoomIdForAlias } from '../../lib/chat';
-import { rawSetActiveConversationId } from '.';
+import { rawSetActiveConversationId, setIsConversationErrorDialogOpen } from '.';
 import { joinRoom as apiJoinRoom } from './api';
 
 const featureFlags = { allowJoinRoom: false };
@@ -22,8 +22,24 @@ describe(performValidateActiveConversation, () => {
     return expectSaga(...args).provide([
       [matchers.call.fn(getRoomIdForAlias), 'room-id'],
       [matchers.call.fn(apiJoinRoom), { success: true, response: { roomId: 'room-id' } }],
+      [matchers.call.fn(openFirstConversation), null],
     ]);
   }
+
+  it('sets the dialog to closed & opens the first conversation if no active conversation', async () => {
+    const initialState = new StoreBuilder()
+      .withChat({ isConversationErrorDialogOpen: true })
+      .withCurrentUser({ id: 'current-user' })
+      .withActiveConversation({ id: null });
+
+    const { storeState } = await subject(performValidateActiveConversation, undefined)
+      .withReducer(rootReducer, initialState.build())
+      .put(setIsConversationErrorDialogOpen(false))
+      .call(openFirstConversation)
+      .run();
+
+    expect(storeState.chat.isConversationErrorDialogOpen).toBe(false);
+  });
 
   it('sets the dialog to closed if user is member of conversation', async () => {
     const initialState = new StoreBuilder()

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -109,6 +109,7 @@ function* isMemberOfActiveConversation(activeConversationId) {
 export function* performValidateActiveConversation(activeConversationId: string) {
   if (!activeConversationId) {
     yield put(setIsConversationErrorDialogOpen(false));
+    yield call(openFirstConversation);
     return;
   }
 

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -115,6 +115,9 @@ export function* performValidateActiveConversation(activeConversationId: string)
   if (!featureFlags.allowJoinRoom) {
     const isUserMemberOfActiveConversation = yield call(isMemberOfActiveConversation, activeConversationId);
     yield put(setIsConversationErrorDialogOpen(!isUserMemberOfActiveConversation));
+    if (isUserMemberOfActiveConversation) {
+      yield put(rawSetActiveConversationId(activeConversationId));
+    }
     return;
   }
 

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -1,4 +1,4 @@
-import { call, put, race, select, spawn, take, takeLatest } from 'redux-saga/effects';
+import { call, put, race, spawn, take, takeLatest } from 'redux-saga/effects';
 
 import {
   EmailLoginErrors,
@@ -14,9 +14,6 @@ import { getSignedToken, getSignedTokenForConnector, isWeb3AccountConnected } fr
 import { authenticateByEmail, logout, nonceOrAuthorize, terminate } from '../authentication/saga';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { Web3Events, getWeb3Channel } from '../web3/channels';
-import { ConversationEvents, getConversationsBus } from '../channels-list/channels';
-import { openFirstConversation } from '../channels/saga';
-import { activeConversationIdSelector } from '../chat/selectors';
 
 export function* emailLogin(action) {
   const { email, password } = action.payload;
@@ -140,21 +137,9 @@ function* listenForUserLogin() {
   while (true) {
     yield take(authChannel, AuthEvents.UserLogin);
 
-    // After successful login
-    yield spawn(openFirstConversationAfterChannelsLoaded);
-
     if (yield call(isWeb3AccountConnected)) {
       yield spawn(listenForWeb3AccountChanges);
     }
-  }
-}
-
-export function* openFirstConversationAfterChannelsLoaded() {
-  const channel = yield call(getConversationsBus);
-  yield take(channel, ConversationEvents.ConversationsLoaded);
-  const activeConversationId = yield select(activeConversationIdSelector);
-  if (!activeConversationId) {
-    yield call(openFirstConversation);
   }
 }
 


### PR DESCRIPTION
### What does this do?

Since we're validating the active conversation each time the components mounts/updates (after channels load), we can remove a previous function which was opening the first conversation after loading the channels. We can just open the first conversation in `performValidateActiveConversation` only.

Earlier this was causing an issue since two events were fired at the same time: `openFirstConversation` (by `openFirstConversationAfterChannelsLoaded` saga event), and the `validateActiveConversation` saga event. 
