### PR TITLE
Set the raw data to null if we can't find a conversation rather than redirecting

### DIFF
--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -9,6 +9,7 @@ import { chat } from '../../lib/chat';
 import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
 import { ParentMessage } from '../../lib/chat/types';
+import { rawSetActiveConversationId } from '../chat';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -60,7 +61,7 @@ export function* openFirstConversation() {
     yield call(openConversation, conversation.id);
   } else {
     // Not sure this is the right choice. Maybe there's a redirectToRoot at some point.
-    yield call(setActiveConversation, '');
+    yield call(rawSetActiveConversationId, null);
   }
 }
 


### PR DESCRIPTION
### What does this do?

Infinite loop fix. If you don't have any conversations then this used to redirect to the empty conversation url which then tries to "open first conversation" again....

