### PR TITLE
feat: add subLabel, primaryZID and wallets props to option and item type

### DIFF
--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -52,7 +52,7 @@ describe('autocomplete-members', () => {
 
     // Ensure that state.results is correctly updated with filtered results
     expect(wrapper.state('results')).toEqual([
-      { value: 'result-2', label: 'Result 2', image: undefined },
+      { value: 'result-2', label: 'Result 2', image: undefined, subLabel: '' },
     ]);
 
     // Ensure that the component renders the filtered result
@@ -123,7 +123,7 @@ describe('autocomplete-members', () => {
       .find('.autocomplete-members__search-results > div')
       .simulate('click', { currentTarget: { dataset: { id: 'result-1' } } });
 
-    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1' });
+    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1', subLabel: '' });
   });
 
   it('fires onSelect when enter is pressed on a result', async () => {
@@ -139,7 +139,7 @@ describe('autocomplete-members', () => {
       .find('.autocomplete-members__search-results > div')
       .simulate('keydown', { key: 'Enter', currentTarget: { dataset: { id: 'result-1' } } });
 
-    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1' });
+    expect(onSelect).toHaveBeenCalledWith({ value: 'result-1', label: 'Result 1', subLabel: '' });
   });
 
   it('clears search input when a member is selected', async () => {

--- a/src/components/messenger/lib/types.ts
+++ b/src/components/messenger/lib/types.ts
@@ -1,11 +1,16 @@
+import { Wallet } from '../../../store/authentication/types';
+
 export interface Item {
   id: string;
   name: string;
   image?: string;
+  primaryZID?: string;
+  wallets?: Wallet[];
 }
 
 export interface Option {
   value: string;
   label: string;
   image?: string;
+  subLabel?: string;
 }

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -3,10 +3,13 @@ import { Channel, User } from '../../../store/channels';
 import { Wallet } from '../../../store/authentication/types';
 
 export const itemToOption = (item: Item): Option => {
+  const userHandle = getUserHandle(item?.primaryZID, item?.wallets);
+
   return {
     value: item.id,
     label: item.name,
     image: item.image,
+    subLabel: userHandle,
   };
 };
 

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -247,8 +247,8 @@ describe('ConversationListPanel', () => {
     let userSearchResults = renderedUserSearchResults(wrapper);
 
     expect(userSearchResults).toStrictEqual([
-      { value: 'user-1', label: 'jack', image: 'image-1' },
-      { value: 'user-3', label: 'jacklyn', image: 'image-3' },
+      { value: 'user-1', label: 'jack', image: 'image-1', subLabel: '' },
+      { value: 'user-3', label: 'jacklyn', image: 'image-3', subLabel: '' },
     ]);
   });
 


### PR DESCRIPTION
### What does this do?
- adds `subLabel` prop to `Option` type.
- adds `primaryZID` prop to `Item` type.
- adds `wallets` prop to `Item` type.

### Why are we making this change?
- adding these props enables us to set either the `primaryZID` or users `publicWalletAddress` to the subLabel prop.
- display the `subLabel` on user search result items.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
