### PR TITLE
feat(user-search-results-component): expose sub-label to search result items

### DIFF
--- a/src/components/messenger/list/user-search-results/index.test.tsx
+++ b/src/components/messenger/list/user-search-results/index.test.tsx
@@ -23,9 +23,9 @@ describe('UserSearchResults', () => {
 
   it('renders user search results', function () {
     const userResults = [
-      { value: 'user-1', label: 'jack', image: 'image-1' },
-      { value: 'user-2', label: 'bob', image: 'image-2' },
-      { value: 'user-3', label: 'jacklyn', image: 'image-3' },
+      { value: 'user-1', label: 'jack', image: 'image-1', subLabel: '0://jack.test' },
+      { value: 'user-2', label: 'bob', image: 'image-2', subLabel: '0://bob.test' },
+      { value: 'user-3', label: 'jacklyn', image: 'image-3', subLabel: '0x1234...3456' },
     ];
     const wrapper = subject({ results: userResults });
 
@@ -36,6 +36,7 @@ describe('UserSearchResults', () => {
       expect(node.key()).toEqual(userResults[index].value);
       expect(node.find('Avatar').prop('imageURL')).toEqual(userResults[index].image);
       expect(node.find('.user-search-results__label').text()).toEqual(userResults[index].label);
+      expect(node.find('.user-search-results__sub-label').text()).toEqual(userResults[index].subLabel);
     });
   });
 

--- a/src/components/messenger/list/user-search-results/index.test.tsx
+++ b/src/components/messenger/list/user-search-results/index.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { UserSearchResults, Properties } from '.';
+import { Avatar } from '@zero-tech/zui/components';
+
+import { bem } from '../../../../lib/bem';
+
+const c = bem('.user-search-results');
 
 describe('UserSearchResults', () => {
   const subject = (props: Partial<Properties>) => {
@@ -18,7 +23,7 @@ describe('UserSearchResults', () => {
   it('renders the title', function () {
     const wrapper = subject({});
 
-    expect(wrapper.find('.user-search-results__title').text()).toEqual('Start a new conversation:');
+    expect(wrapper.find(c('title')).text()).toEqual('Start a new conversation:');
   });
 
   it('renders user search results', function () {
@@ -29,15 +34,33 @@ describe('UserSearchResults', () => {
     ];
     const wrapper = subject({ results: userResults });
 
-    const renderedResults = wrapper.find('.user-search-results__item');
+    const renderedResults = wrapper.find(c('item'));
     expect(renderedResults).toHaveLength(userResults.length);
 
     renderedResults.forEach((node, index) => {
       expect(node.key()).toEqual(userResults[index].value);
-      expect(node.find('Avatar').prop('imageURL')).toEqual(userResults[index].image);
-      expect(node.find('.user-search-results__label').text()).toEqual(userResults[index].label);
-      expect(node.find('.user-search-results__sub-label').text()).toEqual(userResults[index].subLabel);
+      expect(node.find(Avatar)).toHaveProp('imageURL', userResults[index].image);
+      expect(node.find(c('label'))).toHaveText(userResults[index].label);
+      expect(node.find(c('sub-label'))).toHaveText(userResults[index].subLabel);
     });
+  });
+
+  it('should render sublabel if it is available', function () {
+    const userResults = [
+      { value: 'user-1', label: 'jack', image: 'image-1', subLabel: '0://jack.test' },
+    ];
+    const wrapper = subject({ results: userResults });
+
+    expect(wrapper).toHaveElement(c('sub-label'));
+  });
+
+  it('should not render sublabel if it is not available', function () {
+    const userResults = [
+      { value: 'user-1', label: 'jack', image: 'image-1' },
+    ];
+    const wrapper = subject({ results: userResults });
+
+    expect(wrapper).not.toHaveElement(c('sub-label'));
   });
 
   it('triggers onCreate when a user is clicked', function () {
@@ -47,7 +70,7 @@ describe('UserSearchResults', () => {
     ];
     const wrapper = subject({ results: userResults, onCreate: handleCreate });
 
-    wrapper.find('.user-search-results__item').simulate('click');
+    wrapper.find(c('item')).simulate('click');
 
     expect(handleCreate).toHaveBeenCalledWith(userResults[0].value);
   });
@@ -59,7 +82,7 @@ describe('UserSearchResults', () => {
     ];
     const wrapper = subject({ results: userResults, onCreate: handleCreate });
 
-    wrapper.find('.user-search-results__item').simulate('keydown', { key: 'Enter' });
+    wrapper.find(c('item')).simulate('keydown', { key: 'Enter' });
 
     expect(handleCreate).toHaveBeenCalledWith(userResults[0].value);
   });

--- a/src/components/messenger/list/user-search-results/index.tsx
+++ b/src/components/messenger/list/user-search-results/index.tsx
@@ -44,7 +44,11 @@ export class UserSearchResults extends React.Component<Properties> {
             key={userResult.value}
           >
             <Avatar size='regular' type='circle' imageURL={userResult.image} tabIndex={-1} />
-            <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
+
+            <div {...cn('user-details')}>
+              <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
+              {userResult?.subLabel && <div {...cn('sub-label')}>{userResult.subLabel}</div>}
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/messenger/list/user-search-results/user-search-results.scss
+++ b/src/components/messenger/list/user-search-results/user-search-results.scss
@@ -1,6 +1,7 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../../../variables';
 @import '../../../../layout';
+@import '../../../../glass';
 
 .user-search-results {
   display: flex;
@@ -24,18 +25,34 @@
 
     &:hover,
     &:focus {
-      background-color: theme.$color-primary-3;
+      @include glass-state-hover-color;
+
       border-radius: 8px;
       outline: none;
     }
   }
 
+  &__user-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex: 1 0 0;
+  }
+
   &__label {
+    @include glass-text-primary-color;
+
     font-size: $font-size-medium;
-    line-height: 17px;
-    color: theme.$color-greyscale-12;
+    line-height: 20px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+
+  &__sub-label {
+    @include glass-text-tertiary-color;
+
+    font-size: 10px;
+    line-height: 14px;
   }
 }


### PR DESCRIPTION
### What does this do?
- exposes `subLabel` to search result items for the `UserSearchResults` component.

### Why are we making this change?
- to display the users `primaryZID` (or, after some follow up changes, the users `publicWalletAddress`).

### How do I test this?
- on the conversation list panel, search users that have a primaryZID set and check it is displayed as per screenshot below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Sub-Label:

<img width="318" alt="Screenshot 2024-02-06 at 11 54 51" src="https://github.com/zer0-os/zOS/assets/39112648/7eea8f90-82ce-4552-be45-9b8a4367a02c">
