### PR TITLE
Render Primary ZID while mentioning users

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -247,18 +247,18 @@ describe('MessageInput', () => {
   it('sorts by search string index', async function () {
     const getUsersForMentions = async (_searchString) =>
       Promise.resolve([
-        { id: 'd-2', display: '2-dale', profileImage: 'http://example.com/2' },
-        { id: 'd-3', display: '3--dale', profileImage: 'http://example.com/3' },
-        { id: 'd-1', display: 'dale', profileImage: 'http://example.com/' },
+        { id: 'd-2', display: '2-dale', profileImage: 'http://example.com/2', primaryZID: '0://d-2:dale' },
+        { id: 'd-3', display: '3--dale', profileImage: 'http://example.com/3', primaryZID: '0://d-3:dale' },
+        { id: 'd-1', display: 'dale', profileImage: 'http://example.com/', primaryZID: '0://d-1:dale' },
       ]);
     const wrapper = subject({ getUsersForMentions });
 
     const searchResults = await userSearch(wrapper, 'da');
 
     expect(searchResults).toEqual([
-      { display: 'dale', id: 'd-1', profileImage: 'http://example.com/' },
-      { display: '2-dale', id: 'd-2', profileImage: 'http://example.com/2' },
-      { display: '3--dale', id: 'd-3', profileImage: 'http://example.com/3' },
+      { display: 'dale', id: 'd-1', profileImage: 'http://example.com/', primaryZID: '0://d-1:dale' },
+      { display: '2-dale', id: 'd-2', profileImage: 'http://example.com/2', primaryZID: '0://d-2:dale' },
+      { display: '3--dale', id: 'd-3', profileImage: 'http://example.com/3', primaryZID: '0://d-3:dale' },
     ]);
   });
 

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -231,7 +231,12 @@ export class MessageInput extends React.Component<Properties, State> {
         renderSuggestion={(suggestion) => (
           <>
             <Avatar size={'small'} type={'circle'} imageURL={suggestion.profileImage} />
-            <div className='message-input__mentions-text-area-wrap__suggestions__item-name'>{suggestion.display}</div>
+            <div>
+              <div className='message-input__mentions-text-area-wrap__suggestions__item-name'>{suggestion.display}</div>
+              <div className='message-input__mentions-text-area-wrap__suggestions__item-zid'>
+                {suggestion.primaryZID}
+              </div>
+            </div>
           </>
         )}
       />,

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -219,7 +219,7 @@
         align-items: center;
         gap: 10px;
         border-radius: 8px;
-        line-height: 24px;
+        line-height: 14px;
 
         &--focused {
           background-color: theme.$color-primary-4;
@@ -234,6 +234,19 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 20px;
+
+        @include glass-text-primary-color;
+      }
+
+      &__item-zid {
+        font-size: 10px;
+        font-weight: 400;
+        display: flex;
+
+        @include glass-text-tertiary-color;
       }
     }
   }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -268,7 +268,12 @@ export class MatrixClient implements IChatClient {
 
   async searchMentionableUsersForChannel(channelId: string, search: string, channelMembers: UserModel[]) {
     const searchResults = await getFilteredMembersForAutoComplete(channelMembers, search);
-    return searchResults.map((u) => ({ id: u.id, display: u.displayName, profileImage: u.profileImage }));
+    return searchResults.map((u) => ({
+      id: u.id,
+      display: u.displayName,
+      profileImage: u.profileImage,
+      primaryZID: u.primaryZID,
+    }));
   }
 
   private getRelatedEventId(event): string {

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -51,6 +51,7 @@ export async function getFilteredMembersForAutoComplete(roomMembers: ChannelMemb
         id: member.userId || member.matrixId,
         displayName: `${member.firstName || ''} ${member.lastName || ''}`,
         profileImage: member.profileImage,
+        primaryZID: member.primaryZID,
       });
     }
   }


### PR DESCRIPTION
### What does this do?

Renders primary ZID of user while mentioning users in a chat.

<img width="258" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/d3d8d5e9-222b-4d39-b8ae-225810b5fc9e">

<img width="269" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/359591f3-270b-48fd-a0ee-a70eed9d1167">

<img width="217" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/284626d7-f339-46f7-a54e-f1a52f58badb">

NOTE: I didn't update the UI much, as there is a task dedicated to mentions redesign in the backlog. 
