### PR TITLE
Reset the login stage during logout

### DIFF
--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -17,6 +17,7 @@ import { Connectors } from '../../lib/web3';
 import { Events, getAuthChannel } from './channels';
 import { getHistory } from '../../lib/browser';
 import { completePendingUserProfile } from '../registration/saga';
+import { LoginStage, setStage } from '../login';
 
 export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
@@ -64,6 +65,7 @@ export function* terminate(isAccountChange = false) {
   }
 
   yield call(clearUserState);
+  yield put(setStage(LoginStage.Web3Login));
   yield call(redirectUnauthenticatedUser, isAccountChange);
   yield call(publishUserLogout);
 }


### PR DESCRIPTION
### What does this do?

Sets the LoginStage to the default Web3 when logging out.

### Why are we making this change?

There was a bug where if you start on the login page and login via email...then logout... instead of redirecting to the login page you'd remain at the root url. This happened because the completion of email logout sets the stage to Login.Done. So, the login page itself thought it was done and would redirect to the root url but the root url would detect is was not authenticated and thus not render anything.

