### PR TITLE
refactor: remove max invites per user

### DIFF
--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -12,6 +12,7 @@ describe('Container', () => {
       inviteCode: '',
       inviteUrl: '',
       assetPath: '',
+      inviteCount: '',
       invitesUsed: 0,
       isLoading: false,
       fetchInvite: () => null,

--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -13,7 +13,6 @@ describe('Container', () => {
       inviteUrl: '',
       assetPath: '',
       invitesUsed: 0,
-      maxUses: 0,
       isLoading: false,
       fetchInvite: () => null,
       clearInvite: () => null,

--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -12,7 +12,7 @@ describe('Container', () => {
       inviteCode: '',
       inviteUrl: '',
       assetPath: '',
-      inviteCount: '',
+      inviteCount: 0,
       invitesUsed: 0,
       isLoading: false,
       fetchInvite: () => null,

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -12,6 +12,7 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   inviteCode: string;
   invitesUsed: number;
+  inviteCount: string;
   inviteUrl: string;
   assetPath: string;
   isLoading: boolean;
@@ -30,6 +31,7 @@ export class Container extends React.Component<Properties> {
       assetPath: config.imageAssetsPath,
       invitesUsed: createInvitation.invitesUsed,
       isLoading: createInvitation.isLoading,
+      inviteCount: createInvitation.inviteCount,
     };
   }
 
@@ -50,6 +52,7 @@ export class Container extends React.Component<Properties> {
       <InviteDialog
         inviteCode={this.props.inviteCode}
         invitesUsed={this.props.invitesUsed}
+        inviteCount={this.props.inviteCount}
         inviteUrl={this.props.inviteUrl}
         assetsPath={this.props.assetPath}
         onClose={this.props.onClose}

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -30,8 +30,8 @@ export class Container extends React.Component<Properties> {
       inviteUrl: createInvitation.url,
       assetPath: config.imageAssetsPath,
       invitesUsed: createInvitation.invitesUsed,
-      isLoading: createInvitation.isLoading,
       inviteCount: createInvitation.inviteCount,
+      isLoading: createInvitation.isLoading,
     };
   }
 

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -12,7 +12,6 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   inviteCode: string;
   invitesUsed: number;
-  maxUses: number;
   inviteUrl: string;
   assetPath: string;
   isLoading: boolean;
@@ -30,7 +29,6 @@ export class Container extends React.Component<Properties> {
       inviteUrl: createInvitation.url,
       assetPath: config.imageAssetsPath,
       invitesUsed: createInvitation.invitesUsed,
-      maxUses: createInvitation.maxUses,
       isLoading: createInvitation.isLoading,
     };
   }
@@ -52,7 +50,6 @@ export class Container extends React.Component<Properties> {
       <InviteDialog
         inviteCode={this.props.inviteCode}
         invitesUsed={this.props.invitesUsed}
-        maxUses={this.props.maxUses}
         inviteUrl={this.props.inviteUrl}
         assetsPath={this.props.assetPath}
         onClose={this.props.onClose}

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -12,7 +12,7 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   inviteCode: string;
   invitesUsed: number;
-  inviteCount: string;
+  inviteCount: number;
   inviteUrl: string;
   assetPath: string;
   isLoading: boolean;

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -14,7 +14,6 @@ describe('InviteDialog', () => {
       inviteUrl: '',
       assetsPath: '',
       invitesUsed: 0,
-      maxUses: 0,
       clipboard: { write: () => null },
       isLoading: false,
       ...props,
@@ -22,12 +21,6 @@ describe('InviteDialog', () => {
 
     return shallow(<InviteDialog {...allProps} />);
   };
-
-  it('renders the code remaining number of invites', function () {
-    const wrapper = subject({ inviteCode: '23817', maxUses: 5, invitesUsed: 3 });
-
-    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
-  });
 
   it('copies the invitation to the clipboard', function () {
     const clipboard = { write: jest.fn() };

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -24,7 +24,7 @@ describe('InviteDialog', () => {
   };
 
   it('renders the code remaining number of invites', function () {
-    const wrapper = subject({ inviteCode: '23817', inviteCount: '5' });
+    const wrapper = subject({ inviteCode: '23817', inviteCount: '2' });
 
     expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
   });

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -11,10 +11,10 @@ describe('InviteDialog', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       inviteCode: '',
-      inviteCount: '',
       inviteUrl: '',
       assetsPath: '',
       invitesUsed: 0,
+      inviteCount: '',
       clipboard: { write: () => null },
       isLoading: false,
       ...props,
@@ -22,6 +22,12 @@ describe('InviteDialog', () => {
 
     return shallow(<InviteDialog {...allProps} />);
   };
+
+  it('renders the code remaining number of invites', function () {
+    const wrapper = subject({ inviteCode: '23817', inviteCount: '5' });
+
+    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
+  });
 
   it('copies the invitation to the clipboard', function () {
     const clipboard = { write: jest.fn() };

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -14,7 +14,7 @@ describe('InviteDialog', () => {
       inviteUrl: '',
       assetsPath: '',
       invitesUsed: 0,
-      inviteCount: '',
+      inviteCount: 0,
       clipboard: { write: () => null },
       isLoading: false,
       ...props,
@@ -24,9 +24,9 @@ describe('InviteDialog', () => {
   };
 
   it('renders the code remaining number of invites', function () {
-    const wrapper = subject({ inviteCode: '23817', inviteCount: '2' });
+    const wrapper = subject({ inviteCode: '23817', inviteCount: 2 });
 
-    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
+    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual(2);
   });
 
   it('copies the invitation to the clipboard', function () {

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -26,7 +26,7 @@ describe('InviteDialog', () => {
   it('renders the code remaining number of invites', function () {
     const wrapper = subject({ inviteCode: '23817', inviteCount: 2 });
 
-    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual(2);
+    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
   });
 
   it('copies the invitation to the clipboard', function () {

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -11,6 +11,7 @@ describe('InviteDialog', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       inviteCode: '',
+      inviteCount: '',
       inviteUrl: '',
       assetsPath: '',
       invitesUsed: 0,

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -40,6 +40,10 @@ export class InviteDialog extends React.Component<Properties, State> {
     clearTimeout(this.buttonTimeout);
   }
 
+  getInvitesRemaining() {
+    return 5;
+  }
+
   get inviteText() {
     return `Use this code to join me on ZERO Messenger: ${this.props.inviteCode} ${config.inviteUrl}`;
   }
@@ -70,6 +74,15 @@ export class InviteDialog extends React.Component<Properties, State> {
           <Button onPress={this.writeInviteToClipboard} isDisabled={!this.props.inviteCode}>
             {this.state.copyText}
           </Button>
+
+          <div {...cn('remaining-invite-container')}>
+            {!this.props.isLoading && (
+              <>
+                <div {...cn('remaining-invite')}>{this.getInvitesRemaining()}</div>
+                <>Remaining</>
+              </>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -17,6 +17,7 @@ export interface Clipboard {
 
 export interface Properties {
   inviteCode: string;
+  inviteCount: string;
   invitesUsed: number;
   inviteUrl: string;
   assetsPath: string;
@@ -41,7 +42,7 @@ export class InviteDialog extends React.Component<Properties, State> {
   }
 
   getInvitesRemaining() {
-    return 5;
+    return this.props.inviteCount;
   }
 
   get inviteText() {

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -18,7 +18,6 @@ export interface Clipboard {
 export interface Properties {
   inviteCode: string;
   invitesUsed: number;
-  maxUses: number;
   inviteUrl: string;
   assetsPath: string;
   isLoading: boolean;
@@ -39,10 +38,6 @@ export class InviteDialog extends React.Component<Properties, State> {
 
   componentWillUnmount() {
     clearTimeout(this.buttonTimeout);
-  }
-
-  getInvitesRemaining() {
-    return Math.max(this.props.maxUses - this.props.invitesUsed, 0);
   }
 
   get inviteText() {
@@ -75,15 +70,6 @@ export class InviteDialog extends React.Component<Properties, State> {
           <Button onPress={this.writeInviteToClipboard} isDisabled={!this.props.inviteCode}>
             {this.state.copyText}
           </Button>
-
-          <div {...cn('remaining-invite-container')}>
-            {!this.props.isLoading && (
-              <>
-                <div {...cn('remaining-invite')}>{this.getInvitesRemaining()}</div>
-                <>Remaining</>
-              </>
-            )}
-          </div>
         </div>
       </div>
     );

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -18,7 +18,7 @@ export interface Clipboard {
 export interface Properties {
   inviteCode: string;
   invitesUsed: number;
-  inviteCount: string;
+  inviteCount: number;
   inviteUrl: string;
   assetsPath: string;
   isLoading: boolean;

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -17,8 +17,8 @@ export interface Clipboard {
 
 export interface Properties {
   inviteCode: string;
-  inviteCount: string;
   invitesUsed: number;
+  inviteCount: string;
   inviteUrl: string;
   assetsPath: string;
   isLoading: boolean;

--- a/src/components/invite-dialog/styles.scss
+++ b/src/components/invite-dialog/styles.scss
@@ -47,4 +47,24 @@
     line-height: 29px;
     width: 171px;
   }
+
+  &__remaining-invite-container {
+    @include glass-text-secondary-color;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: $font-size-medium;
+    line-height: 17px;
+    gap: 4px;
+    height: 20px;
+
+    margin-top: 16px;
+    animation: fadeIn 0.2s ease-in;
+  }
+
+  &__remaining-invite {
+    font-weight: 600;
+    line-height: 20px;
+  }
 }

--- a/src/components/invite-dialog/styles.scss
+++ b/src/components/invite-dialog/styles.scss
@@ -47,24 +47,4 @@
     line-height: 29px;
     width: 171px;
   }
-
-  &__remaining-invite-container {
-    @include glass-text-secondary-color;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: $font-size-medium;
-    line-height: 17px;
-    gap: 4px;
-    height: 20px;
-
-    margin-top: 16px;
-    animation: fadeIn 0.2s ease-in;
-  }
-
-  &__remaining-invite {
-    font-weight: 600;
-    line-height: 20px;
-  }
 }

--- a/src/store/create-invitation/index.ts
+++ b/src/store/create-invitation/index.ts
@@ -12,6 +12,7 @@ export type CreateInvitationState = {
   code: string;
   url: string;
   invitesUsed: number;
+  inviteCount: string;
   isLoading: boolean;
 };
 
@@ -19,6 +20,7 @@ const initialState: CreateInvitationState = {
   code: '',
   url: '',
   invitesUsed: 0,
+  inviteCount: '',
   isLoading: false,
 };
 
@@ -30,6 +32,7 @@ const slice = createSlice({
       state.code = action.payload.code;
       state.url = action.payload.url;
       state.invitesUsed = action.payload.invitesUsed;
+      state.inviteCount = action.payload.inviteCount;
     },
     setLoading: (state, action: PayloadAction<CreateInvitationState['isLoading']>) => {
       state.isLoading = action.payload;
@@ -38,6 +41,7 @@ const slice = createSlice({
       state.code = initialState.code;
       state.url = initialState.url;
       state.invitesUsed = initialState.invitesUsed;
+      state.inviteCount = initialState.inviteCount;
     },
   },
 });

--- a/src/store/create-invitation/index.ts
+++ b/src/store/create-invitation/index.ts
@@ -12,7 +12,6 @@ export type CreateInvitationState = {
   code: string;
   url: string;
   invitesUsed: number;
-  maxUses: number;
   isLoading: boolean;
 };
 
@@ -20,7 +19,6 @@ const initialState: CreateInvitationState = {
   code: '',
   url: '',
   invitesUsed: 0,
-  maxUses: 0,
   isLoading: false,
 };
 
@@ -32,7 +30,6 @@ const slice = createSlice({
       state.code = action.payload.code;
       state.url = action.payload.url;
       state.invitesUsed = action.payload.invitesUsed;
-      state.maxUses = action.payload.maxUses;
     },
     setLoading: (state, action: PayloadAction<CreateInvitationState['isLoading']>) => {
       state.isLoading = action.payload;
@@ -41,7 +38,6 @@ const slice = createSlice({
       state.code = initialState.code;
       state.url = initialState.url;
       state.invitesUsed = initialState.invitesUsed;
-      state.maxUses = initialState.maxUses;
     },
   },
 });

--- a/src/store/create-invitation/index.ts
+++ b/src/store/create-invitation/index.ts
@@ -12,7 +12,7 @@ export type CreateInvitationState = {
   code: string;
   url: string;
   invitesUsed: number;
-  inviteCount: string;
+  inviteCount: number;
   isLoading: boolean;
 };
 
@@ -20,7 +20,7 @@ const initialState: CreateInvitationState = {
   code: '',
   url: '',
   invitesUsed: 0,
-  inviteCount: '',
+  inviteCount: 0,
   isLoading: false,
 };
 

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -20,7 +20,7 @@ describe('fetchInvite', () => {
           ],
         ])
         .withReducer(rootReducer, {
-          createInvitation: { code: '', url: '', invitesUsed: 0, inviteCount: '', isLoading: false },
+          createInvitation: { code: '', url: '', invitesUsed: 0, inviteCount: 0, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.GetCode })
         .run();
@@ -29,6 +29,7 @@ describe('fetchInvite', () => {
         code: '98762',
         url: 'https://www.example.com/invite',
         invitesUsed: 3,
+        inviteCount: 0,
         isLoading: false,
       });
     });
@@ -38,12 +39,12 @@ describe('fetchInvite', () => {
         storeState: { createInvitation },
       } = await expectSaga(fetchInvite)
         .withReducer(rootReducer, {
-          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, inviteCount: '3', isLoading: false },
+          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, inviteCount: 3, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.Cancel })
         .run();
 
-      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, inviteCount: '', isLoading: false });
+      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, inviteCount: 0, isLoading: false });
     });
   });
 });

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -16,11 +16,11 @@ describe('fetchInvite', () => {
         .provide([
           [
             call(getInvite),
-            { slug: '98762', invitesUsed: 3, maxInvitesPerUser: 6 },
+            { slug: '98762', invitesUsed: 3 },
           ],
         ])
         .withReducer(rootReducer, {
-          createInvitation: { code: '', url: '', invitesUsed: 0, maxUses: 0, isLoading: false },
+          createInvitation: { code: '', url: '', invitesUsed: 0, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.GetCode })
         .run();
@@ -29,7 +29,6 @@ describe('fetchInvite', () => {
         code: '98762',
         url: 'https://www.example.com/invite',
         invitesUsed: 3,
-        maxUses: 6,
         isLoading: false,
       });
     });
@@ -39,12 +38,12 @@ describe('fetchInvite', () => {
         storeState: { createInvitation },
       } = await expectSaga(fetchInvite)
         .withReducer(rootReducer, {
-          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, maxUses: 3, isLoading: false },
+          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.Cancel })
         .run();
 
-      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, maxUses: 0, isLoading: false });
+      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, isLoading: false });
     });
   });
 });

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -16,7 +16,7 @@ describe('fetchInvite', () => {
         .provide([
           [
             call(getInvite),
-            { slug: '98762', invitesUsed: 3 },
+            { slug: '98762', invitesUsed: 3, inviteCount: 0 },
           ],
         ])
         .withReducer(rootReducer, {

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -20,7 +20,7 @@ describe('fetchInvite', () => {
           ],
         ])
         .withReducer(rootReducer, {
-          createInvitation: { code: '', url: '', invitesUsed: 0, inviteCount: 0, isLoading: false },
+          createInvitation: { code: '', url: '', invitesUsed: 0, inviteCount: '', isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.GetCode })
         .run();
@@ -38,12 +38,12 @@ describe('fetchInvite', () => {
         storeState: { createInvitation },
       } = await expectSaga(fetchInvite)
         .withReducer(rootReducer, {
-          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, inviteCount: 3, isLoading: false },
+          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, inviteCount: '3', isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.Cancel })
         .run();
 
-      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, inviteCount: 0, isLoading: false });
+      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, inviteCount: '', isLoading: false });
     });
   });
 });

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -20,7 +20,7 @@ describe('fetchInvite', () => {
           ],
         ])
         .withReducer(rootReducer, {
-          createInvitation: { code: '', url: '', invitesUsed: 0, isLoading: false },
+          createInvitation: { code: '', url: '', invitesUsed: 0, inviteCount: 0, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.GetCode })
         .run();
@@ -38,12 +38,12 @@ describe('fetchInvite', () => {
         storeState: { createInvitation },
       } = await expectSaga(fetchInvite)
         .withReducer(rootReducer, {
-          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, isLoading: false },
+          createInvitation: { code: 'something', url: 'url', invitesUsed: 2, inviteCount: 3, isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.Cancel })
         .run();
 
-      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, isLoading: false });
+      expect(createInvitation).toEqual({ code: '', url: '', invitesUsed: 0, inviteCount: 0, isLoading: false });
     });
   });
 });

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -20,7 +20,6 @@ export function* fetchInvite() {
         code: invitation.slug,
         url: config.inviteUrl,
         invitesUsed: invitation.invitesUsed,
-        maxUses: invitation.maxInvitesPerUser,
       })
     );
     return;

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -20,6 +20,7 @@ export function* fetchInvite() {
         code: invitation.slug,
         url: config.inviteUrl,
         invitesUsed: invitation.invitesUsed,
+        inviteCount: invitation.inviteCount,
       })
     );
     return;


### PR DESCRIPTION
### What does this do?
- removes `maxInvitesPerUser` / `maxUses`.

### Why are we making this change?
- no longer require a max value for invites.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


NOTE:: I notice the designs still contain the remaining count of invites displayed on the invite dialog. Are we sure we no longer require an invite count?

<img width="899" alt="Screenshot 2024-03-26 at 08 31 55" src="https://github.com/zer0-os/zOS/assets/39112648/df264b3c-e520-49b3-89bf-316adff131ab">

After deletions:
<img width="899" alt="Screenshot 2024-03-26 at 08 33 04" src="https://github.com/zer0-os/zOS/assets/39112648/01fbfffd-73d6-4b35-8df2-ed5608571c04">
