### PR TITLE
Update edit-profile modal design for success & error alerts

### DIFF
--- a/src/components/edit-profile/index.test.tsx
+++ b/src/components/edit-profile/index.test.tsx
@@ -169,7 +169,7 @@ describe('EditProfile', () => {
   it('renders image errors', () => {
     const wrapper = subject({ errors: { image: 'error uploading image' } });
 
-    expect(wrapper.find(Alert).prop('children')).toEqual('error uploading image');
+    expect(wrapper.find(Alert).childAt(0)).toHaveText('error uploading image');
   });
 
   it('renders name error when name is empty', () => {
@@ -190,13 +190,13 @@ describe('EditProfile', () => {
   it('renders general errors', () => {
     const wrapper = subject({ errors: { general: 'invalid' } });
 
-    expect(wrapper.find(Alert).prop('children')).toEqual('invalid');
+    expect(wrapper.find(Alert).childAt(0)).toHaveText('invalid');
   });
 
   it('renders changesSaved message when editProfileState is SUCCESS', () => {
     const wrapper = subject({ editProfileState: EditProfileState.SUCCESS });
 
-    expect(wrapper.find(Alert).prop('children')).toEqual('Your changes have been saved');
+    expect(wrapper.find(Alert).childAt(0)).toHaveText('Changes saved successfully');
   });
 
   it('does not render changesSaved message when editProfileState is not SUCCESS', () => {

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -210,18 +210,19 @@ export class EditProfile extends React.Component<Properties, State> {
           )}
         </div>
         {this.imageError && (
-          <Alert className={c('alert-large')} variant='error'>
-            {this.imageError}
+          <Alert className={c('alert-small')} variant='error'>
+            <div className={c('alert-text')}>{this.imageError}</div>
           </Alert>
         )}
         {this.generalError && (
-          <Alert className={c('alert-large')} variant='error'>
-            {this.generalError}
+          <Alert className={c('alert-small')} variant='error'>
+            <div className={c('alert-text')}>{this.generalError}</div>
           </Alert>
         )}
+
         {this.changesSaved && (
-          <Alert className={c('alert-large')} variant='success'>
-            Your changes have been saved
+          <Alert className={c('alert-small')} variant='success'>
+            <div className={c('alert-text')}>Changes saved successfully</div>
           </Alert>
         )}
 

--- a/src/components/edit-profile/styles.scss
+++ b/src/components/edit-profile/styles.scss
@@ -36,25 +36,24 @@
   }
 
   &__body {
-    //margin-top: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 32px;
-    margin: 40px 0px;
+    margin: 40px 0px 0px 0px;
   }
 
   &__body-input {
-    width: 240px;
+    width: 256px;
     gap: 4px;
     line-height: normal;
   }
 
   &__zid-select-menu {
-    min-width: 224px;
-
     max-height: 220px;
     overflow-y: auto;
+
+    width: 240px;
   }
 
   &__zid-menu-item-option {
@@ -104,7 +103,13 @@
     width: 144px;
   }
 
-  &__alert-large {
-    height: 56px;
+  &__alert-small {
+    margin-top: 8px;
+    padding: 4px 8px 4px 8px;
+  }
+
+  &__alert-text {
+    font-size: 14px;
+    line-height: 20px;
   }
 }


### PR DESCRIPTION
### What does this do?

<img width="365" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/317995cd-6539-4d47-8939-530d60d61611">

<img width="375" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2c805e0c-d6a3-44da-bc24-ca5503600954">

<img width="418" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/338e3154-7f80-4512-b833-2fb6b43a3f8d">


