### PR TITLE
feat: wire up ui for rendering backup dialog when user has not performed key backup

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -16,11 +16,17 @@ import { previewDisplayDate } from '../../../lib/chat/chat-message';
 import { GroupManagementContainer } from './group-management/container';
 import { UserHeader } from './user-header';
 import { ErrorDialog } from '../../error-dialog';
+import { SecureBackupContainer } from '../../secure-backup/container';
 
 const mockSearchMyNetworksByName = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
   return { searchMyNetworksByName: async (...args) => await mockSearchMyNetworksByName(...args) };
 });
+
+const featureFlags = { allowManageSecureBackupPrompt: false };
+jest.mock('../../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
 
 describe('messenger-list', () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -40,6 +46,7 @@ describe('messenger-list', () => {
       joinRoomErrorContent: null,
       onConversationClick: jest.fn(),
       createConversation: jest.fn(),
+      isBackupDialogOpen: false,
       closeConversationErrorDialog: () => null,
       startCreateConversation: () => null,
       membersSelected: () => null,
@@ -47,6 +54,7 @@ describe('messenger-list', () => {
       back: () => null,
       receiveSearchResults: () => null,
       logout: () => null,
+      closeBackupDialog: () => null,
 
       ...props,
     };
@@ -222,6 +230,14 @@ describe('messenger-list', () => {
     expect(wrapper).toHaveElement(ErrorDialog);
   });
 
+  it('renders Secure Backup Dialog if isBackupDialogOpen', function () {
+    featureFlags.allowManageSecureBackupPrompt = true;
+
+    const wrapper = subject({ isBackupDialogOpen: true });
+
+    expect(wrapper).toHaveElement(SecureBackupContainer);
+  });
+
   it('calls closeConversationErrorDialog when error dialog is closed', function () {
     const closeConversationErrorDialog = jest.fn();
     const wrapper = subject({
@@ -308,6 +324,7 @@ describe('messenger-list', () => {
         },
         registration: {},
         groupManagement: {},
+        matrix: {},
       } as RootState;
     };
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -36,9 +36,12 @@ import { GroupManagementContainer } from './group-management/container';
 import { UserHeader } from './user-header';
 import { getUserSubHandle } from '../../../lib/user';
 import { VerifyIdDialog } from '../../verify-id-dialog';
+import { closeBackupDialog } from '../../../store/matrix';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
+import { SecureBackupContainer } from '../../secure-backup/container';
+import { featureFlags } from '../../../lib/feature-flags';
 
 const cn = bemClassName('direct-message-members');
 
@@ -59,6 +62,7 @@ export interface Properties extends PublicProperties {
   activeConversationId?: string;
   groupManangemenetStage: GroupManagementSagaStage;
   joinRoomErrorContent: ErrorDialogContent;
+  isBackupDialogOpen: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -69,6 +73,7 @@ export interface Properties extends PublicProperties {
   logout: () => void;
   receiveSearchResults: (data) => void;
   closeConversationErrorDialog: () => void;
+  closeBackupDialog: () => void;
 }
 
 interface State {
@@ -84,6 +89,7 @@ export class Container extends React.Component<Properties, State> {
       authentication: { user },
       chat: { activeConversationId, joinRoomErrorContent },
       groupManagement,
+      matrix: { isBackupDialogOpen },
     } = state;
 
     const conversations = denormalizeConversations(state).map(addLastMessageMeta(state)).sort(byLastMessageOrCreation);
@@ -103,6 +109,7 @@ export class Container extends React.Component<Properties, State> {
       myUserId: user?.data?.id,
       groupManangemenetStage: groupManagement.stage,
       joinRoomErrorContent,
+      isBackupDialogOpen,
     };
   }
 
@@ -117,6 +124,7 @@ export class Container extends React.Component<Properties, State> {
       logout,
       receiveSearchResults,
       closeConversationErrorDialog,
+      closeBackupDialog,
     };
   }
 
@@ -172,6 +180,10 @@ export class Container extends React.Component<Properties, State> {
     this.props.closeConversationErrorDialog();
   };
 
+  closeBackupDialog = () => {
+    this.props.closeBackupDialog();
+  };
+
   get userStatus(): 'active' | 'offline' {
     return this.props.userIsOnline ? 'active' : 'offline';
   }
@@ -206,6 +218,14 @@ export class Container extends React.Component<Properties, State> {
           linkPath={this.props.joinRoomErrorContent?.linkPath}
           onClose={this.closeErrorDialog}
         />
+      </Modal>
+    );
+  };
+
+  renderSecureBackupDialog = (): JSX.Element => {
+    return (
+      <Modal open={this.props.isBackupDialogOpen} onOpenChange={this.closeBackupDialog}>
+        <SecureBackupContainer onClose={this.closeBackupDialog} />
       </Modal>
     );
   };
@@ -300,6 +320,8 @@ export class Container extends React.Component<Properties, State> {
           {this.state.isInviteDialogOpen && this.renderInviteDialog()}
           {this.state.isVerifyIdDialogOpen && this.renderVerifyIdDialog()}
           {this.props.joinRoomErrorContent && this.renderErrorDialog()}
+          {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}
+
           {this.renderToastNotification()}
         </div>
       </>


### PR DESCRIPTION
### What does this do?
- renders backup dialog when a user has not performed key backup and has sent first message on login.

### Why are we making this change?
- to convince the user to backup.

### How do I test this?
- login with a user that has not yet secured backup > send a message > wait for 10 second delay > check secure backup dialog is rendered .

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO:


https://github.com/zer0-os/zOS/assets/39112648/9e81bf86-904b-4764-bc9c-cf2587477a11

