### PR TITLE
Display loading indicator while fetching owned_zid's of user (during edit profile)

### DIFF
--- a/src/components/edit-profile/container.test.tsx
+++ b/src/components/edit-profile/container.test.tsx
@@ -14,6 +14,7 @@ describe('Container', () => {
       currentProfileImage: 'profile.jpg',
       currentPrimaryZID: '0://john:doe',
       ownedZIDs: [],
+      loading: false,
       editProfile: () => null,
       startProfileEdit: () => null,
       leaveGlobalNetwork: () => null,

--- a/src/components/edit-profile/container.tsx
+++ b/src/components/edit-profile/container.tsx
@@ -26,6 +26,7 @@ export interface Properties extends PublicProperties {
   currentProfileImage: string;
   currentPrimaryZID: string;
   ownedZIDs: string[];
+  loading: boolean;
   editProfile: (data: { name: string; image: File; primaryZID: string }) => void;
   startProfileEdit: () => void;
   leaveGlobalNetwork: () => void;
@@ -46,6 +47,7 @@ export class Container extends React.Component<Properties> {
       currentPrimaryZID: user?.data?.primaryZID,
       ownedZIDs: editProfile.ownedZIDs,
       editProfileState: editProfile.state,
+      loading: editProfile.loading,
     };
   }
 
@@ -69,6 +71,7 @@ export class Container extends React.Component<Properties> {
         currentProfileImage={this.props.currentProfileImage}
         currentPrimaryZID={this.props.currentPrimaryZID}
         ownedZIDs={this.props.ownedZIDs}
+        loading={this.props.loading}
         onLeaveGlobal={this.props.leaveGlobalNetwork}
         onJoinGlobal={this.props.joinGlobalNetwork}
       />

--- a/src/components/edit-profile/index.test.tsx
+++ b/src/components/edit-profile/index.test.tsx
@@ -21,6 +21,7 @@ describe('EditProfile', () => {
       currentProfileImage: 'profile.jpg',
       currentPrimaryZID: '0://john:doe',
       ownedZIDs: [],
+      loading: false,
       onEdit: () => null,
       onClose: () => null,
       onLeaveGlobal: () => null,
@@ -107,6 +108,18 @@ describe('EditProfile', () => {
 
     expect(items.length).toEqual(3);
     expect(items[0].id).toEqual('0://jane:smith');
+  });
+
+  it('renders dropdown with loading state when fetching ownedZIDs', () => {
+    featureFlags.allowEditPrimaryZID = true;
+
+    const wrapper = subject({ currentPrimaryZID: '0://jane:smith', loading: true });
+
+    const dropdown = wrapper.find('SelectInput');
+    const items: any = dropdown.prop('items');
+
+    expect(items.length).toEqual(1);
+    expect(items[0].id).toEqual('Fetching ZERO IDs');
   });
 
   it('calls onEdit with correct data when Save Changes button is clicked', () => {

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { IconButton, Alert, Button, Input, Tooltip, SelectInput } from '@zero-tech/zui/components';
+import { IconButton, Alert, Button, Input, Tooltip, SelectInput, LoadingIndicator } from '@zero-tech/zui/components';
 
 import './styles.scss';
 import { bem } from '../../lib/bem';
@@ -22,6 +22,7 @@ export interface Properties {
   currentPrimaryZID: string;
   currentProfileImage: string;
   ownedZIDs: string[];
+  loading: boolean;
   onEdit: (data: { name: string; image: File; primaryZID: string }) => void;
   onClose?: () => void;
 
@@ -112,9 +113,25 @@ export class EditProfile extends React.Component<Properties, State> {
     );
   }
 
-  get menuItems() {
-    const options = [];
+  renderLoadingState() {
+    return [
+      {
+        id: 'Fetching ZERO IDs',
+        label: this.renderOwnedZIDItem(
+          'Fetching ZERO IDs',
+          <LoadingIndicator className={c('zid-menu-item-option-loading-spinner')} />
+        ),
+        onSelect: () => {},
+      },
+    ];
+  }
 
+  get menuItems() {
+    if (this.props.loading) {
+      return this.renderLoadingState();
+    }
+
+    const options = [];
     if (this.props.currentPrimaryZID) {
       options.push({
         id: this.props.currentPrimaryZID,

--- a/src/components/edit-profile/styles.scss
+++ b/src/components/edit-profile/styles.scss
@@ -75,6 +75,11 @@
     flex-grow: 0;
   }
 
+  &__zid-menu-item-option-loading-spinner {
+    width: 24px;
+    height: 22px;
+  }
+
   &__primary-zid-lable {
     display: flex;
     align-items: center;

--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -18,12 +18,14 @@ export type EditProfileState = {
   errors: string[];
   state: State;
   ownedZIDs: string[];
+  loading: boolean;
 };
 
 export const initialState: EditProfileState = {
   errors: [],
   state: State.NONE,
   ownedZIDs: [],
+  loading: false,
 };
 
 export const editProfile = createAction<{
@@ -54,8 +56,11 @@ const slice = createSlice({
     setOwnedZIDs: (state, action: PayloadAction<EditProfileState['ownedZIDs']>) => {
       state.ownedZIDs = action.payload;
     },
+    setLoading: (state, action: PayloadAction<EditProfileState['loading']>) => {
+      state.loading = action.payload;
+    },
   },
 });
 
-export const { setErrors, startProfileEdit, setState, setOwnedZIDs } = slice.actions;
+export const { setErrors, startProfileEdit, setState, setOwnedZIDs, setLoading } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -3,7 +3,7 @@ import { call } from 'redux-saga/effects';
 import { editProfile as editProfileSaga, updateUserProfile, fetchOwnedZIDs } from './saga';
 import { editUserProfile as apiEditUserProfile, fetchOwnedZIDs as apiFetchOwnedZIDs } from './api';
 import { uploadImage } from '../registration/api';
-import { EditProfileState, State, initialState as initialEditProfileState } from '.';
+import { EditProfileState, State, initialState as initialEditProfileState, setLoading } from '.';
 import { rootReducer } from '../reducer';
 import { User } from '../authentication/types';
 import { ProfileDetailsErrors } from '../registration';
@@ -147,10 +147,12 @@ describe('fetchOwnedZIDs', () => {
         [call(apiFetchOwnedZIDs), ownedZIDs],
       ])
       .withReducer(rootReducer, initialState())
+      .put(setLoading(true))
       .put(setOwnedZIDs(ownedZIDs))
       .run();
 
     expect(editProfile.ownedZIDs).toEqual(ownedZIDs);
+    expect(editProfile.loading).toEqual(false);
   });
 });
 

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects';
-import { SagaActionTypes, State, setErrors, setOwnedZIDs, setState } from '.';
+import { SagaActionTypes, State, setErrors, setLoading, setOwnedZIDs, setState } from '.';
 import {
   editUserProfile as apiEditUserProfile,
   saveUserMatrixCredentials as apiSaveUserMatrixCredentials,
@@ -81,12 +81,16 @@ export function* joinGlobalNetwork() {
 }
 
 export function* fetchOwnedZIDs() {
+  yield put(setLoading(true));
+
   try {
     const ownedZIDs = yield call(fetchOwnedZIDsApi);
     yield put(setOwnedZIDs(ownedZIDs));
   } catch (error) {
     yield put(setErrors([ProfileDetailsErrors.FETCH_OWNED_ZIDs_ERROR]));
   }
+
+  yield put(setLoading(false));
 }
 
 export function* saga() {


### PR DESCRIPTION
### What does this do?

<img width="394" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6aab92c5-5fb6-44da-beff-e3748868be3f">

https://github.com/zer0-os/zOS/assets/33264364/80c819c3-d2e0-454f-9223-819a41253a6a