### PR TITLE
feat: adjust user handle wallet address truncation

### DIFF
--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -52,8 +52,8 @@ describe('getUserHandle', () => {
   });
 
   it('returns truncated publicAddress from the first wallet when primaryZID is absent', () => {
-    const user = { primaryZID: null, wallets: [{ id: 'wallet-id-1', publicAddress: '123456789' }] };
-    expect(getUserHandle(user.primaryZID, user.wallets)).toEqual('1234...6789');
+    const user = { primaryZID: null, wallets: [{ id: 'wallet-id-1', publicAddress: '0x123456789' }] };
+    expect(getUserHandle(user.primaryZID, user.wallets)).toEqual('0x1234...6789');
   });
 
   it('returns empty string when both primaryZID and wallets are absent', () => {

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -51,7 +51,7 @@ export function getUserHandle(primaryZID: string, wallets: Wallet[]) {
   const publicAddress = wallets?.[0]?.publicAddress;
 
   if (publicAddress) {
-    return `${publicAddress.substring(0, 4)}...${publicAddress.substring(publicAddress.length - 4)}`;
+    return `${publicAddress.substring(0, 6)}...${publicAddress.substring(publicAddress.length - 4)}`;
   }
 
   return '';


### PR DESCRIPTION
### What does this do?
- exposes first 6 characters of users wallet address (for user handle) rather than the first 4.

### Why are we making this change?
- as per figma designs.

### How do I test this?
- log in using a wallet > check user handle in conversation list header (user-header) as shown below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
<img width="300" alt="Screenshot 2024-01-24 at 09 44 25" src="https://github.com/zer0-os/zOS/assets/39112648/8d3744f3-7642-448e-90de-e11b1d3cb659">

