### PR TITLE
feat: display loading state during validation when joining a conversation

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -11,6 +11,7 @@ import { Media } from '../../message-input/utils';
 import { otherMembersToString } from '../../../platform-apps/channels/util';
 import { IconCurrencyEthereum, IconUsers1 } from '@zero-tech/zui/icons';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
+import { JoiningConversationDialog } from '../../joining-conversation-dialog';
 
 import { bem } from '../../../lib/bem';
 
@@ -34,6 +35,7 @@ describe(DirectMessageChat, () => {
       sendMessage: () => null,
       onRemoveReply: () => null,
       isCurrentUserRoomAdmin: false,
+      isJoiningConversation: false,
       startAddGroupMember: () => null,
       startEditConversation: () => null,
       setLeaveGroupStatus: () => null,
@@ -48,6 +50,34 @@ describe(DirectMessageChat, () => {
     const wrapper = subject({ activeConversationId: '123' });
 
     expect(wrapper.find(ChatViewContainer)).toHaveProp('channelId', '123');
+  });
+
+  it('renders JoiningConversationDialog when isJoiningConversation is true', () => {
+    const wrapper = subject({ isJoiningConversation: true });
+
+    expect(wrapper).toHaveElement(JoiningConversationDialog);
+  });
+
+  it('does not render ChatViewContainer when isJoiningConversation is true', () => {
+    const wrapper = subject({ isJoiningConversation: true });
+
+    expect(wrapper).not.toHaveElement(ChatViewContainer);
+  });
+
+  it('renders ChatViewContainer when isJoiningConversation is false', () => {
+    const wrapper = subject({
+      isJoiningConversation: false,
+      activeConversationId: '123',
+      directMessage: { otherMembers: [stubUser({ firstName: 'Johnny', lastName: 'Sanderson' })] } as Channel,
+    });
+
+    expect(wrapper).toHaveElement(ChatViewContainer);
+  });
+
+  it('does not render JoiningConversationDialog when isJoiningConversation is false', () => {
+    const wrapper = subject({ isJoiningConversation: false });
+
+    expect(wrapper).not.toHaveElement(JoiningConversationDialog);
   });
 
   describe('title', () => {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -22,11 +22,12 @@ import {
 } from '../../../store/group-management';
 import { Modal } from '@zero-tech/zui/components';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
-
-import './styles.scss';
+import { JoiningConversationDialog } from '../../joining-conversation-dialog';
 import { MessageInput } from '../../message-input/container';
 import { searchMentionableUsersForChannel } from '../../../platform-apps/channels/util/api';
 import { Media } from '../../message-input/utils';
+
+import './styles.scss';
 
 export interface PublicProperties {}
 
@@ -34,6 +35,7 @@ export interface Properties extends PublicProperties {
   activeConversationId: string;
   directMessage: Channel;
   isCurrentUserRoomAdmin: boolean;
+  isJoiningConversation: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
@@ -53,7 +55,7 @@ export class Container extends React.Component<Properties> {
 
   static mapState(state: RootState): Partial<Properties> {
     const {
-      chat: { activeConversationId },
+      chat: { activeConversationId, isJoiningConversation },
       groupManagement,
     } = state;
 
@@ -66,6 +68,7 @@ export class Container extends React.Component<Properties> {
       directMessage,
       isCurrentUserRoomAdmin,
       leaveGroupDialogStatus: groupManagement.leaveGroupDialogStatus,
+      isJoiningConversation,
     };
   }
 
@@ -216,7 +219,7 @@ export class Container extends React.Component<Properties> {
   };
 
   render() {
-    if (!this.props.activeConversationId || !this.props.directMessage) {
+    if ((!this.props.activeConversationId || !this.props.directMessage) && !this.props.isJoiningConversation) {
       return null;
     }
 
@@ -260,14 +263,16 @@ export class Container extends React.Component<Properties> {
             </div>
           </div>
 
-          <ChatViewContainer
-            key={this.props.directMessage.optimisticId || this.props.directMessage.id} // Render new component for a new chat
-            channelId={this.props.activeConversationId}
-            className='direct-message-chat__channel'
-            isDirectMessage
-            showSenderAvatar={!this.isOneOnOne()}
-            ref={this.chatViewContainerRef}
-          />
+          {!this.props.isJoiningConversation && (
+            <ChatViewContainer
+              key={this.props.directMessage.optimisticId || this.props.directMessage.id} // Render new component for a new chat
+              channelId={this.props.activeConversationId}
+              className='direct-message-chat__channel'
+              isDirectMessage
+              showSenderAvatar={!this.isOneOnOne()}
+              ref={this.chatViewContainerRef}
+            />
+          )}
 
           <div className='direct-message-chat__footer-position'>
             <div className='direct-message-chat__footer'>
@@ -275,7 +280,7 @@ export class Container extends React.Component<Properties> {
                 id={this.props.activeConversationId}
                 onSubmit={this.handleSendMessage}
                 getUsersForMentions={this.searchMentionableUsers}
-                reply={this.props.directMessage.reply}
+                reply={this.props.directMessage?.reply}
                 onRemoveReply={this.props.onRemoveReply}
               />
             </div>
@@ -283,6 +288,7 @@ export class Container extends React.Component<Properties> {
           <div className='direct-message-chat__footer-gradient'></div>
 
           {this.isLeaveGroupDialogOpen && this.renderLeaveGroupDialog()}
+          {this.props.isJoiningConversation && <JoiningConversationDialog />}
         </div>
       </div>
     );


### PR DESCRIPTION
### What does this do?
- displays the`JoiningConversationDialog` when `isJoiningConversation` is true.

### Why are we making this change?
- to indicate to the user a loading state for joining a conversation (when loading the page).

### How do I test this?
- log in and refresh the page or enter a url > check the loading state is displayed as demo'd below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO


https://github.com/zer0-os/zOS/assets/39112648/fe152659-5d35-4e6e-ba17-8e58dc9f38ea

