### PR TITLE
feat: add util to parse content body, filtering out fallback content

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -2,6 +2,7 @@ import { CustomEventType, MatrixConstants, MembershipStateType, NotifiableEventT
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { decryptFile } from './media';
 import { AdminMessageType, Message, MessageSendStatus } from '../../../store/messages';
+import { parseFormattedReply } from './utils';
 
 async function parseMediaData(matrixMessage) {
   const { content } = matrixMessage;
@@ -35,9 +36,14 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
   const parent = matrixMessage.content['m.relates_to'];
   const senderData = sdkMatrixClient.getUser(senderId);
 
+  let messageContent = content.body;
+  if (content.format === 'org.matrix.custom.html' && content.formatted_body) {
+    messageContent = parseFormattedReply(content.formatted_body);
+  }
+
   return {
     id: event_id,
-    message: content.body,
+    message: messageContent,
     createdAt: origin_server_ts,
     updatedAt: updatedAt,
     sender: {

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -1,5 +1,6 @@
 import { EventType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { User as ChannelMember } from '../../../store/channels';
+import DOMPurify from 'dompurify';
 
 // Copied from the matrix-react-sdk
 export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: string): Promise<void> {
@@ -57,4 +58,11 @@ export async function getFilteredMembersForAutoComplete(roomMembers: ChannelMemb
   }
 
   return filteredResults;
+}
+
+export function parseFormattedReply(formattedBody) {
+  const replyBlockRegex = /<mx-reply>[\s\S]*?<\/mx-reply>/;
+  const cleanBody = formattedBody.replace(replyBlockRegex, '').trim();
+  const sanitizedBody = DOMPurify.sanitize(cleanBody);
+  return sanitizedBody;
 }


### PR DESCRIPTION
### What does this do?
- adds util to parse the content body body to filter out fallback content. 

### Why are we making this change?
- ensures that the displayed messages contain only the original content added by the user.

### How do I test this?
- run tests as usual > send messages from mobile device to web

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
