### PR TITLE
feat(chat-client): add getAliasForRoomId to client

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -80,6 +80,7 @@ export interface IChatClient {
   saveSecureBackup: (MatrixKeyBackupInfo) => Promise<void>;
   restoreSecureBackup: (recoveryKey: string) => Promise<void>;
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
+  getAliasForRoomId: (id: string) => Promise<string | undefined>;
 }
 
 export class Chat {
@@ -196,6 +197,10 @@ export class Chat {
     return this.matrix.getRoomIdForAlias(alias);
   }
 
+  async getAliasForRoomId(id: string) {
+    return this.matrix.getAliasForRoomId(id);
+  }
+
   async displayRoomKeys(roomId: string) {
     return this.matrix.displayRoomKeys(roomId);
   }
@@ -272,4 +277,8 @@ export async function fetchConversationsWithUsers(users: User[]) {
 
 export async function getRoomIdForAlias(alias: string) {
   return chat.get().getRoomIdForAlias(alias);
+}
+
+export async function getAliasForRoomId(id: string) {
+  return chat.get().getAliasForRoomId(id);
 }


### PR DESCRIPTION
### What does this do?
- adds `getAliasForRoomId` to the `IChatClient`.

### Why are we making this change?
- to access and use `getAliasForRoomId`  from the matrix-client.

### How do I test this?
- call method and console log the result in chat/saga.ts > load a conversation that has the room id in the url > check logged result is equal to an alias i.e. `#dom:zero-synapse-development.zer0.io`.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
