### PR TITLE
fix(settings-menu): truncate user details

### DIFF
--- a/src/components/settings-menu/styles.scss
+++ b/src/components/settings-menu/styles.scss
@@ -1,6 +1,8 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .settings-menu {
+  max-width: 195px;
+
   > *:first-child {
     &:hover {
       background: none;
@@ -13,14 +15,20 @@
     align-items: center;
     gap: 16px;
     pointer-events: none;
+    overflow: hidden;
 
     &__user-details {
       display: flex;
       flex-direction: column;
       gap: 2px;
+      overflow: hidden;
     }
 
     &__name {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+
       font-size: 14px;
       font-weight: 700;
       line-height: 17px;


### PR DESCRIPTION
### What does this do?
- correctly truncates 'really long' user details in the settings menu.

### Why are we making this change?
- as per design & prevents ui issues shown below.

### How do I test this?
- update your user to have a really long name and check settings menu as shown below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:
<img width="369" alt="Screenshot 2024-02-13 at 12 29 58" src="https://github.com/zer0-os/zOS/assets/39112648/1ee3db3e-71ff-471a-a388-529af15169e3">

After: 
<img width="286" alt="Screenshot 2024-02-13 at 12 29 41" src="https://github.com/zer0-os/zOS/assets/39112648/69be0971-4fbf-4922-af1d-a1f855ef4bf6">
