### PR TITLE
Fix rewards popup blob background

### DIFF
--- a/src/components/rewards-modal/styles.scss
+++ b/src/components/rewards-modal/styles.scss
@@ -55,6 +55,7 @@
 
   &__rewards {
     background: url(cloudAsset('GreenBlob.svg')) no-repeat center;
+    background-size: contain;
     padding: 150px 0px;
     width: 100%;
   }


### PR DESCRIPTION
### What does this do?

Fix the green blob background on the rewards dialog

