### PR TITLE
Add hack to account for zUI badness with pointer events on the body

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -20,6 +20,16 @@ export interface Properties {
 }
 
 export class Modal extends React.Component<Properties> {
+  componentWillUnmount(): void {
+    // The radix-ui library that underpins zUI has issues where the various dropdowns/selects/etc
+    // end up modifying the body and disabling pointer events when the dialog is closed.
+    // This is a total hack to re-enable pointer events after a short delay.
+    // https://github.com/radix-ui/primitives/issues/1241
+    setTimeout(() => {
+      document.body.style.pointerEvents = '';
+    }, 1000);
+  }
+
   publishIfClosing = (open: boolean) => {
     if (!open) {
       this.props.onClose();


### PR DESCRIPTION
### What does this do?

There are known issues with radix-ui where various versions of "dialog-like" things cause the lib to get into a state where it forces pointer events off on the body. This is the hack solution that the community has come up with. :(


The bug can be reproduced by removing this code then log into the app. Once logged in then do a Logout. After logging out you'll be at the login page and none of the buttons will work. This is because the `pointer-events: none` is set on the body element.