### PR TITLE
Add logout confirmation modal

### DIFF
--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -7,7 +7,7 @@ import { MessengerChat } from './components/messenger/chat';
 
 describe(Main, () => {
   const subject = (props: Partial<Properties> = {}) => {
-    const allProps = {
+    const allProps: Properties = {
       isMessengerFullScreen: false,
       context: {
         isAuthenticated: false,

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -10,7 +10,6 @@ import { withContext as withAuthenticationContext } from './components/authentic
 import { MessengerChat } from './components/messenger/chat';
 import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
-import { LogoutConfirmationModalContainer } from './components/logout-confirmation-modal/container';
 
 export interface Properties {
   isMessengerFullScreen: boolean;

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -10,6 +10,7 @@ import { withContext as withAuthenticationContext } from './components/authentic
 import { MessengerChat } from './components/messenger/chat';
 import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
+import { LogoutConfirmationModalContainer } from './components/logout-confirmation-modal/container';
 
 export interface Properties {
   isMessengerFullScreen: boolean;

--- a/src/components/logout-confirmation-modal/container.test.tsx
+++ b/src/components/logout-confirmation-modal/container.test.tsx
@@ -1,0 +1,30 @@
+import { StoreBuilder } from '../../store/test/store';
+import { Container } from './container';
+
+describe(Container, () => {
+  describe('mapState', () => {
+    test('when a backup exists', () => {
+      const state = new StoreBuilder().withoutBackup();
+
+      expect(Container.mapState(state.build())).toEqual(
+        expect.objectContaining({ backupExists: false, backupVerified: false })
+      );
+    });
+
+    test('when a backup exists but is unverified', () => {
+      const state = new StoreBuilder().withUnverifiedBackup();
+
+      expect(Container.mapState(state.build())).toEqual(
+        expect.objectContaining({ backupExists: true, backupVerified: false })
+      );
+    });
+
+    test('when verified backup exists', () => {
+      const state = new StoreBuilder().withVerifiedBackup();
+
+      expect(Container.mapState(state.build())).toEqual(
+        expect.objectContaining({ backupExists: true, backupVerified: true })
+      );
+    });
+  });
+});

--- a/src/components/logout-confirmation-modal/container.tsx
+++ b/src/components/logout-confirmation-modal/container.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { connectContainer } from '../../store/redux-container';
+import { RootState } from '../../store/reducer';
+import { LogoutConfirmationModal } from '.';
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  backupExists: boolean;
+  backupVerified: boolean;
+
+  action: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    const { trustInfo } = state.matrix;
+
+    return {
+      backupExists: !!trustInfo,
+      backupVerified: Boolean(trustInfo?.usable || trustInfo?.trustedLocally),
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {
+      action: () => null,
+    };
+  }
+
+  render() {
+    return <LogoutConfirmationModal backupExists={true} backupVerified={true} />;
+  }
+}
+
+export const LogoutConfirmationModalContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/logout-confirmation-modal/container.tsx
+++ b/src/components/logout-confirmation-modal/container.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connectContainer } from '../../store/redux-container';
 import { RootState } from '../../store/reducer';
 import { LogoutConfirmationModal } from '.';
+import { closeLogoutModal, forceLogout } from '../../store/authentication';
 
 export interface PublicProperties {}
 
@@ -10,7 +11,8 @@ export interface Properties extends PublicProperties {
   backupExists: boolean;
   backupVerified: boolean;
 
-  action: () => void;
+  closeLogoutModal: () => void;
+  forceLogout: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -24,13 +26,18 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return {
-      action: () => null,
-    };
+    return { closeLogoutModal, forceLogout };
   }
 
   render() {
-    return <LogoutConfirmationModal backupExists={true} backupVerified={true} />;
+    return (
+      <LogoutConfirmationModal
+        backupExists={this.props.backupExists}
+        backupVerified={this.props.backupVerified}
+        onLogout={this.props.forceLogout}
+        onClose={this.props.closeLogoutModal}
+      />
+    );
   }
 }
 

--- a/src/components/logout-confirmation-modal/index.test.tsx
+++ b/src/components/logout-confirmation-modal/index.test.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+
+import { LogoutConfirmationModal, Properties } from '.';
+
+describe(LogoutConfirmationModal, () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      backupExists: false,
+      backupVerified: false,
+      ...props,
+    };
+
+    return shallow(<LogoutConfirmationModal {...allProps} />);
+  };
+
+  it('renders the no-backup-text if a user does not have a backup', function () {
+    const wrapper = subject({ backupExists: false });
+
+    expect(wrapper.find('div').text()).toMatch('You have not created');
+  });
+
+  it('renders the unverified-text if a user has a backup but it is not verified', function () {
+    const wrapper = subject({ backupExists: true, backupVerified: false });
+
+    expect(wrapper.find('div').text()).toMatch('You have not verified');
+  });
+
+  it('renders the logout-warning-text if the user has a backup and is verified', function () {
+    const wrapper = subject({ backupExists: true, backupVerified: true });
+
+    expect(wrapper.find('div').text()).toMatch('You will need to enter');
+  });
+});

--- a/src/components/logout-confirmation-modal/index.test.tsx
+++ b/src/components/logout-confirmation-modal/index.test.tsx
@@ -1,12 +1,15 @@
 import { shallow } from 'enzyme';
 
 import { LogoutConfirmationModal, Properties } from '.';
+import { Modal } from '../modal';
 
 describe(LogoutConfirmationModal, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       backupExists: false,
       backupVerified: false,
+      onClose: () => null,
+      onLogout: () => null,
       ...props,
     };
 
@@ -29,5 +32,32 @@ describe(LogoutConfirmationModal, () => {
     const wrapper = subject({ backupExists: true, backupVerified: true });
 
     expect(wrapper.find('div').text()).toMatch('You will need to enter');
+  });
+
+  it('publishes close event on secondary action', async () => {
+    const onClose = jest.fn();
+    const wrapper = subject({ onClose });
+
+    wrapper.find(Modal).simulate('secondary');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('publishes close event on close action', async () => {
+    const onClose = jest.fn();
+    const wrapper = subject({ onClose });
+
+    wrapper.find(Modal).simulate('close');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('publishes logout event', async () => {
+    const onLogout = jest.fn();
+    const wrapper = subject({ onLogout });
+
+    wrapper.find(Modal).simulate('primary');
+
+    expect(onLogout).toHaveBeenCalled();
   });
 });

--- a/src/components/logout-confirmation-modal/index.tsx
+++ b/src/components/logout-confirmation-modal/index.tsx
@@ -1,0 +1,61 @@
+import { ModalConfirmation } from '@zero-tech/zui/components';
+import * as React from 'react';
+
+export interface Properties {
+  backupExists: boolean;
+  backupVerified: boolean;
+}
+
+export class LogoutConfirmationModal extends React.Component<Properties> {
+  get noBackupText() {
+    return (
+      <>
+        <p>You have not created an account backup. If you log out, you will lose some of your message history.</p>
+        <p>You can backup your account in settings.</p>
+      </>
+    );
+  }
+
+  get unverifiedText() {
+    return (
+      <>
+        <p>
+          You have not verified your login. If you log out, you will lose some of your message history. If this is your
+          only active login, you will not be able to see messages you receive while logged out.
+        </p>
+        <p>You can verify your account in settings.</p>
+      </>
+    );
+  }
+
+  get logoutWarningText() {
+    return (
+      <>
+        <p>
+          You will need to enter your backup phrase to see your message history when you log in again. If this is your
+          only active login, you will not be able to see messages you receive while logged out.
+        </p>
+      </>
+    );
+  }
+
+  render() {
+    return (
+      <ModalConfirmation
+        open
+        title='Are you sure?'
+        cancelLabel='Cancel'
+        confirmationLabel='Log Out'
+        onCancel={() => null}
+        onConfirm={() => null}
+        inProgress={false}
+      >
+        <div>
+          {!this.props.backupExists && this.noBackupText}
+          {this.props.backupExists && !this.props.backupVerified && this.unverifiedText}
+          {this.props.backupExists && this.props.backupVerified && this.logoutWarningText}
+        </div>
+      </ModalConfirmation>
+    );
+  }
+}

--- a/src/components/logout-confirmation-modal/index.tsx
+++ b/src/components/logout-confirmation-modal/index.tsx
@@ -1,9 +1,18 @@
-import { ModalConfirmation } from '@zero-tech/zui/components';
 import * as React from 'react';
+
+import { Modal } from '../modal';
+import { bemClassName } from '../../lib/bem';
+
+import './styles.scss';
+
+const cn = bemClassName('logout-confirmation-modal');
 
 export interface Properties {
   backupExists: boolean;
   backupVerified: boolean;
+
+  onClose: () => void;
+  onLogout: () => void;
 }
 
 export class LogoutConfirmationModal extends React.Component<Properties> {
@@ -41,21 +50,20 @@ export class LogoutConfirmationModal extends React.Component<Properties> {
 
   render() {
     return (
-      <ModalConfirmation
-        open
+      <Modal
         title='Are you sure?'
-        cancelLabel='Cancel'
-        confirmationLabel='Log Out'
-        onCancel={() => null}
-        onConfirm={() => null}
-        inProgress={false}
+        primaryText='Log Out'
+        secondaryText='Cancel'
+        onPrimary={this.props.onLogout}
+        onSecondary={this.props.onClose}
+        onClose={this.props.onClose}
       >
-        <div>
+        <div {...cn()}>
           {!this.props.backupExists && this.noBackupText}
           {this.props.backupExists && !this.props.backupVerified && this.unverifiedText}
           {this.props.backupExists && this.props.backupVerified && this.logoutWarningText}
         </div>
-      </ModalConfirmation>
+      </Modal>
     );
   }
 }

--- a/src/components/logout-confirmation-modal/styles.scss
+++ b/src/components/logout-confirmation-modal/styles.scss
@@ -1,0 +1,5 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.logout-confirmation-modal {
+  width: 416px;
+}

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -42,6 +42,7 @@ describe('messenger-list', () => {
       onConversationClick: jest.fn(),
       createConversation: jest.fn(),
       isBackupDialogOpen: false,
+      displayLogoutModal: false,
       closeConversationErrorDialog: () => null,
       startCreateConversation: () => null,
       membersSelected: () => null,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,7 +15,7 @@ import {
   membersSelected,
   startCreateConversation,
 } from '../../../store/create-conversation';
-import { forceLogout } from '../../../store/authentication';
+import { logout } from '../../../store/authentication';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
 import { closeConversationErrorDialog } from '../../../store/chat';
 
@@ -41,6 +41,7 @@ import { closeBackupDialog } from '../../../store/matrix';
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
 import { SecureBackupContainer } from '../../secure-backup/container';
+import { LogoutConfirmationModalContainer } from '../../logout-confirmation-modal/container';
 
 const cn = bemClassName('direct-message-members');
 
@@ -62,6 +63,7 @@ export interface Properties extends PublicProperties {
   groupManangemenetStage: GroupManagementSagaStage;
   joinRoomErrorContent: ErrorDialogContent;
   isBackupDialogOpen: boolean;
+  displayLogoutModal: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -85,7 +87,7 @@ export class Container extends React.Component<Properties, State> {
     const {
       createConversation,
       registration,
-      authentication: { user },
+      authentication: { user, displayLogoutModal },
       chat: { activeConversationId, joinRoomErrorContent },
       groupManagement,
       matrix: { isBackupDialogOpen },
@@ -109,6 +111,7 @@ export class Container extends React.Component<Properties, State> {
       groupManangemenetStage: groupManagement.stage,
       joinRoomErrorContent,
       isBackupDialogOpen,
+      displayLogoutModal,
     };
   }
 
@@ -120,7 +123,7 @@ export class Container extends React.Component<Properties, State> {
       back,
       startGroup,
       membersSelected,
-      logout: forceLogout,
+      logout,
       receiveSearchResults,
       closeConversationErrorDialog,
       closeBackupDialog,
@@ -320,6 +323,7 @@ export class Container extends React.Component<Properties, State> {
           {this.state.isVerifyIdDialogOpen && this.renderVerifyIdDialog()}
           {this.props.joinRoomErrorContent && this.renderErrorDialog()}
           {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}
+          {this.props.displayLogoutModal && <LogoutConfirmationModalContainer />}
 
           {this.renderToastNotification()}
         </div>

--- a/src/store/authentication/index.ts
+++ b/src/store/authentication/index.ts
@@ -4,10 +4,12 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 export enum SagaActionTypes {
   Logout = 'authentication/saga/logout',
   ForceLogout = 'authentication/saga/force-logout',
+  CloseLogoutModal = 'authentication/saga/close-logout-modal',
 }
 
 export const logout = createAction(SagaActionTypes.Logout);
 export const forceLogout = createAction(SagaActionTypes.ForceLogout);
+export const closeLogoutModal = createAction(SagaActionTypes.CloseLogoutModal);
 
 export const initialState: AuthenticationState = {
   user: { data: null },

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -123,9 +123,7 @@ export function* logoutRequest() {
 }
 
 export function* closeLogoutModal() {
-  console.time('XXX closeLogoutModal');
   yield put(setDisplayLogoutModal(false));
-  console.timeEnd('XXX closeLogoutModal');
 }
 
 export function* forceLogout() {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -115,6 +115,7 @@ export function* clearUserState() {
 export function* saga() {
   yield takeLatest(SagaActionTypes.Logout, logoutRequest);
   yield takeLatest(SagaActionTypes.ForceLogout, forceLogout);
+  yield takeLatest(SagaActionTypes.CloseLogoutModal, closeLogoutModal);
 }
 
 export function* logoutRequest() {
@@ -122,7 +123,9 @@ export function* logoutRequest() {
 }
 
 export function* closeLogoutModal() {
+  console.time('XXX closeLogoutModal');
   yield put(setDisplayLogoutModal(false));
+  console.timeEnd('XXX closeLogoutModal');
 }
 
 export function* forceLogout() {

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -224,7 +224,7 @@ describe(onVerifyKey, () => {
 });
 
 describe(clearBackupState, () => {
-  it('clears the state', async () => {
+  it('clears the temporary state but keeps the trustInfo', async () => {
     const initialState = {
       matrix: {
         isLoaded: true,
@@ -242,7 +242,7 @@ describe(clearBackupState, () => {
     expect(storeState.matrix).toEqual({
       generatedRecoveryKey: null,
       isLoaded: false,
-      trustInfo: null,
+      trustInfo: { trustData: 'here' },
       successMessage: '',
       errorMessage: '',
       backupStage: BackupStage.None,

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -20,6 +20,7 @@ import { waitForChatConnectionCompletion } from '../chat/saga';
 
 export function* saga() {
   yield spawn(listenForUserLogin);
+  yield spawn(listenForUserLogout);
 
   yield takeLatest(SagaActionTypes.GetBackup, getBackup);
   yield takeLatest(SagaActionTypes.GenerateBackup, generateBackup);
@@ -104,7 +105,6 @@ export function* restoreBackup(action) {
 
 export function* clearBackupState() {
   yield put(setLoaded(false));
-  yield put(setTrustInfo(null));
   yield put(setGeneratedRecoveryKey(null));
   yield put(setSuccessMessage(''));
   yield put(setErrorMessage(''));
@@ -164,6 +164,14 @@ export function* closeBackupDialog() {
 
 export function* openBackupDialog() {
   yield put(setIsBackupDialogOpen(true));
+}
+
+function* listenForUserLogout() {
+  const userChannel = yield call(getAuthChannel);
+  while (true) {
+    yield take(userChannel, AuthEvents.UserLogout);
+    yield put(setTrustInfo(null));
+  }
 }
 
 function* listenForUserLogin() {

--- a/src/store/test/store.ts
+++ b/src/store/test/store.ts
@@ -6,6 +6,7 @@ import { User as AuthenticatedUser } from '../authentication/types';
 import { initialState as initialGroupManagementState } from '../group-management';
 import { ChatState } from '../chat/types';
 import { initialState as authenticationInitialState } from '../authentication';
+import { MatrixState, initialState as initialMatrixState } from '../matrix';
 
 export class StoreBuilder {
   channelList: Partial<Channel>[] = [];
@@ -19,6 +20,7 @@ export class StoreBuilder {
   otherState: any = {};
   chatState: Partial<ChatState> = {};
   activeConversationId: string = '';
+  matrix: MatrixState = { ...initialMatrixState };
 
   withActiveConversation(conversation: Partial<Channel>) {
     this.activeConversation = conversation;
@@ -81,6 +83,21 @@ export class StoreBuilder {
     return this;
   }
 
+  withoutBackup() {
+    this.matrix.trustInfo = null;
+    return this;
+  }
+
+  withUnverifiedBackup() {
+    this.matrix.trustInfo = { usable: false, trustedLocally: false, isLegacy: false };
+    return this;
+  }
+
+  withVerifiedBackup() {
+    this.matrix.trustInfo = { usable: false, trustedLocally: true, isLegacy: false };
+    return this;
+  }
+
   build() {
     const { result: channelsList, entities: channelEntitities } = normalizeChannel(
       [
@@ -117,6 +134,9 @@ export class StoreBuilder {
         user: { data: this.currentUser },
       },
       groupManagement: this.groupManagement,
+      matrix: {
+        ...this.matrix,
+      },
       ...this.otherState,
     } as RootState;
   }


### PR DESCRIPTION
### What does this do?

Adds a new modal to warn users of the consequences of logging out given the state of their backup.

### Why are we making this change?

To try to keep users from logging themselves out, or at least doing so with an understanding of what will happen.

