### PR TITLE
refactor(messenger-chat): add mapState tests for messenger chat container

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -137,38 +137,6 @@ describe(DirectMessageChat, () => {
   });
 
   describe('room management', () => {
-    describe('add members', () => {
-      it('allows adding of members if user is an admin and conversation is not a 1 on 1', () => {
-        const wrapper = subject({ isCurrentUserRoomAdmin: true });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canAddMembers', true);
-      });
-
-      it('does NOT allow adding of members if user is NOT an admin', () => {
-        const wrapper = subject({
-          isCurrentUserRoomAdmin: false,
-          directMessage: stubConversation({ isOneOnOne: false }),
-        });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canAddMembers', false);
-      });
-
-      it('does NOT allow adding of members if conversation is considered a 1 on 1', () => {
-        const wrapper = subject({
-          isCurrentUserRoomAdmin: true,
-          directMessage: stubConversation({ isOneOnOne: true }),
-        });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canAddMembers', false);
-      });
-    });
-
     describe('view group information', () => {
       it('allows viewing of group information if conversation is not a 1 on 1', () => {
         const wrapper = subject({ directMessage: stubConversation({ isOneOnOne: false }) });
@@ -298,6 +266,30 @@ describe(DirectMessageChat, () => {
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
+    });
+
+    describe('canAddMembers', () => {
+      it('is false when one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: true }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+
+      it('is false when current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'] }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+
+      it('is true when current user is room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'] }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
       });
     });
   });

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -39,6 +39,7 @@ describe(DirectMessageChat, () => {
       activeConversationId: '1',
       leaveGroupDialogStatus: LeaveGroupDialogStatus.CLOSED,
       directMessage: { id: '1', otherMembers: [] } as any,
+      canLeaveRoom: false,
       sendMessage: () => null,
       onRemoveReply: () => null,
       isCurrentUserRoomAdmin: false,

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -1,29 +1,16 @@
-/**
- * @jest-environment jsdom
- */
-
 import React from 'react';
-// import { shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { Container as DirectMessageChat, Properties } from '.';
 import { Channel, User } from '../../../store/channels';
-import Tooltip from '../../tooltip';
 import { ChatViewContainer } from '../../chat-view-container/chat-view-container';
-import { GroupManagementMenu } from '../../group-management-menu';
 import { LeaveGroupDialogStatus } from '../../../store/group-management';
 import { MessageInput } from '../../message-input/container';
 import { Media } from '../../message-input/utils';
-import { IconCurrencyEthereum, IconUsers1 } from '@zero-tech/zui/icons';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
 import { JoiningConversationDialog } from '../../joining-conversation-dialog';
 
-import { bem } from '../../../lib/bem';
-import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
-import { store } from '../../../store';
 import { StoreBuilder, stubAuthenticatedUser } from '../../../store/test/store';
 import { ConversationHeader } from './conversation-header';
-
-const c = bem('.direct-message-chat');
 
 const mockSearchMentionableUsersForChannel = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -41,6 +28,9 @@ describe(DirectMessageChat, () => {
       leaveGroupDialogStatus: LeaveGroupDialogStatus.CLOSED,
       directMessage: { id: '1', otherMembers: [] } as any,
       canLeaveRoom: false,
+      canEdit: false,
+      canAddMembers: false,
+      canViewDetails: false,
       sendMessage: () => null,
       onRemoveReply: () => null,
       isCurrentUserRoomAdmin: false,
@@ -52,11 +42,7 @@ describe(DirectMessageChat, () => {
       ...props,
     };
 
-    return mount(
-      <Provider store={store}>
-        <DirectMessageChat {...allProps} />
-      </Provider>
-    );
+    return shallow(<DirectMessageChat {...allProps} />);
   };
 
   it('render channel view component', function () {
@@ -97,13 +83,12 @@ describe(DirectMessageChat, () => {
     const startAddGroupMember = jest.fn();
     const wrapper = subject({ startAddGroupMember });
 
-    wrapper.find(ConversationHeader).prop('onAddMember')();
+    wrapper.find(ConversationHeader).simulate('addMember');
 
     expect(startAddGroupMember).toHaveBeenCalledOnce();
   });
 
-  // Skipping these tests as modal doesn't render in `mount` mode - will restore once reverted back to shallow render
-  describe.skip('leave group dialog', () => {
+  describe('leave group dialog', () => {
     it('renders leave group dialog when status is OPEN', async () => {
       const wrapper = subject({ leaveGroupDialogStatus: LeaveGroupDialogStatus.OPEN });
 
@@ -145,7 +130,7 @@ describe(DirectMessageChat, () => {
 
       const wrapper = subject({ sendMessage, activeConversationId: channelId });
 
-      wrapper.find(MessageInput).prop('onSubmit')(message, mentionedUserIds, []);
+      wrapper.find(MessageInput).simulate('submit', message, mentionedUserIds, []);
 
       expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ channelId, message, mentionedUserIds }));
     });
@@ -162,7 +147,7 @@ describe(DirectMessageChat, () => {
         directMessage: { reply, otherMembers: [] } as any,
       });
 
-      wrapper.find(MessageInput).prop('onSubmit')(message, [], []);
+      wrapper.find(MessageInput).simulate('submit', message, [], []);
 
       expect(sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({ channelId, message, mentionedUserIds: [], parentMessage: reply })
@@ -176,7 +161,7 @@ describe(DirectMessageChat, () => {
 
       const wrapper = subject({ sendMessage, activeConversationId: channelId });
 
-      wrapper.find(MessageInput).prop('onSubmit')(message, [], [{ id: 'file-id', name: 'file-name' } as Media]);
+      wrapper.find(MessageInput).simulate('submit', message, [], [{ id: 'file-id', name: 'file-name' } as Media]);
 
       expect(sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({ channelId, files: [{ id: 'file-id', name: 'file-name' }] })

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -21,6 +21,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { store } from '../../../store';
 import { StoreBuilder, stubAuthenticatedUser } from '../../../store/test/store';
+import { ConversationHeader } from './conversation-header';
 
 const c = bem('.direct-message-chat');
 
@@ -92,88 +93,13 @@ describe(DirectMessageChat, () => {
     expect(wrapper).not.toHaveElement(JoiningConversationDialog);
   });
 
-  describe('one on one chat', function () {
-    it('can start add group member group management saga', async function () {
-      const startAddGroupMember = jest.fn();
-      const wrapper = subject({ startAddGroupMember });
+  it('calls start add group member', async function () {
+    const startAddGroupMember = jest.fn();
+    const wrapper = subject({ startAddGroupMember });
 
-      wrapper.find(GroupManagementMenu).prop('onStartAddMember')();
+    wrapper.find(ConversationHeader).prop('onAddMember')();
 
-      expect(startAddGroupMember).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe('one to many chat', function () {
-    it('header renders full names in the title', function () {
-      const wrapper = subject({
-        directMessage: {
-          otherMembers: [
-            stubUser({ firstName: 'Johnny', lastName: 'Sanderson' }),
-            stubUser({ firstName: 'Jack', lastName: 'Black' }),
-          ],
-        } as Channel,
-      });
-
-      const tooltip = wrapper.find(Tooltip);
-
-      expect(tooltip.html()).toContain('Johnny Sanderson, Jack Black');
-    });
-
-    it('header renders online status in the subtitle if any member is online', function () {
-      const wrapper = subject({
-        directMessage: { otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: true })] } as Channel,
-      });
-
-      const subtitle = wrapper.find(c('subtitle'));
-
-      expect(subtitle).toHaveText('Online');
-    });
-
-    it('header renders online status if any member is online', function () {
-      const wrapper = subject({
-        directMessage: { otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: true })] } as Channel,
-      });
-
-      expect(wrapper).toHaveElement(c('header-avatar--online'));
-    });
-
-    it('header renders offline status', function () {
-      const wrapper = subject({
-        directMessage: { otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: false })] } as Channel,
-      });
-
-      expect(wrapper).toHaveElement(c('header-avatar--offline'));
-    });
-
-    it('header renders avatar with group icon when there is no avatar url', function () {
-      const wrapper = subject({
-        directMessage: { otherMembers: [stubUser(), stubUser()] } as Channel,
-      });
-
-      const headerAvatar = wrapper.find(c('header-avatar'));
-
-      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url()' });
-      expect(headerAvatar).not.toHaveElement(IconCurrencyEthereum);
-      expect(headerAvatar).toHaveElement(IconUsers1);
-    });
-
-    it('header renders avatar with custom background when there is an avatar url', function () {
-      const wrapper = subject({
-        directMessage: {
-          icon: 'https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg',
-          otherMembers: [stubUser(), stubUser()],
-        } as Channel,
-      });
-
-      const headerAvatar = wrapper.find(c('header-avatar'));
-
-      expect(headerAvatar).toHaveProp('style', {
-        backgroundImage:
-          'url(https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg)',
-      });
-      expect(headerAvatar).not.toHaveElement(IconCurrencyEthereum);
-      expect(headerAvatar).not.toHaveElement(IconUsers1);
-    });
+    expect(startAddGroupMember).toHaveBeenCalledOnce();
   });
 
   // Skipping these tests as modal doesn't render in `mount` mode - will restore once reverted back to shallow render

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -136,29 +136,6 @@ describe(DirectMessageChat, () => {
     });
   });
 
-  describe('room management', () => {
-    describe('view group information', () => {
-      it('allows viewing of group information if conversation is not a 1 on 1', () => {
-        const wrapper = subject({ directMessage: stubConversation({ isOneOnOne: false }) });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canViewGroupInformation', true);
-      });
-
-      it('does NOT allow viewing of group information if conversation is considered a 1 on 1', () => {
-        const wrapper = subject({
-          isCurrentUserRoomAdmin: true,
-          directMessage: stubConversation({ isOneOnOne: true }),
-        });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canViewGroupInformation', false);
-      });
-    });
-  });
-
   describe('message input', () => {
     it('passes sendMessage prop to message input', () => {
       const sendMessage = jest.fn();
@@ -290,6 +267,20 @@ describe(DirectMessageChat, () => {
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+    });
+
+    describe('canViewDetails', () => {
+      it('is false when one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: true }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: false }));
+      });
+
+      it('is true when not a one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: false }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
       });
     });
   });

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -137,38 +137,6 @@ describe(DirectMessageChat, () => {
   });
 
   describe('room management', () => {
-    describe('edit members', () => {
-      it('allows editing if user is an admin and conversation is not a 1 on 1', () => {
-        const wrapper = subject({ isCurrentUserRoomAdmin: true });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canEdit', true);
-      });
-
-      it('does NOT allow editing if user is NOT an admin', () => {
-        const wrapper = subject({
-          isCurrentUserRoomAdmin: false,
-          directMessage: stubConversation({ isOneOnOne: false }),
-        });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canEdit', false);
-      });
-
-      it('does NOT allow editing if conversation is considered a 1 on 1', () => {
-        const wrapper = subject({
-          isCurrentUserRoomAdmin: true,
-          directMessage: stubConversation({ isOneOnOne: true }),
-        });
-
-        const groupManagementMenu = wrapper.find(GroupManagementMenu);
-
-        expect(groupManagementMenu).toHaveProp('canEdit', false);
-      });
-    });
-
     describe('add members', () => {
       it('allows adding of members if user is an admin and conversation is not a 1 on 1', () => {
         const wrapper = subject({ isCurrentUserRoomAdmin: true });
@@ -306,6 +274,30 @@ describe(DirectMessageChat, () => {
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
+      });
+    });
+
+    describe('canEdit', () => {
+      it('is false when one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: true }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
+      });
+
+      it('is false when current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'] }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
+      });
+
+      it('is true when current user is room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'] }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
       });
     });
   });

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -32,6 +32,7 @@ export interface Properties extends PublicProperties {
   isCurrentUserRoomAdmin: boolean;
   isJoiningConversation: boolean;
   canLeaveRoom: boolean;
+  canEdit: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
@@ -59,6 +60,7 @@ export class Container extends React.Component<Properties> {
     const currentUser = currentUserSelector(state);
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
     const canLeaveRoom = !isCurrentUserRoomAdmin && (directMessage?.otherMembers || []).length > 1;
+    const canEdit = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
 
     return {
       activeConversationId,
@@ -67,6 +69,7 @@ export class Container extends React.Component<Properties> {
       leaveGroupDialogStatus: groupManagement.leaveGroupDialogStatus,
       isJoiningConversation,
       canLeaveRoom,
+      canEdit,
     };
   }
 
@@ -165,7 +168,7 @@ export class Container extends React.Component<Properties> {
                 otherMembers={this.props.directMessage.otherMembers || []}
                 canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                 canLeaveRoom={this.props.canLeaveRoom}
-                canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+                canEdit={this.props.canEdit}
                 canViewDetails={!this.isOneOnOne()}
                 onLeaveRoom={this.openLeaveGroupDialog}
                 onViewDetails={this.onViewGroupInformation}

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -33,6 +33,7 @@ export interface Properties extends PublicProperties {
   isJoiningConversation: boolean;
   canLeaveRoom: boolean;
   canEdit: boolean;
+  canAddMembers: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
@@ -61,6 +62,7 @@ export class Container extends React.Component<Properties> {
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
     const canLeaveRoom = !isCurrentUserRoomAdmin && (directMessage?.otherMembers || []).length > 1;
     const canEdit = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
+    const canAddMembers = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
 
     return {
       activeConversationId,
@@ -70,6 +72,7 @@ export class Container extends React.Component<Properties> {
       isJoiningConversation,
       canLeaveRoom,
       canEdit,
+      canAddMembers,
     };
   }
 
@@ -166,7 +169,7 @@ export class Container extends React.Component<Properties> {
                 name={this.props.directMessage.name}
                 isOneOnOne={this.isOneOnOne()}
                 otherMembers={this.props.directMessage.otherMembers || []}
-                canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
+                canAddMembers={this.props.canAddMembers}
                 canLeaveRoom={this.props.canLeaveRoom}
                 canEdit={this.props.canEdit}
                 canViewDetails={!this.isOneOnOne()}

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -106,10 +106,6 @@ export class Container extends React.Component<Properties> {
     this.props.setLeaveGroupStatus(LeaveGroupDialogStatus.CLOSED);
   };
 
-  onViewGroupInformation = () => {
-    this.props.viewGroupInformation();
-  };
-
   renderLeaveGroupDialog = (): JSX.Element => {
     return (
       <Modal open={this.isLeaveGroupDialogOpen} onOpenChange={this.closeLeaveGroupDialog}>
@@ -177,7 +173,7 @@ export class Container extends React.Component<Properties> {
                 canEdit={this.props.canEdit}
                 canViewDetails={this.props.canViewDetails}
                 onLeaveRoom={this.openLeaveGroupDialog}
-                onViewDetails={this.onViewGroupInformation}
+                onViewDetails={this.props.viewGroupInformation}
                 onAddMember={this.props.startAddGroupMember}
                 onEdit={this.props.startEditConversation}
               />

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -34,6 +34,7 @@ export interface Properties extends PublicProperties {
   canLeaveRoom: boolean;
   canEdit: boolean;
   canAddMembers: boolean;
+  canViewDetails: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
@@ -63,6 +64,7 @@ export class Container extends React.Component<Properties> {
     const canLeaveRoom = !isCurrentUserRoomAdmin && (directMessage?.otherMembers || []).length > 1;
     const canEdit = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
     const canAddMembers = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
+    const canViewDetails = !directMessage?.isOneOnOne;
 
     return {
       activeConversationId,
@@ -73,6 +75,7 @@ export class Container extends React.Component<Properties> {
       canLeaveRoom,
       canEdit,
       canAddMembers,
+      canViewDetails,
     };
   }
 
@@ -172,7 +175,7 @@ export class Container extends React.Component<Properties> {
                 canAddMembers={this.props.canAddMembers}
                 canLeaveRoom={this.props.canLeaveRoom}
                 canEdit={this.props.canEdit}
-                canViewDetails={!this.isOneOnOne()}
+                canViewDetails={this.props.canViewDetails}
                 onLeaveRoom={this.openLeaveGroupDialog}
                 onViewDetails={this.onViewGroupInformation}
                 onAddMember={this.props.startAddGroupMember}

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -31,6 +31,7 @@ export interface Properties extends PublicProperties {
   directMessage: Channel;
   isCurrentUserRoomAdmin: boolean;
   isJoiningConversation: boolean;
+  canLeaveRoom: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
@@ -57,6 +58,7 @@ export class Container extends React.Component<Properties> {
     const directMessage = denormalize(activeConversationId, state);
     const currentUser = currentUserSelector(state);
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
+    const canLeaveRoom = !isCurrentUserRoomAdmin && (directMessage?.otherMembers || []).length > 1;
 
     return {
       activeConversationId,
@@ -64,6 +66,7 @@ export class Container extends React.Component<Properties> {
       isCurrentUserRoomAdmin,
       leaveGroupDialogStatus: groupManagement.leaveGroupDialogStatus,
       isJoiningConversation,
+      canLeaveRoom,
     };
   }
 
@@ -161,9 +164,7 @@ export class Container extends React.Component<Properties> {
                 isOneOnOne={this.isOneOnOne()}
                 otherMembers={this.props.directMessage.otherMembers || []}
                 canAddMembers={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
-                canLeaveRoom={
-                  !this.props.isCurrentUserRoomAdmin && (this.props.directMessage.otherMembers || []).length > 1
-                }
+                canLeaveRoom={this.props.canLeaveRoom}
                 canEdit={this.props.isCurrentUserRoomAdmin && !this.isOneOnOne()}
                 canViewDetails={!this.isOneOnOne()}
                 onLeaveRoom={this.openLeaveGroupDialog}

--- a/src/store/test/store.ts
+++ b/src/store/test/store.ts
@@ -123,7 +123,7 @@ export class StoreBuilder {
 }
 
 let stubCount = 0;
-function stubAuthenticatedUser(attrs: Partial<AuthenticatedUser> = {}): Partial<AuthenticatedUser> {
+export function stubAuthenticatedUser(attrs: Partial<AuthenticatedUser> = {}): Partial<AuthenticatedUser> {
   stubCount++;
   return {
     id: `default-stub-user-id-${stubCount}`,


### PR DESCRIPTION
### What does this do?
- moves permissions logic into mapState.
- adds test coverage for mapState.
- exports stub authenticated user helper.

### Why are we making this change?
- code quality / tidy up.

### How do I test this?
- run messenger chat `index.test.tsx`.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
