### PR TITLE
Make Learn More link not take up the full width of the modal

### DIFF
--- a/src/components/secure-backup/styles.scss
+++ b/src/components/secure-backup/styles.scss
@@ -64,6 +64,7 @@
 
   &__learn-more {
     display: flex;
+    align-self: start;
     color: theme.$color-secondary-11;
     gap: 4px;
     margin-top: -32px;


### PR DESCRIPTION
### What does this do?

Renders the Learn More link only as wide as the content so the whole row isn't clickable

