### PR TITLE
feat: implement secure backup prompt management

### DIFF
--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -13,6 +13,7 @@ export enum SagaActionTypes {
   DiscardOlm = 'chat/discard-olm',
   RestartOlm = 'chat/restart-olm',
   ShareHistoryKeys = 'chat/share-history-keys',
+  CloseBackupDialog = 'chat/close-backup-dialog',
 }
 
 export type MatrixState = {
@@ -22,6 +23,8 @@ export type MatrixState = {
   successMessage: string;
   errorMessage: string;
   deviceId: string;
+  isBackupCheckComplete: boolean;
+  isBackupDialogOpen: boolean;
 };
 
 export const initialState: MatrixState = {
@@ -31,6 +34,8 @@ export const initialState: MatrixState = {
   successMessage: '',
   errorMessage: '',
   deviceId: '',
+  isBackupCheckComplete: false,
+  isBackupDialogOpen: false,
 };
 
 export const getBackup = createAction(SagaActionTypes.GetBackup);
@@ -45,6 +50,7 @@ export const resendKeyRequests = createAction(SagaActionTypes.ResendKeyRequests)
 export const discardOlm = createAction<string>(SagaActionTypes.DiscardOlm);
 export const restartOlm = createAction<string>(SagaActionTypes.RestartOlm);
 export const shareHistoryKeys = createAction<{ roomId: string; userIds: string[] }>(SagaActionTypes.ShareHistoryKeys);
+export const closeBackupDialog = createAction(SagaActionTypes.CloseBackupDialog);
 
 const slice = createSlice({
   name: 'matrix',
@@ -68,9 +74,23 @@ const slice = createSlice({
     setDeviceId: (state, action: PayloadAction<MatrixState['deviceId']>) => {
       state.deviceId = action.payload;
     },
+    setIsBackupCheckComplete: (state, action: PayloadAction<MatrixState['isBackupCheckComplete']>) => {
+      state.isBackupCheckComplete = action.payload;
+    },
+    setIsBackupDialogOpen: (state, action: PayloadAction<MatrixState['isBackupDialogOpen']>) => {
+      state.isBackupDialogOpen = action.payload;
+    },
   },
 });
 
-export const { setLoaded, setGeneratedRecoveryKey, setTrustInfo, setSuccessMessage, setErrorMessage, setDeviceId } =
-  slice.actions;
+export const {
+  setLoaded,
+  setIsBackupCheckComplete,
+  setIsBackupDialogOpen,
+  setGeneratedRecoveryKey,
+  setTrustInfo,
+  setSuccessMessage,
+  setErrorMessage,
+  setDeviceId,
+} = slice.actions;
 export const { reducer } = slice;

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -155,17 +155,17 @@ export function* resetBackupCheckStatus() {
   clearBackupCheckStatusFromLocalStorage();
 }
 
+export function* loadBackupCheckStatus() {
+  const isBackupCheckComplete = JSON.parse(localStorage.getItem('isBackupCheckComplete') || 'false');
+  yield put(setIsBackupCheckComplete(isBackupCheckComplete));
+}
+
 export function setBackupCheckStatusInLocalStorage() {
   localStorage.setItem('isBackupCheckComplete', 'true');
 }
 
 export function clearBackupCheckStatusFromLocalStorage() {
   localStorage.removeItem('isBackupCheckComplete');
-}
-
-export function* loadBackupCheckStatus() {
-  const isBackupCheckComplete = JSON.parse(localStorage.getItem('isBackupCheckComplete') || 'false');
-  yield put(setIsBackupCheckComplete(isBackupCheckComplete));
 }
 
 export function* closeBackupDialog() {


### PR DESCRIPTION
### What does this do?
- adds secure backup prompt management to `matrix/saga.ts`.

### Why are we making this change?
- enables the handling for checking secure backup status.
- enables the handling for opening/closing secure backup dialog.
- enables the handling of backup check status for current session (local storage).

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO (demo shows full flow - wiring up of the flow to come in follow up PR) 
10 second delay applied :


https://github.com/zer0-os/zOS/assets/39112648/5264d802-cae4-4f40-b876-84eaac1958ef

