### PR TITLE
fix(user-header-conversation-list): truncate user details

### DIFF
--- a/src/components/messenger/list/user-header/styles.scss
+++ b/src/components/messenger/list/user-header/styles.scss
@@ -14,15 +14,21 @@
     flex-direction: column;
     align-items: flex-start;
     flex: 1 0 0;
+    width: 100%;
+    overflow: hidden;
   }
 
   &__name {
     @include glass-text-primary-color;
 
-    width: 100%;
     font-size: $font-size-small;
     font-weight: 600;
     line-height: 15px;
+
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__handle {


### PR DESCRIPTION
### What does this do?
- correctly truncates 'really long' user details in the user header.

### Why are we making this change?
- as per design & prevents ui issues shown below.

### How do I test this?
- update your user to have a really long name and check user header as shown below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before
<img width="286" alt="Screenshot 2024-02-13 at 12 12 14" src="https://github.com/zer0-os/zOS/assets/39112648/aea60a59-7521-443d-af55-8ea41077d86e">

After
<img width="286" alt="Screenshot 2024-02-13 at 12 10 59" src="https://github.com/zer0-os/zOS/assets/39112648/5a5077bc-6c46-4ba7-8685-c84ebb5e99a9">

