### PR TITLE
feat: return primaryZID when fetching user data

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -560,6 +560,7 @@ function stubUser(attrs: Partial<User> = {}): User {
     profileId: 'profile-id',
     profileImage: 'image-url',
     lastSeenAt: 'last-seen',
+    primaryZID: 'primary-zid',
     ...attrs,
   };
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -944,6 +944,7 @@ export class MatrixClient implements IChatClient {
       isOnline: false,
       profileImage: user?.avatarUrl,
       lastSeenAt: '',
+      primaryZID: '',
     };
   }
 

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -38,6 +38,7 @@ export interface User {
   wallets: Wallet[];
   matrixId?: string;
   matrixAccessToken?: string;
+  primaryZID?: string;
 }
 
 export interface AuthenticationState {

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -114,6 +114,6 @@ export function rawUserToDomainUser(u): User {
     lastName: u.profileSummary?.lastName,
     profileImage: u.profileSummary?.profileImage,
     lastSeenAt: u.lastActiveAt,
-    primaryZID: u?.primaryZID,
+    primaryZID: u.primaryZID,
   };
 }

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -114,5 +114,6 @@ export function rawUserToDomainUser(u): User {
     lastName: u.profileSummary?.lastName,
     profileImage: u.profileSummary?.profileImage,
     lastSeenAt: u.lastActiveAt,
+    primaryZID: u?.primaryZID,
   };
 }

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -15,6 +15,7 @@ export interface User {
   isOnline: Boolean;
   profileImage: string;
   lastSeenAt: string;
+  primaryZID: string;
 }
 
 export enum GroupChannelType {


### PR DESCRIPTION
### What does this do?
- returns primaryZID when fetching user data.

### Why are we making this change?
- to use/display the users primaryZID in the UI, i.e. display users primaryZID with user details/search by primaryZID.

### How do I test this?
- run api locally, set primaryZID in database table and check data is returned when fetching user data by logging the primaryZID.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1439" alt="Screenshot 2024-01-23 at 10 33 16" src="https://github.com/zer0-os/zOS/assets/39112648/0aadb362-f637-4b9f-b8c5-9467992fa6a5">
