### PR TITLE
Remove unused steps in create-tag action

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -13,7 +13,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: '${{ secrets.COMMIT_KEY }}'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
       - run: ./.github/create-tag


### PR DESCRIPTION
### What does this do?

Removes the node setup step from the create-tag github action

