### PR TITLE
Add state for rendering the logout confirmation modal

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,7 +15,7 @@ import {
   membersSelected,
   startCreateConversation,
 } from '../../../store/create-conversation';
-import { logout } from '../../../store/authentication';
+import { forceLogout } from '../../../store/authentication';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
 import { closeConversationErrorDialog } from '../../../store/chat';
 
@@ -120,7 +120,7 @@ export class Container extends React.Component<Properties, State> {
       back,
       startGroup,
       membersSelected,
-      logout,
+      logout: forceLogout,
       receiveSearchResults,
       closeConversationErrorDialog,
       closeBackupDialog,

--- a/src/store/authentication/index.ts
+++ b/src/store/authentication/index.ts
@@ -3,12 +3,15 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export enum SagaActionTypes {
   Logout = 'authentication/saga/logout',
+  ForceLogout = 'authentication/saga/force-logout',
 }
 
 export const logout = createAction(SagaActionTypes.Logout);
+export const forceLogout = createAction(SagaActionTypes.ForceLogout);
 
-const initialState: AuthenticationState = {
+export const initialState: AuthenticationState = {
   user: { data: null },
+  displayLogoutModal: false,
 };
 
 const slice = createSlice({
@@ -18,8 +21,11 @@ const slice = createSlice({
     setUser: (state, action: PayloadAction<AuthenticationState['user']>) => {
       state.user = action.payload;
     },
+    setDisplayLogoutModal: (state, action: PayloadAction<boolean>) => {
+      state.displayLogoutModal = action.payload;
+    },
   },
 });
 
-export const { setUser } = slice.actions;
+export const { setUser, setDisplayLogoutModal } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -1,6 +1,6 @@
 import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, all } from 'redux-saga/effects';
-import { SagaActionTypes, setUser } from '.';
+import { SagaActionTypes, setDisplayLogoutModal, setUser } from '.';
 import {
   nonceOrAuthorize as nonceOrAuthorizeApi,
   fetchCurrentUser,
@@ -113,10 +113,20 @@ export function* clearUserState() {
 }
 
 export function* saga() {
-  yield takeLatest(SagaActionTypes.Logout, logout);
+  yield takeLatest(SagaActionTypes.Logout, logoutRequest);
+  yield takeLatest(SagaActionTypes.ForceLogout, forceLogout);
 }
 
-export function* logout() {
+export function* logoutRequest() {
+  yield put(setDisplayLogoutModal(true));
+}
+
+export function* closeLogoutModal() {
+  yield put(setDisplayLogoutModal(false));
+}
+
+export function* forceLogout() {
+  yield closeLogoutModal();
   yield call(updateConnector, { payload: Connectors.None });
   yield call(terminate);
 }

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -45,4 +45,5 @@ export interface User {
 export interface AuthenticationState {
   user: UserPayload;
   nonce?: string;
+  displayLogoutModal: boolean;
 }

--- a/src/store/login/saga.ts
+++ b/src/store/login/saga.ts
@@ -11,7 +11,7 @@ import {
   setStage,
 } from '.';
 import { getSignedToken, getSignedTokenForConnector, isWeb3AccountConnected } from '../web3/saga';
-import { authenticateByEmail, logout, nonceOrAuthorize, terminate } from '../authentication/saga';
+import { authenticateByEmail, forceLogout, nonceOrAuthorize, terminate } from '../authentication/saga';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { Web3Events, getWeb3Channel } from '../web3/channels';
 
@@ -97,7 +97,7 @@ export function* web3ChangeAccount() {
     // in a weird state where the cookie doesn't match the current connection.
     // You an always log back in. It may not be ideal but at least we're not in
     // a corrupt state.
-    yield call(logout);
+    yield call(forceLogout);
     return;
   }
 

--- a/src/store/test/store.ts
+++ b/src/store/test/store.ts
@@ -5,6 +5,7 @@ import { normalize as normalizeUser } from '../users';
 import { User as AuthenticatedUser } from '../authentication/types';
 import { initialState as initialGroupManagementState } from '../group-management';
 import { ChatState } from '../chat/types';
+import { initialState as authenticationInitialState } from '../authentication';
 
 export class StoreBuilder {
   channelList: Partial<Channel>[] = [];
@@ -112,6 +113,7 @@ export class StoreBuilder {
         },
       },
       authentication: {
+        ...authenticationInitialState,
         user: { data: this.currentUser },
       },
       groupManagement: this.groupManagement,


### PR DESCRIPTION
### What does this do?

Adds an intermediate logout saga which sets the (to be developed) logout confirmation modal to open and adds a forceLogout.

The app still currently uses the forceLogout until the modal is complete.

