### PR TITLE
Change `unable to decrypt message` text & design

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -8,6 +8,7 @@ import { Channel, ConversationStatus, denormalize, joinChannel, onReply } from '
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
 import { EditPayload, Payload as PayloadFetchMessages } from '../../store/messages/saga';
+import { openBackupDialog } from '../../store/matrix';
 import { Payload as PayloadJoinChannel } from '../../store/channels/types';
 import { ParentMessage } from '../../lib/chat/types';
 import { compareDatesAsc } from '../../lib/date';
@@ -20,7 +21,7 @@ export interface Properties extends PublicProperties {
   editMessage: (payload: EditPayload) => void;
   joinChannel: (payload: PayloadJoinChannel) => void;
   onReply: ({ reply }: { reply: ParentMessage }) => void;
-
+  openBackupDialog: () => void;
   activeConversationId?: string;
   context: {
     isAuthenticated: boolean;
@@ -64,6 +65,7 @@ export class Container extends React.Component<Properties> {
       joinChannel,
       editMessage,
       onReply,
+      openBackupDialog,
     };
   }
 
@@ -221,6 +223,7 @@ export class Container extends React.Component<Properties> {
           isOneOnOne={this.isOneOnOne}
           onReply={this.props.onReply}
           conversationErrorMessage={this.conversationErrorMessage}
+          onHiddenMessageInfoClick={this.props.openBackupDialog}
           ref={this.chatViewRef}
         />
       </>

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -43,6 +43,7 @@ describe('ChatView', () => {
       isOneOnOne: false,
       sendDisabledMessage: '',
       conversationErrorMessage: '',
+      onHiddenMessageInfoClick: () => null,
       ...props,
     };
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -47,6 +47,7 @@ export interface Properties {
     data?: Partial<EditMessageOptions>
   ) => void;
   onReply: ({ reply }: { reply: ParentMessage }) => void;
+  onHiddenMessageInfoClick: () => void;
   joinChannel: () => void;
   className?: string;
   isDirectMessage: boolean;
@@ -152,6 +153,7 @@ export class ChatView extends React.Component<Properties, State> {
                 messageId={message.id}
                 updatedAt={message.updatedAt}
                 isOwner={this.isUserOwnerOfMessage(message)}
+                isHidden={message.isHidden}
                 onDelete={this.props.deleteMessage}
                 onEdit={this.props.editMessage}
                 onReply={this.props.onReply}
@@ -163,6 +165,7 @@ export class ChatView extends React.Component<Properties, State> {
                 showSenderAvatar={this.props.showSenderAvatar}
                 showTimestamp={messageRenderProps.showTimestamp}
                 showAuthorName={messageRenderProps.showAuthorName}
+                onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
                 {...message}
               />
             </div>

--- a/src/components/content-highlighter/content-highlight.test.tsx
+++ b/src/components/content-highlighter/content-highlight.test.tsx
@@ -46,4 +46,18 @@ describe('ContentHighlighter', () => {
     });
     expect(wrapper.find('.content-highlighter__user-mention').prop('data-variant')).toEqual('negative');
   });
+
+  it('renders content with hidden message', () => {
+    const onHiddenMessageInfoClick = jest.fn();
+    const wrapper = render({
+      message: 'Message hidden',
+      isHidden: true,
+      onHiddenMessageInfoClick,
+    });
+
+    expect(wrapper.find('.content-highlighter__hidden-message-text')).toHaveText('Message hidden');
+
+    wrapper.find('IconButton').simulate('click');
+    expect(onHiddenMessageInfoClick).toHaveBeenCalled();
+  });
 });

--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { textToPlainEmojis } from './text-to-emojis';
+import { IconButton } from '@zero-tech/zui/components';
+import { IconHelpCircle } from '@zero-tech/zui/icons';
 
 import './styles.scss';
 import Linkify from 'linkify-react';
 import * as linkifyjs from 'linkifyjs';
+import { bemClassName } from '../../lib/bem';
 
 export interface Properties {
   message: string;
   variant?: 'negative';
   tabIndex?: number;
+  isHidden?: boolean;
+  onHiddenMessageInfoClick?: () => void;
 }
+
+const cn = bemClassName('content-highlighter');
 
 export class ContentHighlighter extends React.Component<Properties> {
   renderContent(message) {
@@ -24,7 +31,7 @@ export class ContentHighlighter extends React.Component<Properties> {
       if (match[2] === 'user') {
         const mention = `${match[1]}`.trim();
         const props: { className: string; key: string } = {
-          className: 'content-highlighter__user-mention',
+          ...cn('user-mention'),
           key: match[3] + index,
         };
 
@@ -55,15 +62,28 @@ export class ContentHighlighter extends React.Component<Properties> {
             },
           }}
         >
-          <div className='content-highlighter'>{this.renderContent(this.props.message)}</div>
+          <div {...cn('')}>{this.renderContent(this.props.message)}</div>
         </Linkify>
       );
     } else {
-      return <div className='content-highlighter'>{this.renderContent(this.props.message)}</div>;
+      return <div {...cn('')}>{this.renderContent(this.props.message)}</div>;
     }
   }
 
