### PR TITLE
refactor(restore-backup): use built in input error state for border

### DIFF
--- a/src/components/secure-backup/restore-backup/index.test.tsx
+++ b/src/components/secure-backup/restore-backup/index.test.tsx
@@ -5,9 +5,6 @@ import { pressButton } from '../../../test/utils';
 
 import { Alert, Button, Input } from '@zero-tech/zui/components';
 
-import { bem } from '../../../lib/bem';
-const c = bem('.secure-backup');
-
 describe('RestoreBackup', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
@@ -54,17 +51,5 @@ describe('RestoreBackup', () => {
     wrapper.find(Input).simulate('change', 'test-recovery-key');
 
     expect(wrapper.find(Button)).toHaveProp('isDisabled', false);
-  });
-
-  it('applies the error class to Input when error message exists', function () {
-    const wrapper = subject({ errorMessage: 'Invalid key prhase' });
-
-    expect(wrapper.find(c('input--error'))).toExist();
-  });
-
-  it('does not apply the error class to Input when error message does not exist', function () {
-    const wrapper = subject({ errorMessage: '' });
-
-    expect(wrapper.find(c('input--error'))).not.toExist();
   });
 });

--- a/src/components/secure-backup/restore-backup/index.tsx
+++ b/src/components/secure-backup/restore-backup/index.tsx
@@ -45,10 +45,10 @@ export class RestoreBackup extends React.Component<Properties, State> {
 
           <div {...cn('input-container')}>
             <Input
-              {...cn('input', `${this.props.errorMessage && 'error'}`)}
               placeholder='Enter your recovery key'
               onChange={this.trackRecoveryKey}
               value={this.recoveryKey}
+              error={!!this.props.errorMessage}
             />
 
             {this.props.errorMessage && (


### PR DESCRIPTION
### What does this do?
- makes use of input border error state fix in latest zui version.
- replaces styles set for input error state border and uses the built in error styles
- removes outdated test