### PR TITLE
Remove `onUserReceivedInvitation` event

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -10,7 +10,6 @@ export interface RealtimeChatEvents {
   receiveDeleteMessage: (roomId: string, messageId: string) => void;
   onMessageUpdated: (channelId: string, message: Message) => void;
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
-  onUserReceivedInvitation: (channel) => void;
   onUserJoinedChannel: (conversation) => void;
   invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -730,9 +730,7 @@ export class MatrixClient implements IChatClient {
 
     this.matrix.on(RoomMemberEvent.Membership, async (_event, member) => {
       if (member.membership === MembershipStateType.Invite && member.userId === this.userId) {
-        if (await this.autoJoinRoom(member.roomId)) {
-          this.events.onUserReceivedInvitation(member.roomId);
-        }
+        await this.autoJoinRoom(member.roomId);
       }
     });
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -255,11 +255,6 @@ function* listenForUserLogin() {
   }
 }
 
-export function* currentUserAddedToChannel(_action) {
-  // For now, just force a fetch of conversations to refresh the list.
-  yield fetchConversations();
-}
-
 export function* userLeftChannel(channelId, matrixId) {
   const currentUser = yield select(currentUserSelector);
 
@@ -288,7 +283,6 @@ export function* saga() {
   yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
 
   const chatBus = yield call(getChatBus);
-  yield takeEveryFromBus(chatBus, ChatEvents.ChannelInvitationReceived, currentUserAddedToChannel);
   yield takeEveryFromBus(chatBus, ChatEvents.UserLeftChannel, ({ payload }) =>
     userLeftChannel(payload.channelId, payload.userId)
   );

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -53,8 +53,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const receiveUnreadCount = (channelId, unreadCount) =>
       emit({ type: Events.UnreadCountChanged, payload: { channelId, unreadCount } });
     const invalidChatAccessToken = () => emit({ type: Events.InvalidToken, payload: {} });
-    const onUserReceivedInvitation = (channelId) =>
-      emit({ type: Events.ChannelInvitationReceived, payload: { channelId } });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
     const onUserPresenceChanged = (matrixId, isOnline, lastSeenAt) =>
@@ -73,7 +71,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       receiveDeleteMessage,
       receiveUnreadCount,
       invalidChatAccessToken,
-      onUserReceivedInvitation,
       onUserLeft,
       onUserJoinedChannel,
       onUserPresenceChanged,


### PR DESCRIPTION
### What does this do?

We can remove this event (triggerred via `MemberShip.Invite`), since we're handling `currentUserAddedToChannel` via `MemberShip.Join` event