### PR TITLE
Remove unused property from UserHeader

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -214,7 +214,6 @@ export class Container extends React.Component<Properties, State> {
         userName={this.props.userName}
         userHandle={this.props.userHandle}
         userAvatarUrl={this.props.userAvatarUrl}
-        includeUserSettings={true}
         startConversation={this.props.startCreateConversation}
         onLogout={this.props.logout}
         onVerifyId={this.openVerifyIdDialog}

--- a/src/components/messenger/list/user-header/index.test.tsx
+++ b/src/components/messenger/list/user-header/index.test.tsx
@@ -3,8 +3,6 @@ import { Properties, UserHeader } from '.';
 import { Button, IconButton } from '@zero-tech/zui/components';
 
 import { bem } from '../../../../lib/bem';
-import { SettingsMenuContainer } from '../../../settings-menu/container';
-
 const c = bem('.user-header');
 
 const featureFlags = { allowVerifyId: false };
@@ -19,7 +17,6 @@ describe(UserHeader, () => {
       userHandle: '',
       userAvatarUrl: '',
       userIsOnline: true,
-      includeUserSettings: false,
 
       onLogout: () => null,
       onVerifyId: () => null,
@@ -29,16 +26,6 @@ describe(UserHeader, () => {
 
     return shallow(<UserHeader {...allProps} />);
   };
-
-  it('renders SettingsMenu when includeUserSettings is true', function () {
-    const wrapper = subject({ includeUserSettings: true });
-    expect(wrapper).toHaveElement(SettingsMenuContainer);
-  });
-
-  it('does not render SettingsMenu when includeUserSettings is false', function () {
-    const wrapper = subject({ includeUserSettings: false });
-    expect(wrapper).not.toHaveElement(SettingsMenuContainer);
-  });
 
   it('renders userHandle when user handle is not empty', function () {
     const wrapper = subject({ userHandle: '0://zid.example' });

--- a/src/components/messenger/list/user-header/index.tsx
+++ b/src/components/messenger/list/user-header/index.tsx
@@ -16,7 +16,6 @@ export interface Properties {
   userHandle: string;
   userAvatarUrl: string;
   userIsOnline: boolean;
-  includeUserSettings?: boolean;
 
   onLogout?: () => void;
   onVerifyId: () => void;
@@ -58,15 +57,13 @@ export class UserHeader extends React.Component<Properties> {
   render() {
     return (
       <div {...cn('')}>
-        {this.props.includeUserSettings && (
-          <SettingsMenuContainer
-            onLogout={this.props.onLogout}
-            userName={this.props.userName}
-            userHandle={this.props.userHandle}
-            userAvatarUrl={this.props.userAvatarUrl}
-            userStatus={this.userStatus}
-          />
-        )}
+        <SettingsMenuContainer
+          onLogout={this.props.onLogout}
+          userName={this.props.userName}
+          userHandle={this.props.userHandle}
+          userAvatarUrl={this.props.userAvatarUrl}
+          userStatus={this.userStatus}
+        />
 
         {this.renderUserDetails()}
 


### PR DESCRIPTION
### What does this do?

This property was hard coded to `true` based on previous feature changes. This now removes the property outright.

