### PR TITLE
Removing `decodeURIComponent` (to decode `%23` from the conversation URL if the `conversationId` is an alias)

### DIFF
--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -41,16 +41,6 @@ describe('MessengerMain', () => {
     expect(setActiveConversationId).toHaveBeenCalledWith({ id: '123' });
   });
 
-  it('decodeURIComponent the conversationId from the url on mount', () => {
-    const setActiveConversationId = jest.fn();
-    subject({
-      setActiveConversationId,
-      match: { params: { conversationId: '%23wilderworld:zos-dev.zero.io' } },
-    });
-
-    expect(setActiveConversationId).toHaveBeenCalledWith({ id: '#wilderworld:zos-dev.zero.io' });
-  });
-
   it('updates the conversation id when the route changes', () => {
     const setActiveConversationId = jest.fn();
     const wrapper = subject({

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -45,7 +45,7 @@ export class Container extends React.Component<Properties> {
   }
 
   get conversationId() {
-    return decodeURIComponent(this.idFrom(this.props));
+    return this.idFrom(this.props);
   }
 
   idChanged(prevProps: Properties) {

--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -120,7 +120,7 @@ describe(performValidateActiveConversation, () => {
   it('gets the matrix roomId if the active conversation id is an alias', async () => {
     featureFlags.allowJoinRoom = true;
 
-    const alias = '#wildebeest:matrix.org';
+    const alias = 'wildebeest:matrix.org';
     const conversationId = '!wildebeest:matrix.org';
     const initialState = new StoreBuilder().withCurrentUser({ id: 'current-user' }).withConversationList({
       id: '!wildebeest:matrix.org',
@@ -133,7 +133,7 @@ describe(performValidateActiveConversation, () => {
       .provide([
         [matchers.call.fn(getRoomIdForAlias), conversationId],
       ])
-      .call(getRoomIdForAlias, alias)
+      .call(getRoomIdForAlias, '#' + alias)
       .not.call(apiJoinRoom, conversationId)
       .put(rawSetActiveConversationId(conversationId))
       .run();
@@ -146,7 +146,7 @@ describe(performValidateActiveConversation, () => {
 
     const initialState = new StoreBuilder().withCurrentUser({ id: 'current-user' });
 
-    await subject(performValidateActiveConversation, '#convo-not-exists')
+    await subject(performValidateActiveConversation, 'convo-not-exists')
       .withReducer(rootReducer, initialState.build())
       .provide([
         [matchers.call.fn(getRoomIdForAlias), undefined],
@@ -160,7 +160,7 @@ describe(performValidateActiveConversation, () => {
   it('joins the conversation if the active conversation id is an alias and the user is not a member', async () => {
     featureFlags.allowJoinRoom = true;
 
-    const alias = '#some-other-convo:matrix.org';
+    const alias = 'some-other-convo:matrix.org';
     const initialState = new StoreBuilder()
       .withCurrentUser({ id: 'current-user' })
       .withConversationList({ id: 'convo-1', name: 'Conversation 1', otherMembers: [{ userId: 'user-2' } as User] });
@@ -170,7 +170,7 @@ describe(performValidateActiveConversation, () => {
       .provide([
         [matchers.call.fn(getRoomIdForAlias), '!some-other-convo:matrix.org'],
       ])
-      .call(getRoomIdForAlias, alias)
+      .call(getRoomIdForAlias, '#' + alias)
       .call(apiJoinRoom, '!some-other-convo:matrix.org')
       .run();
   });

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -14,7 +14,7 @@ import { getHistory } from '../../lib/browser';
 import { openFirstConversation } from '../channels/saga';
 import { rawConversationsList, waitForChannelListLoad } from '../channels-list/saga';
 import { featureFlags } from '../../lib/feature-flags';
-import { translateJoinRoomApiError } from './utils';
+import { translateJoinRoomApiError, parseAlias, isAlias } from './utils';
 import { joinRoom as apiJoinRoom } from './api';
 
 function* initChat(userId, chatAccessToken) {
@@ -80,11 +80,6 @@ export function* validateActiveConversation(conversationId: string) {
   if (isLoaded) {
     yield call(performValidateActiveConversation, conversationId);
   }
-}
-
-// conversation can be referenced by an id or an alias
-function isAlias(id: string) {
-  return id.startsWith('#');
 }
 
 export function* joinRoom(roomIdOrAlias: string) {
@@ -153,6 +148,7 @@ export function* performValidateActiveConversation(activeConversationId: string)
 
   let conversationId = activeConversationId;
   if (isAlias(activeConversationId)) {
+    activeConversationId = parseAlias(activeConversationId);
     conversationId = yield call(getRoomIdForAlias, activeConversationId);
   }
 

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -40,13 +40,7 @@ export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | stri
 
 // conversation can be referenced by an id or an alias
 export function isAlias(id: string) {
-  const isAlias = !id.startsWith('!');
-  if (isAlias) {
-    id = '#' + id;
-    return true;
-  }
-
-  return false;
+  return !id.startsWith('!');
 }
 
 // alias is prefixed with a #, and we don't want to store that in the URL,

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -37,3 +37,24 @@ export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | stri
 
   return content;
 }
+
+// conversation can be referenced by an id or an alias
+export function isAlias(id: string) {
+  const isAlias = !id.startsWith('!');
+  if (isAlias) {
+    id = '#' + id;
+    return true;
+  }
+
+  return false;
+}
+
+// alias is prefixed with a #, and we don't want to store that in the URL,
+// but we do want to store it in the state
+export function parseAlias(id: string) {
+  if (isAlias(id)) {
+    return '#' + id;
+  }
+
+  return id;
+}


### PR DESCRIPTION
### What does this do?

Removes having to use `%23` in the conversation url (which was needed to parse the alias before). Now, you don't need to use any encoded char before the alias string. 

The logic is update to check if the id starts with `!`, then it's a valid (unique) ID, otherwise it's an alias.



### Usage (for eg. alias = `#hite:zos-dev.zer0.io`)

Before you'll hit this url:
`http://localhost:3002/conversation/%23hite:zos-dev.zer0.io`

Now the url updates to:
`http://localhost:3002/conversation/hite:zos-dev.zer0.io`

Screenshot
<img width="500" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/e8c6ab5e-3f8c-4add-86f8-ab28d3391ea1">

