### PR TITLE
fix: remove appemded alias and use root explorer url when navigating user to site

### DIFF
--- a/src/store/chat/utils.test.ts
+++ b/src/store/chat/utils.test.ts
@@ -19,14 +19,11 @@ describe(translateJoinRoomApiError, () => {
   });
 
   it('returns expected message with link data for ACCESS_TOKEN_REQUIRED error code', () => {
-    const accessTokenRequiredErrorMessage = translateJoinRoomApiError(
-      JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED,
-      'exampleRoom'
-    );
+    const accessTokenRequiredErrorMessage = translateJoinRoomApiError(JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED);
     expect(accessTokenRequiredErrorMessage).toEqual({
       header: 'World Members Only',
       body: 'You cannot join this conversation as your wallet does not hold a domain in this world. Buy a domain or switch to a wallet that holds one.',
-      linkPath: `${config.znsExplorerUrl}/exampleRoom`,
+      linkPath: config.znsExplorerUrl,
       linkText: 'Buy A Domain',
     });
   });

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -15,7 +15,7 @@ export const ERROR_DIALOG_CONTENT = {
   [JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED]: {
     header: 'World Members Only',
     body: 'You cannot join this conversation as your wallet does not hold a domain in this world. Buy a domain or switch to a wallet that holds one.',
-    linkPath: `${config.znsExplorerUrl}/{roomAlias}`,
+    linkPath: config.znsExplorerUrl,
     linkText: 'Buy A Domain',
   },
   [JoinRoomApiErrorCode.GENERAL_ERROR]: {
@@ -28,14 +28,8 @@ export const ERROR_DIALOG_CONTENT = {
   },
 };
 
-export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string, roomAlias?: string) {
-  const content = ERROR_DIALOG_CONTENT[errorCode] || ERROR_DIALOG_CONTENT[JoinRoomApiErrorCode.UNKNOWN_ERROR];
-
-  if (content.linkPath && content.linkPath.includes('{roomAlias}')) {
-    content.linkPath = content.linkPath.replace('{roomAlias}', roomAlias);
-  }
-
-  return content;
+export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string) {
+  return ERROR_DIALOG_CONTENT[errorCode] || ERROR_DIALOG_CONTENT[JoinRoomApiErrorCode.UNKNOWN_ERROR];
 }
 
 // conversation can be referenced by an id or an alias


### PR DESCRIPTION
### What does this do?
- replaces navigating user to a specific explorer url path to navigating the user to the root - when access to room is denied and user clicks `Buy A Domain` link.

### Why are we making this change?
- currently attempting to navigate the user to a specific url i.e. `https://zapp-zns-sepolia.netlify.app/worldone` - we should just navigate the user to the root domain.

### How do I test this?
- try accessing a room you are not a member of > click `buy a domain` link > check url is the root url of explorer.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/a4db160d-4b20-47cf-8be9-b3d9494eddda

