### PR TITLE
Render customIcon first as the conversationImage header (if set)

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -36,13 +36,14 @@ export class ConversationHeader extends React.Component<Properties> {
       return '';
     }
 
+    if (isCustomIcon(this.props.icon)) {
+      return this.props.icon;
+    }
+
     if (this.isOneOnOne() && this.props.otherMembers[0]) {
       return this.props.otherMembers[0].profileImage;
     }
 
-    if (isCustomIcon(this.props.icon)) {
-      return this.props.icon;
-    }
 
     return '';
   }

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -58,28 +58,11 @@ export class ConversationItem extends React.Component<Properties> {
   };
 
   renderAvatar() {
+    let imageUrl;
     if (isCustomIcon(this.props.conversation.icon)) {
-      return (
-        <Avatar
-          size={'regular'}
-          type={'circle'}
-          imageURL={this.props.conversation.icon}
-          statusType={this.conversationStatus}
-          tabIndex={-1}
-          isRaised
-        />
-      );
+      imageUrl = this.props.conversation.icon;
     } else if (this.props.conversation.isOneOnOne && this.props.conversation.otherMembers[0]?.profileImage) {
-      return (
-        <Avatar
-          size={'regular'}
-          type={'circle'}
-          imageURL={this.props.conversation.otherMembers[0].profileImage}
-          statusType={this.conversationStatus}
-          tabIndex={-1}
-          isRaised
-        />
-      );
+      imageUrl = this.props.conversation.otherMembers[0].profileImage;
     } else if (!this.props.conversation.isOneOnOne) {
       return (
         <div {...cn('group-icon')}>
@@ -89,7 +72,16 @@ export class ConversationItem extends React.Component<Properties> {
       );
     }
 
-    return <Avatar size={'regular'} type={'circle'} statusType={this.conversationStatus} tabIndex={-1} isRaised />;
+    return (
+      <Avatar
+        size={'regular'}
+        type={'circle'}
+        imageURL={imageUrl}
+        statusType={this.conversationStatus}
+        tabIndex={-1}
+        isRaised
+      />
+    );
   }
 
   render() {

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -58,23 +58,23 @@ export class ConversationItem extends React.Component<Properties> {
   };
 
   renderAvatar() {
-    if (this.props.conversation.isOneOnOne && this.props.conversation.otherMembers[0]?.profileImage) {
-      return (
-        <Avatar
-          size={'regular'}
-          type={'circle'}
-          imageURL={this.props.conversation.otherMembers[0].profileImage}
-          statusType={this.conversationStatus}
-          tabIndex={-1}
-          isRaised
-        />
-      );
-    } else if (isCustomIcon(this.props.conversation.icon)) {
+    if (isCustomIcon(this.props.conversation.icon)) {
       return (
         <Avatar
           size={'regular'}
           type={'circle'}
           imageURL={this.props.conversation.icon}
+          statusType={this.conversationStatus}
+          tabIndex={-1}
+          isRaised
+        />
+      );
+    } else if (this.props.conversation.isOneOnOne && this.props.conversation.otherMembers[0]?.profileImage) {
+      return (
+        <Avatar
+          size={'regular'}
+          type={'circle'}
+          imageURL={this.props.conversation.otherMembers[0].profileImage}
           statusType={this.conversationStatus}
           tabIndex={-1}
           isRaised


### PR DESCRIPTION
### What does this do?

This gives priority to the "custom icon" set in the conversation data received from matrix. 

For eg. if there's a `oneOnOne` conversation with a `"icon"` value set, then we'll display that icon instead of the `profileImage` of the "other member".

### Why was this required?
This was required to display the conversationImage in a token-gated-chat, when there's only you & admin in the room. Instead of displaying the admin's profileImage, we want to display the conversationImage set in the "conversation" by the backend.

<img width="566" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/b3b1c309-8a61-4832-a3e5-fdf2e6e3d62b">
