### PR TITLE
refactor: use invite url config path in place of zos root url

### DIFF
--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -37,7 +37,7 @@ describe('InviteDialog', () => {
 
     expect(wrapper.find(Button).prop('isDisabled')).toBeFalse();
     expect(clipboard.write).toHaveBeenCalledWith(
-      expect.stringMatching(`Use this code to join me on ZERO Messenger: 23817 ${config.zosRootUrl}/get-access`)
+      expect.stringMatching(`Use this code to join me on ZERO Messenger: 23817 ${config.inviteUrl}`)
     );
   });
 

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -46,7 +46,7 @@ export class InviteDialog extends React.Component<Properties, State> {
   }
 
   get inviteText() {
-    return `Use this code to join me on ZERO Messenger: ${this.props.inviteCode} ${config.zosRootUrl}/get-access`;
+    return `Use this code to join me on ZERO Messenger: ${this.props.inviteCode} ${config.inviteUrl}`;
   }
 
   writeInviteToClipboard = async () => {


### PR DESCRIPTION
### What does this do?
- replaces `config.zosRootUrl` with `config.inviteUrl`

### Why are we making this change?
- duplicated env variables not required.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
