### PR TITLE
Allow user to edit the primary zid (UI)

### DIFF
--- a/src/components/edit-profile/container.test.tsx
+++ b/src/components/edit-profile/container.test.tsx
@@ -12,6 +12,7 @@ describe('Container', () => {
       editProfileState: 0, // Set the initial editProfileState to State.NONE
       currentDisplayName: 'John Doe',
       currentProfileImage: 'profile.jpg',
+      currentPrimaryZID: '0://john:doe',
       editProfile: () => null,
       startProfileEdit: () => null,
       leaveGlobalNetwork: () => null,
@@ -31,6 +32,7 @@ describe('Container', () => {
         editProfileState: 0,
         currentDisplayName: 'John Doe',
         currentProfileImage: 'profile.jpg',
+        currentPrimaryZID: '0://john:doe',
       })
     );
   });
@@ -58,6 +60,7 @@ describe('Container', () => {
               firstName: 'John Doe',
               profileImage: 'profile.jpg',
             },
+            primaryZID: '0://john:doe',
           },
         },
       },
@@ -79,6 +82,12 @@ describe('Container', () => {
       const props = Container.mapState(stateMock);
 
       expect(props.currentProfileImage).toEqual('profile.jpg');
+    });
+
+    it('currentPrimaryZID', () => {
+      const props = Container.mapState(stateMock);
+
+      expect(props.currentPrimaryZID).toEqual('0://john:doe');
     });
 
     it('errors', () => {

--- a/src/components/edit-profile/container.tsx
+++ b/src/components/edit-profile/container.tsx
@@ -17,7 +17,8 @@ export interface Properties extends PublicProperties {
   editProfileState: State;
   currentDisplayName: string;
   currentProfileImage: string;
-  editProfile: (data: { name: string; image: File }) => void;
+  currentPrimaryZID: string;
+  editProfile: (data: { name: string; image: File; primaryZID: string }) => void;
   startProfileEdit: () => void;
   leaveGlobalNetwork: () => void;
   joinGlobalNetwork: () => void;
@@ -33,6 +34,7 @@ export class Container extends React.Component<Properties> {
       errors: RegistrationContainer.mapErrors(editProfile.errors),
       currentDisplayName: user?.data?.profileSummary.firstName,
       currentProfileImage: user?.data?.profileSummary.profileImage,
+      currentPrimaryZID: user?.data?.primaryZID,
       editProfileState: editProfile.state,
     };
   }
@@ -54,6 +56,7 @@ export class Container extends React.Component<Properties> {
         editProfileState={this.props.editProfileState}
         currentDisplayName={this.props.currentDisplayName}
         currentProfileImage={this.props.currentProfileImage}
+        currentPrimaryZID={this.props.currentPrimaryZID}
         onLeaveGlobal={this.props.leaveGlobalNetwork}
         onJoinGlobal={this.props.joinGlobalNetwork}
       />

--- a/src/components/edit-profile/index.test.tsx
+++ b/src/components/edit-profile/index.test.tsx
@@ -7,7 +7,7 @@ import { ImageUpload } from '../../components/image-upload';
 import { State as EditProfileState } from '../../store/edit-profile';
 import { buttonLabelled } from '../../test/utils';
 
-const featureFlags = { internalUsage: false };
+const featureFlags = { internalUsage: false, allowEditPrimaryZID: false };
 jest.mock('../../lib/feature-flags', () => ({
   featureFlags: featureFlags,
 }));
@@ -19,6 +19,7 @@ describe('EditProfile', () => {
       errors: {},
       currentDisplayName: 'John Doe',
       currentProfileImage: 'profile.jpg',
+      currentPrimaryZID: '0://john:doe',
       onEdit: () => null,
       onClose: () => null,
       onLeaveGlobal: () => null,
@@ -59,6 +60,7 @@ describe('EditProfile', () => {
     expect(onEditMock).toHaveBeenCalledWith({
       name: 'John Doe',
       image: null,
+      primaryZID: '0://john:doe',
     });
   });
 
@@ -75,7 +77,11 @@ describe('EditProfile', () => {
   });
 
   it('disables Save Changes button when no changes are made', () => {
-    const wrapper = subject({ currentDisplayName: 'John Doe', currentProfileImage: 'profile.jpg' });
+    const wrapper = subject({
+      currentDisplayName: 'John Doe',
+      currentProfileImage: 'profile.jpg',
+      currentPrimaryZID: '0://john:doe',
+    });
 
     expect(saveButton(wrapper).prop('isDisabled')).toEqual(true);
   });
@@ -88,16 +94,20 @@ describe('EditProfile', () => {
   });
 
   it('calls onEdit with correct data when Save Changes button is clicked', () => {
+    featureFlags.allowEditPrimaryZID = true;
+
     const onEditMock = jest.fn();
     const wrapper = subject({ onEdit: onEditMock });
 
     const formData = {
       name: 'Jane Smith',
       image: 'new-image.jpg', // note: this is actually supposed to be a nodejs FILE object
+      primaryZID: '0://jane:smith',
     };
 
     wrapper.find('Input[name="name"]').simulate('change', formData.name);
     wrapper.find(ImageUpload).simulate('change', formData.image);
+    wrapper.find('Input[name="primaryZID"]').simulate('change', formData.primaryZID);
     saveButton(wrapper).simulate('press');
 
     expect(onEditMock).toHaveBeenCalledWith(formData);

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -19,8 +19,9 @@ export interface Properties {
     general?: string;
   };
   currentDisplayName: string;
+  currentPrimaryZID: string;
   currentProfileImage: string;
-  onEdit: (data: { name: string; image: File }) => void;
+  onEdit: (data: { name: string; image: File; primaryZID: string }) => void;
   onClose?: () => void;
 
   onLeaveGlobal: () => void;
@@ -30,11 +31,13 @@ export interface Properties {
 interface State {
   name: string;
   image: File | null;
+  primaryZID: string;
 }
 
 export class EditProfile extends React.Component<Properties, State> {
   state = {
     name: this.props.currentDisplayName,
+    primaryZID: this.props.currentPrimaryZID,
     image: null,
   };
 
@@ -42,11 +45,13 @@ export class EditProfile extends React.Component<Properties, State> {
     this.props.onEdit({
       name: this.state.name,
       image: this.state.image,
+      primaryZID: this.state.primaryZID,
     });
   };
 
   trackName = (value) => this.setState({ name: value });
   trackImage = (image) => this.setState({ image });
+  trackPrimaryZID = (value) => this.setState({ primaryZID: value });
 
   get isValid() {
     return this.state.name.trim().length > 0;
@@ -79,7 +84,9 @@ export class EditProfile extends React.Component<Properties, State> {
     return (
       !!this.nameError ||
       this.isLoading ||
-      (this.state.name === this.props.currentDisplayName && this.state.image === null)
+      (this.state.name === this.props.currentDisplayName &&
+        this.state.image === null &&
+        this.state.primaryZID === this.props.currentPrimaryZID)
     );
   }
 
@@ -112,6 +119,15 @@ export class EditProfile extends React.Component<Properties, State> {
             alert={this.nameError}
             className={c('body-input')}
           />
+          {featureFlags.allowEditPrimaryZID && (
+            <Input
+              label='Primary ZID'
+              name='primaryZID'
+              value={this.state.primaryZID}
+              onChange={this.trackPrimaryZID}
+              className={c('body-input')}
+            />
+          )}
         </div>
         {this.imageError && (
           <Alert className={c('alert-large')} variant='error'>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -97,6 +97,14 @@ export class FeatureFlags {
   set allowVerifyId(value: boolean) {
     this._setBoolean('allowVerifyId', value);
   }
+
+  get allowEditPrimaryZID() {
+    return this._getBoolean('allowEditPrimaryZID', false);
+  }
+
+  set allowEditPrimaryZID(value: boolean) {
+    this._setBoolean('allowEditPrimaryZID', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -26,6 +26,7 @@ export const initialState: EditProfileState = {
 export const editProfile = createAction<{
   name: string;
   image: File | null;
+  primaryZID: string;
 }>(SagaActionTypes.EditProfile);
 
 export const leaveGlobalNetwork = createAction(SagaActionTypes.LeaveGlobal);

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -13,7 +13,8 @@ import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
 
 export function* editProfile(action) {
-  const { name, image } = action.payload;
+  const { name, image, primaryZID } = action.payload;
+  console.log('primaryZID ', primaryZID);
 
   yield put(setState(State.INPROGRESS));
   try {


### PR DESCRIPTION
### What does this do?

Edit the primary ZID of the user (this is just the ui part for now, so this is feature flagged)
<img width="828" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/d54d02e8-7e43-4660-a3bf-47a590ec90cb">

Upcoming: API work, and integration

