### PR TITLE
Add new event for when all matrix queued events are processed

### DIFF
--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -13,7 +13,6 @@ import {
   otherUserLeftChannel,
   mapToZeroUsers,
   fetchUserPresence,
-  waitForChannelListLoad,
 } from './saga';
 
 import { RootState, rootReducer } from '../reducer';
@@ -25,7 +24,6 @@ import { expectSaga } from '../../test/saga';
 import { getZEROUsers } from './api';
 import { mapAdminUserIdToZeroUserId, mapChannelMembers } from './utils';
 import { openFirstConversation } from '../channels/saga';
-import { AsyncListStatus } from '../normalized';
 
 const mockChannel = (id: string) => ({
   id: `channel_${id}`,
@@ -593,33 +591,5 @@ describe('channels list saga', () => {
         .next()
         .isDone();
     });
-  });
-});
-
-describe(waitForChannelListLoad, () => {
-  it('returns true if channel list already loaded', () => {
-    testSaga(waitForChannelListLoad).next().next(AsyncListStatus.Stopped).returns(true);
-  });
-
-  it('waits for load if channel list not yet loaded', () => {
-    testSaga(waitForChannelListLoad)
-      .next()
-      .next(AsyncListStatus.Fetching)
-      .next('fake/conversation/bus')
-      .next('fake/auth/bus')
-      // Conversation bus fires event
-      .next({ conversationsLoaded: {} })
-      .returns(true);
-  });
-
-  it('returns false if the channel load was aborted', () => {
-    testSaga(waitForChannelListLoad)
-      .next()
-      .next(AsyncListStatus.Fetching)
-      .next('fake/conversation/bus')
-      .next('fake/auth/bus')
-      // Auth bus fires user logout event
-      .next({ abort: {} })
-      .returns(false);
   });
 });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ChannelType } from './types';
 import getDeepProperty from 'lodash.get';
 import uniqBy from 'lodash.uniqby';
-import { fork, put, call, take, all, select, spawn, race } from 'redux-saga/effects';
+import { fork, put, call, take, all, select, spawn } from 'redux-saga/effects';
 import { receive, denormalizeConversations, setStatus } from '.';
 import { chat } from '../../lib/chat';
 import { receive as receiveUser } from '../users';
@@ -91,6 +91,11 @@ export function* fetchConversations() {
   );
 
   yield put(setStatus(AsyncListStatus.Stopped));
+
+  // This event means an initial fetch of conversations has completed and is now in
+  // state but it does not mean _all_ current known conversations are in state
+  // as there are often follow up events still to be processed which would add
+  // new conversations to the state. You may prefer waitForChatConnectionCompletion
   const channel = yield call(getConversationsBus);
   yield put(channel, { type: ConversationEvents.ConversationsLoaded });
 }
@@ -372,18 +377,4 @@ export function* otherUserLeftChannel(roomId: string, user: User) {
       otherMembers: channel?.otherMembers?.filter((userId) => userId !== existingUser.userId) || [],
     })
   );
-}
-
-export function* waitForChannelListLoad() {
-  const status = String(yield select(channelListStatus));
-  if (status !== AsyncListStatus.Stopped) {
-    const { abort } = yield race({
-      conversationsLoaded: take(yield call(getConversationsBus), ConversationEvents.ConversationsLoaded),
-      abort: take(yield call(getAuthChannel), AuthEvents.UserLogout),
-    });
-    if (abort) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/src/store/chat/bus.test.ts
+++ b/src/store/chat/bus.test.ts
@@ -7,11 +7,16 @@ describe('chat bus', () => {
       receivedEvents.push(action);
     }
 
+    // Set up the chat connection fully
     const { chatConnection, activate } = createChatConnection('user-id', 'token', stubClient as any);
-    chatConnection.take(trackEvents);
+    await chatConnection.take(trackEvents);
     await activate();
+    // Consume the ChatConnectionComplete event
+    await chatConnection.take(trackEvents);
+    receivedEvents.pop();
 
     await stubClient.handlers.onOtherUserJoinedChannel('channel-id', 'user-id');
+    await chatConnection.take(trackEvents);
 
     expect(receivedEvents.map((e) => e.type)).toEqual(['chat/channel/otherUserJoined']);
   });
@@ -23,7 +28,7 @@ describe('chat bus', () => {
     }
 
     const { chatConnection, activate } = createChatConnection('user-id', 'token', stubClient as any);
-    chatConnection.take(trackEvents);
+    await chatConnection.take(trackEvents);
 
     stubClient.handlers.onOtherUserJoinedChannel('channel-id', 'user-id');
     expect(receivedEvents.map((e) => e.type)).toEqual([]);

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -9,6 +9,7 @@ const initialState: ChatState = {
   activeConversationId: null,
   joinRoomErrorContent: null,
   isJoiningConversation: false,
+  isChatConnectionComplete: false,
 };
 
 export enum SagaActionTypes {
@@ -39,6 +40,9 @@ const slice = createSlice({
     setIsJoiningConversation: (state, action: PayloadAction<ChatState['isJoiningConversation']>) => {
       state.isJoiningConversation = action.payload;
     },
+    setIsChatConnectionComplete: (state, action: PayloadAction<ChatState['isChatConnectionComplete']>) => {
+      state.isChatConnectionComplete = action.payload;
+    },
   },
 });
 
@@ -48,6 +52,7 @@ export const {
   setJoinRoomErrorContent,
   clearJoinRoomErrorContent,
   setIsJoiningConversation,
+  setIsChatConnectionComplete,
 } = slice.actions;
 export const { reducer } = slice;
 export { closeConversationErrorDialog };

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -13,4 +13,5 @@ export interface ChatState {
   activeConversationId: string;
   joinRoomErrorContent: ErrorDialogContent;
   isJoiningConversation: boolean;
+  isChatConnectionComplete: boolean;
 }


### PR DESCRIPTION
### What does this do?

This adds some more consistent processing of Matrix events upon first load.

When connecting for the first time we queue up all matrix "catch up" events and then process all of them prior to allowing other events to process. This also publishes a new event that indicates that we've caught up with publishing the "catch up" events. It's not necessarily an indication that all business logic is complete but it's at least an indicator that our connection is in full working mode.

