### PR TITLE
feat: fallback content construction for message replies and handle parsing of plain body

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -493,28 +493,6 @@ describe('matrix client', () => {
 
       expect(result).toMatchObject({ id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c' });
     });
-
-    it('sends a reply message with correct properties', async () => {
-      const sendMessage = jest.fn().mockResolvedValue({ event_id: 'reply_event_id' });
-      const client = subject({ createClient: jest.fn(() => getSdkClient({ sendMessage })) });
-      const parentMessage = { messageId: 'parent_event_id' } as any;
-
-      await client.connect(null, 'token');
-      await client.sendMessagesByChannelId('channel-id', 'message', [], parentMessage);
-
-      expect(sendMessage).toHaveBeenCalledWith(
-        'channel-id',
-        expect.objectContaining({
-          'm.relates_to': {
-            'm.in_reply_to': {
-              event_id: parentMessage.messageId,
-            },
-          },
-          format: 'org.matrix.custom.html',
-          formatted_body: 'message',
-        })
-      );
-    });
   });
 
   describe('deleteMessageByRoomId', () => {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -6,7 +6,7 @@ import { when } from 'jest-when';
 import { config } from '../../config';
 import { PowerLevels } from './types';
 
-jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined), parsePlainBody: jest.fn() }));
+jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
 
 const mockUploadImage = jest.fn();
 jest.mock('../../store/channels-list/api', () => {

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -6,7 +6,7 @@ import { when } from 'jest-when';
 import { config } from '../../config';
 import { PowerLevels } from './types';
 
-jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined), parsePlainBody: jest.fn() }));
 
 const mockUploadImage = jest.fn();
 jest.mock('../../store/channels-list/api', () => {
@@ -540,6 +540,7 @@ describe('matrix client', () => {
       const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
 
       expect(fetchedMessages).toHaveLength(1);
+      console.log('FESTCHED', fetchedMessages);
       expect(fetchedMessages[0].message).toEqual('message 2');
     });
 
@@ -574,6 +575,7 @@ describe('matrix client', () => {
 
       await client.connect(null, 'token');
       const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
+      console.log('FESTCHED', fetchedMessages);
 
       expect(fetchedMessages).toHaveLength(3);
     });

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -540,7 +540,6 @@ describe('matrix client', () => {
       const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
 
       expect(fetchedMessages).toHaveLength(1);
-      console.log('FESTCHED', fetchedMessages);
       expect(fetchedMessages[0].message).toEqual('message 2');
     });
 
@@ -575,7 +574,6 @@ describe('matrix client', () => {
 
       await client.connect(null, 'token');
       const { messages: fetchedMessages } = await client.getMessagesByChannelId('channel-id');
-      console.log('FESTCHED', fetchedMessages);
 
       expect(fetchedMessages).toHaveLength(3);
     });

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -493,6 +493,28 @@ describe('matrix client', () => {
 
       expect(result).toMatchObject({ id: '$cz6gG4_AGHTZGiPiPDCxaOZAGqGhANGPnB058ZSrE9c' });
     });
+
+    it('sends a reply message with correct properties', async () => {
+      const sendMessage = jest.fn().mockResolvedValue({ event_id: 'reply_event_id' });
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ sendMessage })) });
+      const parentMessage = { messageId: 'parent_event_id' } as any;
+
+      await client.connect(null, 'token');
+      await client.sendMessagesByChannelId('channel-id', 'message', [], parentMessage);
+
+      expect(sendMessage).toHaveBeenCalledWith(
+        'channel-id',
+        expect.objectContaining({
+          'm.relates_to': {
+            'm.in_reply_to': {
+              event_id: parentMessage.messageId,
+            },
+          },
+          format: 'org.matrix.custom.html',
+          formatted_body: 'message',
+        })
+      );
+    });
   });
 
   describe('deleteMessageByRoomId', () => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -455,7 +455,8 @@ export class MatrixClient implements IChatClient {
           event_id: parentMessage.messageId,
         },
       };
