### PR TITLE
feat: add manage secure backup prompt feature flag

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -105,6 +105,14 @@ export class FeatureFlags {
   set allowEditPrimaryZID(value: boolean) {
     this._setBoolean('allowEditPrimaryZID', value);
   }
+
+  get allowManageSecureBackupPrompt() {
+    return this._getBoolean('allowManageSecureBackupPrompt', true);
+  }
+
+  set allowManageSecureBackupPrompt(value: boolean) {
+    this._setBoolean('allowManageSecureBackupPrompt', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -107,7 +107,7 @@ export class FeatureFlags {
   }
 
   get allowManageSecureBackupPrompt() {
-    return this._getBoolean('allowManageSecureBackupPrompt', true);
+    return this._getBoolean('allowManageSecureBackupPrompt', false);
   }
 
   set allowManageSecureBackupPrompt(value: boolean) {


### PR DESCRIPTION
### What does this do?
- adds feature flag.

### Why are we making this change?
- to use in follow up secure backup prompt flow.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
