### PR TITLE
feat: update invite clipboard text

### DIFF
--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { InviteDialog, Properties } from '.';
 import { Button } from '@zero-tech/zui/components';
 import { releaseThread } from '../../test/utils';
+import { config } from '../../config';
 
 describe('InviteDialog', () => {
   const subject = (props: Partial<Properties>) => {
@@ -36,7 +37,7 @@ describe('InviteDialog', () => {
 
     expect(wrapper.find(Button).prop('isDisabled')).toBeFalse();
     expect(clipboard.write).toHaveBeenCalledWith(
-      expect.stringMatching('Use this code to join me on ZERO Messenger: 23817 https://zos.zer0.io/get-access')
+      expect.stringMatching(`Use this code to join me on ZERO Messenger: 23817 ${config.zosRootUrl}/get-access`)
     );
   });
 

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -35,7 +35,9 @@ describe('InviteDialog', () => {
     wrapper.find(Button).simulate('press');
 
     expect(wrapper.find(Button).prop('isDisabled')).toBeFalse();
-    expect(clipboard.write).toHaveBeenCalledWith(expect.stringContaining('23817'));
+    expect(clipboard.write).toHaveBeenCalledWith(
+      expect.stringMatching('Use this code to join me on ZERO Messenger: 23817 https://zos.zer0.io/get-access')
+    );
   });
 
   it('sets copy text to copied for a few seconds after copying the text', async function () {

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -45,7 +45,7 @@ export class InviteDialog extends React.Component<Properties, State> {
   }
 
   get inviteText() {
-    return this.props.inviteCode;
+    return `Use this code to join me on ZERO Messenger: ${this.props.inviteCode} https://zos.zer0.io/get-access`;
   }
 
   writeInviteToClipboard = async () => {

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -5,6 +5,7 @@ import { IconXClose } from '@zero-tech/zui/icons';
 
 import { clipboard } from '../../lib/clipboard';
 import { bemClassName } from '../../lib/bem';
+import { config } from '../../config';
 
 import './styles.scss';
 
@@ -45,7 +46,7 @@ export class InviteDialog extends React.Component<Properties, State> {
   }
 
   get inviteText() {
-    return `Use this code to join me on ZERO Messenger: ${this.props.inviteCode} https://zos.zer0.io/get-access`;
+    return `Use this code to join me on ZERO Messenger: ${this.props.inviteCode} ${config.zosRootUrl}/get-access`;
   }
 
   writeInviteToClipboard = async () => {


### PR DESCRIPTION
### What does this do?
- updates the clipboard text when copying invite code

### Why are we making this change?
- as per requirements/design
- this gives more context/info to the person who receives the invite code that a current user has copied and sent.

### How do I test this?
- run test as usual.
- checkout branch > run UI > copy invite code > paste and check string has the same structure as below screenshot.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="567" alt="Screenshot 2024-03-13 at 17 58 14" src="https://github.com/zer0-os/zOS/assets/39112648/06bbdb99-3c3f-495a-ba4a-d7bb45c28cb2">
