### PR TITLE
Render PrimaryZID in group-info & group-edit panels

### DIFF
--- a/src/components/citizen-list-item/index.test.tsx
+++ b/src/components/citizen-list-item/index.test.tsx
@@ -22,6 +22,12 @@ describe(CitizenListItem, () => {
     expect(wrapper.find(c('name')).text()).toEqual('John Doe');
   });
 
+  it('renders the user primary zid', function () {
+    const wrapper = subject({ user: { primaryZID: '0://zero:tech' } as any });
+
+    expect(wrapper.find(c('primary-zid')).text()).toEqual('0://zero:tech');
+  });
+
   it('renders the user status', function () {
     const wrapper = subject({ user: { isOnline: false } as any });
 

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -35,7 +35,11 @@ export class CitizenListItem extends React.Component<Properties> {
           tabIndex={-1}
           statusType={this.statusType}
         />
-        <span {...cn('name')}>{displayName(this.props.user)}</span>
+        <div>
+          <span {...cn('name')}>{displayName(this.props.user)}</span>
+          <span {...cn('primary-zid')}>{this.props.user.primaryZID}</span>
+        </div>
+
         {this.props.tag && <div {...cn('tag')}>{this.props.tag}</div>}
         {this.props.onRemove && (
           <div {...cn('remove')}>

--- a/src/components/citizen-list-item/styles.scss
+++ b/src/components/citizen-list-item/styles.scss
@@ -27,6 +27,15 @@
     white-space: nowrap;
   }
 
+  &__primary-zid {
+    font-size: 10px;
+    font-style: normal;
+    font-weight: 400;
+    display: flex;
+
+    @include glass-text-tertiary-color;
+  }
+
   &__remove {
     display: none;
   }

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -22,6 +22,7 @@ import { GroupManagementErrors, EditConversationState } from '../../../../store/
 import { User, denormalize as denormalizeChannel } from '../../../../store/channels';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
 import { RemoveMemberDialogContainer } from '../../../group-management/remove-member-dialog/container';
+import { getUserHandle } from '../utils/utils';
 
 export interface PublicProperties {
   searchUsers: (search: string) => Promise<any>;
@@ -78,6 +79,7 @@ export class Container extends React.Component<Properties> {
         profileImage: currentUser?.profileSummary.profileImage,
         matrixId: currentUser?.matrixId,
         isOnline: currentUser?.isOnline,
+        primaryZID: getUserHandle(currentUser?.primaryZID, currentUser?.wallets),
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,


### PR DESCRIPTION
### What does this do?

Group Info Panel:
<img width="419" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/5d0ecacb-a155-4eed-afe3-09953351a39d">

Group Edit panel:
<img width="360" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/9a3bbadc-f81b-4d1b-9491-07936683c44e">
