### PR TITLE
feat: expose and use current user primary wallet address for user handle

### DIFF
--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -80,7 +80,7 @@ export class Container extends React.Component<Properties> {
         matrixId: currentUser?.matrixId,
         isOnline: currentUser?.isOnline,
         primaryZID: currentUser?.primaryZID,
-        displaySubHandle: getUserHandle(currentUser?.primaryZID, currentUser?.wallets?.[0]?.publicAddress),
+        displaySubHandle: getUserHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -85,8 +85,7 @@ export class Container extends React.Component<Properties, State> {
     } = state;
 
     const conversations = denormalizeConversations(state).map(addLastMessageMeta(state)).sort(byLastMessageOrCreation);
-    const userHandle = getUserHandle(user?.data?.primaryZID, user?.data?.wallets?.[0]?.publicAddress);
-
+    const userHandle = getUserHandle(user?.data?.primaryZID, user?.data?.primaryWalletAddress);
     return {
       conversations,
       activeConversationId,

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -39,6 +39,7 @@ export interface User {
   matrixId?: string;
   matrixAccessToken?: string;
   primaryZID?: string;
+  primaryWalletAddress?: string;
 }
 
 export interface AuthenticationState {


### PR DESCRIPTION
### What does this do?
- exposes and uses `primaryWalletAddress` for current user - specifically for passing this value to `getUserHandle`.

### Why are we making this change?
- to use the actual default public wallet address as the primary wallet address rather than using the first wallet from wallets list.

### How do I test this?
- check redux auth>user state for primaryWalletAddress.
- check user handle is truncated address (user details -- if no zid)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1403" alt="Screenshot 2024-02-09 at 09 50 52" src="https://github.com/zer0-os/zOS/assets/39112648/68ee7757-a8c8-4623-86b6-7df66f1ac93f">
