### PR TITLE
Remove hasJoined property from Channel

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -935,7 +935,6 @@ export class MatrixClient implements IChatClient {
       groupChannelType: GroupChannelType.Private,
       category: '',
       unreadCount,
-      hasJoined: true,
       createdAt,
       conversationStatus: ConversationStatus.CREATED,
       adminMatrixIds: this.getRoomAdmins(room),

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -29,7 +29,6 @@ const mockConversation = (id: string) => ({
   id: `conversation_${id}`,
   name: `conversation ${id}`,
   icon: 'conversation-icon',
-  hasJoined: true,
   messages: [
     { isAdmin: true, admin: { userId: 'admin-id-1' } },
     { sender: { userId: 'user-id-1' } },

--- a/src/store/channels-list/utils.test.ts
+++ b/src/store/channels-list/utils.test.ts
@@ -9,7 +9,6 @@ describe(toLocalChannel, () => {
       icon: 'channel-icon',
       category: 'channel-category',
       unreadCount: 'unread-count',
-      hasJoined: 'has-joined',
       createdAt: 1000003,
     };
 

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -12,7 +12,6 @@ export const toLocalChannel = (input): Partial<Channel> => {
     icon: input.icon,
     category: input.category,
     unreadCount: input.unreadCount,
-    hasJoined: input.hasJoined,
     createdAt: input.createdAt,
     otherMembers,
     lastMessage: input.lastMessage || null,

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -52,7 +52,6 @@ export interface Channel {
   lastMessage: Message;
   category?: string;
   unreadCount?: number;
-  hasJoined?: boolean;
   groupChannelType: GroupChannelType;
   icon?: string;
   isOneOnOne: boolean;
@@ -73,7 +72,6 @@ export const CHANNEL_DEFAULTS = {
   createdAt: 0,
   lastMessage: null,
   unreadCount: 0,
-  hasJoined: true,
   groupChannelType: GroupChannelType.Private,
   icon: '',
   isOneOnOne: true,

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -119,7 +119,6 @@ const CHANNEL_DEFAULTS = {
   createdAt: 0,
   lastMessage: null,
   unreadCount: 0,
-  hasJoined: true,
   groupChannelType: GroupChannelType.Private,
   icon: '',
   isOneOnOne: true,


### PR DESCRIPTION
### What does this do?

Removes the `hasJoined` property from Channel.

