### PR TITLE
feat: add error handling - generate backup saga

### DIFF
--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -115,6 +115,17 @@ describe(generateBackup, () => {
 
     expect(storeState.matrix.backupStage).toEqual(BackupStage.GenerateBackup);
   });
+
+  it('handles error during backup generation', async () => {
+    const error = new Error('Failed to generate backup');
+    const { storeState } = await subject(generateBackup)
+      .provide([[call([chatClient, chatClient.generateSecureBackup]), throwError(error)]])
+      .withReducer(rootReducer)
+      .run();
+
+    expect(storeState.matrix.errorMessage).toEqual('Failed to generate backup. Please try again.');
+    expect(storeState.matrix.backupStage).toEqual(BackupStage.None);
+  });
 });
 
 describe(saveBackup, () => {

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -123,7 +123,7 @@ describe(generateBackup, () => {
       .withReducer(rootReducer)
       .run();
 
-    expect(storeState.matrix.errorMessage).toEqual('Failed to generate backup. Please try again.');
+    expect(storeState.matrix.errorMessage).toEqual('Failed to generate backup key. Please try again.');
     expect(storeState.matrix.backupStage).toEqual(BackupStage.None);
   });
 });

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -64,7 +64,7 @@ export function* generateBackup() {
     const key = yield call([chatClient, chatClient.generateSecureBackup]);
     yield put(setGeneratedRecoveryKey(key));
   } catch (error) {
-    yield put(setErrorMessage('Failed to generate backup. Please try again.'));
+    yield put(setErrorMessage('Failed to generate backup key. Please try again.'));
     yield put(setBackupStage(BackupStage.None));
   }
 }

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -58,10 +58,15 @@ export function* getBackup() {
 }
 
 export function* generateBackup() {
-  yield put(setBackupStage(BackupStage.GenerateBackup));
-  const chatClient = yield call(chat.get);
-  const key = yield call([chatClient, chatClient.generateSecureBackup]);
-  yield put(setGeneratedRecoveryKey(key));
+  try {
+    yield put(setBackupStage(BackupStage.GenerateBackup));
+    const chatClient = yield call(chat.get);
+    const key = yield call([chatClient, chatClient.generateSecureBackup]);
+    yield put(setGeneratedRecoveryKey(key));
+  } catch (error) {
+    yield put(setErrorMessage('Failed to generate backup. Please try again.'));
+    yield put(setBackupStage(BackupStage.None));
+  }
 }
 
 export function* saveBackup() {

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -58,9 +58,10 @@ export function* getBackup() {
 }
 
 export function* generateBackup() {
+  yield put(setBackupStage(BackupStage.GenerateBackup));
+  const chatClient = yield call(chat.get);
+
   try {
-    yield put(setBackupStage(BackupStage.GenerateBackup));
-    const chatClient = yield call(chat.get);
     const key = yield call([chatClient, chatClient.generateSecureBackup]);
     yield put(setGeneratedRecoveryKey(key));
   } catch (error) {


### PR DESCRIPTION
### What does this do?
- error handling for generate backup call - sets stage, sets error message.

### Why are we making this change?
- error message to display in UI.
- handle stage.

### How do I test this?
- run tests / throw error in `generateBackup` saga function and open secure backup with a user who has not yet backed up. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
