### PR TITLE
[Fix] Non Admin member (non-creator) should NOT be able to add new users to group

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -364,7 +364,7 @@ describe('matrix client', () => {
       );
     });
 
-    it('set the appropriate power_level_content_override for each user, and other defaults in group conversation', async () => {
+    it('set the appropriate defaul power_levels in group conversation', async () => {
       const createRoom = jest.fn().mockResolvedValue({ room_id: 'new-room-id' });
       const client = await subject({ createRoom }, { userId: '@this.user' });
 
@@ -382,8 +382,6 @@ describe('matrix client', () => {
         expect.objectContaining({
           power_level_content_override: {
             users: {
-              '@first.user': 0,
-              '@second.user': 0,
               '@this.user': 100, // the user who created the room
             },
             invite: PowerLevels.Owner,

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -4,6 +4,7 @@ import { setAsDM } from './matrix/utils';
 import { uploadImage as _uploadImage } from '../../store/channels-list/api';
 import { when } from 'jest-when';
 import { config } from '../../config';
+import { PowerLevels } from './types';
 
 jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
 
@@ -363,7 +364,7 @@ describe('matrix client', () => {
       );
     });
 
-    it('set the appropriate power_level_content_override for each user in group conversation', async () => {
+    it('set the appropriate power_level_content_override for each user, and other defaults in group conversation', async () => {
       const createRoom = jest.fn().mockResolvedValue({ room_id: 'new-room-id' });
       const client = await subject({ createRoom }, { userId: '@this.user' });
 
@@ -385,22 +386,30 @@ describe('matrix client', () => {
               '@second.user': 0,
               '@this.user': 100, // the user who created the room
             },
+            invite: PowerLevels.Owner,
+            kick: PowerLevels.Owner,
+            redact: PowerLevels.Owner,
+            ban: PowerLevels.Owner,
+            users_default: PowerLevels.Viewer,
           },
         })
       );
     });
 
-    it('specifies the invited users', async () => {
+    it('invites the users after createRoom', async () => {
       const createRoom = jest.fn().mockResolvedValue({ room_id: 'new-room-id' });
+      const invite = jest.fn().mockResolvedValue({});
       const users = [
         { userId: 'id-1', matrixId: '@first.user' },
         { userId: 'id-2', matrixId: '@second.user' },
       ];
-      const client = await subject({ createRoom });
+      const client = await subject({ createRoom, invite });
 
       await client.createConversation(users, null, null, null);
 
-      expect(createRoom).toHaveBeenCalledWith(expect.objectContaining({ invite: ['@first.user', '@second.user'] }));
+      expect(createRoom).toHaveBeenCalledWith(expect.objectContaining({ invite: [] }));
+      expect(invite).toHaveBeenCalledWith('new-room-id', '@first.user');
+      expect(invite).toHaveBeenCalledWith('new-room-id', '@second.user');
     });
 
     it('sets the conversation as a Matrix direct message', async () => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -396,7 +396,7 @@ export class MatrixClient implements IChatClient {
     const options: ICreateRoomOpts = {
       preset: Preset.TrustedPrivateChat,
       visibility: Visibility.Private,
-      invite: users.map((u) => u.matrixId),
+      invite: [],
       is_direct: true,
       initial_state,
       power_level_content_override: {
@@ -404,6 +404,12 @@ export class MatrixClient implements IChatClient {
           ...users.reduce((acc, u) => ({ ...acc, [u.matrixId]: PowerLevels.Viewer }), {}),
           [this.userId]: PowerLevels.Owner,
         },
+        invite: PowerLevels.Owner, // default is PL0
+        // default is PL50
+        kick: PowerLevels.Owner,
+        redact: PowerLevels.Owner,
+        ban: PowerLevels.Owner,
+        users_default: PowerLevels.Viewer,
       },
     };
     if (name) {
@@ -416,6 +422,9 @@ export class MatrixClient implements IChatClient {
 
     const room = this.matrix.getRoom(result.room_id);
     this.initializeRoomEventHandlers(room);
+    for (const user of users) {
+      await this.matrix.invite(result.room_id, user.matrixId);
+    }
     return await this.mapConversation(room);
   }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -401,11 +401,10 @@ export class MatrixClient implements IChatClient {
       initial_state,
       power_level_content_override: {
         users: {
-          ...users.reduce((acc, u) => ({ ...acc, [u.matrixId]: PowerLevels.Viewer }), {}),
           [this.userId]: PowerLevels.Owner,
         },
         invite: PowerLevels.Owner, // default is PL0
-        // default is PL50
+        // all below except users_default, default to PL50
         kick: PowerLevels.Owner,
         redact: PowerLevels.Owner,
         ban: PowerLevels.Owner,


### PR DESCRIPTION
### What does this do?

- Updates `createConversation` flow to first create a room, and then invite the appropriate users. 
- Sets the default power levels for all users (including new users which add to room)

Earlier, if you add a new member to room, then that member can still add other users to the group (this is disabled via UI, but you can still call the API directly and it will add new members). This is fixed now.

If you try to add a new member now, and you're not an admin, you'll get this error:
<img width="886" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/26eee970-15ae-4994-9eaa-d716c1b19262">
 
 Similar code has been added on the API side as well.
