### PR TITLE
feat: centre align messenger background image

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -24,6 +24,7 @@ body {
   background-image: url(cloudAsset('Messenger-BG-02.png'));
   background-size: cover;
   background-repeat: no-repeat;
+  background-position: center top;
 
   transition: color animation.$animation-duration-double ease-out;
 


### PR DESCRIPTION
### What does this do?
- aligns messenger background image as shown in below demo.

### Why are we making this change?
- when screen size decreases/increases the background image should be aligned to the centre of the browser window.

### How do I test this?
- open messenger and decrease/increase screen size > check background is centre aligned 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Before:

https://github.com/zer0-os/zOS/assets/39112648/c9475817-ee4e-4468-82b3-ea8f8d5e1066


After:

https://github.com/zer0-os/zOS/assets/39112648/b9fda520-7df4-40df-b71b-9bfd70320504

