### PR TITLE
chore: bump version (`1.10.0`) -> (`1.11.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zOS",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zOS",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
         "@craco/craco": "^6.4.3",
         "@ethersproject/bytes": "^5.4.0",
@@ -8719,6 +8719,7 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -8748,6 +8749,7 @@
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -8905,6 +8907,7 @@
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -8912,6 +8915,7 @@
     },
     "node_modules/aws4": {
       "version": "1.11.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/axe-core": {
@@ -9492,6 +9496,7 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -9925,6 +9930,7 @@
     },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
@@ -9933,6 +9939,7 @@
     },
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/buffer-crc32": {
@@ -9953,6 +9960,7 @@
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/buffer-from": {
@@ -10420,6 +10428,7 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ccount": {
@@ -12091,6 +12100,7 @@
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -12798,6 +12808,7 @@
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
@@ -15540,6 +15551,7 @@
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -15895,6 +15907,7 @@
     },
     "node_modules/getpass": {
       "version": "0.1.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -16108,6 +16121,7 @@
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -16115,6 +16129,7 @@
     },
     "node_modules/har-validator": {
       "version": "5.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
@@ -16894,6 +16909,7 @@
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
@@ -17785,6 +17801,7 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -20784,6 +20801,7 @@
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -20880,6 +20898,7 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
+      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -20899,6 +20918,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json3": {
@@ -20931,6 +20951,7 @@
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
@@ -23105,6 +23126,7 @@
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -26969,6 +26991,7 @@
     },
     "node_modules/request": {
       "version": "2.88.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -27044,6 +27067,7 @@
     },
     "node_modules/request/node_modules/form-data": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -27056,6 +27080,7 @@
     },
     "node_modules/request/node_modules/qs": {
       "version": "6.5.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
@@ -27063,6 +27088,7 @@
     },
     "node_modules/request/node_modules/tough-cookie": {
       "version": "2.5.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.28",
@@ -27074,6 +27100,7 @@
     },
     "node_modules/request/node_modules/uuid": {
       "version": "3.4.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -28464,6 +28491,7 @@
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
@@ -29679,6 +29707,7 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -29689,6 +29718,7 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type": {
@@ -30488,6 +30518,7 @@
     },
     "node_modules/verror": {
       "version": "1.10.0",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -30500,6 +30531,7 @@
     },
     "node_modules/verror/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {
@@ -37886,6 +37918,7 @@
     },
     "asn1": {
       "version": "0.2.6",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -37923,7 +37956,8 @@
       }
     },
     "assert-plus": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0"
@@ -38017,10 +38051,12 @@
       }
     },
     "aws-sign2": {
-      "version": "0.7.0"
+      "version": "0.7.0",
+      "dev": true
     },
     "aws4": {
-      "version": "1.11.0"
+      "version": "1.11.0",
+      "dev": true
     },
     "axe-core": {
       "version": "4.3.5"
@@ -38432,6 +38468,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -38729,13 +38766,15 @@
     },
     "buffer-alloc": {
       "version": "1.2.0",
+      "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -38746,7 +38785,8 @@
       "dev": true
     },
     "buffer-fill": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2"
@@ -39047,7 +39087,8 @@
       "version": "2.3.0"
     },
     "caseless": {
-      "version": "0.12.0"
+      "version": "0.12.0",
+      "dev": true
     },
     "ccount": {
       "version": "2.0.1"
@@ -40153,6 +40194,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -40625,6 +40667,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -42238,7 +42281,8 @@
       }
     },
     "extsprintf": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3"
@@ -42447,7 +42491,8 @@
       "version": "1.0.2"
     },
     "forever-agent": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "4.1.6",
@@ -42674,6 +42719,7 @@
     },
     "getpass": {
       "version": "0.1.7",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -42817,10 +42863,12 @@
       "version": "2.0.1"
     },
     "har-schema": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.5",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -43342,6 +43390,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -43846,7 +43895,8 @@
       "version": "3.0.1"
     },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0"
@@ -45911,7 +45961,8 @@
       }
     },
     "jsbn": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "jsdom": {
       "version": "16.7.0",
@@ -45974,7 +46025,8 @@
       "version": "1.0.1"
     },
     "json-schema": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1"
@@ -45989,7 +46041,8 @@
       "version": "1.0.1"
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "json3": {
       "version": "3.3.3"
@@ -46009,6 +46062,7 @@
     },
     "jsprim": {
       "version": "1.4.2",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -47413,7 +47467,8 @@
       "version": "2.2.0"
     },
     "oauth-sign": {
-      "version": "0.9.0"
+      "version": "0.9.0",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1"
@@ -49981,6 +50036,7 @@
     },
     "request": {
       "version": "2.88.2",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -50006,6 +50062,7 @@
       "dependencies": {
         "form-data": {
           "version": "2.3.3",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -50013,17 +50070,20 @@
           }
         },
         "qs": {
-          "version": "6.5.3"
+          "version": "6.5.3",
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.5.0",
+          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
         },
         "uuid": {
-          "version": "3.4.0"
+          "version": "3.4.0",
+          "dev": true
         }
       }
     },
@@ -51020,6 +51080,7 @@
     },
     "sshpk": {
       "version": "1.17.0",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -51786,12 +51847,14 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
-      "version": "0.14.5"
+      "version": "0.14.5",
+      "dev": true
     },
     "type": {
       "version": "1.2.0"
@@ -52279,6 +52342,7 @@
     },
     "verror": {
       "version": "1.10.0",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -52286,7 +52350,8 @@
       },
       "dependencies": {
         "core-util-is": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zOS",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "main": "./public/electron.js",
   "engines": {


### PR DESCRIPTION
- chore: bump version (`1.10.0`) -> (`1.11.0`)