### PR TITLE
fix: navigate to explorer if access to room is denied

### DIFF
--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -96,7 +96,7 @@ export function* joinRoom(roomIdOrAlias: string) {
   const { success, response } = yield call(apiJoinRoom, roomIdOrAlias);
 
   if (!success) {
-    const error = translateJoinRoomApiError(response);
+    const error = translateJoinRoomApiError(response, roomIdOrAlias);
     yield put(setJoinRoomErrorContent(error));
   } else {
     yield put(clearJoinRoomErrorContent());

--- a/src/store/chat/utils.test.ts
+++ b/src/store/chat/utils.test.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { translateJoinRoomApiError, JoinRoomApiErrorCode } from './utils';
+import { translateJoinRoomApiError, JoinRoomApiErrorCode, extractRoomAlias } from './utils';
 
 describe(translateJoinRoomApiError, () => {
   it('returns expected message for known error codes', () => {
@@ -21,7 +21,7 @@ describe(translateJoinRoomApiError, () => {
   it('returns expected message with link data for ACCESS_TOKEN_REQUIRED error code', () => {
     const accessTokenRequiredErrorMessage = translateJoinRoomApiError(
       JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED,
-      'exampleRoom'
+      '#exampleRoom:server'
     );
     expect(accessTokenRequiredErrorMessage).toEqual({
       header: 'World Members Only',
@@ -29,5 +29,10 @@ describe(translateJoinRoomApiError, () => {
       linkPath: `${config.znsExplorerUrl}/exampleRoom`,
       linkText: 'Buy A Domain',
     });
+  });
+
+  it('correctly extracts alias from room ID or alias', () => {
+    const alias = extractRoomAlias('#exampleRoom:server');
+    expect(alias).toEqual('exampleRoom');
   });
 });

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -31,10 +31,13 @@ export const ERROR_DIALOG_CONTENT = {
 export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string, roomAlias?: string) {
   const content = ERROR_DIALOG_CONTENT[errorCode] || ERROR_DIALOG_CONTENT[JoinRoomApiErrorCode.UNKNOWN_ERROR];
 
-  if (content.linkPath && content.linkPath.includes('{roomAlias}')) {
-    content.linkPath = content.linkPath.replace('{roomAlias}', roomAlias);
-  }
+  if (errorCode === JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED && roomAlias) {
+    const alias = extractRoomAlias(roomAlias);
 
+    if (content.linkPath && content.linkPath.includes('{roomAlias}')) {
+      content.linkPath = content.linkPath.replace('{roomAlias}', alias);
+    }
+  }
   return content;
 }
 
@@ -51,4 +54,9 @@ export function parseAlias(id: string) {
   }
 
   return id;
+}
+
+export function extractRoomAlias(roomIdOrAlias) {
+  const aliasMatch = roomIdOrAlias.match(/^#([^:]+):.*/);
+  return aliasMatch ? aliasMatch[1] : '';
 }


### PR DESCRIPTION
### What does this do?
- fixes navigation to the explorer when user is denied access to an existing room.

### Why are we making this change?
- so the user can correctly navigate to the explorer

### How do I test this?
- visit a url that is an existing conversation > click `Buy A Domain` > check you are directed to the correct world in the explorer.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


DEMO:

https://github.com/zer0-os/zOS/assets/39112648/a858c095-c4d0-474d-b519-1e18238513c2


