### PR TITLE
fix(citizen-list-item): truncate user details - prevent horizontal scroll

### DIFF
--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -36,7 +36,7 @@ export class CitizenListItem extends React.Component<Properties> {
             tabIndex={-1}
             statusType={this.statusType}
           />
-          <div>
+          <div {...cn('text-container')}>
             <span {...cn('name')}>{displayName(this.props.user)}</span>
             <span {...cn('handle')}>{this.props.user.displaySubHandle}</span>
           </div>

--- a/src/components/citizen-list-item/styles.scss
+++ b/src/components/citizen-list-item/styles.scss
@@ -10,6 +10,7 @@
   justify-content: space-between;
   align-items: center;
   border-radius: 8px;
+  overflow: hidden;
 
   &:hover {
     @include glass-state-hover-color;
@@ -19,17 +20,21 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 16px;
+    gap: 8px;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  &__text-container {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 
   &__name {
     font-size: 14px;
     line-height: 20px;
     flex-grow: 1;
-
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
 
     @include glass-text-primary-color;
   }
@@ -54,5 +59,6 @@
 
     font-size: 12px;
     line-height: 15px;
+    padding-left: 4px;
   }
 }


### PR DESCRIPTION
### What does this do?
- correctly truncates 'really long' user details in the citizen list item.

### Why are we making this change?
- prevents horizontal scroll

### How do I test this?
- update your user to have a really long name and check members list on group info and edit group panels.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before
<img width="286" alt="Screenshot 2024-02-13 at 12 04 55" src="https://github.com/zer0-os/zOS/assets/39112648/4ff83c4b-de18-4311-8aa1-7914a9998066">

After
<img width="286" alt="Screenshot 2024-02-13 at 11 57 21" src="https://github.com/zer0-os/zOS/assets/39112648/c50835cf-3ba9-4bc8-9079-76ff58f7a14c">
<img width="286" alt="Screenshot 2024-02-13 at 11 57 11" src="https://github.com/zer0-os/zOS/assets/39112648/d90994e5-9bf3-4fa0-a0f2-14294e89f361">
<img width="286" alt="Screenshot 2024-02-13 at 11 56 59" src="https://github.com/zer0-os/zOS/assets/39112648/f94f66c1-4321-4dbd-be4d-450d5c44c15a">
<img width="286" alt="Screenshot 2024-02-13 at 11 56 45" src="https://github.com/zer0-os/zOS/assets/39112648/f4417cfd-a0c2-4a9f-95da-11f2fd5fee58">

