### PR TITLE
feat: handle search result filtering to include primary zid direct and indirect matches

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -81,19 +81,25 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     for (const conversation of this.props.conversations) {
       const isNameMatch = searchRegEx.test(conversation.name ?? '');
       const isDirectMatch =
-        conversation.otherMembers.length === 1 && searchRegEx.test(otherMembersToString(conversation.otherMembers));
+        conversation.otherMembers.length === 1 &&
+        (searchRegEx.test(otherMembersToString(conversation.otherMembers)) ||
+          conversation.otherMembers.some((member) => searchRegEx.test(member.primaryZID)));
 
       if (isNameMatch || isDirectMatch) {
         directMatches.push(conversation);
-      } else if (searchRegEx.test(otherMembersToString(conversation.otherMembers))) {
-        inDirectMatches.push(conversation);
+      } else {
+        const isIndirectNameMatch = searchRegEx.test(otherMembersToString(conversation.otherMembers));
+        const isIndirectZIDMatch = conversation.otherMembers.some(
+          (member) => member.primaryZID && searchRegEx.test(member.primaryZID)
+        );
+
+        if (isIndirectNameMatch || isIndirectZIDMatch) {
+          inDirectMatches.push(conversation);
+        }
       }
     }
 
-    return [
-      ...directMatches,
-      ...inDirectMatches,
-    ];
+    return [...directMatches, ...inDirectMatches];
   }
 
   openInviteDialog = (): void => {

--- a/src/components/messenger/list/conversation-list-panel/utils.ts
+++ b/src/components/messenger/list/conversation-list-panel/utils.ts
@@ -1,0 +1,38 @@
+import { otherMembersToString } from '../../../../platform-apps/channels/util';
+
+function matchesConversationName(conversation, searchRegEx) {
+  return searchRegEx.test(conversation.name ?? '');
+}
+
+function matchesMembersName(conversation, searchRegEx) {
+  const membersNames = otherMembersToString(conversation.otherMembers);
+  return searchRegEx.test(membersNames);
+}
+
+function matchesMembersPrimaryZID(conversation, searchRegEx) {
+  return conversation.otherMembers.some((member) => searchRegEx.test(member.primaryZID));
+}
+
+function isOneOnOneConversationMatch(conversation, searchRegEx) {
+  return (
+    conversation.otherMembers.length === 1 &&
+    (matchesMembersName(conversation, searchRegEx) || matchesMembersPrimaryZID(conversation, searchRegEx))
+  );
+}
+
+export function getDirectMatches(conversations, searchRegEx) {
+  return conversations.filter(
+    (conversation) =>
+      matchesConversationName(conversation, searchRegEx) || isOneOnOneConversationMatch(conversation, searchRegEx)
+  );
+}
+
+export function getIndirectMatches(conversations, searchRegEx) {
+  const directMatches = getDirectMatches(conversations, searchRegEx);
+
+  return conversations.filter(
+    (conversation) =>
+      !directMatches.includes(conversation) &&
+      (matchesMembersName(conversation, searchRegEx) || matchesMembersPrimaryZID(conversation, searchRegEx))
+  );
+}

--- a/src/store/users/index.ts
+++ b/src/store/users/index.ts
@@ -9,6 +9,7 @@ export interface SearchResult {
   id: string;
   name: string;
   profileImage: string;
+  primaryZID: string;
 }
 
 const slice = createNormalizedSlice({

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -28,8 +28,8 @@ describe(clearUsers, () => {
 
 describe(receiveSearchResults, () => {
   it('translates the search results into user records', async () => {
-    const user1 = { id: 'user-1', name: 'Test User 1', profileImage: 'image-url-1' };
-    const user2 = { id: 'user-2', name: 'Test User 2', profileImage: 'image-url-2' };
+    const user1 = { id: 'user-1', name: 'Test User 1', profileImage: 'image-url-1', primaryZID: 'zid-1' };
+    const user2 = { id: 'user-2', name: 'Test User 2', profileImage: 'image-url-2', primaryZID: 'zid-2' };
 
     const { storeState } = await expectSaga(receiveSearchResults, [
       user1,
@@ -43,6 +43,7 @@ describe(receiveSearchResults, () => {
         userId: user1.id,
         firstName: user1.name,
         profileImage: user1.profileImage,
+        primaryZID: user1.primaryZID,
       })
     );
     expect(denormalize(user2.id, storeState)).toEqual(
@@ -50,6 +51,7 @@ describe(receiveSearchResults, () => {
         userId: user2.id,
         firstName: user2.name,
         profileImage: user2.profileImage,
+        primaryZID: user2.primaryZID,
       })
     );
   });

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -16,7 +16,13 @@ export function* receiveSearchResults(searchResults) {
   const mappedUsers = searchResults
     .filter((r) => !existingUserIds.includes(r.id))
     .map((r) => {
-      return { userId: r.id, firstName: r.name, profileImage: r.profileImage, matrixId: r.matrixId };
+      return {
+        userId: r.id,
+        firstName: r.name,
+        profileImage: r.profileImage,
+        matrixId: r.matrixId,
+        primaryZID: r.primaryZID,
+      };
     });
   yield put(receive(mappedUsers));
 }

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -4,4 +4,5 @@ export interface MemberNetworks {
   profileImage: string;
   name: string;
   type: string;
+  primaryZID: string;
 }


### PR DESCRIPTION
### What does this do?
- handles primary zid when searching and filtering conversations.

### Why are we making this change?
- to ensure a users `primaryZID` is considered when searching and filtering in the conversation list.

### How do I test this?
- you will need to have test users that have a `primaryZID` which will allow you to search using a ZID in the search input and render results.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
