### PR TITLE
refactor: simplify old conversation selector

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -22,9 +22,8 @@ import { rawChannel } from '../channels/selectors';
 import { getZEROUsers } from './api';
 import { union } from 'lodash';
 import { uniqNormalizedList } from '../utils';
-import { channelListStatus } from './selectors';
+import { channelListStatus, rawConversationsList } from './selectors';
 
-export const rawConversationsList = () => (state) => getDeepProperty(state, 'channelsList.value', []);
 export const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
 export function* mapToZeroUsers(channels: any[]) {
@@ -162,7 +161,7 @@ export function* createOptimisticConversation(userIds: string[], name: string = 
     lastMessageAt: adminMessage.createdAt,
   };
 
-  const existingConversationsList = yield select(rawConversationsList());
+  const existingConversationsList = yield select(rawConversationsList);
 
   yield put(
     receive([
@@ -179,7 +178,7 @@ export function* receiveCreatedConversation(conversation, optimisticConversation
     return;
   }
 
-  const existingConversationsList = yield select(rawConversationsList());
+  const existingConversationsList = yield select(rawConversationsList);
   const listWithoutOptimistic = existingConversationsList.filter((id) => id !== optimisticConversation.id);
 
   if (!existingConversationsList.includes(conversation.id)) {
@@ -219,7 +218,7 @@ export function* channelsReceived(action) {
   const { channels } = action.payload;
 
   const newChannels = channels.map(toLocalChannel);
-  const existingDirectMessages = yield select(rawConversationsList());
+  const existingDirectMessages = yield select(rawConversationsList);
 
   const newChannelList = uniqBy(
     [
@@ -302,7 +301,7 @@ function* otherUserLeftChannelAction({ payload }) {
 }
 
 export function* addChannel(channel) {
-  const conversationsList = yield select(rawConversationsList());
+  const conversationsList = yield select(rawConversationsList);
   yield call(mapToZeroUsers, [channel]);
   yield fork(fetchUserPresence, channel.otherMembers);
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from 'uuid';
-import { ChannelType } from './types';
 import getDeepProperty from 'lodash.get';
 import uniqBy from 'lodash.uniqby';
 import { fork, put, call, take, all, select, spawn } from 'redux-saga/effects';
@@ -8,7 +7,7 @@ import { chat } from '../../lib/chat';
 import { receive as receiveUser } from '../users';
 
 import { AsyncListStatus } from '../normalized';
-import { toLocalChannel, filterChannelsList, mapChannelMembers, mapChannelMessages } from './utils';
+import { toLocalChannel, mapChannelMembers, mapChannelMessages } from './utils';
 import { clearChannels, openConversation, openFirstConversation, receiveChannel } from '../channels/saga';
 import { ConversationEvents, getConversationsBus } from './channels';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
@@ -25,7 +24,7 @@ import { union } from 'lodash';
 import { uniqNormalizedList } from '../utils';
 import { channelListStatus } from './selectors';
 
-export const rawConversationsList = () => (state) => filterChannelsList(state, ChannelType.DirectMessage);
+export const rawConversationsList = () => (state) => getDeepProperty(state, 'channelsList.value', []);
 export const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
 export function* mapToZeroUsers(channels: any[]) {

--- a/src/store/channels-list/selectors.ts
+++ b/src/store/channels-list/selectors.ts
@@ -7,6 +7,10 @@ export function channelListStatus(state) {
   return getDeepProperty(state, 'channelsList.status', AsyncListStatus.Idle);
 }
 
+export function rawConversationsList(state) {
+  return getDeepProperty(state, 'channelsList.value', []);
+}
+
 export function mostRecentConversation(state) {
   const roomIds = getDeepProperty(state, 'channelsList.value', []);
   if (!roomIds.length) {

--- a/src/store/channels-list/types.ts
+++ b/src/store/channels-list/types.ts
@@ -1,10 +1,5 @@
 import { Channel, User } from '../channels';
 
-export enum ChannelType {
-  Channel,
-  DirectMessage,
-}
-
 export interface DirectMessage extends Channel {
   otherMembers: User[];
 }

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -1,23 +1,7 @@
-import { ChannelType } from './types';
 import { Channel, ConversationStatus, User } from './../channels/index';
-import { denormalize } from './../channels/index';
-import getDeepProperty from 'lodash.get';
 import { select } from 'redux-saga/effects';
 import { currentUserSelector } from '../authentication/selectors';
 import { getUserSubHandle } from '../../lib/user';
-
-export function filterChannelsList(state, filter: ChannelType) {
-  const channelIdList = getDeepProperty(state, 'channelsList.value', []);
-  return channelIdList.filter((channelId) => {
-    const channel = denormalize(channelId, state);
-
-    if (filter === ChannelType.DirectMessage) {
-      return !channel.isChannel;
-    } else {
-      return channel.isChannel;
-    }
-  });
-}
 
 export const toLocalChannel = (input): Partial<Channel> => {
   const isChannel = (input.isChannel ?? true) || !!input.isChannel;

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -19,9 +19,9 @@ import { chat, getRoomIdForAlias, isRoomMember } from '../../lib/chat';
 import { ConversationEvents, getConversationsBus } from '../channels-list/channels';
 import { getHistory } from '../../lib/browser';
 import { openFirstConversation } from '../channels/saga';
-import { rawConversationsList } from '../channels-list/saga';
 import { translateJoinRoomApiError, parseAlias, isAlias, extractDomainFromAlias } from './utils';
 import { joinRoom as apiJoinRoom } from './api';
+import { rawConversationsList } from '../channels-list/selectors';
 
 function* initChat(userId, chatAccessToken) {
   const { chatConnection, connectionPromise, activate } = createChatConnection(userId, chatAccessToken, chat.get());
@@ -131,7 +131,7 @@ export function* joinRoom(roomIdOrAlias: string) {
 }
 
 export function* isMemberOfActiveConversation(activeConversationId) {
-  const conversationList = yield select(rawConversationsList());
+  const conversationList = yield select(rawConversationsList);
   const isRoomInState = conversationList.includes(activeConversationId);
   if (isRoomInState) {
     return true;


### PR DESCRIPTION
### What does this do?

Removes the selector that was filtering channels based on the isChannel flag as we don't use that any more

