### PR TITLE
refactor: github actions common setup usage

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -5,9 +5,6 @@ description: 'Setup nodejs and cache'
 runs:
   using: 'composite'
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -30,10 +30,11 @@ jobs:
       REACT_APP_ZNS_EXPLORER_URL: ${{vars.ZNS_EXPLORER_URL}}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
+      - name: Common Setup
+        uses: ./.github/actions/common
+
       - run: echo '//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}' >> .npmrc
+
       - run: npm install
       - name: get-npm-version
         id: package-version


### PR DESCRIPTION
### What does this do?
* Removes a redundant step in the common setup action. You have to checkout the code in the original action in order for the common action to be available.
* Use common setup during production github action

