### PR TITLE
feat: render primary zid in conversation list header

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -82,7 +82,7 @@ export class Container extends React.Component<Properties, State> {
       chat: { activeConversationId, joinRoomErrorContent },
       groupManagement,
     } = state;
-    const hasWallet = user?.data?.wallets?.length > 0;
+    const hasPrimaryZID = user?.data?.primaryZID;
 
     const conversations = denormalizeConversations(state).map(addLastMessageMeta(state)).sort(byLastMessageOrCreation);
 
@@ -95,7 +95,7 @@ export class Container extends React.Component<Properties, State> {
       isFirstTimeLogin: registration.isFirstTimeLogin,
       isInviteNotificationOpen: registration.isInviteToastOpen,
       userName: user?.data?.profileSummary?.firstName || '',
-      userHandle: (hasWallet ? user?.data?.wallets[0]?.publicAddress : user?.data?.profileSummary?.primaryEmail) || '',
+      userHandle: (hasPrimaryZID ? user?.data?.primaryZID : user?.data?.wallets[0]?.publicAddress) || '',
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
       userIsOnline: !!user?.data?.isOnline,
       myUserId: user?.data?.id,

--- a/src/components/messenger/list/user-header/index.test.tsx
+++ b/src/components/messenger/list/user-header/index.test.tsx
@@ -1,7 +1,11 @@
 import { shallow } from 'enzyme';
 import { Properties, UserHeader } from '.';
 import { SettingsMenu } from '../../../settings-menu';
-import { IconButton } from '@zero-tech/zui/components';
+import { Address, IconButton } from '@zero-tech/zui/components';
+
+import { bem } from '../../../../lib/bem';
+
+const cn = bem('.user-header');
 
 describe(UserHeader, () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -22,20 +26,17 @@ describe(UserHeader, () => {
 
   it('renders SettingsMenu when includeUserSettings is true', function () {
     const wrapper = subject({ includeUserSettings: true });
-
     expect(wrapper).toHaveElement(SettingsMenu);
   });
 
   it('does not render SettingsMenu when includeUserSettings is false', function () {
     const wrapper = subject({ includeUserSettings: false });
-
     expect(wrapper).not.toHaveElement(SettingsMenu);
   });
 
   it('renders users name ', function () {
     const wrapper = subject({ userName: 'Joe Bloggs' });
-
-    expect(wrapper.find('.user-header__user-name').text()).toEqual('Joe Bloggs');
+    expect(wrapper.find(cn('name'))).toHaveText('Joe Bloggs');
   });
 
   it('renders IconButton', function () {
@@ -49,5 +50,20 @@ describe(UserHeader, () => {
 
     wrapper.find(IconButton).simulate('click');
     expect(startConversationMock).toHaveBeenCalled();
+  });
+
+  it('renders Address component when userHandle is not a ZID', function () {
+    const wrapper = subject({ userHandle: '0x1234567890' });
+    expect(wrapper.find(Address)).toExist();
+  });
+
+  it('renders user handle as text when it is a ZID', function () {
+    const wrapper = subject({ userHandle: '0://zid.example' });
+    expect(wrapper.find(cn('handle'))).toHaveText('0://zid.example');
+  });
+
+  it('does not render user handle when it is null', function () {
+    const wrapper = subject({ userHandle: null });
+    expect(wrapper.find(cn('handle'))).toHaveText('');
   });
 });

--- a/src/components/messenger/list/user-header/index.tsx
+++ b/src/components/messenger/list/user-header/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { SettingsMenu } from '../../../settings-menu';
 import { IconButton } from '@zero-tech/zui/components';
 import { IconPlus } from '@zero-tech/zui/icons';
+import { Address } from '@zero-tech/zui/components';
 
 import { bemClassName } from '../../../../lib/bem';
 import './styles.scss';
@@ -25,6 +26,20 @@ export class UserHeader extends React.Component<Properties> {
     return this.props.userIsOnline ? 'active' : 'offline';
   }
 
+  get isZID() {
+    return this.props.userHandle.includes('0://');
+  }
+
+  get getUserHandle() {
+    const { userHandle } = this.props;
+
+    if (!userHandle) {
+      return null;
+    }
+
+    return this.isZID ? userHandle : <Address {...cn('address')} address={userHandle} />;
+  }
+
   render() {
     return (
       <div {...cn('')}>
@@ -32,12 +47,15 @@ export class UserHeader extends React.Component<Properties> {
           <SettingsMenu
             onLogout={this.props.onLogout}
             userName={this.props.userName}
-            userHandle={this.props.userHandle}
+            userHandle={this.getUserHandle}
             userAvatarUrl={this.props.userAvatarUrl}
             userStatus={this.userStatus}
           />
         )}
-        <div {...cn('user-name')}>{this.props.userName}</div>
+        <div {...cn('user-details')}>
+          <div {...cn('name')}>{this.props.userName}</div>
+          <div {...cn('handle')}>{this.getUserHandle}</div>
+        </div>
 
         <IconButton Icon={IconPlus} onClick={this.props.startConversation} size={32} />
       </div>

--- a/src/components/messenger/list/user-header/styles.scss
+++ b/src/components/messenger/list/user-header/styles.scss
@@ -9,12 +9,30 @@
   height: 32px;
   gap: 8px;
 
-  &__user-name {
+  &__user-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex: 1 0 0;
+  }
+
+  &__name {
     @include glass-text-primary-color;
 
     width: 100%;
     font-size: $font-size-small;
     font-weight: 600;
     line-height: 15px;
+  }
+
+  &__handle {
+    @include glass-text-tertiary-color;
+
+    font-size: 10px;
+    line-height: 13px;
+  }
+
+  &__address {
+    @include glass-text-tertiary-color;
   }
 }


### PR DESCRIPTION
### What does this do?
- renders primary zid in conversation list header.
- renders wallet address if handle is not a primary zid.
- does not render handle if no zid or wallet address.

### Why are we making this change?
- to display the primary zid in the list header as per design.

### How do I test this?
- for now you will only be able to render a users wallet address. login with a wallet, check truncated wallet address under users avatar in the user header of the conversation list header.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Wallet
<img width="300" alt="Screenshot 2024-01-23 at 11 24 40" src="https://github.com/zer0-os/zOS/assets/39112648/4d796045-1b07-40d1-9724-0e1b7e4bc3a4">

ZID
<img width="300" alt="Screenshot 2024-01-23 at 11 24 54" src="https://github.com/zer0-os/zOS/assets/39112648/783f0293-0aa6-40d6-9253-e73ca04554f6">