-      (content['format'] = 'org.matrix.custom.html'), (content['formatted_body'] = message);
+      content['format'] = 'org.matrix.custom.html';
+      content['formatted_body'] = message;
     }
 
     const messageResult = await this.matrix.sendMessage(channelId, content);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -455,6 +455,7 @@ export class MatrixClient implements IChatClient {
           event_id: parentMessage.messageId,
         },
       };
+      (content['format'] = 'org.matrix.custom.html'), (content['formatted_body'] = message);
     }
 
     const messageResult = await this.matrix.sendMessage(channelId, content);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -35,7 +35,7 @@ import {
   MatrixConstants,
   MembershipStateType,
 } from './matrix/types';
-import { getFilteredMembersForAutoComplete, setAsDM } from './matrix/utils';
+import { constructFallbackForParentMessage, getFilteredMembersForAutoComplete, setAsDM } from './matrix/utils';
 import { uploadImage } from '../../store/channels-list/api';
 import { SessionStorage } from './session-storage';
 import { encryptFile } from './matrix/media';
@@ -450,13 +450,15 @@ export class MatrixClient implements IChatClient {
     };
 
     if (parentMessage) {
+      const fallback = constructFallbackForParentMessage(parentMessage);
+
+      content.body = `${fallback}\n\n${message}`;
+
       content['m.relates_to'] = {
         'm.in_reply_to': {
           event_id: parentMessage.messageId,
         },
       };
-      content['format'] = 'org.matrix.custom.html';
-      content['formatted_body'] = message;
     }
 
     const messageResult = await this.matrix.sendMessage(channelId, content);

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -36,7 +36,10 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
   const parent = matrixMessage.content['m.relates_to'];
   const senderData = sdkMatrixClient.getUser(senderId);
 
