### PR TITLE
Split backup phases to user/system initiated ones

### DIFF
--- a/src/components/secure-backup/generate-prompt/index.tsx
+++ b/src/components/secure-backup/generate-prompt/index.tsx
@@ -10,7 +10,7 @@ import '../styles.scss';
 const cn = bemClassName('secure-backup');
 
 export interface Properties {
-  isSystemPrompt: boolean;
+  isSystemPrompt?: boolean;
   errorMessage: string;
 
   onGenerate: () => void;

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -13,7 +13,7 @@ import { Success } from './success';
 import { bem } from '../../lib/bem';
 const c = bem('.secure-backup');
 
-describe('SecureBackup', () => {
+describe(SecureBackup, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       recoveryKey: 'stub-key',

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -146,6 +146,12 @@ describe('SecureBackup', () => {
   });
 
   describe(RecoveredBackup, () => {
+    it('renders RecoveredBackup when stage is RecoveredBackupInfo', function () {
+      const wrapper = subject({ backupStage: BackupStage.RecoveredBackupInfo });
+
+      expect(wrapper).toHaveElement(RecoveredBackup);
+    });
+
     it('renders RecoveredBackup when stage is None, backup is recovered, backup exists and no recovery key', function () {
       const wrapper = subject({
         backupStage: BackupStage.None,

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -47,7 +47,7 @@ describe('SecureBackup', () => {
     it('renders GeneratePrompt when stage is None, backup does not exists and no recovery key', function () {
       const wrapper = subject({ backupStage: BackupStage.None, backupExists: false, recoveryKey: '' });
 
-      expect(wrapper).toHaveElement(GeneratePrompt);
+      expect(wrapper.find(GeneratePrompt)).toHaveProp('isSystemPrompt', false);
     });
 
     it('publishes onGenerate for system prompt', function () {

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -86,6 +86,12 @@ describe('SecureBackup', () => {
   });
 
   describe(RestorePrompt, () => {
+    it('renders RestorePrompt when stage is SystemRestorePrompt', function () {
+      const wrapper = subject({ backupStage: BackupStage.SystemRestorePrompt });
+
+      expect(wrapper.find(RestorePrompt)).toHaveProp('isSystemPrompt', true);
+    });
+
     it('renders RestorePrompt when stage is None, backup exists, backup not restored and recovery key exists', function () {
       const wrapper = subject({
         backupStage: BackupStage.None,

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -38,6 +38,12 @@ describe('SecureBackup', () => {
   };
 
   describe(GeneratePrompt, () => {
+    it('renders GeneratePrompt when stage is SystemGeneratePrompt', function () {
+      const wrapper = subject({ backupStage: BackupStage.SystemGeneratePrompt });
+
+      expect(wrapper.find(GeneratePrompt)).toHaveProp('isSystemPrompt', true);
+    });
+
     it('renders GeneratePrompt when stage is None, backup does not exists and no recovery key', function () {
       const wrapper = subject({ backupStage: BackupStage.None, backupExists: false, recoveryKey: '' });
 

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -44,10 +44,10 @@ describe('SecureBackup', () => {
       expect(wrapper.find(GeneratePrompt)).toHaveProp('isSystemPrompt', true);
     });
 
-    it('renders GeneratePrompt when stage is None, backup does not exists and no recovery key', function () {
-      const wrapper = subject({ backupStage: BackupStage.None, backupExists: false, recoveryKey: '' });
+    it('renders GeneratePrompt when stage is UserGeneratePrompt', function () {
+      const wrapper = subject({ backupStage: BackupStage.UserGeneratePrompt });
 
-      expect(wrapper.find(GeneratePrompt)).toHaveProp('isSystemPrompt', false);
+      expect(wrapper.find(GeneratePrompt).prop('isSystemPrompt')).toBeFalsy();
     });
 
     it('publishes onGenerate for system prompt', function () {
@@ -61,12 +61,7 @@ describe('SecureBackup', () => {
 
     it('publishes onGenerate for user prompt', function () {
       const onGenerate = jest.fn();
-      const wrapper = subject({
-        backupStage: BackupStage.None,
-        backupExists: false,
-        recoveryKey: '',
-        onGenerate,
-      });
+      const wrapper = subject({ backupStage: BackupStage.UserGeneratePrompt, onGenerate });
 
       wrapper.find(GeneratePrompt).simulate('generate');
 
@@ -90,15 +85,10 @@ describe('SecureBackup', () => {
       expect(wrapper.find(RestorePrompt)).toHaveProp('isSystemPrompt', true);
     });
 
-    it('renders RestorePrompt when stage is None, backup exists, backup not restored and recovery key exists', function () {
-      const wrapper = subject({
-        backupStage: BackupStage.None,
-        backupExists: true,
-        isBackupRecovered: false,
-        recoveryKey: 'key',
-      });
+    it('renders RestorePrompt when stage is UserRestoreBackup', function () {
+      const wrapper = subject({ backupStage: BackupStage.UserRestorePrompt });
 
-      expect(wrapper.find(RestorePrompt)).toHaveProp('isSystemPrompt', false);
+      expect(wrapper.find(RestorePrompt).prop('isSystemPrompt')).toBeFalsy();
     });
 
     it('publishes onVerifyKey (system)', function () {
@@ -112,13 +102,7 @@ describe('SecureBackup', () => {
 
     it('publishes onVerifyKey (user)', function () {
       const onVerifyKey = jest.fn();
-      const wrapper = subject({
-        backupStage: BackupStage.None,
-        backupExists: true,
-        isBackupRecovered: false,
-        recoveryKey: 'key',
-        onVerifyKey,
-      });
+      const wrapper = subject({ backupStage: BackupStage.UserRestorePrompt, onVerifyKey });
 
       wrapper.find(RestorePrompt).simulate('next');
 

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -22,7 +22,7 @@ describe('SecureBackup', () => {
       isLegacy: false,
       successMessage: '',
       errorMessage: '',
-      backupStage: BackupStage.None,
+      backupStage: BackupStage.UserGeneratePrompt,
 
       onGenerate: () => null,
       onRestore: () => null,
@@ -126,41 +126,9 @@ describe('SecureBackup', () => {
       expect(wrapper).toHaveElement(RecoveredBackup);
     });
 
-    it('renders RecoveredBackup when stage is None, backup is recovered, backup exists and no recovery key', function () {
-      const wrapper = subject({
-        backupStage: BackupStage.None,
-        backupExists: true,
-        isBackupRecovered: true,
-        recoveryKey: '',
-      });
-
-      expect(wrapper).toHaveElement(RecoveredBackup);
-    });
-
     it('publishes onClose', function () {
       const onClose = jest.fn();
-      const wrapper = subject({
-        backupStage: BackupStage.RecoveredBackupInfo,
-        backupExists: true,
-        isBackupRecovered: true,
-        recoveryKey: '',
-        onClose,
-      });
-
-      wrapper.find(RecoveredBackup).simulate('close');
-
-      expect(onClose).toHaveBeenCalled();
-    });
-
-    it('publishes onClose (deprecated user)', function () {
-      const onClose = jest.fn();
-      const wrapper = subject({
-        backupStage: BackupStage.None,
-        backupExists: true,
-        isBackupRecovered: true,
-        recoveryKey: '',
-        onClose,
-      });
+      const wrapper = subject({ backupStage: BackupStage.RecoveredBackupInfo, onClose });
 
       wrapper.find(RecoveredBackup).simulate('close');
 
@@ -170,14 +138,7 @@ describe('SecureBackup', () => {
     // TODO: this goes away!
     it('publishes onGenerate when isLegacy is true', function () {
       const onGenerate = jest.fn();
-      const wrapper = subject({
-        backupStage: BackupStage.None,
-        backupExists: true,
-        isBackupRecovered: true,
-        recoveryKey: '',
-        onGenerate,
-        isLegacy: true,
-      });
+      const wrapper = subject({ backupStage: BackupStage.RecoveredBackupInfo, onGenerate, isLegacy: true });
 
       wrapper.find(RecoveredBackup).simulate('generate');
 

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -58,10 +58,6 @@ export class SecureBackup extends React.PureComponent<Properties> {
     return this.props.backupExists && !this.props.isBackupRecovered;
   }
 
-  get isSystemPrompt() {
-    return this.backupStage === BackupStage.SystemPrompt;
-  }
-
   renderHeader = () => {
     const title = this.backupNotRestored ? 'Verify Login' : 'Account Backup';
 
@@ -103,21 +99,18 @@ export class SecureBackup extends React.PureComponent<Properties> {
       case BackupStage.RecoveredBackupInfo:
         return <RecoveredBackup onClose={onClose} onGenerate={onGenerate} isLegacy={isLegacy} />;
       case BackupStage.None:
-      case BackupStage.SystemPrompt:
         return (
           <>
             {this.noBackupExists && (
               <GeneratePrompt
-                isSystemPrompt={this.isSystemPrompt}
+                isSystemPrompt={false}
                 errorMessage={errorMessage}
                 onGenerate={onGenerate}
                 onClose={onClose}
               />
             )}
 
-            {this.backupNotRestored && (
-              <RestorePrompt isSystemPrompt={this.isSystemPrompt} onNext={onVerifyKey} onClose={onClose} />
-            )}
+            {this.backupNotRestored && <RestorePrompt isSystemPrompt={false} onNext={onVerifyKey} onClose={onClose} />}
 
             {this.isRecovered && <RecoveredBackup onClose={onClose} onGenerate={onGenerate} isLegacy={isLegacy} />}
           </>

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -42,24 +42,12 @@ export interface Properties {
 }
 
 export class SecureBackup extends React.PureComponent<Properties> {
-  get backupStage() {
-    return this.props.backupStage;
-  }
-
-  get isRecovered() {
-    return this.props.backupExists && this.props.isBackupRecovered && !this.props.recoveryKey;
-  }
-
-  get noBackupExists() {
-    return !this.props.backupExists && !this.props.recoveryKey;
-  }
-
-  get backupNotRestored() {
+  get existingBackupNotRestored() {
     return this.props.backupExists && !this.props.isBackupRecovered;
   }
 
   renderHeader = () => {
-    const title = this.backupNotRestored ? 'Verify Login' : 'Account Backup';
+    const title = this.existingBackupNotRestored ? 'Verify Login' : 'Account Backup';
 
     return (
       <div {...cn('header')}>

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -94,31 +94,18 @@ export class SecureBackup extends React.PureComponent<Properties> {
     switch (backupStage) {
       case BackupStage.UserGeneratePrompt:
         return <GeneratePrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
+
       case BackupStage.UserRestorePrompt:
         return <RestorePrompt onNext={onVerifyKey} onClose={onClose} />;
+
       case BackupStage.SystemGeneratePrompt:
         return <GeneratePrompt isSystemPrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
+
       case BackupStage.SystemRestorePrompt:
         return <RestorePrompt isSystemPrompt onNext={onVerifyKey} onClose={onClose} />;
+
       case BackupStage.RecoveredBackupInfo:
         return <RecoveredBackup onClose={onClose} onGenerate={onGenerate} isLegacy={isLegacy} />;
-      case BackupStage.None:
-        return (
-          <>
-            {this.noBackupExists && (
-              <GeneratePrompt
-                isSystemPrompt={false}
-                errorMessage={errorMessage}
-                onGenerate={onGenerate}
-                onClose={onClose}
-              />
-            )}
-
-            {this.backupNotRestored && <RestorePrompt isSystemPrompt={false} onNext={onVerifyKey} onClose={onClose} />}
-
-            {this.isRecovered && <RecoveredBackup onClose={onClose} onGenerate={onGenerate} isLegacy={isLegacy} />}
-          </>
-        );
 
       case BackupStage.GenerateBackup:
         return <GenerateBackup recoveryKey={recoveryKey} errorMessage={errorMessage} onNext={onVerifyKey} />;

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -100,6 +100,8 @@ export class SecureBackup extends React.PureComponent<Properties> {
         return <GeneratePrompt isSystemPrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
       case BackupStage.SystemRestorePrompt:
         return <RestorePrompt isSystemPrompt onNext={onVerifyKey} onClose={onClose} />;
+      case BackupStage.RecoveredBackupInfo:
+        return <RecoveredBackup onClose={onClose} onGenerate={onGenerate} isLegacy={isLegacy} />;
       case BackupStage.None:
       case BackupStage.SystemPrompt:
         return (

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -98,6 +98,8 @@ export class SecureBackup extends React.PureComponent<Properties> {
     switch (backupStage) {
       case BackupStage.SystemGeneratePrompt:
         return <GeneratePrompt isSystemPrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
+      case BackupStage.SystemRestorePrompt:
+        return <RestorePrompt isSystemPrompt onNext={onVerifyKey} onClose={onClose} />;
       case BackupStage.None:
       case BackupStage.SystemPrompt:
         return (

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -92,6 +92,10 @@ export class SecureBackup extends React.PureComponent<Properties> {
     } = this.props;
 
     switch (backupStage) {
+      case BackupStage.UserGeneratePrompt:
+        return <GeneratePrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
+      case BackupStage.UserRestorePrompt:
+        return <RestorePrompt onNext={onVerifyKey} onClose={onClose} />;
       case BackupStage.SystemGeneratePrompt:
         return <GeneratePrompt isSystemPrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
       case BackupStage.SystemRestorePrompt:
@@ -129,7 +133,7 @@ export class SecureBackup extends React.PureComponent<Properties> {
         return <Success successMessage={successMessage} onClose={onClose} />;
 
       default:
-        return null;
+        assertNeverReached(backupStage);
     }
   };
 
@@ -142,4 +146,9 @@ export class SecureBackup extends React.PureComponent<Properties> {
       </div>
     );
   }
+}
+
+// Ensure all enum values are handled
+function assertNeverReached(x: never): never {
+  throw new Error('Unexpected type: ' + x);
 }

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -96,6 +96,8 @@ export class SecureBackup extends React.PureComponent<Properties> {
     } = this.props;
 
     switch (backupStage) {
+      case BackupStage.SystemGeneratePrompt:
+        return <GeneratePrompt isSystemPrompt errorMessage={errorMessage} onGenerate={onGenerate} onClose={onClose} />;
       case BackupStage.None:
       case BackupStage.SystemPrompt:
         return (

--- a/src/components/secure-backup/restore-prompt/index.tsx
+++ b/src/components/secure-backup/restore-prompt/index.tsx
@@ -15,7 +15,7 @@ enum Status {
 }
 
 export interface Properties {
-  isSystemPrompt: boolean;
+  isSystemPrompt?: boolean;
 
   onNext: () => void;
   onClose: () => void;

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -21,6 +21,7 @@ export enum SagaActionTypes {
 export enum BackupStage {
   None = 'none',
   SystemPrompt = 'system_prompt',
+  SystemGeneratePrompt = 'system_generate_prompt',
   VerifyKeyPhrase = 'verify_key_phrase',
   GenerateBackup = 'generate_backup',
   RestoreBackup = 'restore_backup',

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -23,6 +23,7 @@ export enum BackupStage {
   SystemPrompt = 'system_prompt',
   SystemGeneratePrompt = 'system_generate_prompt',
   SystemRestorePrompt = 'system_restore_prompt',
+  RecoveredBackupInfo = 'recovered_backup_info',
   VerifyKeyPhrase = 'verify_key_phrase',
   GenerateBackup = 'generate_backup',
   RestoreBackup = 'restore_backup',

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -19,7 +19,6 @@ export enum SagaActionTypes {
 }
 
 export enum BackupStage {
-  None = 'none',
   UserGeneratePrompt = 'user_generate_prompt',
   UserRestorePrompt = 'user_restore_prompt',
   SystemGeneratePrompt = 'system_generate_prompt',

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -20,7 +20,6 @@ export enum SagaActionTypes {
 
 export enum BackupStage {
   None = 'none',
-  SystemPrompt = 'system_prompt',
   SystemGeneratePrompt = 'system_generate_prompt',
   SystemRestorePrompt = 'system_restore_prompt',
   RecoveredBackupInfo = 'recovered_backup_info',

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -22,6 +22,7 @@ export enum BackupStage {
   None = 'none',
   SystemPrompt = 'system_prompt',
   SystemGeneratePrompt = 'system_generate_prompt',
+  SystemRestorePrompt = 'system_restore_prompt',
   VerifyKeyPhrase = 'verify_key_phrase',
   GenerateBackup = 'generate_backup',
   RestoreBackup = 'restore_backup',

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -20,6 +20,8 @@ export enum SagaActionTypes {
 
 export enum BackupStage {
   None = 'none',
+  UserGeneratePrompt = 'user_generate_prompt',
+  UserRestorePrompt = 'user_restore_prompt',
   SystemGeneratePrompt = 'system_generate_prompt',
   SystemRestorePrompt = 'system_restore_prompt',
   RecoveredBackupInfo = 'recovered_backup_info',
@@ -48,7 +50,7 @@ export const initialState: MatrixState = {
   errorMessage: '',
   deviceId: '',
   isBackupDialogOpen: false,
-  backupStage: BackupStage.None,
+  backupStage: BackupStage.UserGeneratePrompt, // Assume there is no backup by default
 };
 
 export const getBackup = createAction(SagaActionTypes.GetBackup);

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -391,7 +391,7 @@ describe(handleBackupUserPrompts, () => {
 });
 
 describe(systemInitiatedBackupDialog, () => {
-  it('opens the backup dialog in GeneratePrompt state if user has no backup', async () => {
+  it('opens the backup dialog in SystemGeneratePrompt state if user has no backup', async () => {
     const state = new StoreBuilder().withoutBackup();
     const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
 
@@ -399,8 +399,16 @@ describe(systemInitiatedBackupDialog, () => {
     expect(storeState.matrix.backupStage).toBe(BackupStage.SystemGeneratePrompt);
   });
 
-  it('opens the backup dialog and sets stage - deprecated', async () => {
-    const state = new StoreBuilder().withUnverifiedBackup();
+  it('opens the backup dialog in SystemRestorePrompt state if user has an unrestored backup', async () => {
+    const state = new StoreBuilder().withUnrestoredBackup();
+    const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+
+    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.backupStage).toBe(BackupStage.SystemRestorePrompt);
+  });
+
+  it('opens the backup dialog in Deprecated state if user has a restored backup - default but probably should not happen', async () => {
+    const state = new StoreBuilder().withRestoredBackup();
     const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
 
     expect(storeState.matrix.isBackupDialogOpen).toBe(true);

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -407,12 +407,12 @@ describe(systemInitiatedBackupDialog, () => {
     expect(storeState.matrix.backupStage).toBe(BackupStage.SystemRestorePrompt);
   });
 
-  it('opens the backup dialog in Deprecated state if user has a restored backup - default but probably should not happen', async () => {
+  it('opens the backup dialog in RecoveredBackupInfo state if user has a restored backup - default but probably should not happen', async () => {
     const state = new StoreBuilder().withRestoredBackup();
     const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
 
     expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.SystemPrompt);
+    expect(storeState.matrix.backupStage).toBe(BackupStage.RecoveredBackupInfo);
   });
 });
 

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -275,7 +275,7 @@ describe(clearBackupState, () => {
         trustInfo: { trustData: 'here' },
         successMessage: 'Stuff happened',
         errorMessage: 'An error',
-        backupStage: BackupStage.SystemPrompt,
+        backupStage: BackupStage.SystemGeneratePrompt,
       },
     };
     const { storeState } = await subject(clearBackupState)

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -228,11 +228,15 @@ export function* handleBackupUserPrompts() {
 
 export function* systemInitiatedBackupDialog() {
   const trustInfo = yield select((state) => state.matrix.trustInfo);
+
   if (!trustInfo) {
     yield put(setBackupStage(BackupStage.SystemGeneratePrompt));
+  } else if (!trustInfo.usable && !trustInfo.trustedLocally) {
+    yield put(setBackupStage(BackupStage.SystemRestorePrompt));
   } else {
     yield put(setBackupStage(BackupStage.SystemPrompt));
   }
+
   yield put(setIsBackupDialogOpen(true));
 }
 

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -234,7 +234,8 @@ export function* systemInitiatedBackupDialog() {
   } else if (!trustInfo.usable && !trustInfo.trustedLocally) {
     yield put(setBackupStage(BackupStage.SystemRestorePrompt));
   } else {
-    yield put(setBackupStage(BackupStage.SystemPrompt));
+    // Probably never trigger this stage by the system but keep it as a default case
+    yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
   }
 
   yield put(setIsBackupDialogOpen(true));

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -27,7 +27,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.SaveBackup, saveBackup);
   yield takeLatest(SagaActionTypes.RestoreBackup, restoreBackup);
   yield takeLatest(SagaActionTypes.ClearBackup, clearBackupState);
-  yield takeLatest(SagaActionTypes.OpenBackupDialog, openBackupDialog);
+  yield takeLatest(SagaActionTypes.OpenBackupDialog, userInitiatedBackupDialog);
   yield takeLatest(SagaActionTypes.CloseBackupDialog, closeBackupDialog);
   yield takeLatest(SagaActionTypes.VerifyKey, proceedToVerifyKey);
 
@@ -76,7 +76,7 @@ export function* generateBackup() {
     yield put(setGeneratedRecoveryKey(key));
   } catch (error) {
     yield put(setErrorMessage('Failed to generate backup key. Please try again.'));
-    yield put(setBackupStage(BackupStage.None));
+    yield call(userInitiatedBackupDialog);
   }
 }
 
@@ -134,7 +134,6 @@ export function* clearBackupState() {
   yield put(setGeneratedRecoveryKey(null));
   yield put(setSuccessMessage(''));
   yield put(setErrorMessage(''));
-  yield put(setBackupStage(BackupStage.None));
 }
 
 export function* debugDeviceList(action) {
@@ -187,7 +186,17 @@ export function* closeBackupDialog() {
   yield put(setIsBackupDialogOpen(false));
 }
 
-export function* openBackupDialog() {
+export function* userInitiatedBackupDialog() {
+  const trustInfo = yield select((state) => state.matrix.trustInfo);
+
+  if (!trustInfo) {
+    yield put(setBackupStage(BackupStage.UserGeneratePrompt));
+  } else if (!isBackupRestored(trustInfo)) {
+    yield put(setBackupStage(BackupStage.UserRestorePrompt));
+  } else {
+    yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
+  }
+
   yield put(setIsBackupDialogOpen(true));
 }
 
@@ -230,7 +239,7 @@ export function* systemInitiatedBackupDialog() {
 
   if (!trustInfo) {
     yield put(setBackupStage(BackupStage.SystemGeneratePrompt));
-  } else if (!trustInfo.usable && !trustInfo.trustedLocally) {
+  } else if (!isBackupRestored(trustInfo)) {
     yield put(setBackupStage(BackupStage.SystemRestorePrompt));
   } else {
     // Probably never trigger this stage by the system but keep it as a default case
@@ -241,7 +250,7 @@ export function* systemInitiatedBackupDialog() {
 }
 
 function isBackupRestored(trustInfo: any) {
-  return trustInfo?.usable && trustInfo?.trustedLocally;
+  return trustInfo?.usable || trustInfo?.trustedLocally;
 }
 
 export function* checkBackupOnFirstSentMessage() {

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -178,8 +178,7 @@ export function* ensureUserHasBackup() {
   const backup = yield call(getSecureBackup);
   if (!backup?.backupInfo) {
     if (yield call(performUnlessLogout, delay(10000))) {
-      yield put(setBackupStage(BackupStage.SystemPrompt));
-      yield put(setIsBackupDialogOpen(true));
+      yield call(systemInitiatedBackupDialog);
     }
   }
 }

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -223,7 +223,16 @@ export function* handleBackupUserPrompts() {
     return;
   }
 
-  yield put(setBackupStage(BackupStage.SystemPrompt));
+  yield call(systemInitiatedBackupDialog);
+}
+
+export function* systemInitiatedBackupDialog() {
+  const trustInfo = yield select((state) => state.matrix.trustInfo);
+  if (!trustInfo) {
+    yield put(setBackupStage(BackupStage.SystemGeneratePrompt));
+  } else {
+    yield put(setBackupStage(BackupStage.SystemPrompt));
+  }
   yield put(setIsBackupDialogOpen(true));
 }
 


### PR DESCRIPTION
### What does this do?

Splits up the early backup dialog phases into separate User initiated and System initiated phases

### Why are we making this change?

Makes the component easier to read and pushes the state logic up into the sagas

### How do I test this?

Do all the secure backup things!

