### PR TITLE
refactor: move get user handle to messenger lib utils folder

### DIFF
--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -1,5 +1,6 @@
 import { Item, Option } from './types';
 import { Channel, User } from '../../../store/channels';
+import { Wallet } from '../../../store/authentication/types';
 
 export const itemToOption = (item: Item): Option => {
   return {
@@ -34,3 +35,17 @@ export const highlightFilter = (text, filter) => {
 
   return text;
 };
+
+export function getUserHandle(primaryZID: string, wallets: Wallet[]) {
+  if (primaryZID) {
+    return primaryZID;
+  }
+
+  const publicAddress = wallets?.[0]?.publicAddress;
+
+  if (publicAddress) {
+    return `${publicAddress.substring(0, 6)}...${publicAddress.substring(publicAddress.length - 4)}`;
+  }
+
+  return '';
+}

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -22,7 +22,7 @@ import { GroupManagementErrors, EditConversationState } from '../../../../store/
 import { User, denormalize as denormalizeChannel } from '../../../../store/channels';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
 import { RemoveMemberDialogContainer } from '../../../group-management/remove-member-dialog/container';
-import { getUserHandle } from '../utils/utils';
+import { getUserHandle } from '../../lib/utils';
 
 export interface PublicProperties {
   searchUsers: (search: string) => Promise<any>;

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -34,7 +34,7 @@ import { receiveSearchResults } from '../../../store/users';
 import { Stage as GroupManagementSagaStage } from '../../../store/group-management';
 import { GroupManagementContainer } from './group-management/container';
 import { UserHeader } from './user-header';
-import { getUserHandle } from './utils/utils';
+import { getUserHandle } from '../lib/utils';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';

--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -1,5 +1,6 @@
-import { getUserHandle, isUserAdmin, sortMembers } from './utils';
+import { isUserAdmin, sortMembers } from './utils';
 import { User } from '../../../../store/channels';
+import { getUserHandle } from '../../lib/utils';
 
 describe('sortMembers', () => {
   it('sorts members correctly with admins first, then online status and alphabetically', () => {

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -1,6 +1,5 @@
 import { monthsSince, fromNow } from '../../../../lib/date';
 import { User } from '../../../../store/channels';
-import { Wallet } from '../../../../store/authentication/types';
 
 export function lastSeenText(user): string {
   if (user.isOnline) {
@@ -41,18 +40,4 @@ export function sortMembers(members: User[], adminIds: string[]) {
     // Finally sort alphabetically by firstName
     return a.firstName!.localeCompare(b.firstName);
   });
-}
-
-export function getUserHandle(primaryZID: string, wallets: Wallet[]) {
-  if (primaryZID) {
-    return primaryZID;
-  }
-
-  const publicAddress = wallets?.[0]?.publicAddress;
-
-  if (publicAddress) {
-    return `${publicAddress.substring(0, 6)}...${publicAddress.substring(publicAddress.length - 4)}`;
-  }
-
-  return '';
 }

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -4,7 +4,7 @@ import { denormalize } from './../channels/index';
 import getDeepProperty from 'lodash.get';
 import { select } from 'redux-saga/effects';
 import { currentUserSelector } from '../authentication/selectors';
-import { getUserHandle } from '../../components/messenger/list/utils/utils';
+import { getUserHandle } from '../../components/messenger/lib/utils';
 
 export function filterChannelsList(state, filter: ChannelType) {
   const channelIdList = getDeepProperty(state, 'channelsList.value', []);


### PR DESCRIPTION
### What does this do?
- moves method higher up to libs folder in messenger 

### Why are we making this change?
- we'll be using this util outside of the `list` folder, therefore moving higher up in the `messenger` tree.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