+  renderHiddenMessage(): React.ReactElement {
+    return (
+      <div {...cn('hidden-message-block')}>
+        <span {...cn('hidden-message-text')}>{this.props.message}</span>
+        <IconButton Icon={IconHelpCircle} size={24} onClick={this.props.onHiddenMessageInfoClick} />
+      </div>
+    );
+  }
+
   render() {
+    if (this.props.isHidden) {
+      return this.renderHiddenMessage();
+    }
+
     return this.renderMessageWithLinks();
   }
 }

--- a/src/components/content-highlighter/styles.scss
+++ b/src/components/content-highlighter/styles.scss
@@ -1,4 +1,5 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../glass';
 
 .content-highlighter {
   overflow: hidden;
@@ -23,6 +24,19 @@
       background-color: unset;
       color: theme.$color-greyscale-11;
     }
+  }
+
+  &__hidden-message-block {
+    display: flex;
+    gap: 4px;
+  }
+
+  &__hidden-message-text {
+    font-size: 14px;
+    font-style: italic;
+    font-weight: 400;
+
+    @include glass-text-secondary-color;
   }
 }
 

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -44,6 +44,8 @@ interface Properties extends MessageModel {
   showSenderAvatar?: boolean;
   showTimestamp: boolean;
   showAuthorName: boolean;
+  isHidden: boolean;
+  onHiddenMessageInfoClick: () => void;
 }
 
 export interface State {
@@ -276,11 +278,17 @@ export class Message extends React.Component<Properties, State> {
   }
 
   renderBody() {
-    const { message } = this.props;
+    const { message, isHidden } = this.props;
 
     return (
       <div {...cn('block-body')}>
-        {message && <ContentHighlighter message={message} />}
+        {message && (
+          <ContentHighlighter
+            message={message}
+            isHidden={isHidden}
+            onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
+          />
+        )}
         {this.renderFooter()}
       </div>
     );

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,4 +1,4 @@
-import { CustomEventType, MembershipStateType, NotifiableEventType } from './types';
+import { CustomEventType, MatrixConstants, MembershipStateType, NotifiableEventType } from './types';
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { decryptFile } from './media';
 import { AdminMessageType, Message, MessageSendStatus } from '../../../store/messages';
@@ -58,6 +58,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     },
     parentMessageText: '',
     parentMessageId: parent ? parent['m.in_reply_to']?.event_id : null,
+    isHidden: content?.msgtype === MatrixConstants.BAD_ENCRYPTED_MSGTYPE,
     ...(await parseMediaData(matrixMessage)),
   };
 }

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -13,6 +13,7 @@ export enum SagaActionTypes {
   DiscardOlm = 'chat/discard-olm',
   RestartOlm = 'chat/restart-olm',
   ShareHistoryKeys = 'chat/share-history-keys',
+  OpenBackupDialog = 'chat/open-backup-dialog',
   CloseBackupDialog = 'chat/close-backup-dialog',
 }
 
@@ -48,6 +49,7 @@ export const resendKeyRequests = createAction(SagaActionTypes.ResendKeyRequests)
 export const discardOlm = createAction<string>(SagaActionTypes.DiscardOlm);
 export const restartOlm = createAction<string>(SagaActionTypes.RestartOlm);
 export const shareHistoryKeys = createAction<{ roomId: string; userIds: string[] }>(SagaActionTypes.ShareHistoryKeys);
+export const openBackupDialog = createAction(SagaActionTypes.OpenBackupDialog);
 export const closeBackupDialog = createAction(SagaActionTypes.CloseBackupDialog);
 
 const slice = createSlice({

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -33,6 +33,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.DiscardOlm, discardOlm);
   yield takeLatest(SagaActionTypes.RestartOlm, restartOlm);
   yield takeLatest(SagaActionTypes.ShareHistoryKeys, shareHistoryKeys);
+  yield takeLatest(SagaActionTypes.OpenBackupDialog, openBackupDialog);
   yield takeLatest(SagaActionTypes.CloseBackupDialog, closeBackupDialog);
 }
 
@@ -145,6 +146,10 @@ export function* ensureUserHasBackup() {
 
 export function* closeBackupDialog() {
   yield put(setIsBackupDialogOpen(false));
+}
+
+export function* openBackupDialog() {
+  yield put(setIsBackupDialogOpen(true));
 }
 
 function* listenForUserLogin() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -106,6 +106,10 @@ export function* mapMessagesAndPreview(messages, channelId) {
   const zeroUsersMap = yield call(mapMessageSenders, messages, channelId);
   yield call(mapAdminUserIdToZeroUserId, [{ messages }], zeroUsersMap);
   for (const message of messages) {
+    if (message.isHidden) {
+      message.message = 'Message hidden';
+    }
+
     const preview = yield call(getPreview, message.message);
     if (preview) {
       message.preview = preview;


### PR DESCRIPTION
### What does this do?

Before:
<img width="369" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6c51d635-9af0-4011-9a19-f6c9203ca130">


After:
<img width="278" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/543254c0-a5e8-4762-bd57-8f9faf0d0e52">


When you click on "help" icon:

https://github.com/zer0-os/zOS/assets/33264364/12a063e8-aff9-479e-94b0-bd32e1ac1e2d