-  const parsedContentBody = parsePlainBody(content.body);
+  let parsedContentBody = content.body;
+  if (parent && parent['m.in_reply_to']) {
+    parsedContentBody = await parsePlainBody(content.body);
+  }
 
   return {
     id: event_id,

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -36,14 +36,14 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
   const parent = matrixMessage.content['m.relates_to'];
   const senderData = sdkMatrixClient.getUser(senderId);
 
-  let parsedContentBody = content.body;
+  let messageContent = content.body;
   if (parent && parent['m.in_reply_to']) {
-    parsedContentBody = await parsePlainBody(content.body);
+    messageContent = await parsePlainBody(content.body);
   }
 
   return {
     id: event_id,
-    message: parsedContentBody,
+    message: messageContent,
     createdAt: origin_server_ts,
     updatedAt: updatedAt,
     sender: {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -38,7 +38,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
 
   let messageContent = content.body;
   if (parent && parent['m.in_reply_to']) {
-    messageContent = await parsePlainBody(content.body);
+    messageContent = parsePlainBody(content.body);
   }
 
   return {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -2,6 +2,7 @@ import { CustomEventType, MatrixConstants, MembershipStateType, NotifiableEventT
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { decryptFile } from './media';
 import { AdminMessageType, Message, MessageSendStatus } from '../../../store/messages';
+import { parsePlainBody } from './utils';
 
 async function parseMediaData(matrixMessage) {
   const { content } = matrixMessage;
@@ -35,9 +36,11 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
   const parent = matrixMessage.content['m.relates_to'];
   const senderData = sdkMatrixClient.getUser(senderId);
 
+  const parsedContentBody = parsePlainBody(content.body);
+
   return {
     id: event_id,
-    message: content.body,
+    message: parsedContentBody,
     createdAt: origin_server_ts,
     updatedAt: updatedAt,
     sender: {

--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -1,5 +1,5 @@
 // Import your function and any necessary dependencies
-import { constructFallbackForParentMessage, getFilteredMembersForAutoComplete } from './utils';
+import { constructFallbackForParentMessage, getFilteredMembersForAutoComplete, parsePlainBody } from './utils';
 
 // Example room members data
 const roomMembers: any[] = [
@@ -105,5 +105,19 @@ describe(constructFallbackForParentMessage, () => {
     const fallback = constructFallbackForParentMessage(parentMessage);
 
     expect(fallback).toEqual('');
+  });
+});
+
+describe(parsePlainBody, () => {
+  it("filters out lines starting with '> '", () => {
+    const body = '> <@user:example.org> This is the first line\n> This is the second line\n\nThis is the reply message';
+    const expected = 'This is the reply message';
+
+    expect(parsePlainBody(body)).toEqual(expected);
+  });
+
+  it('returns an empty string if all lines are whitespace or quoted', () => {
+    const body = '> Quoted line\n    \n> Another quoted line';
+    expect(parsePlainBody(body)).toEqual('');
   });
 });

--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -1,5 +1,5 @@
 // Import your function and any necessary dependencies
-import { getFilteredMembersForAutoComplete } from './utils';
+import { constructFallbackForParentMessage, getFilteredMembersForAutoComplete } from './utils';
 
 // Example room members data
 const roomMembers: any[] = [
@@ -83,5 +83,27 @@ describe('getFilteredMembersForAutoComplete', () => {
         profileImage: '',
       },
     ]);
+  });
+});
+
+describe(constructFallbackForParentMessage, () => {
+  it('constructs fallback content correctly for a valid parent message', () => {
+    const parentMessage = {
+      messageId: 123,
+      sender: { matrixId: '@user:example.org' },
+      message: 'This is the first line\nThis is the second line',
+    };
+
+    const fallback = constructFallbackForParentMessage(parentMessage);
+
+    expect(fallback).toEqual('> <@user:example.org> This is the first line\n> This is the second line');
+  });
+
+  it('returns an empty string if parent message is empty', () => {
+    const parentMessage = { messageId: 123, sender: { matrixId: '@user:example.org' }, message: '' };
+
+    const fallback = constructFallbackForParentMessage(parentMessage);
+
+    expect(fallback).toEqual('');
   });
 });

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -58,3 +58,14 @@ export async function getFilteredMembersForAutoComplete(roomMembers: ChannelMemb
 
   return filteredResults;
 }
+
+export function constructFallbackForParentMessage(parentMessage) {
+  if (!parentMessage.message) return '';
+
+  const fallback = parentMessage.message
+    .split('\n')
+    .map((line, index) => (index === 0 ? `> <${parentMessage.sender.matrixId}> ${line}` : `> ${line}`))
+    .join('\n');
+
+  return fallback;
+}

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -69,3 +69,15 @@ export function constructFallbackForParentMessage(parentMessage) {
 
   return fallback;
 }
+
+export function parsePlainBody(body) {
+  if (!body) return '';
+
+  const parsedBody = body
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => !line.startsWith('> ') && line !== '')
+    .join('\n');
+
+  return parsedBody;
+}


### PR DESCRIPTION
### What does this do?
- implements the construction of fallback content for message replies, automatically generating a quoted format of the parent message that precedes the reply content.
- adds util to parse the content body body to filter out fallback content. 

### Why are we making this change?
- to align with Mobile (android/ios) content body expectations.
- ensures that the displayed messages contain only the original content added by the user.

### How do I test this?
- run tests > send replies between android and web devices.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  Constructing the fallback
<img width="666" alt="Screenshot 2024-03-25 at 14 11 09" src="https://github.com/zer0-os/zOS/assets/39112648/59d6ca80-074f-4c87-a58b-add97f1c70cb">


Before:

<img width="757" alt="Screenshot 2024-03-25 at 14 40 56" src="https://github.com/zer0-os/zOS/assets/39112648/10bb8144-7444-494c-a3c9-3a414d4f5af0">
  



After:
<img width="757" alt="Screenshot 2024-03-25 at 14 39 07" src="https://github.com/zer0-os/zOS/assets/39112648/2bb5517d-98b0-4596-8410-4f59e8750032">

