### PR TITLE
Render primary ZID in conversation header

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -116,6 +116,55 @@ describe(DirectMessageChat, () => {
       expect(wrapper).toHaveElement(c('header-avatar--offline'));
     });
 
+    it('renders primaryZID in the subtitle if oneOnOne chat', function () {
+      const wrapper = subject({
+        directMessage: {
+          isOneOnOne: true,
+          otherMembers: [
+            stubUser({
+              primaryZID: '0://arc:vet',
+            }),
+          ],
+        } as Channel,
+      });
+
+      const subtitle = wrapper.find(c('subtitle'));
+      expect(subtitle.text()).toEqual('0://arc:vet');
+    });
+
+    it('does not render primaryZID in the subtitle if group chat', function () {
+      const wrapper = subject({
+        directMessage: {
+          isOneOnOne: false,
+          otherMembers: [
+            stubUser({
+              primaryZID: '0://arc:vet',
+              isOnline: false,
+            }),
+          ],
+        } as Channel,
+      });
+
+      const subtitle = wrapper.find(c('subtitle'));
+      expect(subtitle.text()).toEqual('Offline');
+    });
+
+    it('renders empty subtitle in oneOnOne chat if no primaryZID', function () {
+      const wrapper = subject({
+        directMessage: {
+          isOneOnOne: true,
+          otherMembers: [
+            stubUser({
+              primaryZID: '',
+            }),
+          ],
+        } as Channel,
+      });
+
+      const subtitle = wrapper.find(c('subtitle'));
+      expect(subtitle.text()).toEqual('');
+    });
+
     it('header renders users avatar when there is a avatar url', function () {
       const wrapper = subject({
         directMessage: { isOneOnOne: true, otherMembers: [stubUser({ profileImage: 'avatar-url' })] } as Channel,

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -108,6 +108,8 @@ export class Container extends React.Component<Properties> {
   renderSubTitle() {
     if (!this.props.directMessage?.otherMembers) {
       return '';
+    } else if (this.isOneOnOne() && this.props.directMessage.otherMembers[0]) {
+      return this.props.directMessage.otherMembers[0].primaryZID;
     } else {
       return this.anyOthersOnline() ? 'Online' : 'Offline';
     }

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -190,9 +190,11 @@ $recent-indicator-size: 8px;
     text-overflow: ellipsis;
     display: inline-block;
     font-weight: 400;
-    font-size: 12px;
-    line-height: 15px;
-    color: theme.$color-greyscale-11;
+    font-size: 10px;
+    line-height: normal;
+    font-family: 'Roboto Mono';
+
+    @include glass-text-tertiary-color;
   }
 
   &__group-management-menu-container {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -136,4 +136,4 @@ function convertToNotifiableEventType(eventType) {
   }
 }
 
-const ADMIN_USER = { userId: 'admin', firstName: '', lastName: '', profileImage: '', profileId: '' };
+const ADMIN_USER = { userId: 'admin', firstName: '', lastName: '', profileImage: '', profileId: '', primaryZID: '' };

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -343,6 +343,7 @@ describe('channels list saga', () => {
         profileId: 'profile-1',
         firstName: 'first-1',
         lastName: 'last-1',
+        primaryZID: 'primary-zid-1',
       },
       {
         userId: 'user-2',
@@ -350,6 +351,7 @@ describe('channels list saga', () => {
         profileId: 'profile-2',
         firstName: 'first-2',
         lastName: 'last-2',
+        primaryZID: 'primary-zid-2',
       },
       {
         userId: 'user-3',
@@ -357,6 +359,7 @@ describe('channels list saga', () => {
         profileId: 'profile-3',
         firstName: 'first-3',
         lastName: 'last-3',
+        primaryZID: '',
       },
     ] as any;
 
@@ -375,6 +378,7 @@ describe('channels list saga', () => {
           profileId: 'profile-1',
           firstName: 'first-1',
           lastName: 'last-1',
+          primaryZID: 'primary-zid-1',
         },
         'matrix-id-2': {
           userId: 'user-2',
@@ -382,6 +386,7 @@ describe('channels list saga', () => {
           profileId: 'profile-2',
           firstName: 'first-2',
           lastName: 'last-2',
+          primaryZID: 'primary-zid-2',
         },
         'matrix-id-3': {
           userId: 'user-3',
@@ -389,6 +394,7 @@ describe('channels list saga', () => {
           profileId: 'profile-3',
           firstName: 'first-3',
           lastName: 'last-3',
+          primaryZID: '',
         },
       };
 
@@ -416,6 +422,7 @@ describe('channels list saga', () => {
           firstName: 'first-1',
           lastName: 'last-1',
           profileImage: undefined,
+          primaryZID: 'primary-zid-1',
         },
         {
           matrixId: 'matrix-id-2',
@@ -424,6 +431,7 @@ describe('channels list saga', () => {
           firstName: 'first-2',
           lastName: 'last-2',
           profileImage: undefined,
+          primaryZID: 'primary-zid-2',
         },
       ]);
 
@@ -436,6 +444,7 @@ describe('channels list saga', () => {
           firstName: 'first-3',
           lastName: 'last-3',
           profileImage: undefined,
+          primaryZID: '',
         },
       ]);
     });
@@ -460,6 +469,7 @@ describe('channels list saga', () => {
         firstName: 'first-1',
         lastName: 'last-1',
         profileImage: undefined,
+        primaryZID: 'primary-zid-1',
       });
       expect(channels[0].messages[1].sender).toStrictEqual({
         userId: 'user-2',
@@ -467,6 +477,7 @@ describe('channels list saga', () => {
         firstName: 'first-2',
         lastName: 'last-2',
         profileImage: undefined,
+        primaryZID: 'primary-zid-2',
       });
       expect(channels[1].messages[0].sender).toStrictEqual({
         userId: 'user-3',
@@ -474,6 +485,7 @@ describe('channels list saga', () => {
         firstName: 'first-3',
         lastName: 'last-3',
         profileImage: undefined,
+        primaryZID: '',
       });
     });
   });

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -4,6 +4,7 @@ import { denormalize } from './../channels/index';
 import getDeepProperty from 'lodash.get';
 import { select } from 'redux-saga/effects';
 import { currentUserSelector } from '../authentication/selectors';
+import { getUserHandle } from '../../components/messenger/list/utils/utils';
 
 export function filterChannelsList(state, filter: ChannelType) {
   const channelIdList = getDeepProperty(state, 'channelsList.value', []);
@@ -92,6 +93,7 @@ export function replaceZOSUserFields(
     lastName: string;
     profileImage: string;
     profileId: string;
+    primaryZID: string;
   },
   zeroUser: User
 ) {
@@ -101,6 +103,7 @@ export function replaceZOSUserFields(
     member.firstName = zeroUser.firstName;
     member.lastName = zeroUser.lastName;
     member.profileImage = zeroUser.profileImage;
+    member.primaryZID = getUserHandle(zeroUser.primaryZID, zeroUser.wallets);
   }
 }
 
@@ -115,5 +118,6 @@ export function rawUserToDomainUser(u): User {
     profileImage: u.profileSummary?.profileImage,
     lastSeenAt: u.lastActiveAt,
     primaryZID: u.primaryZID,
+    wallets: u.wallets,
   };
 }

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -5,6 +5,7 @@ import { schema as userSchema } from '../users';
 import { createAction } from '@reduxjs/toolkit';
 import { Payload, UnreadCountUpdatedPayload } from './types';
 import { ParentMessage } from '../../lib/chat/types';
+import { Wallet } from '../authentication/types';
 
 export interface User {
   userId: string;
@@ -16,6 +17,7 @@ export interface User {
   profileImage: string;
   lastSeenAt: string;
   primaryZID: string;
+  wallets?: Wallet[];
 }
 
 export enum GroupChannelType {

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -19,6 +19,7 @@ interface Sender {
   lastName: string;
   profileImage: string;
   profileId: string;
+  primaryZID: string;
 }
 
 export enum MediaType {

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -53,6 +53,7 @@ export function createOptimisticMessageObject(
       lastName: user.profileSummary.lastName,
       profileImage: user.profileSummary.profileImage,
       profileId: user.profileId,
+      primaryZID: user.primaryZID,
     },
     updatedAt: 0,
     preview: null,


### PR DESCRIPTION
### What does this do?

Renders primary ZID OR wallet_address (or empty string if none exist) in conversation header.

Before:
<img width="290" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/498a402c-5c4b-4062-ae62-dd916879244f">


After:
<img width="337" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/e3a2a3d9-b6c2-40f6-a5ba-bde5f3b9f774">


NOTE: For group conversations we still show online/offline status
<img width="209" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/ca313535-bba0-4ae2-b428-5fc8cb03dbcb">

