### PR TITLE
fix: handle conversation header avatar

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -179,7 +179,6 @@ describe('messenger-chat', () => {
       const headerAvatar = wrapper.find('.direct-message-chat__header-avatar');
 
       expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url(avatar-url)' });
-
       expect(headerAvatar.find('IconUsers1').exists()).toBeFalse();
     });
 

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -164,7 +164,7 @@ describe('messenger-chat', () => {
       expect(offlineAvatar.exists()).toBeTrue();
     });
 
-    it('header renders avatar', function () {
+    it('header renders users avatar when there is a avatar url', function () {
       const wrapper = subject({
         directMessage: {
           isOneOnOne: true,
@@ -178,8 +178,27 @@ describe('messenger-chat', () => {
 
       const headerAvatar = wrapper.find('.direct-message-chat__header-avatar');
 
-      expect(headerAvatar.prop('style').backgroundImage).toEqual('url(avatar-url)');
+      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url(avatar-url)' });
+
       expect(headerAvatar.find('IconUsers1').exists()).toBeFalse();
+    });
+
+    it('header renders avatar with eth icon when there is no avatar url', function () {
+      const wrapper = subject({
+        directMessage: {
+          isOneOnOne: true,
+          otherMembers: [
+            stubUser({
+              profileImage: '',
+            }),
+          ],
+        } as Channel,
+      });
+
+      const headerAvatar = wrapper.find('.direct-message-chat__header-avatar');
+
+      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url()' });
+      expect(headerAvatar.find('IconCurrencyEthereum').exists()).toBeTrue();
     });
 
     it('header renders group management menu icon button', function () {
@@ -315,15 +334,15 @@ describe('messenger-chat', () => {
       expect(offlineAvatar.exists()).toBeTrue();
     });
 
-    it('header renders avatar with users icon', function () {
+    it('header renders avatar with group icon when there is no avatar url', function () {
       const wrapper = subject({
         directMessage: {
           otherMembers: [
             stubUser({
-              profileImage: 'avatar-url-1',
+              profileImage: '',
             }),
             stubUser({
-              profileImage: 'avatar-url-2',
+              profileImage: '',
             }),
           ],
         } as Channel,
@@ -331,11 +350,11 @@ describe('messenger-chat', () => {
 
       const headerAvatar = wrapper.find('.direct-message-chat__header-avatar');
 
-      expect(headerAvatar.prop('style').backgroundImage).toEqual('url()');
+      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url()' });
       expect(headerAvatar.find('IconUsers1').exists()).toBeTrue();
     });
 
-    it('header renders avatar in case if custom icon is set', function () {
+    it('header renders avatar with custom background when there is an avatar url', function () {
       const wrapper = subject({
         directMessage: {
           icon: 'https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg',
@@ -352,9 +371,10 @@ describe('messenger-chat', () => {
 
       const headerAvatar = wrapper.find('.direct-message-chat__header-avatar');
 
-      expect(headerAvatar.prop('style').backgroundImage).toEqual(
-        'url(https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg)'
-      );
+      expect(headerAvatar).toHaveProp('style', {
+        backgroundImage:
+          'url(https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg)',
+      });
     });
   });
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconUsers1 } from '@zero-tech/zui/icons';
+import { IconCurrencyEthereum, IconUsers1 } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 import { RootState } from '../../../store/reducer';
 import { connectContainer } from '../../../store/redux-container';
@@ -205,6 +205,14 @@ export class Container extends React.Component<Properties> {
     }
   };
 
+  renderIcon = () => {
+    return this.isOneOnOne() ? (
+      <IconCurrencyEthereum size={16} className={this.isOneOnOne && 'direct-message-chat__header-avatar--isOneOnOne'} />
+    ) : (
+      <IconUsers1 size={16} />
+    );
+  };
+
   render() {
     if (!this.props.activeConversationId || !this.props.directMessage) {
       return null;
@@ -226,7 +234,7 @@ export class Container extends React.Component<Properties> {
                     `direct-message-chat__header-avatar--${this.avatarStatus()}`
                   )}
                 >
-                  {!this.isOneOnOne() && <IconUsers1 size={16} />}
+                  {!this.avatarUrl() && this.renderIcon()}
                 </div>
               </span>
               <span className='direct-message-chat__description'>

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -86,14 +86,27 @@ $recent-indicator-size: 8px;
     }
 
     &-avatar {
+      @include glass-separator-primary;
+
       background-position: center;
       background-repeat: no-repeat;
       background-size: cover;
-      background-color: theme.$color-primary-4;
       position: relative;
       width: 32px;
       height: 32px;
       border-radius: 50%;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: inherit;
+
+        @include glass-materials-raised;
+      }
 
       &::after {
         content: '';
@@ -104,6 +117,10 @@ $recent-indicator-size: 8px;
         position: absolute;
         top: 22px;
         left: 22px;
+      }
+
+      &--isOneOnOne {
+        color: theme.$color-secondary-11;
       }
 
       &--online::after {


### PR DESCRIPTION
### What does this do?
- correctly handles the conversation header avatar for group conversations, one on one conversations and whether there is a custom icon or not.

### Why are we making this change?
- to fix how the avatar is displayed in the conversation header depending on the conditions mentioned above.

### How do I test this?
- open messenger and check the avatar of the different types of conversations and set icons.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Before: 
<img width="294" alt="Screenshot 2024-01-19 at 12 29 03" src="https://github.com/zer0-os/zOS/assets/39112648/7a2134e7-8249-48d0-a64d-d64d405f85f2">
<img width="294" alt="Screenshot 2024-01-19 at 12 29 19" src="https://github.com/zer0-os/zOS/assets/39112648/a614d9d2-023e-409a-83e0-95787f811bc6">
<img width="294" alt="Screenshot 2024-01-19 at 12 29 21" src="https://github.com/zer0-os/zOS/assets/39112648/0700454b-b082-4462-ac6c-7bf08c07a879">

After:
<img width="294" alt="Screenshot 2024-01-19 at 12 26 47" src="https://github.com/zer0-os/zOS/assets/39112648/6d4ed4ad-b805-4e99-b39c-aa057a7fef1a">
<img width="294" alt="Screenshot 2024-01-19 at 12 26 44" src="https://github.com/zer0-os/zOS/assets/39112648/a63036c8-4eca-46ca-9cb7-5cddcc0eec67">
<img width="294" alt="Screenshot 2024-01-19 at 12 26 41" src="https://github.com/zer0-os/zOS/assets/39112648/477498fa-389e-4a61-b45b-8c6cc4238e04">
