### PR TITLE
Display `Message Hidden` text if edit message cannot be decrypted

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -348,6 +348,7 @@ export class MatrixClient implements IChatClient {
       ...message,
       content: { ...message.content, body: newContent.body },
       updatedAt: timestamp,
+      isHidden: false,
     };
   }
 
@@ -355,8 +356,9 @@ export class MatrixClient implements IChatClient {
     return {
       ...message,
       content: { ...message.content },
-      message: 'Message edit cannot be decrypted.',
+      message: 'Message hidden',
       updatedAt: timestamp,
+      isHidden: true,
     };
   }
 

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -27,7 +27,7 @@ function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
       }
 
       message.parentMessage = parentMessage;
-      message.parentMessageText = parentMessage.message;
+      message.parentMessageText = parentMessage.isHidden ? 'Message hidden' : parentMessage.message;
     }
   }
 }


### PR DESCRIPTION
### What does this do?

Before:

<img width="732" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/3499770d-3064-46dc-b367-1d8a2d46f7c2">

<img width="565" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/79d6f137-f56c-45cd-8d49-c6fd76ac7048">

After

<img width="210" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/9d122aba-3097-4088-9d06-480fd2751c7b">

<img width="216" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/df851220-147b-41d5-8728-dc8ce74926fe">
