### PR TITLE
Fetch a list of owned ZID's while editing a user's profile

### DIFF
--- a/src/components/edit-profile/container.test.tsx
+++ b/src/components/edit-profile/container.test.tsx
@@ -13,10 +13,12 @@ describe('Container', () => {
       currentDisplayName: 'John Doe',
       currentProfileImage: 'profile.jpg',
       currentPrimaryZID: '0://john:doe',
+      ownedZIDs: [],
       editProfile: () => null,
       startProfileEdit: () => null,
       leaveGlobalNetwork: () => null,
       joinGlobalNetwork: () => null,
+      fetchOwnedZIDs: () => null,
       ...props,
     };
 
@@ -33,6 +35,7 @@ describe('Container', () => {
         currentDisplayName: 'John Doe',
         currentProfileImage: 'profile.jpg',
         currentPrimaryZID: '0://john:doe',
+        ownedZIDs: [],
       })
     );
   });
@@ -46,12 +49,22 @@ describe('Container', () => {
     expect(startProfileEditMock).toHaveBeenCalled();
   });
 
+  it('calls fetchOwnedZIDs on componentDidMount', () => {
+    const fetchOwnedZIDsMock = jest.fn();
+    const wrapper = subject({ fetchOwnedZIDs: fetchOwnedZIDsMock });
+
+    wrapper.instance().componentDidMount();
+
+    expect(fetchOwnedZIDsMock).toHaveBeenCalled();
+  });
+
   describe('mapState', () => {
     // Mock the state with relevant properties for the editProfileState and user
     const stateMock: RootState = {
       editProfile: {
         errors: [],
         state: 0, // Set the initial editProfileState to State.NONE
+        ownedZIDs: [],
       },
       authentication: {
         user: {
@@ -88,6 +101,12 @@ describe('Container', () => {
       const props = Container.mapState(stateMock);
 
       expect(props.currentPrimaryZID).toEqual('0://john:doe');
+    });
+
+    it('ownedZIDs', () => {
+      const props = Container.mapState(stateMock);
+
+      expect(props.ownedZIDs).toEqual([]);
     });
 
     it('errors', () => {

--- a/src/components/edit-profile/container.tsx
+++ b/src/components/edit-profile/container.tsx
@@ -2,7 +2,14 @@ import * as React from 'react';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { EditProfile } from '.';
-import { State, editProfile, joinGlobalNetwork, leaveGlobalNetwork, startProfileEdit } from '../../store/edit-profile';
+import {
+  State,
+  editProfile,
+  joinGlobalNetwork,
+  leaveGlobalNetwork,
+  startProfileEdit,
+  fetchOwnedZIDs,
+} from '../../store/edit-profile';
 import { Container as RegistrationContainer } from '../../authentication/create-account-details/container';
 export interface PublicProperties {
   onClose?: () => void;
@@ -18,10 +25,12 @@ export interface Properties extends PublicProperties {
   currentDisplayName: string;
   currentProfileImage: string;
   currentPrimaryZID: string;
+  ownedZIDs: string[];
   editProfile: (data: { name: string; image: File; primaryZID: string }) => void;
   startProfileEdit: () => void;
   leaveGlobalNetwork: () => void;
   joinGlobalNetwork: () => void;
+  fetchOwnedZIDs: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -35,16 +44,18 @@ export class Container extends React.Component<Properties> {
       currentDisplayName: user?.data?.profileSummary.firstName,
       currentProfileImage: user?.data?.profileSummary.profileImage,
       currentPrimaryZID: user?.data?.primaryZID,
+      ownedZIDs: editProfile.ownedZIDs,
       editProfileState: editProfile.state,
     };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { editProfile, startProfileEdit, joinGlobalNetwork, leaveGlobalNetwork };
+    return { editProfile, startProfileEdit, joinGlobalNetwork, leaveGlobalNetwork, fetchOwnedZIDs };
   }
 
   componentDidMount(): void {
     this.props.startProfileEdit();
+    this.props.fetchOwnedZIDs();
   }
 
   render() {
@@ -57,6 +68,7 @@ export class Container extends React.Component<Properties> {
         currentDisplayName={this.props.currentDisplayName}
         currentProfileImage={this.props.currentProfileImage}
         currentPrimaryZID={this.props.currentPrimaryZID}
+        ownedZIDs={this.props.ownedZIDs}
         onLeaveGlobal={this.props.leaveGlobalNetwork}
         onJoinGlobal={this.props.joinGlobalNetwork}
       />

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -21,6 +21,7 @@ export interface Properties {
   currentDisplayName: string;
   currentPrimaryZID: string;
   currentProfileImage: string;
+  ownedZIDs: string[];
   onEdit: (data: { name: string; image: File; primaryZID: string }) => void;
   onClose?: () => void;
 

--- a/src/store/edit-profile/api.ts
+++ b/src/store/edit-profile/api.ts
@@ -1,4 +1,4 @@
-import { post, put } from '../../lib/api/rest';
+import { get, post, put } from '../../lib/api/rest';
 
 export async function editUserProfile({
   name,
@@ -39,4 +39,9 @@ export async function leaveGlobalNetwork() {
 
 export async function joinGlobalNetwork() {
   await post('/networks/global/join').send();
+}
+
+export async function fetchOwnedZIDs() {
+  const response = await get('/api/v2/users/owned-zids');
+  return response.body;
 }

--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -4,6 +4,7 @@ export enum SagaActionTypes {
   EditProfile = 'profile/edit',
   LeaveGlobal = 'profile/edit/leaveGlobal',
   JoinGlobal = 'profile/edit/joinGlobal',
+  FetchOwnedZIDs = 'profile/edit/fetchOwnedZIDs',
 }
 
 export enum State {
@@ -16,11 +17,13 @@ export enum State {
 export type EditProfileState = {
   errors: string[];
   state: State;
+  ownedZIDs: string[];
 };
 
 export const initialState: EditProfileState = {
   errors: [],
   state: State.NONE,
+  ownedZIDs: [],
 };
 
 export const editProfile = createAction<{
@@ -31,6 +34,7 @@ export const editProfile = createAction<{
 
 export const leaveGlobalNetwork = createAction(SagaActionTypes.LeaveGlobal);
 export const joinGlobalNetwork = createAction(SagaActionTypes.JoinGlobal);
+export const fetchOwnedZIDs = createAction(SagaActionTypes.FetchOwnedZIDs);
 
 const slice = createSlice({
   name: 'edit-profile',
@@ -39,6 +43,7 @@ const slice = createSlice({
     startProfileEdit: (state, _action: PayloadAction) => {
       state.errors = [];
       state.state = State.NONE;
+      state.ownedZIDs = [];
     },
     setErrors: (state, action: PayloadAction<EditProfileState['errors']>) => {
       state.errors = action.payload;
@@ -46,8 +51,11 @@ const slice = createSlice({
     setState: (state, action: PayloadAction<EditProfileState['state']>) => {
       state.state = action.payload;
     },
+    setOwnedZIDs: (state, action: PayloadAction<EditProfileState['ownedZIDs']>) => {
+      state.ownedZIDs = action.payload;
+    },
   },
 });
 
-export const { setErrors, startProfileEdit, setState } = slice.actions;
+export const { setErrors, startProfileEdit, setState, setOwnedZIDs } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -1,13 +1,14 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
-import { editProfile as editProfileSaga, updateUserProfile } from './saga';
-import { editUserProfile as apiEditUserProfile } from './api';
+import { editProfile as editProfileSaga, updateUserProfile, fetchOwnedZIDs } from './saga';
+import { editUserProfile as apiEditUserProfile, fetchOwnedZIDs as apiFetchOwnedZIDs } from './api';
 import { uploadImage } from '../registration/api';
 import { EditProfileState, State, initialState as initialEditProfileState } from '.';
 import { rootReducer } from '../reducer';
 import { User } from '../authentication/types';
 import { ProfileDetailsErrors } from '../registration';
 import { throwError } from 'redux-saga-test-plan/providers';
+import { setOwnedZIDs } from './index';
 
 describe('editProfile', () => {
   const name = 'John Doe';
@@ -137,6 +138,27 @@ describe('updateUserProfile', () => {
     };
 
     expect(authentication.user.data).toEqual(updatedUser);
+  });
+});
+
+describe('fetchOwnedZIDs', () => {
+  it('fetches owned ZIDs', async () => {
+    const ownedZIDs = ['0://zid:1', '0://zid:2'];
+
+    const {
+      storeState: { editProfile },
+    } = await expectSaga(fetchOwnedZIDs)
+      .provide([
+        [
+          call(apiFetchOwnedZIDs),
+          ownedZIDs,
+        ],
+      ])
+      .withReducer(rootReducer, initialState())
+      .put(setOwnedZIDs(ownedZIDs))
+      .run();
+
+    expect(editProfile.ownedZIDs).toEqual(ownedZIDs);
   });
 });
 

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -1,10 +1,11 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects';
-import { SagaActionTypes, State, setErrors, setState } from '.';
+import { SagaActionTypes, State, setErrors, setOwnedZIDs, setState } from '.';
 import {
   editUserProfile as apiEditUserProfile,
   saveUserMatrixCredentials as apiSaveUserMatrixCredentials,
   joinGlobalNetwork as joinGlobalNetworkApi,
   leaveGlobalNetwork as leaveGlobalNetworkApi,
+  fetchOwnedZIDs as fetchOwnedZIDsApi,
 } from './api';
 import { ProfileDetailsErrors } from '../registration';
 import { uploadImage } from '../registration/api';
@@ -79,8 +80,18 @@ export function* joinGlobalNetwork() {
   yield joinGlobalNetworkApi();
 }
 
+export function* fetchOwnedZIDs() {
+  try {
+    const ownedZIDs = yield call(fetchOwnedZIDsApi);
+    yield put(setOwnedZIDs(ownedZIDs));
+  } catch (error) {
+    yield put(setErrors([ProfileDetailsErrors.FetchOwned_ZIDs_ERROR]));
+  }
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.EditProfile, editProfile);
   yield takeLatest(SagaActionTypes.LeaveGlobal, leaveGlobalNetwork);
   yield takeLatest(SagaActionTypes.JoinGlobal, joinGlobalNetwork);
+  yield takeLatest(SagaActionTypes.FetchOwnedZIDs, fetchOwnedZIDs);
 }

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -55,6 +55,7 @@ export enum ProfileDetailsErrors {
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
   NAME_REQUIRED = 'NAME_REQUIRED',
   FILE_UPLOAD_ERROR = 'FILE_UPLOAD_ERROR',
+  FetchOwned_ZIDs_ERROR = 'FetchOwned_ZIDs_ERROR',
 }
 
 export const initialState: RegistrationState = {


### PR DESCRIPTION
### What does this do?

Adds saga logic for fetching ownedZID's when the user opens the edit profile modal.
