### PR TITLE
chore: bump version (1.8.3) -> (1.8.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@web3-react/network-connector": "^6.1.9",
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
-        "@zero-tech/zui": "1.8.3",
+        "@zero-tech/zui": "1.8.4",
         "assert": "^2.1.0",
         "audio-react-recorder-fixed": "^1.0.3",
         "buffer": "^6.0.3",
@@ -9888,9 +9888,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.8.3.tgz",
-      "integrity": "sha512-77tVIEhEd5+fo7soLgAUJKFX7NZMIdmn5OP06rWgrPYPFhDvX/Rek0rIUG+y5t6s2T13I/2ZU3QOZXaQQpr60Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.8.4.tgz",
+      "integrity": "sha512-xcGlicDBmYsn2nqd32VGX+jQ3/m44fsw+3IY4q1EawKmVLLOwexsq+l3g0BpX8wFSFjQLn55VzeEhiBcbQiIWg==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -42054,9 +42054,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.8.3.tgz",
-      "integrity": "sha512-77tVIEhEd5+fo7soLgAUJKFX7NZMIdmn5OP06rWgrPYPFhDvX/Rek0rIUG+y5t6s2T13I/2ZU3QOZXaQQpr60Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.8.4.tgz",
+      "integrity": "sha512-xcGlicDBmYsn2nqd32VGX+jQ3/m44fsw+3IY4q1EawKmVLLOwexsq+l3g0BpX8wFSFjQLn55VzeEhiBcbQiIWg==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@web3-react/network-connector": "^6.1.9",
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
-    "@zero-tech/zui": "1.8.3",
+    "@zero-tech/zui": "1.8.4",
     "assert": "^2.1.0",
     "audio-react-recorder-fixed": "^1.0.3",
     "buffer": "^6.0.3",


### PR DESCRIPTION
- Includes the removal of "slide up" animation, which is failing in zOS due to possibly radix related issues.