### PR TITLE
Return the trustInfo when calling the getBackup saga

### DIFF
--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -32,7 +32,7 @@ function subject(...args: Parameters<typeof expectSaga>) {
 
 describe(getBackup, () => {
   it('fetches the existing backup', async () => {
-    const { storeState } = await subject(getBackup)
+    const { returnValue, storeState } = await subject(getBackup)
       .provide([
         [
           call(getSecureBackup),
@@ -51,10 +51,11 @@ describe(getBackup, () => {
         errorMessage: '',
       })
     );
+    expect(returnValue).toEqual({ usable: true, trustedLocally: true, isLegacy: true });
   });
 
   it('clears the backup if none found', async () => {
-    const { storeState } = await subject(getBackup)
+    const { returnValue, storeState } = await subject(getBackup)
       .provide([[call(getSecureBackup), undefined]])
       .withReducer(rootReducer)
       .run();
@@ -68,10 +69,11 @@ describe(getBackup, () => {
         errorMessage: '',
       })
     );
+    expect(returnValue).toBeNull();
   });
 
   it('clears the backup if backupInfo not found', async () => {
-    const { storeState } = await subject(getBackup)
+    const { returnValue, storeState } = await subject(getBackup)
       .provide([[call(getSecureBackup), { backupInfo: undefined }]])
       .withReducer(rootReducer)
       .run();
@@ -85,6 +87,7 @@ describe(getBackup, () => {
         errorMessage: '',
       })
     );
+    expect(returnValue).toBeNull();
   });
 });
 

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -37,19 +37,20 @@ export function* saga() {
 
 export function* getBackup() {
   yield put(setLoaded(false));
+  let trustInfo = null;
+
   const existingBackup = yield call(getSecureBackup);
-  if (!existingBackup || !existingBackup.backupInfo) {
-    yield put(setTrustInfo(null));
-  } else {
-    yield put(
-      setTrustInfo({
-        usable: existingBackup.trustInfo.usable,
-        trustedLocally: existingBackup.trustInfo.trusted_locally,
-        isLegacy: existingBackup.isLegacy,
-      })
-    );
+  if (existingBackup?.backupInfo) {
+    trustInfo = {
+      usable: existingBackup.trustInfo.usable,
+      trustedLocally: existingBackup.trustInfo.trusted_locally,
+      isLegacy: existingBackup.isLegacy,
+    };
   }
+
+  yield put(setTrustInfo(trustInfo));
   yield put(setLoaded(true));
+  return trustInfo;
 }
 
 export function* generateBackup() {


### PR DESCRIPTION
### What does this do?

Refactor: return the trustInfo from getBackup so callers can use the result directly

