### PR TITLE
Remove logic that converts channel to conversation in state

### DIFF
--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -128,19 +128,6 @@ describe('channels list saga', () => {
         'conversation-id',
       ]);
     });
-
-    it('removes channels that are duplicates of the newly fetched conversations', async () => {
-      const fetchedConversations = [{ id: 'previously-a-channel', messages: [] }];
-
-      const initialState = new StoreBuilder().withChannelList({ id: 'previously-a-channel' });
-
-      const { storeState } = await subject(fetchConversations)
-        .provide([[matchers.call([chatClient, chatClient.getConversations]), fetchedConversations]])
-        .withReducer(rootReducer, initialState.build())
-        .run();
-
-      expect(storeState.channelsList.value).toIncludeSameMembers(['previously-a-channel']);
-    });
   });
 
   describe(userLeftChannel, () => {

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -78,13 +78,8 @@ export function* fetchConversations() {
     .filter((c) => c.conversationStatus !== ConversationStatus.CREATED)
     .map((c) => c.id);
 
-  const channelsList = yield select(rawChannelsList());
-  const conversationIds = conversations.map((c) => c.id);
-  // Channels can change to conversations (due to the nature of Matrix)
-  const filteredChannelsList = channelsList.filter((id) => !conversationIds.includes(id));
   yield put(
     receive([
-      ...filteredChannelsList,
       ...optimisticConversationIds,
       ...conversations,
     ])


### PR DESCRIPTION
### What does this do?

Removes some logic that was related to delayed discovery of whether a room was a channel or conversation.

### Why are we making this change?

We treat all rooms as conversations now so this is no longer a situation that can be reached.

