### PR TITLE
feat: add verify key phrase component

### DIFF
--- a/src/components/secure-backup/styles.scss
+++ b/src/components/secure-backup/styles.scss
@@ -110,6 +110,11 @@
     padding: 8px;
   }
 
+  &__alert {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
   &__error-message {
     text-align: center;
     color: theme.$color-failure-11;

--- a/src/components/secure-backup/verify-key-phrase/index.test.tsx
+++ b/src/components/secure-backup/verify-key-phrase/index.test.tsx
@@ -1,0 +1,65 @@
+import { shallow } from 'enzyme';
+
+import { VerifyKeyPhrase, Properties } from '.';
+import { buttonLabelled, pressButton } from '../../../test/utils';
+
+import { Alert, Button, Input } from '@zero-tech/zui/components';
+
+describe(VerifyKeyPhrase, () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      errorMessage: '',
+      onBack: () => null,
+      onSubmit: () => null,
+      ...props,
+    };
+
+    return shallow(<VerifyKeyPhrase {...allProps} />);
+  };
+
+  it('publishes onBack when the back button is pressed', function () {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    pressButton(wrapper, 'Back to phrase');
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('publishes onSubmit with the key phrase when the verify button is pressed', function () {
+    const onSubmit = jest.fn();
+    const wrapper = subject({ onSubmit });
+
+    wrapper.find(Input).simulate('change', 'test-key-phrase');
+
+    pressButton(wrapper, 'Verify and complete backup');
+
+    expect(onSubmit).toHaveBeenCalledWith('test-key-phrase');
+  });
+
+  it('disables the verify button when recovery key is empty', function () {
+    const wrapper = subject();
+
+    expect(buttonLabelled(wrapper, 'Verify and complete backup')).toHaveProp('isDisabled', true);
+  });
+
+  it('enables the verify button when a key phrase is entered', function () {
+    const wrapper = subject();
+
+    wrapper.find(Input).simulate('change', 'test-key-phrase');
+
+    expect(buttonLabelled(wrapper, 'Verify and complete backup')).toHaveProp('isDisabled', false);
+  });
+
+  it('renders Alert when errorMessage is provided', function () {
+    const wrapper = subject({ errorMessage: 'Invalid key prhase' });
+
+    expect(wrapper).toHaveElement(Alert);
+  });
+
+  it('does not render Alert when errorMessage is not provided', function () {
+    const wrapper = subject({ errorMessage: '' });
+
+    expect(wrapper).not.toHaveElement(Alert);
+  });
+});

--- a/src/components/secure-backup/verify-key-phrase/index.tsx
+++ b/src/components/secure-backup/verify-key-phrase/index.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+
+import { bemClassName } from '../../../lib/bem';
+
+import { Alert, Button, Input } from '@zero-tech/zui/components';
+
+import '../styles.scss';
+
+const cn = bemClassName('secure-backup');
+
+export interface State {
+  userInputKeyPhrase: string;
+}
+
+export interface Properties {
+  errorMessage: string;
+  onBack: () => void;
+  onSubmit: (keyPhrase: string) => void;
+}
+
+export class VerifyKeyPhrase extends React.Component<Properties, State> {
+  state = { userInputKeyPhrase: '' };
+
+  trackKeyPhrase = (value) => {
+    this.setState({ userInputKeyPhrase: value });
+  };
+
+  back = () => {
+    this.props.onBack();
+  };
+
+  submitKeyPhrase = () => {
+    this.props.onSubmit(this.keyPhrase);
+  };
+
+  get keyPhrase() {
+    return this.state.userInputKeyPhrase;
+  }
+
+  render() {
+    return (
+      <>
+        <div>
+          <p {...cn('primary-text')}>Verify Backup Phrase</p>
+
+          <p {...cn('secondary-text')}>Confirm that you have safely stored your backup phrase by entering it below</p>
+
+          <div {...cn('input-container')}>
+            <Input placeholder='Enter your backup phrase' onChange={this.trackKeyPhrase} value={this.keyPhrase} />
+
+            {this.props.errorMessage && (
+              <Alert {...cn('alert')} variant='error'>
+                {this.props.errorMessage}
+              </Alert>
+            )}
+          </div>
+        </div>
+
+        <div {...cn('footer', 'has-secondary-button')}>
+          <Button {...cn('button')} onPress={this.back} variant='text'>
+            Back to phrase
+          </Button>
+
+          <Button {...cn('button')} onPress={this.submitKeyPhrase} isDisabled={!this.keyPhrase}>
+            Verify and complete backup
+          </Button>
+        </div>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
### What does this do?
- adds the `VerifyKeyPhrase` component.

### Why are we making this change?
- to add a component to use for the verify key phrase stage of the secure backup flow.

### How do I test this?
- run tests / replace an existing component in the secure backup flow with the `VerifyKeyPhrase` component and check ui when rendered.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1009" alt="Screenshot 2024-02-27 at 11 03 48" src="https://github.com/zer0-os/zOS/assets/39112648/476373f5-a162-45b9-a65a-78b49943a78a">


<img width="1009" alt="Screenshot 2024-02-27 at 11 07 58" src="https://github.com/zer0-os/zOS/assets/39112648/1be8f34f-f8e2-4219-b55e-16261e4fa9aa">
