### PR TITLE
feat: use zns explorer url environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ REACT_APP_ASSETS_PATH="https://res.cloudinary.com/fact0ry/image/upload/v16817455
 REACT_APP_ANDROID_STORE_PATH="https://play.google.com/store/apps/details?id=com.zero.android"
 
 REACT_APP_MATRIX_HOME_SERVER_URL='https://zero-synapse-development-db365bf96189.herokuapp.com'
+
+REACT_APP_ZNS_EXPLORER_URL='https://explorer.zero.tech'
+

--- a/src/components/messenger/list/user-header/index.tsx
+++ b/src/components/messenger/list/user-header/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { config } from '../../../../config';
 import { SettingsMenu } from '../../../settings-menu';
 import { IconButton } from '@zero-tech/zui/components';
 import { IconPlus } from '@zero-tech/zui/icons';
@@ -33,7 +34,7 @@ export class UserHeader extends React.Component<Properties> {
 
   renderLink() {
     return (
-      <a {...cn('link')} href={'https://explorer.zero.tech/'} target='_blank' rel='noopener noreferrer'>
+      <a {...cn('link')} href={config.znsExplorerUrl} target='_blank' rel='noopener noreferrer'>
         Verify ID
       </a>
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,4 +23,5 @@ export const config = {
     homeServerUrl: process.env.REACT_APP_MATRIX_HOME_SERVER_URL,
   },
   androidStorePath: process.env.REACT_APP_ANDROID_STORE_PATH,
+  znsExplorerUrl: process.env.REACT_APP_ZNS_EXPLORER_URL,
 };

--- a/src/store/chat/utils.test.ts
+++ b/src/store/chat/utils.test.ts
@@ -1,3 +1,4 @@
+import { config } from '../../config';
 import { translateJoinRoomApiError, JoinRoomApiErrorCode } from './utils';
 
 describe(translateJoinRoomApiError, () => {
@@ -25,7 +26,7 @@ describe(translateJoinRoomApiError, () => {
     expect(accessTokenRequiredErrorMessage).toEqual({
       header: 'World Members Only',
       body: 'You cannot join this conversation as your wallet does not hold a domain in this world. Buy a domain or switch to a wallet that holds one.',
-      linkPath: 'https://explorer.zero.tech/exampleRoom',
+      linkPath: `${config.znsExplorerUrl}/exampleRoom`,
       linkText: 'Buy A Domain',
     });
   });

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -1,3 +1,5 @@
+import { config } from '../../config';
+
 export enum JoinRoomApiErrorCode {
   ROOM_NOT_FOUND = 'ROOM_NOT_FOUND',
   ACCESS_TOKEN_REQUIRED = 'ACCESS_TOKEN_REQUIRED',
@@ -13,7 +15,7 @@ export const ERROR_DIALOG_CONTENT = {
   [JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED]: {
     header: 'World Members Only',
     body: 'You cannot join this conversation as your wallet does not hold a domain in this world. Buy a domain or switch to a wallet that holds one.',
-    linkPath: 'https://explorer.zero.tech/{roomAlias}',
+    linkPath: `${config.znsExplorerUrl}/{roomAlias}`,
     linkText: 'Buy A Domain',
   },
   [JoinRoomApiErrorCode.GENERAL_ERROR]: {


### PR DESCRIPTION
### What does this do?
- replaces the use of the zns explorer url with the environment variable, through the config.

### Why are we making this change?
- we should use the zns explorer urls set by environment variables.

### How do I test this?
- add env variable (in env.example), `npm i`, `npm run start`, click one of the links used to navigate user to the explorer.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
