### PR TITLE
Render `NONE (wallet address)` in dropdown while editing primary zid

### DIFF
--- a/src/components/edit-profile/index.test.tsx
+++ b/src/components/edit-profile/index.test.tsx
@@ -95,7 +95,7 @@ describe('EditProfile', () => {
     expect(saveButton(wrapper).prop('isDisabled')).toEqual(false);
   });
 
-  it('renders dropdown with ownedZIDs with the primaryZID as the first option', () => {
+  it('renders dropdown with ownedZIDs with the primaryZID as the first option and NONE(wallet address) as the last', () => {
     featureFlags.allowEditPrimaryZID = true;
 
     const wrapper = subject({
@@ -106,8 +106,24 @@ describe('EditProfile', () => {
     const dropdown = wrapper.find('SelectInput');
     const items: any = dropdown.prop('items');
 
-    expect(items.length).toEqual(3);
+    expect(items.length).toEqual(4);
     expect(items[0].id).toEqual('0://jane:smith');
+    expect(items[3].id).toEqual('None (wallet address)');
+  });
+
+  it('does not render NONE (wallet address) option, if primaryZID is not set', () => {
+    featureFlags.allowEditPrimaryZID = true;
+
+    const wrapper = subject({
+      currentPrimaryZID: '', // none
+      ownedZIDs: ['0://john:doe'],
+    });
+
+    const dropdown = wrapper.find('SelectInput');
+    const items: any = dropdown.prop('items');
+
+    expect(items.length).toEqual(1); // NONE option is not rendered
+    expect(items[0].id).toEqual('0://john:doe');
   });
 
   it('renders dropdown with loading state when fetching ownedZIDs', () => {

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -47,7 +47,7 @@ export class EditProfile extends React.Component<Properties, State> {
     this.props.onEdit({
       name: this.state.name,
       image: this.state.image,
-      primaryZID: this.state.primaryZID,
+      primaryZID: this.state.primaryZID === 'None (wallet address)' ? '' : this.state.primaryZID,
     });
   };
 
@@ -113,6 +113,14 @@ export class EditProfile extends React.Component<Properties, State> {
     );
   }
 
+  getNoneOption() {
+    return {
+      id: 'None (wallet address)',
+      label: this.renderOwnedZIDItem('None (wallet address)'),
+      onSelect: () => this.trackPrimaryZID('None (wallet address)'),
+    };
+  }
+
   renderLoadingState() {
     return [
       {
@@ -152,6 +160,10 @@ export class EditProfile extends React.Component<Properties, State> {
         onSelect: () => this.trackPrimaryZID(zid),
       });
     }
+
+    if (this.props.currentPrimaryZID) {
+      options.push(this.getNoneOption());
+    }
     return options;
   }
 
@@ -188,7 +200,7 @@ export class EditProfile extends React.Component<Properties, State> {
               <SelectInput
                 items={this.menuItems}
                 label=''
-                placeholder={this.props.currentPrimaryZID}
+                placeholder={this.props.currentPrimaryZID || 'None (wallet address)'}
                 value={this.state.primaryZID}
                 className={c('select-input')}
                 itemSize='spacious'


### PR DESCRIPTION
### What does this do?

- allows the user to set primary_zid as "none"


https://github.com/zer0-os/zOS/assets/33264364/cd2df87a-6fc1-4e32-a564-0c56adee118a

