### PR TITLE
Add call to chat client to verify if user is a member of a room

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -273,3 +273,7 @@ export async function fetchConversationsWithUsers(users: User[]) {
 export async function getRoomIdForAlias(alias: string) {
   return chat.get().getRoomIdForAlias(alias);
 }
+
+export async function isRoomMember(userId: string, roomId: string) {
+  return await chat.get().matrix.isRoomMember(userId, roomId);
+}

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -120,6 +120,15 @@ export class MatrixClient implements IChatClient {
     return [];
   }
 
+  async isRoomMember(userId: string, roomId: string) {
+    if (!userId || !roomId) {
+      return false;
+    }
+
+    const roomIds = (await this.matrix.getJoinedRooms()).joined_rooms;
+    return roomIds.includes(roomId);
+  }
+
   private getRoomAdmins(room: Room): string[] {
     const powerLevels = this.getLatestEvent(room, EventType.RoomPowerLevels);
     if (!powerLevels) {


### PR DESCRIPTION
### What does this do?

Sometimes while verifying if a user is part of a conversation the whole convo list isn't loaded yet. I.E., on refresh when we haven't yet fully processed all the "catchup events". This adds a secondary check that gets the information straight from the matrix client. It's slightly slower but also should only ever happen in very rare cases as we use the initial state as the first check.

### Why are we making this change?

This helps alleviate a race condition that was occurring when refreshing the page just after joining a conversation.

Note: There are more changes to come as we're also now trying to load the messages while the app isn't quite in a full state. There are more data race conditions to resolve.