### PR TITLE
Receive partial channels and provide defaults if channel doesn't already have them

### DIFF
--- a/src/components/dev-panel/container.tsx
+++ b/src/components/dev-panel/container.tsx
@@ -7,7 +7,7 @@ import {
   Channel,
   ConversationStatus,
   denormalize as denormalizeChannel,
-  receive as receiveChannel,
+  rawReceive as receiveChannel,
 } from '../../store/channels';
 import { Message, MessageSendStatus, receive } from '../../store/messages';
 import { denormalizeConversations } from '../../store/channels-list';

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -64,6 +64,27 @@ export interface Channel {
   reply?: ParentMessage;
 }
 
+export const CHANNEL_DEFAULTS = {
+  optimisticId: '',
+  name: '',
+  messages: [],
+  otherMembers: [],
+  memberHistory: [],
+  hasMore: true,
+  createdAt: 0,
+  lastMessage: null,
+  unreadCount: 0,
+  hasJoined: true,
+  groupChannelType: GroupChannelType.Private,
+  icon: '',
+  isOneOnOne: true,
+  isChannel: false,
+  hasLoadedMessages: false,
+  conversationStatus: ConversationStatus.CREATED,
+  messagesFetchStatus: null,
+  adminMatrixIds: [],
+};
+
 export enum SagaActionTypes {
   JoinChannel = 'channels/saga/joinChannel',
   UnreadCountUpdated = 'channels/saga/unreadCountUpdated',
@@ -87,6 +108,6 @@ const slice = createNormalizedSlice({
   },
 });
 
-export const { receiveNormalized, receive } = slice.actions;
+export const { receive: rawReceive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
 export { joinChannel, unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply };


### PR DESCRIPTION
### What does this do?

Adds a saga to take a partial channel and set up all the default fields if the channel isn't in state yet.

### Why are we making this change?

Sometimes we'll get race conditions with events coming in prior to channels actually being in the state list. In these cases we want to ensure valid defaults are set in the data.

### How do I test this?

Create a conversation with someone. Refresh the browser once that's completed. Previously you'll notice that things frequently get trippeed up (eg: the skeleton renders and never disappears). That should no longer happen.

