### PR TITLE
fix: handle token gated join room error navigation

### DIFF
--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -171,7 +171,7 @@ describe(performValidateActiveConversation, () => {
         [matchers.call.fn(getRoomIdForAlias), '!some-other-convo:matrix.org'],
       ])
       .call(getRoomIdForAlias, '#' + alias)
-      .call(apiJoinRoom, '!some-other-convo:matrix.org')
+      .call(apiJoinRoom, '#some-other-convo:matrix.org')
       .run();
   });
 });

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -190,10 +190,6 @@ export function* performValidateActiveConversation(activeConversationId: string)
 
   const isUserMemberOfActiveConversation = yield call(isMemberOfActiveConversation, conversationId);
   if (!conversationId || !isUserMemberOfActiveConversation) {
-    console.log('CONVERSATION ID', conversationId);
-    console.log('ACTIVE CONVERSATION ID', activeConversationId);
-    console.log('EXTRACTED DOMAIN FROM ALIAS', extractedDomainFromAlias);
-
     yield call(joinRoom, conversationId ?? activeConversationId, extractedDomainFromAlias);
     return;
   }

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -96,7 +96,7 @@ export function* joinRoom(roomIdOrAlias: string) {
   const { success, response } = yield call(apiJoinRoom, roomIdOrAlias);
 
   if (!success) {
-    const error = translateJoinRoomApiError(response);
+    const error = translateJoinRoomApiError(response, roomIdOrAlias);
     yield put(setJoinRoomErrorContent(error));
   } else {
     yield put(clearJoinRoomErrorContent());

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -116,11 +116,11 @@ export function* validateActiveConversation(conversationId: string) {
   yield put(setIsJoiningConversation(false));
 }
 
-export function* joinRoom(roomIdOrAlias: string) {
+export function* joinRoom(roomIdOrAlias: string, extractedDomainFromAlias?: string) {
   const { success, response } = yield call(apiJoinRoom, roomIdOrAlias);
 
   if (!success) {
-    const error = translateJoinRoomApiError(response, roomIdOrAlias);
+    const error = translateJoinRoomApiError(response, extractedDomainFromAlias);
     yield put(setJoinRoomErrorContent(error));
   } else {
     yield put(clearJoinRoomErrorContent());
@@ -180,15 +180,21 @@ export function* performValidateActiveConversation(activeConversationId: string)
     return;
   }
 
+  let extractedDomainFromAlias = '';
   let conversationId = activeConversationId;
   if (isAlias(activeConversationId)) {
+    extractedDomainFromAlias = activeConversationId.split(':')[0];
     activeConversationId = parseAlias(activeConversationId);
     conversationId = yield call(getRoomIdForAlias, activeConversationId);
   }
 
   const isUserMemberOfActiveConversation = yield call(isMemberOfActiveConversation, conversationId);
   if (!conversationId || !isUserMemberOfActiveConversation) {
-    yield call(joinRoom, conversationId ?? activeConversationId);
+    console.log('CONVERSATION ID', conversationId);
+    console.log('ACTIVE CONVERSATION ID', activeConversationId);
+    console.log('EXTRACTED DOMAIN FROM ALIAS', extractedDomainFromAlias);
+
+    yield call(joinRoom, conversationId ?? activeConversationId, extractedDomainFromAlias);
     return;
   }
 

--- a/src/store/chat/utils.test.ts
+++ b/src/store/chat/utils.test.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { translateJoinRoomApiError, JoinRoomApiErrorCode, extractRoomAlias } from './utils';
+import { translateJoinRoomApiError, JoinRoomApiErrorCode } from './utils';
 
 describe(translateJoinRoomApiError, () => {
   it('returns expected message for known error codes', () => {
@@ -18,21 +18,16 @@ describe(translateJoinRoomApiError, () => {
     });
   });
 
-  it('returns expected message with link data for ACCESS_TOKEN_REQUIRED error code', () => {
+  it('appends passed in domain to linkPath for ACCESS_TOKEN_REQUIRED error', () => {
     const accessTokenRequiredErrorMessage = translateJoinRoomApiError(
       JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED,
-      '#exampleRoom:server'
+      'exampleDomain'
     );
     expect(accessTokenRequiredErrorMessage).toEqual({
       header: 'World Members Only',
       body: 'You cannot join this conversation as your wallet does not hold a domain in this world. Buy a domain or switch to a wallet that holds one.',
-      linkPath: `${config.znsExplorerUrl}/exampleRoom`,
+      linkPath: `${config.znsExplorerUrl}/exampleDomain`,
       linkText: 'Buy A Domain',
     });
-  });
-
-  it('correctly extracts alias from room ID or alias', () => {
-    const alias = extractRoomAlias('#exampleRoom:server');
-    expect(alias).toEqual('exampleRoom');
   });
 });

--- a/src/store/chat/utils.test.ts
+++ b/src/store/chat/utils.test.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { translateJoinRoomApiError, JoinRoomApiErrorCode } from './utils';
+import { translateJoinRoomApiError, JoinRoomApiErrorCode, extractRoomAlias } from './utils';
 
 describe(translateJoinRoomApiError, () => {
   it('returns expected message for known error codes', () => {
@@ -21,7 +21,7 @@ describe(translateJoinRoomApiError, () => {
   it('returns expected message with link data for ACCESS_TOKEN_REQUIRED error code', () => {
     const accessTokenRequiredErrorMessage = translateJoinRoomApiError(
       JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED,
-      'exampleRoom'
+      '#exampleRoom:server'
     );
     expect(accessTokenRequiredErrorMessage).toEqual({
       header: 'World Members Only',
@@ -29,5 +29,10 @@ describe(translateJoinRoomApiError, () => {
       linkPath: `${config.znsExplorerUrl}/exampleRoom`,
       linkText: 'Buy A Domain',
     });
+  });
+
+  it('correctly extracts alias from room ID or alias', () => {
+    const alias = extractRoomAlias('#exampleRoom:server');
+    expect(alias).toEqual('exampleRoom');
   });
 });

--- a/src/store/chat/utils.test.ts
+++ b/src/store/chat/utils.test.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { translateJoinRoomApiError, JoinRoomApiErrorCode } from './utils';
+import { extractDomainFromAlias, translateJoinRoomApiError, JoinRoomApiErrorCode } from './utils';
 
 describe(translateJoinRoomApiError, () => {
   it('returns expected message for known error codes', () => {
@@ -29,5 +29,17 @@ describe(translateJoinRoomApiError, () => {
       linkPath: `${config.znsExplorerUrl}/exampleDomain`,
       linkText: 'Buy A Domain',
     });
+  });
+});
+
+describe(extractDomainFromAlias, () => {
+  it('correctly extracts the domain from an alias', () => {
+    const alias = '#exampleDomain:matrix.org';
+    expect(extractDomainFromAlias(alias)).toEqual('exampleDomain');
+  });
+
+  it('returns an empty string when the input is not an alias', () => {
+    const notAlias = '!notAnAlias:matrix.org';
+    expect(extractDomainFromAlias(notAlias)).toEqual('');
   });
 });

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -31,9 +31,10 @@ export const ERROR_DIALOG_CONTENT = {
 export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string, domain?: string) {
   const content = ERROR_DIALOG_CONTENT[errorCode] || ERROR_DIALOG_CONTENT[JoinRoomApiErrorCode.UNKNOWN_ERROR];
 
-  if (errorCode === JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED) {
+  if (errorCode === JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED && content.linkPath?.includes('{domain}')) {
     content.linkPath = content.linkPath.replace('{domain}', domain);
   }
+
   return content;
 }
 
@@ -50,4 +51,12 @@ export function parseAlias(id: string) {
   }
 
   return id;
+}
+
+export function extractDomainFromAlias(alias: string): string {
+  if (isAlias(alias)) {
+    return alias.substring(1).split(':')[0];
+  }
+
+  return '';
 }

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -15,7 +15,7 @@ export const ERROR_DIALOG_CONTENT = {
   [JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED]: {
     header: 'World Members Only',
     body: 'You cannot join this conversation as your wallet does not hold a domain in this world. Buy a domain or switch to a wallet that holds one.',
-    linkPath: `${config.znsExplorerUrl}/{roomAlias}`,
+    linkPath: `${config.znsExplorerUrl}/{domain}`,
     linkText: 'Buy A Domain',
   },
   [JoinRoomApiErrorCode.GENERAL_ERROR]: {
@@ -28,15 +28,11 @@ export const ERROR_DIALOG_CONTENT = {
   },
 };
 
-export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string, roomAlias?: string) {
+export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string, domain?: string) {
   const content = ERROR_DIALOG_CONTENT[errorCode] || ERROR_DIALOG_CONTENT[JoinRoomApiErrorCode.UNKNOWN_ERROR];
 
-  if (errorCode === JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED && roomAlias) {
-    const alias = extractRoomAlias(roomAlias);
-
-    if (content.linkPath && content.linkPath.includes('{roomAlias}')) {
-      content.linkPath = content.linkPath.replace('{roomAlias}', alias);
-    }
+  if (errorCode === JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED) {
+    content.linkPath = content.linkPath.replace('{domain}', domain);
   }
   return content;
 }
@@ -54,9 +50,4 @@ export function parseAlias(id: string) {
   }
 
   return id;
-}
-
-export function extractRoomAlias(roomIdOrAlias) {
-  const aliasMatch = roomIdOrAlias.match(/^#([^:]+):.*/);
-  return aliasMatch ? aliasMatch[1] : '';
 }

--- a/src/store/chat/utils.ts
+++ b/src/store/chat/utils.ts
@@ -31,10 +31,13 @@ export const ERROR_DIALOG_CONTENT = {
 export function translateJoinRoomApiError(errorCode: JoinRoomApiErrorCode | string, roomAlias?: string) {
   const content = ERROR_DIALOG_CONTENT[errorCode] || ERROR_DIALOG_CONTENT[JoinRoomApiErrorCode.UNKNOWN_ERROR];
 
-  if (content.linkPath && content.linkPath.includes('{roomAlias}')) {
-    content.linkPath = content.linkPath.replace('{roomAlias}', roomAlias);
-  }
+  if (errorCode === JoinRoomApiErrorCode.ACCESS_TOKEN_REQUIRED && roomAlias) {
+    const alias = extractRoomAlias(roomAlias);
 
+    if (content.linkPath && content.linkPath.includes('{roomAlias}')) {
+      content.linkPath = content.linkPath.replace('{roomAlias}', alias);
+    }
+  }
   return content;
 }
 
@@ -51,4 +54,9 @@ export function parseAlias(id: string) {
   }
 
   return id;
+}
+
+export function extractRoomAlias(roomIdOrAlias) {
+  const aliasMatch = roomIdOrAlias.match(/^#([^:]+):.*/);
+  return aliasMatch ? aliasMatch[1] : '';
 }


### PR DESCRIPTION
### What does this do?
- appends the extracted domain to the explorer url if activeConversationId is an alias.

### Why are we making this change?
- this ensures the user will be directed to the explorer - to a specific world.

### How do I test this?
- attempt to visit a room url (alias not id) > click 'Buy A Domain' link in error dialog > check explorer url (as shown below)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


DEMO:


https://github.com/zer0-os/zOS/assets/39112648/e7bd9480-6d76-45ba-805e-6877f93b8975

