### PR TITLE
feat(error-dialog): add optional link and logic

### DIFF
--- a/src/components/error-dialog/index.test.tsx
+++ b/src/components/error-dialog/index.test.tsx
@@ -48,4 +48,34 @@ describe('ErrorDialog', () => {
 
     expect(wrapper.find(c('body'))).toHaveText('Test error message');
   });
+
+  it('renders a link when linkPath and linkText are provided', function () {
+    const wrapper = subject({ linkPath: 'https://example.com', linkText: 'External Link' });
+
+    expect(wrapper.find('a')).toExist();
+  });
+
+  it('does not render a link when linkText is not provided', function () {
+    const wrapper = subject({ linkPath: 'https://example.com', linkText: '' });
+
+    expect(wrapper.find('a')).not.toExist();
+  });
+
+  it('does not render a link when linkPath is not provided', function () {
+    const wrapper = subject({ linkPath: '', linkText: 'External Link' });
+
+    expect(wrapper.find('a')).not.toExist();
+  });
+
+  it('renders the primary button variant when linkPath is not provided', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find(Button)).toHaveProp('variant', 'primary');
+  });
+
+  it('renders the text button variant when linkPath and linkText is provided', function () {
+    const wrapper = subject({ linkPath: 'https://example.com', linkText: 'External Link' });
+
+    expect(wrapper.find(Button)).toHaveProp('variant', 'text');
+  });
 });

--- a/src/components/error-dialog/index.tsx
+++ b/src/components/error-dialog/index.tsx
@@ -3,27 +3,27 @@ import * as React from 'react';
 import { IconButton, Button } from '@zero-tech/zui/components';
 import { IconXClose } from '@zero-tech/zui/icons';
 
+import classNames from 'classnames';
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
 
 const cn = bemClassName('error-dialog');
 
-export type ErrorDialogContent = {
-  header: string;
-  body: string;
-};
-
 export interface Properties {
   header: string;
   body: string;
+
+  linkPath?: string;
+  linkText?: string;
 
   onClose?: () => void;
 }
 
 export class ErrorDialog extends React.Component<Properties> {
   render() {
-    const { header, body, onClose } = this.props;
+    const { header, body, linkPath, linkText, onClose } = this.props;
+    const hasLink = linkPath && linkText;
 
     return (
       <div {...cn('')}>
@@ -33,10 +33,15 @@ export class ErrorDialog extends React.Component<Properties> {
           <div {...cn('header')}>{header}</div>
         </div>
         <div {...cn('body')}>{body}</div>
-        <div {...cn('footer')}>
-          <Button onPress={onClose} variant='text'>
-            Dismiss
+        <div {...cn('footer', classNames({ 'is-single-button': !hasLink }))}>
+          <Button {...cn('button')} onPress={onClose} variant={hasLink ? 'text' : 'primary'}>
+            Back to my conversations
           </Button>
+          {hasLink && (
+            <a {...cn('link')} href={linkPath} target='_blank' rel='noopener noreferrer'>
+              {linkText}
+            </a>
+          )}
         </div>
       </div>
     );

--- a/src/components/error-dialog/styles.scss
+++ b/src/components/error-dialog/styles.scss
@@ -7,7 +7,6 @@
 
   display: flex;
   flex-direction: column;
-  align-items: center;
   align-self: stretch;
   position: relative;
 
@@ -47,7 +46,56 @@
   &__footer {
     display: flex;
     justify-content: space-between;
+    align-items: center;
 
     width: 100%;
+
+    &--is-single-button {
+      justify-content: flex-end;
+    }
+  }
+
+  &__button {
+    padding: 0 8px;
+  }
+
+  &__link {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 32px;
+    margin: 0;
+    padding: 0 16px;
+    border-width: 0;
+    border-radius: 1000px;
+    background: theme.$color-secondary-4;
+    color: theme.$color-secondary-11;
+    font-weight: bold;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.1s ease-in-out;
+
+    &:hover {
+      background: theme.$color-secondary-11;
+      color: theme.$color-black;
+    }
+
+    &:active {
+      background: theme.$color-secondary-10;
+    }
+
+    &:after {
+      content: ' ';
+      width: calc(100% - 4px);
+      height: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      border-radius: inherit;
+      border-left: 2px solid theme.$color-secondary-11;
+      border-right: 2px solid theme.$color-secondary-11;
+      transition: border-color 0.1s ease-in-out;
+    }
   }
 }

--- a/src/components/error-dialog/styles.scss
+++ b/src/components/error-dialog/styles.scss
@@ -56,9 +56,10 @@
   }
 
   &__button {
-    padding: 0 8px;
+    padding: 0 4px;
   }
 
+  // link styles are copied from the current zui button component styles
   &__link {
     position: relative;
     display: flex;


### PR DESCRIPTION
### What does this do?
- adds optional link and logic to the error dialog component.

### Why are we making this change?
- these changes have been made so the user can navigate to an external url (e.g. zns explorer) from the error dialog, and, also handle when a link is not required.

### How do I test this?
- pass in the optional props to where the `ErrorDialog` is being used and test that the link is displayed and navigates you to an external path in a new tab, and vice versa, e.g. only render the button if a link path & link text is not provided.

Style/Design as per Figma ['here'](https://www.figma.com/file/btwltL4Os8hAy3eS3pxaa6/ZERO-Messenger-Web-%7C-Glass?type=design&node-id=12825-41059&mode=design&t=dlAwjivfKOymGjtB-0) 



When `linkPath` and `linkText` are provided:
<img width="1019" alt="Screenshot 2024-01-22 at 11 38 57" src="https://github.com/zer0-os/zOS/assets/39112648/8279fafc-410c-4b35-989a-c5c1d5ee4ffd">

When `linkPath` or `linkText` are NOT provided:
<img width="1019" alt="Screenshot 2024-01-22 at 11 39 34" src="https://github.com/zer0-os/zOS/assets/39112648/133f5487-51e5-4936-bfa3-0fe6f31abc14">
