### PR TITLE
Fix error message display on conversations

### DIFF
--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -13,6 +13,9 @@ import { User } from '../../store/authentication/types';
 import moment from 'moment';
 import { MessagesFetchState } from '../../store/channels';
 
+import { bem } from '../../lib/bem';
+const c = bem('.chat-view');
+
 describe('ChatView', () => {
   const MESSAGES_TEST = [
     { id: 1111, message: 'what', sender: { userId: '1' }, createdAt: 1658776625730 },
@@ -135,27 +138,6 @@ describe('ChatView', () => {
     expect(ifAuthenticated.find(MessageInput).exists()).toBe(false);
   });
 
-  it('render joinButton', () => {
-    const wrapper = subject({ messages: MESSAGES_TEST, user: { id: 'userId-test' } as User });
-
-    expect(wrapper.find('.channel-view__join-wrapper').exists()).toBe(true);
-  });
-
-  it('should not render joinButton', () => {
-    const wrapper = subject({ messages: MESSAGES_TEST, hasJoined: true, user: { id: 'userId-test' } as User });
-
-    expect(wrapper.find('.channel-view__join-wrapper').exists()).toBe(false);
-  });
-
-  it('should joinChannel when click joinButton', () => {
-    const joinChannel = jest.fn();
-    const wrapper = subject({ messages: MESSAGES_TEST, user: { id: 'userId-test' } as User, joinChannel });
-
-    wrapper.find('.channel-view__join-wrapper').simulate('click');
-
-    expect(joinChannel).toHaveBeenCalled();
-  });
-
   it('render Waypoint in case we have messages', () => {
     const onFetchMoreSpy = jest.fn();
 
@@ -216,7 +198,7 @@ describe('ChatView', () => {
       messagesFetchStatus: MessagesFetchState.FAILED,
       hasLoadedMessages: true,
     });
-    expect(wrapper.find('.channel-view__failure-message').text()).toContain('Failed to load new messages. Try Reload');
+    expect(wrapper.find(c('failure-message')).text()).toContain('Failed to load new messages. Try Reload');
 
     wrapper = subject({
       messages: MESSAGES_TEST,
@@ -225,7 +207,7 @@ describe('ChatView', () => {
       name: 'channel-name',
     });
 
-    expect(wrapper.find('.channel-view__failure-message').text()).toContain(
+    expect(wrapper.find(c('failure-message')).text()).toContain(
       'Failed to load conversation with channel-name. Try Reload'
     );
 
@@ -237,7 +219,7 @@ describe('ChatView', () => {
       otherMembers: [{ firstName: 'ratik', lastName: 'jindal' } as any],
     });
 
-    expect(wrapper.find('.channel-view__failure-message').text()).toContain(
+    expect(wrapper.find(c('failure-message')).text()).toContain(
       'Failed to load your conversation with ratik. Try Reload'
     );
   });
@@ -251,7 +233,7 @@ describe('ChatView', () => {
       id: 'channel-id',
     });
 
-    wrapper.find('.channel-view__try-reload').simulate('click');
+    wrapper.find(c('try-reload')).simulate('click');
     expect(fetchMessages).toHaveBeenCalledWith({ channelId: 'channel-id' });
   });
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -7,7 +7,6 @@ import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
 import { User as ChannelMember } from '../../store/channels';
-import { IfAuthenticated } from '../authentication/if-authenticated';
 import { Button as ComponentButton } from '@zer0-os/zos-component-library';
 import { ParentMessage } from '../../lib/chat/types';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
@@ -230,7 +229,6 @@ export class ChatView extends React.Component<Properties, State> {
 
   render() {
     const { isLightboxOpen, lightboxMedia, lightboxStartIndex } = this.state;
-    const { hasJoined: isMemberOfChannel } = this.props;
 
     return (
       <div className={classNames('channel-view', this.props.className)}>
@@ -270,31 +268,23 @@ export class ChatView extends React.Component<Properties, State> {
               <ChatSkeleton conversationId={this.props.id} />
             )}
           </div>
-        </InvertedScroll>
 
-        {this.props.messagesFetchStatus === MessagesFetchState.FAILED && (
-          <div className='channel-view__failure-message'>
-            {this.failureMessage}&nbsp;
-            <div
-              className='channel-view__try-reload'
-              onClick={() => {
-                this.props.fetchMessages({ channelId: this.props.id });
-              }}
-            >
-              Try Reload
+          {this.props.messagesFetchStatus === MessagesFetchState.FAILED && (
+            <div {...cn('failure-message')}>
+              {this.failureMessage}&nbsp;
+              <span
+                {...cn('try-reload')}
+                onClick={() => {
+                  this.props.fetchMessages({ channelId: this.props.id });
+                }}
+              >
+                Try Reload
+              </span>
             </div>
-          </div>
-        )}
-
-        {/* i think we can remove the entire code below */}
-        <IfAuthenticated showChildren>
-          {isMemberOfChannel && (
-            <>
-              {this.props.conversationErrorMessage && <div {...cn('error')}>{this.props.conversationErrorMessage}</div>}
-            </>
           )}
-          {!isMemberOfChannel && this.renderJoinButton()}
-        </IfAuthenticated>
+
+          {this.props.conversationErrorMessage && <div {...cn('error')}>{this.props.conversationErrorMessage}</div>}
+        </InvertedScroll>
       </div>
     );
   }

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -5,14 +5,19 @@
 // Note: there are some classes in various other places (src/platform-apps/channels/styles.scss)
 
 .chat-view {
+  &__failure-message,
   &__error {
+    margin-bottom: 96px;
     padding: 8px;
     padding-bottom: 32px;
     color: theme.$color-failure-11;
     text-align: center;
     font-size: 12px;
     font-weight: 400;
-    line-height: normal;
+  }
+
+  &__try-reload {
+    cursor: pointer;
   }
 
   &__message-input-container {


### PR DESCRIPTION
### What does this do?

Fixes thhe rendering of some error messages as they were being rendered below the message input (due to the redesign)


Note: also removes a button that wasn't being rendered ever
