### PR TITLE
Remove trustInfo from state

### DIFF
--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -32,7 +32,6 @@ export enum BackupStage {
 
 export type MatrixState = {
   isLoaded: boolean;
-  trustInfo: { trustedLocally: boolean; usable: boolean; isLegacy: boolean } | null;
   backupExists: boolean;
   backupRestored: boolean;
   generatedRecoveryKey: string | null;
@@ -45,7 +44,6 @@ export type MatrixState = {
 
 export const initialState: MatrixState = {
   isLoaded: false,
-  trustInfo: null,
   backupExists: false,
   backupRestored: false,
   generatedRecoveryKey: null,
@@ -82,9 +80,6 @@ const slice = createSlice({
     setGeneratedRecoveryKey: (state, action: PayloadAction<MatrixState['generatedRecoveryKey']>) => {
       state.generatedRecoveryKey = action.payload;
     },
-    setTrustInfo: (state, action: PayloadAction<MatrixState['trustInfo']>) => {
-      state.trustInfo = action.payload;
-    },
     setSuccessMessage: (state, action: PayloadAction<MatrixState['successMessage']>) => {
       state.successMessage = action.payload;
     },
@@ -113,7 +108,6 @@ export const {
   setLoaded,
   setIsBackupDialogOpen,
   setGeneratedRecoveryKey,
-  setTrustInfo,
   setSuccessMessage,
   setErrorMessage,
   setDeviceId,

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -16,7 +16,7 @@ import {
   checkBackupOnFirstSentMessage,
   systemInitiatedBackupDialog,
   userInitiatedBackupDialog,
-  updateTrustInfo,
+  receiveBackupData,
 } from './saga';
 import { performUnlessLogout } from '../utils';
 
@@ -46,7 +46,7 @@ describe(getBackup, () => {
         [call(getSecureBackup), restoredBackupResponse()],
       ])
       .withReducer(rootReducer)
-      .call(updateTrustInfo, restoredBackupResponse())
+      .call(receiveBackupData, restoredBackupResponse())
       .run();
 
     expect(returnValue).toEqual({ backupExists: true, backupRestored: true });
@@ -65,7 +65,7 @@ describe(getBackup, () => {
     const { returnValue } = await subject(getBackup)
       .provide([[call(getSecureBackup), { trustInfo: undefined }]])
       .withReducer(rootReducer)
-      .call(updateTrustInfo, { trustInfo: undefined })
+      .call(receiveBackupData, { trustInfo: undefined })
       .run();
 
     expect(returnValue).toEqual({ backupExists: false, backupRestored: false });
@@ -412,11 +412,11 @@ describe(userInitiatedBackupDialog, () => {
   });
 });
 
-describe(updateTrustInfo, () => {
+describe(receiveBackupData, () => {
   it('sets metadata if backup exists but is not restored', async () => {
     const state = new StoreBuilder().withOtherState({ matrix: { backupExists: false, backupRestored: true } });
 
-    const { returnValue, storeState } = await subject(updateTrustInfo, unrestoredBackupResponse())
+    const { returnValue, storeState } = await subject(receiveBackupData, unrestoredBackupResponse())
       .withReducer(rootReducer, state.build())
       .run();
 
@@ -429,7 +429,7 @@ describe(updateTrustInfo, () => {
     const state = new StoreBuilder().withOtherState({ matrix: { backupExists: false, backupRestored: false } });
 
     const { returnValue, storeState } = await subject(
-      updateTrustInfo,
+      receiveBackupData,
       restoredBackupResponse({ usable: true, trusted_locally: false })
     )
       .withReducer(rootReducer, state.build())
@@ -444,7 +444,7 @@ describe(updateTrustInfo, () => {
     const state = new StoreBuilder().withOtherState({ matrix: { backupExists: false, backupRestored: false } });
 
     const { returnValue, storeState } = await subject(
-      updateTrustInfo,
+      receiveBackupData,
       restoredBackupResponse({ usable: false, trusted_locally: true })
     )
       .withReducer(rootReducer, state.build())
@@ -458,7 +458,7 @@ describe(updateTrustInfo, () => {
   it('sets metadata if backup does not exist', async () => {
     const state = new StoreBuilder().withOtherState({ matrix: { backupExists: true, backupRestored: true } });
 
-    const { returnValue, storeState } = await subject(updateTrustInfo, { trustedInfo: null })
+    const { returnValue, storeState } = await subject(receiveBackupData, { trustedInfo: null })
       .withReducer(rootReducer, state.build())
       .run();
 
@@ -472,7 +472,7 @@ describe(updateTrustInfo, () => {
 
     const backupResponse = unrestoredBackupResponse();
     backupResponse.isLegacy = true;
-    const { returnValue, storeState } = await subject(updateTrustInfo, backupResponse)
+    const { returnValue, storeState } = await subject(receiveBackupData, backupResponse)
       .withReducer(rootReducer, state.build())
       .run();
 

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -245,12 +245,11 @@ describe(proceedToVerifyKey, () => {
 });
 
 describe(clearBackupState, () => {
-  it('clears the temporary state but keeps the trustInfo and the stage', async () => {
+  it('clears the temporary state but keeps the stage', async () => {
     const initialState = {
       matrix: {
         isLoaded: true,
         generatedRecoveryKey: 'a key',
-        trustInfo: { trustData: 'here' },
         successMessage: 'Stuff happened',
         errorMessage: 'An error',
         backupStage: BackupStage.SystemGeneratePrompt,
@@ -263,7 +262,6 @@ describe(clearBackupState, () => {
     expect(storeState.matrix).toEqual({
       generatedRecoveryKey: null,
       isLoaded: false,
-      trustInfo: { trustData: 'here' },
       successMessage: '',
       errorMessage: '',
       backupStage: BackupStage.SystemGeneratePrompt,
@@ -419,18 +417,6 @@ describe(userInitiatedBackupDialog, () => {
 });
 
 describe(updateTrustInfo, () => {
-  it('updates the trustInfo', async () => {
-    const { storeState } = await subject(updateTrustInfo, {
-      usable: true,
-      trustedLocally: true,
-      isLegacy: true,
-    })
-      .withReducer(rootReducer, new StoreBuilder().build())
-      .run();
-
-    expect(storeState.matrix.trustInfo).toEqual({ usable: true, trustedLocally: true, isLegacy: true });
-  });
-
   it('sets metadata if backup exists but is not restored', async () => {
     const state = new StoreBuilder().withOtherState({ matrix: { backupExists: false, backupRestored: true } });
 

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -47,13 +47,13 @@ export function* getBackup() {
   yield put(setLoaded(false));
 
   const existingBackup = yield call(getSecureBackup);
-  const backupState = yield call(updateTrustInfo, existingBackup);
+  const backupState = yield call(receiveBackupData, existingBackup);
   yield put(setLoaded(true));
 
   return backupState;
 }
 
-export function* updateTrustInfo(existingBackup?) {
+export function* receiveBackupData(existingBackup?) {
   let backupExists = false;
   let backupRestored = false;
 
@@ -223,7 +223,7 @@ function* listenForUserLogout() {
   const userChannel = yield call(getAuthChannel);
   while (true) {
     yield take(userChannel, AuthEvents.UserLogout);
-    yield call(updateTrustInfo, null);
+    yield call(receiveBackupData, null);
   }
 }
 

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -12,7 +12,6 @@ import {
   BackupStage,
   setBackupExists,
   setBackupRestored,
-  MatrixState,
 } from '.';
 import { chat, getSecureBackup } from '../../lib/chat';
 import { performUnlessLogout } from '../utils';
@@ -53,7 +52,7 @@ export function* getBackup() {
   return backupState;
 }
 
-export function* receiveBackupData(existingBackup?) {
+export function* receiveBackupData(existingBackup) {
   let backupExists = false;
   let backupRestored = false;
 

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -7,7 +7,6 @@ import {
   setErrorMessage,
   setLoaded,
   setSuccessMessage,
-  setTrustInfo,
   setIsBackupDialogOpen,
   setBackupStage,
   BackupStage,
@@ -63,10 +62,9 @@ export function* getBackup() {
   return backupData.trustInfo;
 }
 
-export function* updateTrustInfo(trustInfo: MatrixState['trustInfo'] | null) {
+export function* updateTrustInfo(trustInfo: { usable: boolean; trustedLocally: boolean; isLegacy: boolean } | null) {
   const data = { trustInfo };
 
-  yield put(setTrustInfo(trustInfo || null));
   yield put(setBackupExists(!!trustInfo && !trustInfo.isLegacy));
   yield put(setBackupRestored(isBackupRestored(trustInfo) && !trustInfo?.isLegacy));
 
@@ -201,11 +199,11 @@ export function* closeBackupDialog() {
 }
 
 export function* userInitiatedBackupDialog() {
-  const trustInfo = yield select((state) => state.matrix.trustInfo);
+  const { backupExists, backupRestored } = yield select((state) => state.matrix);
 
-  if (!trustInfo) {
+  if (!backupExists) {
     yield put(setBackupStage(BackupStage.UserGeneratePrompt));
-  } else if (!isBackupRestored(trustInfo)) {
+  } else if (!backupRestored) {
     yield put(setBackupStage(BackupStage.UserRestorePrompt));
   } else {
     yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
@@ -249,11 +247,11 @@ export function* handleBackupUserPrompts() {
 }
 
 export function* systemInitiatedBackupDialog() {
-  const trustInfo = yield select((state) => state.matrix.trustInfo);
+  const { backupExists, backupRestored } = yield select((state) => state.matrix);
 
-  if (!trustInfo) {
+  if (!backupExists) {
     yield put(setBackupStage(BackupStage.SystemGeneratePrompt));
-  } else if (!isBackupRestored(trustInfo)) {
+  } else if (!backupRestored) {
     yield put(setBackupStage(BackupStage.SystemRestorePrompt));
   } else {
     // Probably never trigger this stage by the system but keep it as a default case

--- a/src/store/test/store.ts
+++ b/src/store/test/store.ts
@@ -73,21 +73,18 @@ export class StoreBuilder {
   }
 
   withoutBackup() {
-    this.matrix.trustInfo = null;
     this.matrix.backupExists = false;
     this.matrix.backupRestored = false;
     return this;
   }
 
   withUnrestoredBackup() {
-    this.matrix.trustInfo = { usable: false, trustedLocally: false, isLegacy: false };
     this.matrix.backupExists = true;
     this.matrix.backupRestored = false;
     return this;
   }
 
   withRestoredBackup() {
-    this.matrix.trustInfo = { usable: false, trustedLocally: true, isLegacy: false };
     this.matrix.backupExists = true;
     this.matrix.backupRestored = true;
     return this;


### PR DESCRIPTION
### What does this do?

Removes `trustInfo` from the state as that's an internal Matrix format and nothing should reference it aside from the initial parsing saga.

