### PR TITLE
Use the modern way to check for cross-signing

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -165,7 +165,7 @@ export class MatrixClient implements IChatClient {
   }
 
   async getSecureBackup() {
-    const crossSigning = await this.matrix.getStoredCrossSigningForUser(this.userId);
+    const crossSigning = await this.doesUserHaveCrossSigning();
     const backupInfo = await this.matrix.checkKeyBackup();
     (backupInfo as any).isLegacy = !crossSigning;
     return backupInfo;
@@ -200,7 +200,7 @@ export class MatrixClient implements IChatClient {
       throw new Error('Backup broken or not there');
     }
 
-    const crossSigning = await this.matrix.getStoredCrossSigningForUser(this.userId);
+    const crossSigning = await this.doesUserHaveCrossSigning();
     if (crossSigning) {
       await this.restoreSecretStorageBackup(recoveryKey, backup);
     } else {
@@ -1027,6 +1027,10 @@ export class MatrixClient implements IChatClient {
     const key = this.matrix.keyBackupKeyFromRecoveryKey(this.secretStorageKey);
     return [keyId, key];
   };
+
+  private async doesUserHaveCrossSigning() {
+    return await this.matrix.getCrypto()?.userHasCrossSigningKeys(this.userId, true);
+  }
 
   /*
    * DEBUGGING


### PR DESCRIPTION
### What does this do?

This updates the check for existing cross signing to the latest sdk version (non-deprecated).

### Why are we making this change?

Turns out the deprecated one doesn't report accurately if used immediately while the crypto is still being set up. This impacts the backup flows when logging into a new device/session.

