### PR TITLE
feat: add joining conversation loading state to chat saga

### DIFF
--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -8,11 +8,13 @@ const initialState: ChatState = {
   },
   activeConversationId: null,
   joinRoomErrorContent: null,
+  isJoiningConversation: false,
 };
 
 export enum SagaActionTypes {
   CloseConversationErrorDialog = 'chat/saga/closeConversationErrorDialog',
   setActiveConversationId = 'chat/saga/setActiveConversationId',
+  SetIsJoiningConversation = 'chat/saga/setIsJoiningConversation',
 }
 
 const closeConversationErrorDialog = createAction(SagaActionTypes.CloseConversationErrorDialog);
@@ -34,10 +36,18 @@ const slice = createSlice({
     clearJoinRoomErrorContent: (state) => {
       state.joinRoomErrorContent = null;
     },
+    setIsJoiningConversation: (state, action: PayloadAction<ChatState['isJoiningConversation']>) => {
+      state.isJoiningConversation = action.payload;
+    },
   },
 });
 
-export const { setChatAccessToken, rawSetActiveConversationId, setJoinRoomErrorContent, clearJoinRoomErrorContent } =
-  slice.actions;
+export const {
+  setChatAccessToken,
+  rawSetActiveConversationId,
+  setJoinRoomErrorContent,
+  clearJoinRoomErrorContent,
+  setIsJoiningConversation,
+} = slice.actions;
 export const { reducer } = slice;
 export { closeConversationErrorDialog };

--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -15,7 +15,7 @@ import { StoreBuilder } from '../test/store';
 import { User } from '../channels';
 import { testSaga } from 'redux-saga-test-plan';
 import { waitForChannelListLoad } from '../channels-list/saga';
-import { clearJoinRoomErrorContent, rawSetActiveConversationId } from '.';
+import { clearJoinRoomErrorContent, rawSetActiveConversationId, setIsJoiningConversation } from '.';
 import { ERROR_DIALOG_CONTENT, JoinRoomApiErrorCode, translateJoinRoomApiError } from './utils';
 import { getRoomIdForAlias } from '../../lib/chat';
 import { joinRoom as apiJoinRoom } from './api';
@@ -227,9 +227,13 @@ describe(validateActiveConversation, () => {
   it('waits for channel load before validating', async () => {
     testSaga(validateActiveConversation, 'convo-1')
       .next()
+      .put(setIsJoiningConversation(true))
+      .next()
       .call(waitForChannelListLoad)
       .next(true)
       .call(performValidateActiveConversation, 'convo-1')
+      .next()
+      .put(setIsJoiningConversation(false))
       .next()
       .isDone();
   });
@@ -237,8 +241,12 @@ describe(validateActiveConversation, () => {
   it('does not validate if channel load fails', async () => {
     testSaga(validateActiveConversation, 'convo-1')
       .next()
+      .put(setIsJoiningConversation(true))
+      .next()
       .call(waitForChannelListLoad)
       .next(false) // Channels did not load
+      .put(setIsJoiningConversation(false))
+      .next()
       .isDone();
   });
 });

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -135,8 +135,6 @@ export function* setWhenUserJoinedRoom(conversationId: string) {
 }
 
 export function* performValidateActiveConversation(activeConversationId: string) {
-  yield put(setIsJoiningConversation(true));
-
   if (!activeConversationId) {
     yield put(clearJoinRoomErrorContent());
     yield call(openFirstConversation);
@@ -155,7 +153,6 @@ export function* performValidateActiveConversation(activeConversationId: string)
         })
       );
     }
-    yield put(setIsJoiningConversation(false));
     return;
   }
 
@@ -172,7 +169,6 @@ export function* performValidateActiveConversation(activeConversationId: string)
   }
 
   yield put(rawSetActiveConversationId(conversationId));
-  yield put(setIsJoiningConversation(false));
 }
 
 export function* closeErrorDialog() {

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -12,4 +12,5 @@ export interface ChatState {
   };
   activeConversationId: string;
   joinRoomErrorContent: ErrorDialogContent;
+  isJoiningConversation: boolean;
 }


### PR DESCRIPTION
### What does this do?
- adds loading state when validating joining a conversation.

### Why are we making this change?
- to communicate to the user the following : there will be a delay between loading the conversation list and displaying the conversation a user has been linked to. During this delay, the app is checking whether the URL is valid (does conversation exist) and if the user is a member (whether you are already added to the group or, if it is a TGC, whether you have the required token). 

### How do I test this?
- pass state to component level and log the boolean | alternatively add a basic ui component - then navigate to a conversation url.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

When passed to component level:

https://github.com/zer0-os/zOS/assets/39112648/e8f5face-b3c4-43c3-a43e-6b2536f6e6d0

