### PR TITLE
Remove joinChannel button

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -13,7 +13,6 @@ describe('ChannelViewContainer', () => {
       channel: null,
       channelId: '',
       fetchMessages: () => undefined,
-      joinChannel: () => undefined,
       user: {
         isLoading: false,
         data: null,
@@ -107,12 +106,6 @@ describe('ChannelViewContainer', () => {
     expect(wrapper.find(ChatView).prop('name')).toStrictEqual('first channel');
   });
 
-  it('passes hasJoined to channel view', () => {
-    const wrapper = subject({ channel: { hasJoined: true } });
-
-    expect(wrapper.find(ChatView).prop('hasJoined')).toStrictEqual(true);
-  });
-
   it('fetches messages on mount', () => {
     const fetchMessages = jest.fn();
 
@@ -169,20 +162,6 @@ describe('ChannelViewContainer', () => {
       channelId: 'the-channel-id',
       referenceTimestamp: 1658776625730,
     });
-  });
-
-  it('should call joinChannel when join button is clicked', () => {
-    const joinChannel = jest.fn();
-
-    const wrapper = subject({
-      joinChannel,
-      channelId: 'the-channel-id',
-      channel: { hasMore: true, name: 'first channel' },
-    });
-
-    wrapper.find(ChatView).first().prop('joinChannel')();
-
-    expect(joinChannel).toHaveBeenCalledOnce();
   });
 
   it('should call deleteMessage', () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -4,12 +4,11 @@ import { RootState } from '../../store/reducer';
 
 import { connectContainer } from '../../store/redux-container';
 import { fetch as fetchMessages, deleteMessage, editMessage, Message, EditMessageOptions } from '../../store/messages';
-import { Channel, ConversationStatus, denormalize, joinChannel, onReply } from '../../store/channels';
+import { Channel, ConversationStatus, denormalize, onReply } from '../../store/channels';
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
 import { EditPayload, Payload as PayloadFetchMessages } from '../../store/messages/saga';
 import { openBackupDialog } from '../../store/matrix';
-import { Payload as PayloadJoinChannel } from '../../store/channels/types';
 import { ParentMessage } from '../../lib/chat/types';
 import { compareDatesAsc } from '../../lib/date';
 
@@ -19,7 +18,6 @@ export interface Properties extends PublicProperties {
   user: AuthenticationState['user'];
   deleteMessage: (payload: PayloadFetchMessages) => void;
   editMessage: (payload: EditPayload) => void;
-  joinChannel: (payload: PayloadJoinChannel) => void;
   onReply: ({ reply }: { reply: ParentMessage }) => void;
   openBackupDialog: () => void;
   activeConversationId?: string;
@@ -61,7 +59,6 @@ export class Container extends React.Component<Properties> {
     return {
       fetchMessages,
       deleteMessage,
-      joinChannel,
       editMessage,
       onReply,
       openBackupDialog,
@@ -130,13 +127,6 @@ export class Container extends React.Component<Properties> {
     const { channelId } = this.props;
     if (channelId && messageId) {
       this.props.editMessage({ channelId, messageId, message, mentionedUserIds, data });
-    }
-  };
-
-  handleJoinChannel = (): void => {
-    const { channelId } = this.props;
-    if (channelId) {
-      this.props.joinChannel({ channelId });
     }
   };
 
@@ -215,8 +205,6 @@ export class Container extends React.Component<Properties> {
           user={this.props.user.data}
           deleteMessage={this.handleDeleteMessage}
           editMessage={this.handleEditMessage}
-          joinChannel={this.handleJoinChannel}
-          hasJoined={true}
           showSenderAvatar={this.props.showSenderAvatar}
           isOneOnOne={this.isOneOnOne}
           onReply={this.props.onReply}

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -29,7 +29,6 @@ describe('ChatView', () => {
       id: '',
       name: '',
       messages: [],
-      hasJoined: false,
       user: null,
       joinChannel: () => null,
       onFetchMore: () => null,

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -7,7 +7,6 @@ import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
 import { User as ChannelMember } from '../../store/channels';
-import { Button as ComponentButton } from '@zer0-os/zos-component-library';
 import { ParentMessage } from '../../lib/chat/types';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
 import { Message } from '../message';
@@ -37,7 +36,6 @@ export interface Properties {
   onFetchMore: () => void;
   fetchMessages: (payload: PayloadFetchMessages) => void;
   user: User;
-  hasJoined: boolean;
   deleteMessage: (messageId: number) => void;
   editMessage: (
     messageId: number,
@@ -47,7 +45,6 @@ export interface Properties {
   ) => void;
   onReply: ({ reply }: { reply: ParentMessage }) => void;
   onHiddenMessageInfoClick: () => void;
-  joinChannel: () => void;
   className?: string;
   showSenderAvatar?: boolean;
   isOneOnOne: boolean;
@@ -197,14 +194,6 @@ export class ChatView extends React.Component<Properties, State> {
           .map((day) => {
             return this.renderDay(day, { [day]: filteredMessagesByDay[day] });
           })}
-      </div>
-    );
-  }
-
-  renderJoinButton() {
-    return (
-      <div onClick={this.props.joinChannel} className={classNames(this.props.className, 'channel-view__join-wrapper')}>
-        <ComponentButton>Join Channel</ComponentButton>
       </div>
     );
   }

--- a/src/store/channels/api.ts
+++ b/src/store/channels/api.ts
@@ -1,7 +1,0 @@
-import { post } from '../../lib/api/rest';
-
-export async function joinChannel(channelId: string): Promise<number> {
-  const response = await post<any>(`/chatChannels/${channelId}/join`);
-
-  return response.status;
-}

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -3,7 +3,7 @@ import { createNormalizedSlice, removeAll } from '../normalized';
 import { Message, schema as messageSchema } from '../messages';
 import { schema as userSchema } from '../users';
 import { createAction } from '@reduxjs/toolkit';
-import { Payload, UnreadCountUpdatedPayload } from './types';
+import { UnreadCountUpdatedPayload } from './types';
 import { ParentMessage } from '../../lib/chat/types';
 import { Wallet } from '../authentication/types';
 
@@ -84,14 +84,12 @@ export const CHANNEL_DEFAULTS = {
 };
 
 export enum SagaActionTypes {
-  JoinChannel = 'channels/saga/joinChannel',
   UnreadCountUpdated = 'channels/saga/unreadCountUpdated',
   OpenConversation = 'channels/saga/openConversation',
   OnReply = 'channels/saga/onReply',
   OnRemoveReply = 'channels/saga/onRemoveReply',
 }
 
-const joinChannel = createAction<Payload>(SagaActionTypes.JoinChannel);
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
 const onReply = createAction<{ reply: ParentMessage }>(SagaActionTypes.OnReply);
@@ -108,4 +106,4 @@ const slice = createNormalizedSlice({
 
 export const { receive: rawReceive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { joinChannel, unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply };
+export { unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply };

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -1,8 +1,7 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { joinChannel as joinChannelAPI } from './api';
-import { joinChannel, markAllMessagesAsRead, markConversationAsRead, receiveChannel, unreadCountUpdated } from './saga';
+import { markAllMessagesAsRead, markConversationAsRead, receiveChannel, unreadCountUpdated } from './saga';
 
 import { rootReducer } from '../reducer';
 import { ConversationStatus, GroupChannelType, denormalize as denormalizeChannel } from '../channels';
@@ -16,29 +15,6 @@ const mockChatClient = {
 };
 
 describe('channels list saga', () => {
-  it('join channel and add hasJoined to channel state', async () => {
-    const channelId = '248576469_9431f1076aa3e08783b2c2cf3b34df143442bc32';
-
-    const initialState = new StoreBuilder().withConversationList({ id: channelId, hasJoined: false }).build();
-
-    const {
-      storeState: {
-        normalized: { channels },
-      },
-    } = await expectSaga(joinChannel, { payload: { channelId } })
-      .withReducer(rootReducer, initialState as any)
-      .provide([
-        [
-          matchers.call.fn(joinChannelAPI),
-          200,
-        ],
-      ])
-      .call(joinChannelAPI, channelId)
-      .run();
-
-    expect(channels[channelId].hasJoined).toEqual(true);
-  });
-
   it('mark all messages as read', async () => {
     const channelId = '236844224_56299bcd523ac9084181f2422d0d0cfe9df72db4';
     const userId = 'e41dc968-289b-4e92-889b-694bd7f2bc30';

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -1,7 +1,6 @@
 import getDeepProperty from 'lodash.get';
 import { takeLatest, put, call, select, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, rawReceive, schema, removeAll, Channel, CHANNEL_DEFAULTS } from '.';
-import { joinChannel as joinChannelAPI } from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
@@ -14,14 +13,6 @@ import { rawSetActiveConversationId } from '../chat';
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
 };
-
-export function* joinChannel(action) {
-  const { channelId } = action.payload;
-
-  yield call(joinChannelAPI, channelId);
-
-  yield call(receiveChannel, { id: channelId, hasJoined: true });
-}
 
 export function* markAllMessagesAsRead(channelId, userId) {
   if (!userId) {
@@ -107,7 +98,6 @@ export function* receiveChannel(channel: Partial<Channel>) {
 }
 
 export function* saga() {
-  yield takeLatest(SagaActionTypes.JoinChannel, joinChannel);
   yield takeLatest(SagaActionTypes.OpenConversation, ({ payload }: any) => openConversation(payload.conversationId));
   yield takeLatest(SagaActionTypes.OnReply, ({ payload }: any) => onReply(payload.reply));
   yield takeLatest(SagaActionTypes.OnRemoveReply, onRemoveReply);

--- a/src/store/channels/types.ts
+++ b/src/store/channels/types.ts
@@ -1,7 +1,3 @@
-export interface Payload {
-  channelId: string;
-}
-
 export interface MarkAsReadPayload {
   channelId: string;
   userId: string;


### PR DESCRIPTION
### What does this do?

Since we no longer have truly public channels that you can view and then try to join, this button is no longer useful. Remove it and the underlying sagas, etc.

