### PR TITLE
refactor: rename and move `getUserHandle` - (`getUserSubHandle`)

### DIFF
--- a/src/components/messenger/lib/utils.test.ts
+++ b/src/components/messenger/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { getUserSubHandle, highlightFilter } from './utils';
+import { highlightFilter } from './utils';
 
 describe('highlightFilter', () => {
   it('returns unmodified text when filter is an empty string', () => {
@@ -56,22 +56,5 @@ describe('highlightFilter', () => {
     expect(result[1].type).toEqual('span');
     expect(result[1].props.children).toEqual('lo');
     expect(result[2]).toEqual(' World');
-  });
-});
-
-describe('getUserSubHandle', () => {
-  it('returns primaryZID when it is present', () => {
-    const user = { primaryZID: 'zid123', primaryWallet: { id: 'wallet-id-1', publicAddress: 'address456' } };
-    expect(getUserSubHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('zid123');
-  });
-
-  it('returns truncated publicAddress from the first wallet when primaryZID is absent', () => {
-    const user = { primaryZID: null, primaryWallet: { id: 'wallet-id-1', publicAddress: '0x123456789' } };
-    expect(getUserSubHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('0x1234...6789');
-  });
-
-  it('returns empty string when both primaryZID and wallets are absent', () => {
-    const user = { primaryZID: null, primaryWallet: null };
-    expect(getUserSubHandle(user.primaryZID, user.primaryWallet)).toEqual('');
   });
 });

--- a/src/components/messenger/lib/utils.test.ts
+++ b/src/components/messenger/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { getUserHandle, highlightFilter } from './utils';
+import { getUserSubHandle, highlightFilter } from './utils';
 
 describe('highlightFilter', () => {
   it('returns unmodified text when filter is an empty string', () => {
@@ -59,19 +59,19 @@ describe('highlightFilter', () => {
   });
 });
 
-describe('getUserHandle', () => {
+describe('getUserSubHandle', () => {
   it('returns primaryZID when it is present', () => {
     const user = { primaryZID: 'zid123', primaryWallet: { id: 'wallet-id-1', publicAddress: 'address456' } };
-    expect(getUserHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('zid123');
+    expect(getUserSubHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('zid123');
   });
 
   it('returns truncated publicAddress from the first wallet when primaryZID is absent', () => {
     const user = { primaryZID: null, primaryWallet: { id: 'wallet-id-1', publicAddress: '0x123456789' } };
-    expect(getUserHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('0x1234...6789');
+    expect(getUserSubHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('0x1234...6789');
   });
 
   it('returns empty string when both primaryZID and wallets are absent', () => {
     const user = { primaryZID: null, primaryWallet: null };
-    expect(getUserHandle(user.primaryZID, user.primaryWallet)).toEqual('');
+    expect(getUserSubHandle(user.primaryZID, user.primaryWallet)).toEqual('');
   });
 });

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -6,7 +6,7 @@ export const itemToOption = (item: Item): Option => {
     value: item.id,
     label: item.name,
     image: item.image,
-    subLabel: getUserHandle(item.primaryZID, item.primaryWalletAddress),
+    subLabel: getUserSubHandle(item.primaryZID, item.primaryWalletAddress),
   };
 };
 
@@ -36,7 +36,7 @@ export const highlightFilter = (text, filter) => {
   return text;
 };
 
-export function getUserHandle(primaryZID: string, primaryWalletAddress: string) {
+export function getUserSubHandle(primaryZID: string, primaryWalletAddress: string) {
   if (primaryZID) {
     return primaryZID;
   }

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -1,5 +1,6 @@
 import { Item, Option } from './types';
 import { Channel, User } from '../../../store/channels';
+import { getUserSubHandle } from '../../../lib/user';
 
 export const itemToOption = (item: Item): Option => {
   return {
@@ -35,17 +36,3 @@ export const highlightFilter = (text, filter) => {
 
   return text;
 };
-
-export function getUserSubHandle(primaryZID: string, primaryWalletAddress: string) {
-  if (primaryZID) {
-    return primaryZID;
-  }
-
-  if (primaryWalletAddress) {
-    return `${primaryWalletAddress.substring(0, 6)}...${primaryWalletAddress.substring(
-      primaryWalletAddress.length - 4
-    )}`;
-  }
-
-  return '';
-}

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -22,7 +22,7 @@ import { GroupManagementErrors, EditConversationState } from '../../../../store/
 import { User, denormalize as denormalizeChannel } from '../../../../store/channels';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
 import { RemoveMemberDialogContainer } from '../../../group-management/remove-member-dialog/container';
-import { getUserSubHandle } from '../../lib/utils';
+import { getUserSubHandle } from '../../../../lib/user';
 
 export interface PublicProperties {
   searchUsers: (search: string) => Promise<any>;

--- a/src/components/messenger/list/group-management/container.tsx
+++ b/src/components/messenger/list/group-management/container.tsx
@@ -22,7 +22,7 @@ import { GroupManagementErrors, EditConversationState } from '../../../../store/
 import { User, denormalize as denormalizeChannel } from '../../../../store/channels';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
 import { RemoveMemberDialogContainer } from '../../../group-management/remove-member-dialog/container';
-import { getUserHandle } from '../../lib/utils';
+import { getUserSubHandle } from '../../lib/utils';
 
 export interface PublicProperties {
   searchUsers: (search: string) => Promise<any>;
@@ -80,7 +80,7 @@ export class Container extends React.Component<Properties> {
         matrixId: currentUser?.matrixId,
         isOnline: currentUser?.isOnline,
         primaryZID: currentUser?.primaryZID,
-        displaySubHandle: getUserHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
+        displaySubHandle: getUserSubHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -34,7 +34,7 @@ import { receiveSearchResults } from '../../../store/users';
 import { Stage as GroupManagementSagaStage } from '../../../store/group-management';
 import { GroupManagementContainer } from './group-management/container';
 import { UserHeader } from './user-header';
-import { getUserSubHandle } from '../lib/utils';
+import { getUserSubHandle } from '../../../lib/user';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -34,7 +34,7 @@ import { receiveSearchResults } from '../../../store/users';
 import { Stage as GroupManagementSagaStage } from '../../../store/group-management';
 import { GroupManagementContainer } from './group-management/container';
 import { UserHeader } from './user-header';
-import { getUserHandle } from '../lib/utils';
+import { getUserSubHandle } from '../lib/utils';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -85,7 +85,7 @@ export class Container extends React.Component<Properties, State> {
     } = state;
 
     const conversations = denormalizeConversations(state).map(addLastMessageMeta(state)).sort(byLastMessageOrCreation);
-    const userHandle = getUserHandle(user?.data?.primaryZID, user?.data?.primaryWalletAddress);
+    const userHandle = getUserSubHandle(user?.data?.primaryZID, user?.data?.primaryWalletAddress);
     return {
       conversations,
       activeConversationId,

--- a/src/lib/user.test.ts
+++ b/src/lib/user.test.ts
@@ -1,4 +1,4 @@
-import { displayName } from './user';
+import { displayName, getUserSubHandle } from './user';
 
 import { User } from '../store/channels';
 
@@ -22,6 +22,23 @@ describe('User Lib', () => {
 
     it('returns "Unknown" if user is not found', () => {
       expect(displayName(null)).toEqual('Unknown');
+    });
+  });
+
+  describe(getUserSubHandle, () => {
+    it('returns primaryZID when it is present', () => {
+      const user = { primaryZID: 'zid123', primaryWallet: { id: 'wallet-id-1', publicAddress: 'address456' } };
+      expect(getUserSubHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('zid123');
+    });
+
+    it('returns truncated publicAddress from the first wallet when primaryZID is absent', () => {
+      const user = { primaryZID: null, primaryWallet: { id: 'wallet-id-1', publicAddress: '0x123456789' } };
+      expect(getUserSubHandle(user.primaryZID, user.primaryWallet.publicAddress)).toEqual('0x1234...6789');
+    });
+
+    it('returns empty string when both primaryZID and wallets are absent', () => {
+      const user = { primaryZID: null, primaryWallet: null };
+      expect(getUserSubHandle(user.primaryZID, user.primaryWallet)).toEqual('');
     });
   });
 });

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -8,3 +8,17 @@ export function displayName(user: User) {
   const name = `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim();
   return name || 'Unknown';
 }
+
+export function getUserSubHandle(primaryZID: string, primaryWalletAddress: string) {
+  if (primaryZID) {
+    return primaryZID;
+  }
+
+  if (primaryWalletAddress) {
+    return `${primaryWalletAddress.substring(0, 6)}...${primaryWalletAddress.substring(
+      primaryWalletAddress.length - 4
+    )}`;
+  }
+
+  return '';
+}

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -4,7 +4,7 @@ import { denormalize } from './../channels/index';
 import getDeepProperty from 'lodash.get';
 import { select } from 'redux-saga/effects';
 import { currentUserSelector } from '../authentication/selectors';
-import { getUserHandle } from '../../components/messenger/lib/utils';
+import { getUserSubHandle } from '../../components/messenger/lib/utils';
 
 export function filterChannelsList(state, filter: ChannelType) {
   const channelIdList = getDeepProperty(state, 'channelsList.value', []);
@@ -105,7 +105,7 @@ export function replaceZOSUserFields(
     member.lastName = zeroUser.lastName;
     member.profileImage = zeroUser.profileImage;
     member.primaryZID = zeroUser.primaryZID;
-    member.displaySubHandle = getUserHandle(zeroUser.primaryZID, zeroUser.primaryWallet?.publicAddress);
+    member.displaySubHandle = getUserSubHandle(zeroUser.primaryZID, zeroUser.primaryWallet?.publicAddress);
   }
 }
 

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -4,7 +4,7 @@ import { denormalize } from './../channels/index';
 import getDeepProperty from 'lodash.get';
 import { select } from 'redux-saga/effects';
 import { currentUserSelector } from '../authentication/selectors';
-import { getUserSubHandle } from '../../components/messenger/lib/utils';
+import { getUserSubHandle } from '../../lib/user';
 
 export function filterChannelsList(state, filter: ChannelType) {
   const channelIdList = getDeepProperty(state, 'channelsList.value', []);

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -4,7 +4,7 @@ import { Events, getChatBus } from '../chat/bus';
 import { takeEveryFromBus } from '../../lib/saga';
 import { userByMatrixIdSelector } from './selectors';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
-import { getUserHandle } from '../../components/messenger/lib/utils';
+import { getUserSubHandle } from '../../components/messenger/lib/utils';
 
 export function* clearUsers() {
   yield put(removeAll({ schema: schema.key }));
@@ -24,7 +24,7 @@ export function* receiveSearchResults(searchResults) {
         matrixId: r.matrixId,
         primaryZID: r.primaryZID,
         primaryWalletAddress: r.primaryWalletAddress,
-        displaySubHandle: getUserHandle(r.primaryZID, r.primaryWalletAddress),
+        displaySubHandle: getUserSubHandle(r.primaryZID, r.primaryWalletAddress),
       };
     });
   yield put(receive(mappedUsers));

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -4,7 +4,7 @@ import { Events, getChatBus } from '../chat/bus';
 import { takeEveryFromBus } from '../../lib/saga';
 import { userByMatrixIdSelector } from './selectors';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
-import { getUserSubHandle } from '../../components/messenger/lib/utils';
+import { getUserSubHandle } from '../../lib/user';
 
 export function* clearUsers() {
   yield put(removeAll({ schema: schema.key }));


### PR DESCRIPTION
### What does this do?
- renames `getUserHandle` -> `getUserSubHandle`
- moves `getUserSubHandle` to `lib/users`.

### Why are we making this change?
- redux stores shouldn't reference component code - this should be in a more general lib folder.

### How do I test this?
- run tests as usual - manually check ui where primary zid/user wallet address is displayed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
