### PR TITLE
Remove rendering of Backup modal from SettingsMenu

### DIFF
--- a/src/components/messenger/list/user-header/index.test.tsx
+++ b/src/components/messenger/list/user-header/index.test.tsx
@@ -1,9 +1,9 @@
 import { shallow } from 'enzyme';
 import { Properties, UserHeader } from '.';
-import { SettingsMenu } from '../../../settings-menu';
 import { Button, IconButton } from '@zero-tech/zui/components';
 
 import { bem } from '../../../../lib/bem';
+import { SettingsMenuContainer } from '../../../settings-menu/container';
 
 const c = bem('.user-header');
 
@@ -32,12 +32,12 @@ describe(UserHeader, () => {
 
   it('renders SettingsMenu when includeUserSettings is true', function () {
     const wrapper = subject({ includeUserSettings: true });
-    expect(wrapper).toHaveElement(SettingsMenu);
+    expect(wrapper).toHaveElement(SettingsMenuContainer);
   });
 
   it('does not render SettingsMenu when includeUserSettings is false', function () {
     const wrapper = subject({ includeUserSettings: false });
-    expect(wrapper).not.toHaveElement(SettingsMenu);
+    expect(wrapper).not.toHaveElement(SettingsMenuContainer);
   });
 
   it('renders userHandle when user handle is not empty', function () {

--- a/src/components/messenger/list/user-header/index.tsx
+++ b/src/components/messenger/list/user-header/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { SettingsMenu } from '../../../settings-menu';
+import { SettingsMenuContainer } from '../../../settings-menu/container';
 import { Button, IconButton } from '@zero-tech/zui/components';
 import { IconPlus } from '@zero-tech/zui/icons';
 
@@ -59,7 +59,7 @@ export class UserHeader extends React.Component<Properties> {
     return (
       <div {...cn('')}>
         {this.props.includeUserSettings && (
-          <SettingsMenu
+          <SettingsMenuContainer
             onLogout={this.props.onLogout}
             userName={this.props.userName}
             userHandle={this.props.userHandle}

--- a/src/components/settings-menu/container.test.tsx
+++ b/src/components/settings-menu/container.test.tsx
@@ -1,0 +1,12 @@
+import { StoreBuilder } from '../../store/test/store';
+import { Container } from './container';
+
+describe(Container, () => {
+  describe('mapState', () => {
+    test('returns empty props', () => {
+      const state = new StoreBuilder();
+
+      expect(Container.mapState(state.build())).toEqual({});
+    });
+  });
+});

--- a/src/components/settings-menu/container.tsx
+++ b/src/components/settings-menu/container.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { connectContainer } from '../../store/redux-container';
 import { RootState } from '../../store/reducer';
+import { openBackupDialog } from '../../store/matrix';
 import { SettingsMenu } from '.';
 
 export interface PublicProperties {
@@ -13,7 +14,9 @@ export interface PublicProperties {
   onLogout: () => void;
 }
 
-export interface Properties extends PublicProperties {}
+export interface Properties extends PublicProperties {
+  openBackupDialog: typeof openBackupDialog;
+}
 
 export class Container extends React.Component<Properties> {
   static mapState(_state: RootState): Partial<Properties> {
@@ -21,7 +24,7 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return {};
+    return { openBackupDialog };
   }
 
   render() {
@@ -32,6 +35,7 @@ export class Container extends React.Component<Properties> {
         userAvatarUrl={this.props.userAvatarUrl}
         userStatus={this.props.userStatus}
         onLogout={this.props.onLogout}
+        onSecureBackup={this.props.openBackupDialog}
       />
     );
   }

--- a/src/components/settings-menu/container.tsx
+++ b/src/components/settings-menu/container.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { connectContainer } from '../../store/redux-container';
+import { RootState } from '../../store/reducer';
+import { SettingsMenu } from '.';
+
+export interface PublicProperties {
+  userName: string;
+  userHandle: string;
+  userAvatarUrl: string;
+  userStatus: 'active' | 'offline';
+
+  onLogout: () => void;
+}
+
+export interface Properties extends PublicProperties {}
+
+export class Container extends React.Component<Properties> {
+  static mapState(_state: RootState): Partial<Properties> {
+    return {};
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {};
+  }
+
+  render() {
+    return (
+      <SettingsMenu
+        userName={this.props.userName}
+        userHandle={this.props.userHandle}
+        userAvatarUrl={this.props.userAvatarUrl}
+        userStatus={this.props.userStatus}
+        onLogout={this.props.onLogout}
+      />
+    );
+  }
+}
+export const SettingsMenuContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/settings-menu/index.test.tsx
+++ b/src/components/settings-menu/index.test.tsx
@@ -4,6 +4,7 @@ import { Properties, SettingsMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
 import { EditProfileContainer } from '../edit-profile/container';
 import { SecureBackupContainer } from '../secure-backup/container';
+import { selectDropdownItem } from '../../test/utils';
 
 describe('settings-menu', () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -20,27 +21,18 @@ describe('settings-menu', () => {
     return shallow(<SettingsMenu {...allProps} />);
   };
 
-  it('renders DropdownMenu component', function () {
-    const wrapper = subject({});
-
-    expect(wrapper).toHaveElement(DropdownMenu);
-  });
-
   it('opens profile dialog', function () {
     const wrapper = subject({});
-    const dropdownMenu = wrapper.find(DropdownMenu);
 
-    const editProfileItem = dropdownMenu.prop('items').find((item) => item.id === 'edit_profile');
-    editProfileItem.onSelect();
+    selectDropdownItem(wrapper, DropdownMenu, 'edit_profile');
 
     expect(wrapper.find(EditProfileContainer).parent().prop('open')).toBe(true);
   });
 
   it('opens secure backup dialog', function () {
     const wrapper = subject({});
-    const dropdownMenu = wrapper.find(DropdownMenu);
-    const menuItem = dropdownMenu.prop('items').find((item) => item.id === 'secure_backup');
-    menuItem.onSelect();
+
+    selectDropdownItem(wrapper, DropdownMenu, 'secure_backup');
 
     expect(wrapper.find(SecureBackupContainer).parent().prop('open')).toBe(true);
   });
@@ -48,10 +40,9 @@ describe('settings-menu', () => {
   it('calls onLogout prop when logout item is selected', function () {
     const mockOnLogout = jest.fn();
     const wrapper = subject({ onLogout: mockOnLogout });
-    const dropdownMenu = wrapper.find(DropdownMenu);
 
-    const logoutItem = dropdownMenu.prop('items').find((item) => item.id === 'logout');
-    logoutItem.onSelect();
+    selectDropdownItem(wrapper, DropdownMenu, 'logout');
+
     expect(mockOnLogout).toHaveBeenCalled();
   });
 });

--- a/src/components/settings-menu/index.test.tsx
+++ b/src/components/settings-menu/index.test.tsx
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 import { Properties, SettingsMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
 import { EditProfileContainer } from '../edit-profile/container';
-import { SecureBackupContainer } from '../secure-backup/container';
 import { selectDropdownItem } from '../../test/utils';
 
 describe('settings-menu', () => {
@@ -14,6 +13,7 @@ describe('settings-menu', () => {
       userAvatarUrl: '',
       userStatus: 'active',
       onLogout: () => {},
+      onSecureBackup: () => {},
 
       ...props,
     };
@@ -29,12 +29,13 @@ describe('settings-menu', () => {
     expect(wrapper.find(EditProfileContainer).parent().prop('open')).toBe(true);
   });
 
-  it('opens secure backup dialog', function () {
-    const wrapper = subject({});
+  it('fires secure backup selected event', function () {
+    const onSecureBackup = jest.fn();
+    const wrapper = subject({ onSecureBackup });
 
     selectDropdownItem(wrapper, DropdownMenu, 'secure_backup');
 
-    expect(wrapper.find(SecureBackupContainer).parent().prop('open')).toBe(true);
+    expect(onSecureBackup).toHaveBeenCalled();
   });
 
   it('calls onLogout prop when logout item is selected', function () {

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -7,9 +7,6 @@ import { Avatar, DropdownMenu, Modal } from '@zero-tech/zui/components';
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
-import { SecureBackupContainer } from '../secure-backup/container';
-
-const cn = bemClassName('settings-menu');
 
 export interface Properties {
   userName: string;
@@ -18,12 +15,12 @@ export interface Properties {
   userStatus: 'active' | 'offline';
 
   onLogout: () => void;
+  onSecureBackup: () => void;
 }
 
 interface State {
   isDropdownOpen: boolean;
   editProfileDialogOpen: boolean;
-  backupDialogOpen: boolean;
 }
 
 export class SettingsMenu extends React.Component<Properties, State> {
@@ -32,7 +29,6 @@ export class SettingsMenu extends React.Component<Properties, State> {
     this.state = {
       isDropdownOpen: false,
       editProfileDialogOpen: false,
-      backupDialogOpen: false,
     };
   }
 
@@ -65,25 +61,10 @@ export class SettingsMenu extends React.Component<Properties, State> {
     this.setState({ editProfileDialogOpen: false });
   };
 
-  openBackupDialog = (): void => {
-    this.setState({ backupDialogOpen: true });
-  };
-  closeBackupDialog = (): void => {
-    this.setState({ backupDialogOpen: false });
-  };
-
   renderEditProfileDialog = (): JSX.Element => {
     return (
       <Modal open={this.state.editProfileDialogOpen} onOpenChange={this.closeEditProfileDialog}>
         <EditProfileContainer onClose={this.closeEditProfileDialog} />
-      </Modal>
-    );
-  };
-
-  renderBackupDialog = (): JSX.Element => {
-    return (
-      <Modal open={this.state.backupDialogOpen} onOpenChange={this.closeBackupDialog} {...cn('secure-backup-modal')}>
-        <SecureBackupContainer onClose={this.closeBackupDialog} />
       </Modal>
     );
   };
@@ -110,7 +91,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
       className: 'secure_backup',
       id: 'secure_backup',
       label: this.renderSettingsOption(<IconLock1 />, 'Secure Backup'),
-      onSelect: this.openBackupDialog,
+      onSelect: this.props.onSecureBackup,
     });
 
     return [
@@ -162,7 +143,6 @@ export class SettingsMenu extends React.Component<Properties, State> {
           itemSize='spacious'
         />
         {this.renderEditProfileDialog()}
-        {this.renderBackupDialog()}
       </>
     );
   }

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -19,3 +19,9 @@ export function pressButton(wrapper, label: string) {
 export async function releaseThread() {
   await new Promise(jest.requireActual('timers').setImmediate);
 }
+
+export function selectDropdownItem(wrapper, selector, itemId: string) {
+  const dropdownMenu = wrapper.find(selector);
+  const menuItem = dropdownMenu.prop('items').find((item) => item.id === itemId);
+  menuItem.onSelect();
+}


### PR DESCRIPTION
### What does this do?

Since we now render the SecureBackup dialog more globally via state this removes the custom rendering from the SettingsMenu and just uses the saga to open the dialog

