### PR TITLE
feat: handle stage specific secure backup dialog header

### DIFF
--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -9,6 +9,9 @@ import { GenerateBackup } from './generate-backup';
 import { RestoreBackup } from './restore-backup';
 import { Success } from './success';
 
+import { bem } from '../../lib/bem';
+const c = bem('.secure-backup');
+
 describe('SecureBackup', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
@@ -220,6 +223,20 @@ describe('SecureBackup', () => {
       wrapper.find(Success).simulate('close');
 
       expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('header container', () => {
+    it('renders title as "Account Backup" if backup does not exist and backup is not restored', function () {
+      const wrapper = subject({ backupExists: false, isBackupRecovered: false });
+
+      expect(wrapper.find(c('title'))).toHaveText('Account Backup');
+    });
+
+    it('renders title as "Verify Login" if backup exists and backup is not restored', function () {
+      const wrapper = subject({ backupExists: true, isBackupRecovered: false });
+
+      expect(wrapper.find(c('title'))).toHaveText('Verify Login');
     });
   });
 });

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -62,11 +62,11 @@ export class SecureBackup extends React.PureComponent<Properties> {
   }
 
   renderHeader = () => {
-    const header = this.backupNotRestored ? 'Verify Login' : 'Account Backup';
+    const title = this.backupNotRestored ? 'Verify Login' : 'Account Backup';
 
     return (
       <div {...cn('header')}>
-        <h3 {...cn('title')}>{header}</h3>
+        <h3 {...cn('title')}>{title}</h3>
         <IconButton {...cn('close')} Icon={IconXClose} onClick={this.props.onClose} size={40} />
       </div>
     );

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -62,9 +62,11 @@ export class SecureBackup extends React.PureComponent<Properties> {
   }
 
   renderHeader = () => {
+    const header = this.backupNotRestored ? 'Verify Login' : 'Account Backup';
+
     return (
       <div {...cn('header')}>
-        <h3 {...cn('title')}>Account Backup</h3>
+        <h3 {...cn('title')}>{header}</h3>
         <IconButton {...cn('close')} Icon={IconXClose} onClick={this.props.onClose} size={40} />
       </div>
     );


### PR DESCRIPTION
### What does this do?
- displays either `Account Backup` or `Verify Login` header.

### Why are we making this change?
- as per figma design. As shown [here](https://www.figma.com/file/btwltL4Os8hAy3eS3pxaa6/ZERO-Messenger-%2F-Web?type=design&node-id=12598-86331&mode=dev)


<img width="1009" alt="Screenshot 2024-02-27 at 11 36 53" src="https://github.com/zer0-os/zOS/assets/39112648/f5937e43-9924-4853-8c40-d25fa824687d">

<img width="1009" alt="Screenshot 2024-02-27 at 11 37 24" src="https://github.com/zer0-os/zOS/assets/39112648/eadab107-2152-4e83-8962-54e490990fbf">
