### PR TITLE
Account for possibly null otherMembers list

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -159,9 +159,11 @@ export class Container extends React.Component<Properties> {
                 icon={this.props.directMessage.icon}
                 name={this.props.directMessage.name}
                 isOneOnOne={this.isOneOnOne()}
-                otherMembers={this.props.directMessage.otherMembers}
+                otherMembers={this.props.directMessage.otherMembers || []}
                 canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
-                canLeaveRoom={!this.props.isCurrentUserRoomAdmin && this.props.directMessage.otherMembers.length > 1}
+                canLeaveRoom={
+                  !this.props.isCurrentUserRoomAdmin && (this.props.directMessage.otherMembers || []).length > 1
+                }
                 canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                 canViewDetails={!this.isOneOnOne()}
                 onLeaveRoom={this.openLeaveGroupDialog}


### PR DESCRIPTION
### What does this do?

Temporary fix for when we have conversation data with a null/undefined otherMembers attribute. Will find the spot creating this data and fix the default to be an empty array as a follow up.

