### PR TITLE
feat: initiate/trigger secure backup prompt management

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -105,6 +105,14 @@ export class FeatureFlags {
   set allowEditPrimaryZID(value: boolean) {
     this._setBoolean('allowEditPrimaryZID', value);
   }
+
+  get allowManageSecureBackupPrompt() {
+    return this._getBoolean('allowManageSecureBackupPrompt', true);
+  }
+
+  set allowManageSecureBackupPrompt(value: boolean) {
+    this._setBoolean('allowManageSecureBackupPrompt', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -107,7 +107,7 @@ export class FeatureFlags {
   }
 
   get allowManageSecureBackupPrompt() {
-    return this._getBoolean('allowManageSecureBackupPrompt', true);
+    return this._getBoolean('allowManageSecureBackupPrompt', false);
   }
 
   set allowManageSecureBackupPrompt(value: boolean) {

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -13,6 +13,7 @@ export enum SagaActionTypes {
   DiscardOlm = 'chat/discard-olm',
   RestartOlm = 'chat/restart-olm',
   ShareHistoryKeys = 'chat/share-history-keys',
+  CloseBackupDialog = 'chat/close-backup-dialog',
 }
 
 export type MatrixState = {
@@ -22,6 +23,8 @@ export type MatrixState = {
   successMessage: string;
   errorMessage: string;
   deviceId: string;
+  isBackupCheckComplete: boolean;
+  isBackupDialogOpen: boolean;
 };
 
 export const initialState: MatrixState = {
@@ -31,6 +34,8 @@ export const initialState: MatrixState = {
   successMessage: '',
   errorMessage: '',
   deviceId: '',
+  isBackupCheckComplete: false,
+  isBackupDialogOpen: false,
 };
 
 export const getBackup = createAction(SagaActionTypes.GetBackup);
@@ -45,6 +50,7 @@ export const resendKeyRequests = createAction(SagaActionTypes.ResendKeyRequests)
 export const discardOlm = createAction<string>(SagaActionTypes.DiscardOlm);
 export const restartOlm = createAction<string>(SagaActionTypes.RestartOlm);
 export const shareHistoryKeys = createAction<{ roomId: string; userIds: string[] }>(SagaActionTypes.ShareHistoryKeys);
+export const closeBackupDialog = createAction(SagaActionTypes.CloseBackupDialog);
 
 const slice = createSlice({
   name: 'matrix',
@@ -68,9 +74,23 @@ const slice = createSlice({
     setDeviceId: (state, action: PayloadAction<MatrixState['deviceId']>) => {
       state.deviceId = action.payload;
     },
+    setIsBackupCheckComplete: (state, action: PayloadAction<MatrixState['isBackupCheckComplete']>) => {
+      state.isBackupCheckComplete = action.payload;
+    },
+    setIsBackupDialogOpen: (state, action: PayloadAction<MatrixState['isBackupDialogOpen']>) => {
+      state.isBackupDialogOpen = action.payload;
+    },
   },
 });
 
-export const { setLoaded, setGeneratedRecoveryKey, setTrustInfo, setSuccessMessage, setErrorMessage, setDeviceId } =
-  slice.actions;
+export const {
+  setLoaded,
+  setIsBackupCheckComplete,
+  setIsBackupDialogOpen,
+  setGeneratedRecoveryKey,
+  setTrustInfo,
+  setSuccessMessage,
+  setErrorMessage,
+  setDeviceId,
+} = slice.actions;
 export const { reducer } = slice;

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -155,17 +155,17 @@ export function* resetBackupCheckStatus() {
   clearBackupCheckStatusFromLocalStorage();
 }
 
+export function* loadBackupCheckStatus() {
+  const isBackupCheckComplete = JSON.parse(localStorage.getItem('isBackupCheckComplete') || 'false');
+  yield put(setIsBackupCheckComplete(isBackupCheckComplete));
+}
+
 export function setBackupCheckStatusInLocalStorage() {
   localStorage.setItem('isBackupCheckComplete', 'true');
 }
 
 export function clearBackupCheckStatusFromLocalStorage() {
   localStorage.removeItem('isBackupCheckComplete');
-}
-
-export function* loadBackupCheckStatus() {
-  const isBackupCheckComplete = JSON.parse(localStorage.getItem('isBackupCheckComplete') || 'false');
-  yield put(setIsBackupCheckComplete(isBackupCheckComplete));
 }
 
 export function* closeBackupDialog() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -20,6 +20,8 @@ import { mapMessageSenders } from './utils.matrix';
 import { uniqNormalizedList } from '../utils';
 import { NotifiableEventType } from '../../lib/chat/matrix/types';
 import { mapAdminUserIdToZeroUserId } from '../channels-list/utils';
+import { manageSecureBackupPrompt } from '../matrix/saga';
+import { featureFlags } from '../../lib/feature-flags';
 
 export interface Payload {
   channelId: string;
@@ -190,6 +192,10 @@ export function* send(action) {
   }
 
   yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
+
+  if (featureFlags.allowManageSecureBackupPrompt) {
+    yield call(manageSecureBackupPrompt);
+  }
 }
 
 export function* createOptimisticMessages(channelId, message, parentMessage, uploadableFiles?) {


### PR DESCRIPTION
### What does this do?
- initiates/triggers secure backup check management

### Why are we making this change?
- to handle when to prompt the user about securing their backup and store the state when relevant.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
