### PR TITLE
Update zUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@web3-react/network-connector": "^6.1.9",
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
-        "@zero-tech/zui": "^1.7.1",
+        "@zero-tech/zui": "1.8.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "classnames": "^2.3.1",
         "emoji-mart": "^3.0.1",
@@ -8076,9 +8076,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.7.1.tgz",
-      "integrity": "sha512-wb7CW+pirPj6OPZ3pGBjX4KW0LHW5fkuXjFlMyLceka16GA6N2iozNcWhglvyvTy0Z7Y/ldBSv2eqBPJ6V4xiw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.8.0.tgz",
+      "integrity": "sha512-tN8gvGRCUAXWdINm7hfjVSQdaOJ+uzpowkyRtPbDwwGFNAkeA+sp2c8IhuTyEKbpn1h0wrFE9wHAB/ysGUyB2Q==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -8107,7 +8107,7 @@
         "react-infinite-scroll-component": "^6.1.0",
         "react-loading-skeleton": "^3.1.0",
         "react-router-dom": "^6.3.0",
-        "remark-emoji": "^3.0.2",
+        "remark-emoji": "3.0.2",
         "remark-gemoji": "^7.0.1",
         "sass": "^1.52.2"
       },
@@ -37481,9 +37481,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.7.1.tgz",
-      "integrity": "sha512-wb7CW+pirPj6OPZ3pGBjX4KW0LHW5fkuXjFlMyLceka16GA6N2iozNcWhglvyvTy0Z7Y/ldBSv2eqBPJ6V4xiw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.8.0.tgz",
+      "integrity": "sha512-tN8gvGRCUAXWdINm7hfjVSQdaOJ+uzpowkyRtPbDwwGFNAkeA+sp2c8IhuTyEKbpn1h0wrFE9wHAB/ysGUyB2Q==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -37512,7 +37512,7 @@
         "react-infinite-scroll-component": "^6.1.0",
         "react-loading-skeleton": "^3.1.0",
         "react-router-dom": "^6.3.0",
-        "remark-emoji": "^3.0.2",
+        "remark-emoji": "3.0.2",
         "remark-gemoji": "^7.0.1",
         "sass": "^1.52.2"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@web3-react/network-connector": "^6.1.9",
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
-    "@zero-tech/zui": "^1.7.1",
+    "@zero-tech/zui": "1.8.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "classnames": "^2.3.1",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
### What does this do?

Update zUI to 1.8.0

### Why are we making this change?

One of the nested dependencies has a breaking change so this updates zUI with a pinned version. We don't use that component so there's low likelihood of failure here.

