### PR TITLE
fix: workflow environment variable naming to match with github (zns explorer url)

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -44,7 +44,7 @@ jobs:
       REACT_APP_ASSETS_PATH: ${{vars.ASSETS_PATH}}
       REACT_APP_ANDROID_STORE_PATH: ${{vars.ANDROID_STORE_PATH}}
       REACT_APP_MATRIX_HOME_SERVER_URL: ${{vars.MATRIX_HOME_SERVER_URL}}
-      REACT_APP_ZNS_EXPLORER_URL: ${{vars.ZNS_EXPLORER_URL}}
+      REACT_APP_ZNS_EXPLORER_URL: ${{vars.REACT_APP_ZNS_EXPLORER_URL}}
     steps:
       - uses: actions/checkout@v4
       - name: Common Setup

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,7 +27,7 @@ jobs:
       REACT_APP_ASSETS_PATH: ${{vars.ASSETS_PATH}}
       REACT_APP_ANDROID_STORE_PATH: ${{vars.ANDROID_STORE_PATH}}
       REACT_APP_MATRIX_HOME_SERVER_URL: ${{vars.MATRIX_HOME_SERVER_URL}}
-      REACT_APP_ZNS_EXPLORER_URL: ${{vars.ZNS_EXPLORER_URL}}
+      REACT_APP_ZNS_EXPLORER_URL: ${{vars.REACT_APP_ZNS_EXPLORER_URL}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### What does this do?
- updates zns explorer url environment variable naming to match that on github env variables.

### Why are we making this change?
- should fix issue where the environment variable is not being set (due to mismatch of naming).

### How do I test this?
- on development or production we expect the use of this variable to direct you to the explorer url. this will need to be deployed to test.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
