### PR TITLE
Convert SecureBackup to an actual Modal

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -204,11 +204,7 @@ export class Container extends React.Component<Properties, State> {
   };
 
   renderSecureBackupDialog = (): JSX.Element => {
-    return (
-      <Modal open={this.props.isBackupDialogOpen} onOpenChange={this.closeBackupDialog}>
-        <SecureBackupContainer onClose={this.closeBackupDialog} />
-      </Modal>
-    );
+    return <SecureBackupContainer onClose={this.closeBackupDialog} />;
   };
 
   renderUserHeader() {

--- a/src/components/secure-backup/index.test.tsx
+++ b/src/components/secure-backup/index.test.tsx
@@ -9,9 +9,7 @@ import { GenerateBackup } from './generate-backup';
 import { RestoreBackup } from './restore-backup';
 import { VerifyKeyPhrase } from './verify-key-phrase';
 import { Success } from './success';
-
-import { bem } from '../../lib/bem';
-const c = bem('.secure-backup');
+import { Modal } from '../modal';
 
 describe(SecureBackup, () => {
   const subject = (props: Partial<Properties>) => {
@@ -213,13 +211,13 @@ describe(SecureBackup, () => {
     it('renders title as "Account Backup" if backup does not exist and backup is not restored', function () {
       const wrapper = subject({ backupExists: false, backupRestored: false });
 
-      expect(wrapper.find(c('title'))).toHaveText('Account Backup');
+      expect(wrapper.find(Modal)).toHaveProp('title', 'Account Backup');
     });
 
     it('renders title as "Verify Login" if backup exists and backup is not restored', function () {
       const wrapper = subject({ backupExists: true, backupRestored: false });
 
-      expect(wrapper.find(c('title'))).toHaveText('Verify Login');
+      expect(wrapper.find(Modal)).toHaveProp('title', 'Verify Login');
     });
   });
 });

--- a/src/components/secure-backup/index.tsx
+++ b/src/components/secure-backup/index.tsx
@@ -13,10 +13,8 @@ import { RecoveredBackup } from './recovered-backup';
 import { Success } from './success';
 import { VerifyKeyPhrase } from './verify-key-phrase';
 
-import { IconXClose } from '@zero-tech/zui/icons';
-import { IconButton } from '@zero-tech/zui/components';
-
 import './styles.scss';
+import { Modal } from '../modal';
 
 const cn = bemClassName('secure-backup');
 
@@ -57,16 +55,9 @@ export class SecureBackup extends React.PureComponent<Properties, State> {
     this.setState({ showFAQContent: false });
   };
 
-  renderHeader = () => {
-    const title = this.existingBackupNotRestored ? 'Verify Login' : 'Account Backup';
-
-    return (
-      <div {...cn('header')}>
-        <h3 {...cn('title')}>{title}</h3>
-        <IconButton {...cn('close')} Icon={IconXClose} onClick={this.props.onClose} size={40} />
-      </div>
-    );
-  };
+  get title() {
+    return this.existingBackupNotRestored ? 'Verify Login' : 'Account Backup';
+  }
 
   renderVideoBanner = () => {
     if (this.state.showFAQContent) {
@@ -149,11 +140,19 @@ export class SecureBackup extends React.PureComponent<Properties, State> {
 
   render() {
     return (
-      <div {...cn()}>
-        {this.renderHeader()}
-        {this.renderVideoBanner()}
-        {this.renderBackupContent()}
-      </div>
+      <Modal
+        title={this.title}
+        primaryText='Log Out'
+        secondaryText='Cancel'
+        onPrimary={null}
+        onSecondary={null}
+        onClose={this.props.onClose}
+      >
+        <div {...cn()}>
+          {this.renderVideoBanner()}
+          {this.renderBackupContent()}
+        </div>
+      </Modal>
     );
   }
 }


### PR DESCRIPTION
### What does this do?

This converts the SecureBackup to the new Modal component so we can get all the modal goodies that we shouldn't have to re-implement every time.

Note: There will be some UI inconsistency until it gets fully converted. Ex: the buttons are still managed by each independent screen at the moment instead of the modal. Follow ups to come.

Example of how the scroll bar looks at the moment with the button managed by the screens. This is a temporary tradeoff.
![image](https://github.com/zer0-os/zOS/assets/43770/e420e34f-7e09-4605-aa9b-2f91fdd2f8b8)
