### PR TITLE
Wait for `UserJoinedRoom` Event before setting the `rawActiveConversationId`

### DIFF
--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -7,6 +7,7 @@ import {
   performValidateActiveConversation,
   validateActiveConversation,
   isMemberOfActiveConversation,
+  setWhenUserJoinedRoom,
 } from './saga';
 import { openFirstConversation } from '../channels/saga';
 import { rootReducer } from '../reducer';
@@ -148,8 +149,10 @@ describe(performValidateActiveConversation, () => {
       .withReducer(rootReducer, initialState.build())
       .provide([
         [matchers.call.fn(getRoomIdForAlias), undefined],
+        [matchers.call.fn(apiJoinRoom), { success: true, response: { roomId: 'new-room-id' } }],
       ])
       .call(apiJoinRoom, '#convo-not-exists')
+      .call(setWhenUserJoinedRoom, 'new-room-id')
       .run();
   });
 

--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -88,7 +88,7 @@ describe(performValidateActiveConversation, () => {
         [matchers.call.fn(isMemberOfActiveConversation), false],
         [matchers.call.fn(apiJoinRoom), { success: true, response: { roomId: 'convo-1' } }],
       ])
-      .put(rawSetActiveConversationId('convo-1'))
+      .call(setWhenUserJoinedRoom, 'convo-1')
       .put(clearJoinRoomErrorContent())
       .run();
 
@@ -109,6 +109,7 @@ describe(performValidateActiveConversation, () => {
       .provide([
         [matchers.call.fn(apiJoinRoom), { success: false, response: 'M_UNKNOWN', message: 'error message' }],
       ])
+      .not.call(setWhenUserJoinedRoom, expect.any(String))
       .run();
 
     expect(storeState.chat.joinRoomErrorContent).toStrictEqual(

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -95,7 +95,7 @@ export function* joinRoom(roomIdOrAlias: string) {
     yield put(setJoinRoomErrorContent(error));
   } else {
     yield put(clearJoinRoomErrorContent());
-    yield call(setWhenUserJoinedRoom, response.roomId); // wait for user to join room
+    yield call(setWhenUserJoinedRoom, response.roomId);
   }
 }
 


### PR DESCRIPTION
### What does this do?

After calling the API (`/matrix/room/join`), we should wait for the "real time" event from Matrix before setting the conversation Id. 

Previously we were setting the conversationId before even receiving the event, which was causing the UI to not behave properly (eg. messages fetch failed, UI crashing for some users etc).
