### PR TITLE
Fix the Favorite tabs from changing size when changing from active

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -25,6 +25,7 @@ $side-padding: 16px;
   &__tab {
     box-sizing: border-box;
     padding: 8px 16px;
+    border: 1px solid transparent;
 
     @include glass-text-secondary-color;
     font-size: 12px;


### PR DESCRIPTION
### What does this do?

Adds a default border so that the Favorite/All tabs don't bounce when changing
