### PR TITLE
feat(matrix-client): add method for getting alias for the room id

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -791,4 +791,32 @@ describe('matrix client', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('getAliasForRoomId', () => {
+    it('returns alias for room ID', async () => {
+      const alias = '#test-room:zos-dev.zero.io';
+      const getLocalAliases = jest.fn().mockResolvedValue({ aliases: [alias] });
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getLocalAliases })),
+      });
+
+      await client.connect(null, 'token');
+      const result = await client.getAliasForRoomId('!heExvpcoNDAMAPMsRd:zos-dev.zero.io');
+
+      expect(result).toEqual(alias);
+    });
+
+    it('returns undefined if room id is not found (M_NOT_FOUND)', async () => {
+      const getLocalAliases = jest.fn().mockRejectedValue({ errcode: 'M_NOT_FOUND' });
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getLocalAliases })),
+      });
+
+      await client.connect(null, 'token');
+      const result = await client.getAliasForRoomId('!heExvpcoNDAMAPMsRd:zos-dev.zero.io');
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -621,6 +621,18 @@ export class MatrixClient implements IChatClient {
       .then((response) => response && response.room_id);
   }
 
+  async getAliasForRoomId(id: string): Promise<string | undefined> {
+    await this.waitForConnection();
+    return await this.matrix
+      .getLocalAliases(id)
+      .catch((err) => {
+        if (err.errcode === 'M_NOT_FOUND' || err.errcode === 'M_INVALID_PARAM') {
+          Promise.resolve(undefined);
+        }
+      })
+      .then((response) => response && response.aliases[0]);
+  }
+
   async fetchConversationsWithUsers(users: User[]) {
     const userMatrixIds = users.map((u) => u.matrixId);
     const rooms = await this.getRoomsUserIsIn();


### PR DESCRIPTION
### What does this do?
- adds method for getting alias for the room id to the matrix client.

### Why are we making this change?
- to get and be able to convert the room id to an alias, this will allow us to extract the alias to use for navigation (and potentially other means).

### How do I test this?
- call method and console log the result in chat/saga.ts > load a conversation that has the room id in the url > check logged result is equal to an alias i.e. `#dom:zero-synapse-development.zer0.io`

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

