### PR TITLE
Perform backup check when first message is sent

### DIFF
--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -23,7 +23,6 @@ export type MatrixState = {
   successMessage: string;
   errorMessage: string;
   deviceId: string;
-  isBackupCheckComplete: boolean;
   isBackupDialogOpen: boolean;
 };
 
@@ -34,7 +33,6 @@ export const initialState: MatrixState = {
   successMessage: '',
   errorMessage: '',
   deviceId: '',
-  isBackupCheckComplete: false,
   isBackupDialogOpen: false,
 };
 
@@ -74,9 +72,6 @@ const slice = createSlice({
     setDeviceId: (state, action: PayloadAction<MatrixState['deviceId']>) => {
       state.deviceId = action.payload;
     },
-    setIsBackupCheckComplete: (state, action: PayloadAction<MatrixState['isBackupCheckComplete']>) => {
-      state.isBackupCheckComplete = action.payload;
-    },
     setIsBackupDialogOpen: (state, action: PayloadAction<MatrixState['isBackupDialogOpen']>) => {
       state.isBackupDialogOpen = action.payload;
     },
@@ -85,7 +80,6 @@ const slice = createSlice({
 
 export const {
   setLoaded,
-  setIsBackupCheckComplete,
   setIsBackupDialogOpen,
   setGeneratedRecoveryKey,
   setTrustInfo,

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -213,32 +213,18 @@ describe(clearBackupState, () => {
 describe('secure backup status management', () => {
   describe(ensureUserHasBackup, () => {
     it('opens the backup dialog if backup does not exist', async () => {
-      const initialState = {
-        matrix: {
-          isBackupCheckComplete: false,
-          isBackupDialogOpen: false,
-        },
-      };
+      const initialState = { matrix: { isBackupDialogOpen: false } };
 
       const { storeState } = await subject(ensureUserHasBackup)
         .withReducer(rootReducer, initialState as any)
-        .provide([
-          [call(getSecureBackup), undefined],
-          stubDelay(10000),
-        ])
+        .provide([[call(getSecureBackup), undefined], stubDelay(10000)])
         .run();
 
       expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-      expect(storeState.matrix.isBackupCheckComplete).toBe(true);
     });
 
     it('does not open the backup dialog if backup exists', async () => {
-      const initialState = {
-        matrix: {
-          isBackupCheckComplete: false,
-          isBackupDialogOpen: false,
-        },
-      };
+      const initialState = { matrix: { isBackupDialogOpen: false } };
 
       const { storeState } = await subject(ensureUserHasBackup)
         .withReducer(rootReducer, initialState as any)
@@ -251,28 +237,10 @@ describe('secure backup status management', () => {
         .run();
 
       expect(storeState.matrix.isBackupDialogOpen).toBe(false);
-      expect(storeState.matrix.isBackupCheckComplete).toBe(true);
-    });
-
-    it('does nothing if backup check has already been completed', async () => {
-      const initialState = {
-        matrix: {
-          isBackupCheckComplete: true,
-          isBackupDialogOpen: false,
-        },
-      };
-
-      const { storeState } = await subject(ensureUserHasBackup)
-        .withReducer(rootReducer, initialState as any)
-        .run();
-
-      expect(storeState.matrix.isBackupDialogOpen).toBe(false);
     });
 
     it('does not open the backup if user logs out during wait period', async () => {
-      const initialState = {
-        matrix: { isBackupCheckComplete: false, isBackupDialogOpen: false },
-      };
+      const initialState = { matrix: { isBackupDialogOpen: false } };
 
       const { storeState } = await subject(ensureUserHasBackup)
         .withReducer(rootReducer, initialState as any)

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -8,7 +8,6 @@ import {
   setLoaded,
   setSuccessMessage,
   setTrustInfo,
-  setIsBackupCheckComplete,
   setIsBackupDialogOpen,
 } from '.';
 import { chat, getSecureBackup } from '../../lib/chat';

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -1,4 +1,4 @@
-import { call, delay, put, select, takeLatest } from 'redux-saga/effects';
+import { call, delay, put, select, spawn, take, takeLatest } from 'redux-saga/effects';
 
 import {
   SagaActionTypes,
@@ -13,8 +13,12 @@ import {
 } from '.';
 import { chat, getSecureBackup } from '../../lib/chat';
 import { performUnlessLogout } from '../utils';
+import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
+import { ChatMessageEvents, getChatMessageBus } from '../messages/messages';
 
 export function* saga() {
+  yield spawn(listenForUserLogin);
+
   yield takeLatest(SagaActionTypes.GetBackup, getBackup);
   yield takeLatest(SagaActionTypes.GenerateBackup, generateBackup);
   yield takeLatest(SagaActionTypes.SaveBackup, saveBackup);
@@ -131,12 +135,6 @@ export function* shareHistoryKeys(action) {
 }
 
 export function* ensureUserHasBackup() {
-  // Only perform backup check once
-  if (yield select((state) => state.matrix.isBackupCheckComplete)) {
-    return;
-  }
-  yield put(setIsBackupCheckComplete(true));
-
   const backup = yield call(getSecureBackup);
   if (!backup?.backupInfo) {
     if (yield call(performUnlessLogout, delay(10000))) {
@@ -147,4 +145,18 @@ export function* ensureUserHasBackup() {
 
 export function* closeBackupDialog() {
   yield put(setIsBackupDialogOpen(false));
+}
+
+function* listenForUserLogin() {
+  const userChannel = yield call(getAuthChannel);
+  while (true) {
+    yield take(userChannel, AuthEvents.UserLogin);
+    yield call(performUnlessLogout, call(checkBackupOnFirstSentMessage));
+  }
+}
+
+function* checkBackupOnFirstSentMessage() {
+  const bus = yield call(getChatMessageBus);
+  yield take(bus, ChatMessageEvents.Sent);
+  yield call(ensureUserHasBackup);
 }


### PR DESCRIPTION
### What does this do?

Performs a check for the current backup state when a user first sends a message

### Why are we making this change?

To convince users to create a backup!

