### PR TITLE
Add a max height and content scroll to Modal component

### DIFF
--- a/src/components/modal/styles.scss
+++ b/src/components/modal/styles.scss
@@ -7,6 +7,9 @@
   gap: 40px;
   overflow: hidden;
   padding: calc(40px - 24px); // zUI has 24px padding right now but we want 40 total.
+  box-sizing: border-box;
+  max-height: calc(100vh - 54px); // zUI has 24px padding plus 1px border
+  min-height: 250px;
 
   &__title-bar {
     display: flex;
@@ -41,6 +44,7 @@
     font-weight: 400;
     font-size: 16px;
     line-height: 24px;
+    overflow-y: scroll;
   }
 
   &__footer {


### PR DESCRIPTION
### What does this do?

Adds a max height (and min-height) to the Modal component to restrict the content size and forces a scrollbar on tall content.

Note: Red background added to provide contrast for screenshots

Before:
![image](https://github.com/zer0-os/zOS/assets/43770/62713d4a-eae5-4fd0-a00c-ebfb90dfa658)

After:
![image](https://github.com/zer0-os/zOS/assets/43770/9acab6b7-c192-4402-8066-2093a22060bd)
