### PR TITLE
Remove the unused welcome toaster

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -36,7 +36,6 @@ describe('messenger-list', () => {
       userHandle: '',
       userAvatarUrl: '',
       userIsOnline: true,
-      isInviteNotificationOpen: false,
       myUserId: '',
       joinRoomErrorContent: null,
       onConversationClick: jest.fn(),

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -26,8 +26,7 @@ import { GroupDetailsPanel } from './group-details-panel';
 import { Option } from '../lib/types';
 import { MembersSelectedPayload } from '../../../store/create-conversation/types';
 import { getMessagePreview, previewDisplayDate } from '../../../lib/chat/chat-message';
-import { Modal, ToastNotification } from '@zero-tech/zui/components';
-import { InviteDialogContainer } from '../../invite-dialog/container';
+import { Modal } from '@zero-tech/zui/components';
 import { ErrorDialog } from '../../error-dialog';
 import { ErrorDialogContent } from '../../../store/chat/types';
 import { receiveSearchResults } from '../../../store/users';
@@ -57,7 +56,6 @@ export interface Properties extends PublicProperties {
   userHandle: string;
   userAvatarUrl: string;
   userIsOnline: boolean;
-  isInviteNotificationOpen: boolean;
   myUserId: string;
   activeConversationId?: string;
   groupManangemenetStage: GroupManagementSagaStage;
@@ -78,7 +76,6 @@ export interface Properties extends PublicProperties {
 }
 
 interface State {
-  isInviteDialogOpen: boolean;
   isVerifyIdDialogOpen: boolean;
 }
 
@@ -102,7 +99,6 @@ export class Container extends React.Component<Properties, State> {
       groupUsers: createConversation.groupUsers,
       isFetchingExistingConversations: createConversation.startGroupChat.isLoading,
       isFirstTimeLogin: registration.isFirstTimeLogin,
-      isInviteNotificationOpen: registration.isInviteToastOpen,
       userName: user?.data?.profileSummary?.firstName || '',
       userHandle,
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
@@ -131,7 +127,6 @@ export class Container extends React.Component<Properties, State> {
   }
 
   state = {
-    isInviteDialogOpen: false,
     isVerifyIdDialogOpen: false,
   };
 
@@ -162,14 +157,6 @@ export class Container extends React.Component<Properties, State> {
     this.props.createConversation(conversation);
   };
 
-  openInviteDialog = () => {
-    this.setState({ isInviteDialogOpen: true });
-  };
-
-  closeInviteDialog = () => {
-    this.setState({ isInviteDialogOpen: false });
-  };
-
   openVerifyIdDialog = () => {
     this.setState({ isVerifyIdDialogOpen: true });
   };
@@ -193,14 +180,6 @@ export class Container extends React.Component<Properties, State> {
   get isErrorDialogOpen(): boolean {
     return !!this.props.joinRoomErrorContent;
   }
-
-  renderInviteDialog = (): JSX.Element => {
-    return (
-      <Modal open={this.state.isInviteDialogOpen} onOpenChange={this.closeInviteDialog}>
-        <InviteDialogContainer onClose={this.closeInviteDialog} />
-      </Modal>
-    );
-  };
 
   renderVerifyIdDialog = (): JSX.Element => {
     return (
@@ -229,22 +208,6 @@ export class Container extends React.Component<Properties, State> {
       <Modal open={this.props.isBackupDialogOpen} onOpenChange={this.closeBackupDialog}>
         <SecureBackupContainer onClose={this.closeBackupDialog} />
       </Modal>
-    );
-  };
-
-  renderToastNotification = (): JSX.Element => {
-    return (
-      <ToastNotification
-        viewportClassName='invite-toast-notification'
-        title={'Invite your friends'}
-        description={'Build your network and message friends to earn more rewards.'}
-        actionTitle={'Invite Friends'}
-        actionAltText={'invite dialog modal call to action'}
-        positionVariant='left'
-        openToast={this.props.isInviteNotificationOpen}
-        onClick={this.openInviteDialog}
-        duration={10000}
-      />
     );
   };
 
@@ -319,13 +282,10 @@ export class Container extends React.Component<Properties, State> {
 
         <div {...cn('')}>
           {this.renderPanel()}
-          {this.state.isInviteDialogOpen && this.renderInviteDialog()}
           {this.state.isVerifyIdDialogOpen && this.renderVerifyIdDialog()}
           {this.props.joinRoomErrorContent && this.renderErrorDialog()}
           {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}
           {this.props.displayLogoutModal && <LogoutConfirmationModalContainer />}
-
-          {this.renderToastNotification()}
         </div>
       </>
     );

--- a/src/store/registration/index.ts
+++ b/src/store/registration/index.ts
@@ -35,7 +35,6 @@ export type RegistrationState = {
   userId: string;
   inviteCode: string;
   isFirstTimeLogin: boolean;
-  isInviteToastOpen: boolean;
 };
 
 export enum AccountCreationErrors {
@@ -67,7 +66,6 @@ export const initialState: RegistrationState = {
   userId: '',
   inviteCode: '',
   isFirstTimeLogin: false,
-  isInviteToastOpen: false,
 };
 
 export const validateInvite = createAction<{ code: string }>(SagaActionTypes.ValidateInvite);
@@ -108,9 +106,6 @@ const slice = createSlice({
       state.stage = RegistrationStage.WalletAccountCreation;
       state.errors = [];
     },
-    setInviteToastOpen: (state, action: PayloadAction<RegistrationState['isInviteToastOpen']>) => {
-      state.isInviteToastOpen = action.payload;
-    },
   },
 });
 
@@ -124,6 +119,5 @@ export const {
   setFirstTimeLogin,
   registerWithEmail,
   registerWithWallet,
-  setInviteToastOpen,
 } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/registration/saga.test.ts
+++ b/src/store/registration/saga.test.ts
@@ -1,5 +1,4 @@
 import { expectSaga } from '../../test/saga';
-import delayP from '@redux-saga/delay-p';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import {
@@ -7,7 +6,6 @@ import {
   clearRegistrationStateOnLogout,
   createAccount,
   createWelcomeConversation,
-  openInviteToastWhenRewardsPopupClosed,
   updateProfile,
   validateAccountInfo,
   validateInvite,
@@ -29,7 +27,6 @@ import {
   RegistrationState,
   initialState as initialRegistrationState,
 } from '.';
-import { SagaActionTypes as RewardsSagaActionTypes } from '../rewards';
 import { rootReducer } from '../reducer';
 import { fetchCurrentUser } from '../authentication/api';
 import { nonce as nonceApi } from '../authentication/api';
@@ -500,28 +497,6 @@ describe('validateAccountInfo', () => {
     const errors = validateAccountInfo({ email, password });
 
     expect(errors).toEqual([AccountCreationErrors.PASSWORD_TOO_WEAK]);
-  });
-});
-
-describe('openInviteToastWhenRewardsPopupClosed', () => {
-  it('sets the invite open flag after the rewards propup is closed', async () => {
-    const {
-      storeState: { registration },
-    } = await expectSaga(openInviteToastWhenRewardsPopupClosed)
-      .provide([
-        [
-          matchers.take(RewardsSagaActionTypes.RewardsPopupClosed),
-          { type: RewardsSagaActionTypes.RewardsPopupClosed },
-        ],
-        [
-          call(delayP, 10000), // delayP is what delay calls behind the scenes. Not ideal but it works.
-          true,
-        ],
-      ])
-      .withReducer(rootReducer, initialState({ isInviteToastOpen: false }))
-      .run();
-
-    expect(registration.isInviteToastOpen).toEqual(true);
   });
 });
 

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -1,4 +1,4 @@
-import { call, delay, put, race, select, spawn, take } from 'redux-saga/effects';
+import { call, put, race, select, spawn, take } from 'redux-saga/effects';
 import {
   AccountCreationErrors,
   InviteCodeStatus,
@@ -12,9 +12,7 @@ import {
   setInviteCode,
   setUserId,
   setFirstTimeLogin,
-  setInviteToastOpen,
 } from '.';
-import { SagaActionTypes as RewardsSagaActionTypes } from '../rewards';
 import {
   validateInvite as apiValidateInvite,
   createAccount as apiCreateAccount,
@@ -225,7 +223,6 @@ export function* clearRegistrationStateOnLogout() {
   const authChannel = yield call(getAuthChannel);
   yield take(authChannel, AuthEvents.UserLogout);
   yield put(setFirstTimeLogin(false));
-  yield put(setInviteToastOpen(false));
 }
 
 // sets initial state & takes the user to "complete profile" page
@@ -246,15 +243,6 @@ export function* saga() {
   yield validateInvitePage();
   yield createAccountPage();
   yield updateProfilePage();
-
-  // After successful registration
-  yield spawn(openInviteToastWhenRewardsPopupClosed);
-}
-
-export function* openInviteToastWhenRewardsPopupClosed() {
-  yield take(RewardsSagaActionTypes.RewardsPopupClosed);
-  yield delay(10000);
-  yield put(setInviteToastOpen(true));
 }
 
 export function* createWelcomeConversation(userId: string, inviter: { id: string; matrixId: string }) {


### PR DESCRIPTION
### What does this do?

We used to encourage new users to invite more people when they registered but since we've decided not to any more.

This removes that Toast notification.

