### PR TITLE
fix: conversation list panel padding

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -46,7 +46,8 @@ $side-padding: 16px;
     flex-grow: 1;
     // Forcing a height here allows the flex-grow to fill the size without growing too big
     height: 1px;
-    padding: 0px $side-padding;
+    // accounts for 4px scrollbar width on right side of container
+    padding: 0 12px 0 16px;
   }
 
   &__empty {


### PR DESCRIPTION
### What does this do?
- fixes conversation list panel padding - takes scrollbar width (4px) into account - equal padding each side.

Before:
<img width="288" alt="Screenshot 2024-03-05 at 08 53 13" src="https://github.com/zer0-os/zOS/assets/39112648/c3da4dbc-87ea-44d8-8bc6-adf028ba6100">


After:
<img width="288" alt="Screenshot 2024-03-05 at 08 52 43" src="https://github.com/zer0-os/zOS/assets/39112648/bc00ea02-fb3d-45aa-9415-328fd5ee8ded">
