### PR TITLE
refactor(conversation-header): improve props and naming

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -20,10 +20,10 @@ export interface Properties {
   canLeaveRoom: boolean;
   canEdit: boolean;
   canViewGroupInformation: boolean;
-  startAddGroupMember: () => void;
-  startEditConversation: () => void;
+  onAddMember: () => void;
+  onEdit: () => void;
   onLeave: () => void;
-  onViewGroupInformation: () => void;
+  onView: () => void;
 }
 
 export class ConversationHeader extends React.Component<Properties> {
@@ -129,10 +129,10 @@ export class ConversationHeader extends React.Component<Properties> {
             canLeaveRoom={this.props.canLeaveRoom}
             canEdit={this.props.canEdit}
             canViewGroupInformation={this.props.canViewGroupInformation}
-            onStartAddMember={this.props.startAddGroupMember}
+            onStartAddMember={this.props.onAddMember}
             onLeave={this.props.onLeave}
-            onEdit={this.props.startEditConversation}
-            onViewGroupInformation={this.props.onViewGroupInformation}
+            onEdit={this.props.onEdit}
+            onViewGroupInformation={this.props.onView}
           />
         </div>
       </div>

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -61,7 +61,7 @@ export class ConversationHeader extends React.Component<Properties> {
 
   renderIcon = () => {
     return this.isOneOnOne() ? (
-      <IconCurrencyEthereum size={16} className={this.isOneOnOne && 'direct-message-chat__header-avatar--isOneOnOne'} />
+      <IconCurrencyEthereum size={16} className='direct-message-chat__header-avatar--isOneOnOne' />
     ) : (
       <IconUsers1 size={16} />
     );

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -19,11 +19,11 @@ export interface Properties {
   canAddMembers: boolean;
   canLeaveRoom: boolean;
   canEdit: boolean;
-  canViewGroupInformation: boolean;
+  canViewDetails: boolean;
   onAddMember: () => void;
   onEdit: () => void;
-  onLeave: () => void;
-  onView: () => void;
+  onLeaveRoom: () => void;
+  onViewDetails: () => void;
 }
 
 export class ConversationHeader extends React.Component<Properties> {
@@ -128,11 +128,11 @@ export class ConversationHeader extends React.Component<Properties> {
             canAddMembers={this.props.canAddMembers}
             canLeaveRoom={this.props.canLeaveRoom}
             canEdit={this.props.canEdit}
-            canViewGroupInformation={this.props.canViewGroupInformation}
+            canViewGroupInformation={this.props.canViewDetails}
             onStartAddMember={this.props.onAddMember}
-            onLeave={this.props.onLeave}
+            onLeave={this.props.onLeaveRoom}
             onEdit={this.props.onEdit}
-            onViewGroupInformation={this.props.onView}
+            onViewGroupInformation={this.props.onViewDetails}
           />
         </div>
       </div>

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Channel } from '../../../../store/channels';
+import { User } from '../../../../store/channels';
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import Tooltip from '../../../tooltip';
 import { isCustomIcon } from '../../list/utils/utils';
@@ -12,7 +12,10 @@ import { IconCurrencyEthereum, IconUsers1 } from '@zero-tech/zui/icons';
 import classNames from 'classnames';
 
 export interface Properties {
-  directMessage: Channel;
+  isOneOnOne: boolean;
+  otherMembers: User[];
+  icon: string;
+  name: string;
   isCurrentUserRoomAdmin: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
@@ -22,27 +25,27 @@ export interface Properties {
 
 export class ConversationHeader extends React.Component<Properties> {
   isOneOnOne() {
-    return this.props.directMessage?.isOneOnOne;
+    return this.props.isOneOnOne;
   }
 
   avatarUrl() {
-    if (!this.props.directMessage?.otherMembers) {
+    if (!this.props.otherMembers) {
       return '';
     }
 
-    if (this.isOneOnOne() && this.props.directMessage.otherMembers[0]) {
-      return this.props.directMessage.otherMembers[0].profileImage;
+    if (this.isOneOnOne() && this.props.otherMembers[0]) {
+      return this.props.otherMembers[0].profileImage;
     }
 
-    if (isCustomIcon(this.props.directMessage?.icon)) {
-      return this.props.directMessage?.icon;
+    if (isCustomIcon(this.props.icon)) {
+      return this.props.icon;
     }
 
     return '';
   }
 
   avatarStatus() {
-    if (!this.props.directMessage?.otherMembers) {
+    if (!this.props.otherMembers) {
       return 'unknown';
     }
 
@@ -50,7 +53,7 @@ export class ConversationHeader extends React.Component<Properties> {
   }
 
   anyOthersOnline() {
-    return this.props.directMessage.otherMembers.some((m) => m.isOnline);
+    return this.props.otherMembers.some((m) => m.isOnline);
   }
 
   renderIcon = () => {
@@ -62,26 +65,26 @@ export class ConversationHeader extends React.Component<Properties> {
   };
 
   renderSubTitle() {
-    if (!this.props.directMessage?.otherMembers) {
+    if (!this.props.otherMembers) {
       return '';
-    } else if (this.isOneOnOne() && this.props.directMessage.otherMembers[0]) {
-      return this.props.directMessage.otherMembers[0].displaySubHandle;
+    } else if (this.isOneOnOne() && this.props.otherMembers[0]) {
+      return this.props.otherMembers[0].displaySubHandle;
     } else {
       return this.anyOthersOnline() ? 'Online' : 'Offline';
     }
   }
 
   renderTitle() {
-    const { directMessage } = this.props;
+    const { otherMembers, name } = this.props;
 
-    if (!directMessage) return '';
+    if (!name && !otherMembers) return '';
 
-    const otherMembers = otherMembersToString(directMessage.otherMembers);
+    const otherMembersString = otherMembersToString(otherMembers);
 
     return (
       <Tooltip
         placement='left'
-        overlay={otherMembers}
+        overlay={otherMembersString}
         align={{
           offset: [
             -10,
@@ -89,9 +92,8 @@ export class ConversationHeader extends React.Component<Properties> {
           ],
         }}
         className='direct-message-chat__user-tooltip'
-        key={directMessage.id}
       >
-        <div>{directMessage.name || otherMembers}</div>
+        <div>{name || otherMembersString}</div>
       </Tooltip>
     );
   }
@@ -123,7 +125,7 @@ export class ConversationHeader extends React.Component<Properties> {
             canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
             onStartAddMember={this.props.startAddGroupMember}
             onLeave={this.props.onLeave}
-            canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage?.otherMembers?.length > 1}
+            canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.otherMembers.length > 1}
             canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
             onEdit={this.props.startEditConversation}
             onViewGroupInformation={this.props.onViewGroupInformation}

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -16,7 +16,10 @@ export interface Properties {
   otherMembers: User[];
   icon: string;
   name: string;
-  isCurrentUserRoomAdmin: boolean;
+  canAddMembers: boolean;
+  canLeaveRoom: boolean;
+  canEdit: boolean;
+  canViewGroupInformation: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   onLeave: () => void;
@@ -122,14 +125,14 @@ export class ConversationHeader extends React.Component<Properties> {
 
         <div className='direct-message-chat__group-management-menu-container'>
           <GroupManagementMenu
-            canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+            canAddMembers={this.props.canAddMembers}
+            canLeaveRoom={this.props.canLeaveRoom}
+            canEdit={this.props.canEdit}
+            canViewGroupInformation={this.props.canViewGroupInformation}
             onStartAddMember={this.props.startAddGroupMember}
             onLeave={this.props.onLeave}
-            canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.otherMembers.length > 1}
-            canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
             onEdit={this.props.startEditConversation}
             onViewGroupInformation={this.props.onViewGroupInformation}
-            canViewGroupInformation={!this.isOneOnOne()}
           />
         </div>
       </div>

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -154,20 +154,22 @@ export class Container extends React.Component<Properties> {
         <div className='direct-message-chat__content'>
           <div className='direct-message-chat__header-gradient'></div>
           <div className='direct-message-chat__header-position'>
-            <ConversationHeader
-              icon={this.props.directMessage.icon}
-              name={this.props.directMessage.name}
-              isOneOnOne={this.isOneOnOne()}
-              otherMembers={this.props.directMessage.otherMembers}
-              canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
-              canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage.otherMembers.length > 1}
-              canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
-              canViewDetails={!this.isOneOnOne()}
-              onLeaveRoom={this.openLeaveGroupDialog}
-              onViewDetails={this.onViewGroupInformation}
-              onAddMember={this.props.startAddGroupMember}
-              onEdit={this.props.startEditConversation}
-            />
+            {this.props.directMessage && (
+              <ConversationHeader
+                icon={this.props.directMessage.icon}
+                name={this.props.directMessage.name}
+                isOneOnOne={this.isOneOnOne()}
+                otherMembers={this.props.directMessage.otherMembers}
+                canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+                canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage.otherMembers.length > 1}
+                canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+                canViewDetails={!this.isOneOnOne()}
+                onLeaveRoom={this.openLeaveGroupDialog}
+                onViewDetails={this.onViewGroupInformation}
+                onAddMember={this.props.startAddGroupMember}
+                onEdit={this.props.startEditConversation}
+              />
+            )}
           </div>
 
           {!this.props.isJoiningConversation && (

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -155,13 +155,16 @@ export class Container extends React.Component<Properties> {
           <div className='direct-message-chat__header-gradient'></div>
           <div className='direct-message-chat__header-position'>
             <ConversationHeader
-              isOneOnOne={this.isOneOnOne()}
-              otherMembers={this.props.directMessage.otherMembers}
               icon={this.props.directMessage.icon}
               name={this.props.directMessage.name}
+              isOneOnOne={this.isOneOnOne()}
+              otherMembers={this.props.directMessage.otherMembers}
+              canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+              canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage.otherMembers.length > 1}
+              canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+              canViewGroupInformation={!this.isOneOnOne()}
               onLeave={this.openLeaveGroupDialog}
               onViewGroupInformation={this.onViewGroupInformation}
-              isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}
               startAddGroupMember={this.props.startAddGroupMember}
               startEditConversation={this.props.startEditConversation}
             />

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -155,7 +155,10 @@ export class Container extends React.Component<Properties> {
           <div className='direct-message-chat__header-gradient'></div>
           <div className='direct-message-chat__header-position'>
             <ConversationHeader
-              directMessage={this.props.directMessage}
+              isOneOnOne={this.isOneOnOne()}
+              otherMembers={this.props.directMessage.otherMembers}
+              icon={this.props.directMessage.icon}
+              name={this.props.directMessage.name}
               onLeave={this.openLeaveGroupDialog}
               onViewGroupInformation={this.onViewGroupInformation}
               isCurrentUserRoomAdmin={this.props.isCurrentUserRoomAdmin}

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -162,9 +162,9 @@ export class Container extends React.Component<Properties> {
               canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
               canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage.otherMembers.length > 1}
               canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
-              canViewGroupInformation={!this.isOneOnOne()}
-              onLeave={this.openLeaveGroupDialog}
-              onView={this.onViewGroupInformation}
+              canViewDetails={!this.isOneOnOne()}
+              onLeaveRoom={this.openLeaveGroupDialog}
+              onViewDetails={this.onViewGroupInformation}
               onAddMember={this.props.startAddGroupMember}
               onEdit={this.props.startEditConversation}
             />

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -164,9 +164,9 @@ export class Container extends React.Component<Properties> {
               canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
               canViewGroupInformation={!this.isOneOnOne()}
               onLeave={this.openLeaveGroupDialog}
-              onViewGroupInformation={this.onViewGroupInformation}
-              startAddGroupMember={this.props.startAddGroupMember}
-              startEditConversation={this.props.startEditConversation}
+              onView={this.onViewGroupInformation}
+              onAddMember={this.props.startAddGroupMember}
+              onEdit={this.props.startEditConversation}
             />
           </div>
 


### PR DESCRIPTION
### What does this do?
- moves permissions calcs out of conversation header
- flattens direct message props passed in
- renames events and variables
- adds condition to render header if direct message


