### PR TITLE
Fix race syntax in performUnlessLogout

### DIFF
--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -21,7 +21,7 @@ function uniqFavorLast(objectsAndIds: ({ id: string } | string)[]): any {
 
 export function* performUnlessLogout(task) {
   const { complete } = yield race({
-    complete: yield task,
+    complete: task,
     abort: take(yield call(getAuthChannel), AuthEvents.UserLogout),
   });
   return !!complete;


### PR DESCRIPTION
### What does this do?

Fixes the syntax in the `race` call in `performUnlessLogout` helper.

### Why are we making this change?

Fixes bug where logging in as a user without a backup and then logging out wouldn't cancel the tasks that were pending so new logins would then not handle the backup flow properly.

### How do I test this?

This bug could be seen by doing the following:
1. Log in as a user who does not have a backup (this means it will wait until the first message is sent)
2. Logout
3. Log in as a user who DOES have a backup created.

Under normal circumstances this new user should see the backup dialog open prompting them to enter their recovery key. However, it was not. After the fix this should occur correctly.

