### PR TITLE
fix(autocomplete-members): truncate search results user details

### DIFF
--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -54,6 +54,8 @@
     flex-direction: column;
     align-items: flex-start;
     flex: 1 0 0;
+    width: 100%;
+    overflow: hidden;
   }
 
   &__label {
@@ -64,6 +66,7 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    width: 100%;
   }
 
   &__sub-label {
@@ -71,6 +74,10 @@
 
     font-size: 10px;
     line-height: 14px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
### What does this do?
- truncates the user details in the search results in `AutocompleteMembers`.

### Why are we making this change?
- design.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Examples - 

Create Conversation Panel (Autocomplete Members)
<img width="286" alt="Screenshot 2024-02-09 at 18 47 56" src="https://github.com/zer0-os/zOS/assets/39112648/1a919490-1de7-4463-9cc0-f48afbc4f152">

Add Members Panel (Autocomplete Members)
<img width="286" alt="Screenshot 2024-02-09 at 18 48 01" src="https://github.com/zer0-os/zOS/assets/39112648/c488d4bf-7c14-4314-953b-496f05055893">
