### PR TITLE
refactor(message-input): remove `classname` prop

### DIFF
--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -9,7 +9,6 @@ import { ParentMessage } from '../../lib/chat/types';
 import { currentUserSelector } from '../../store/authentication/saga';
 
 export interface PublicProperties {
-  className?: string;
   onSubmit: (message: string, mentionedUserIds: User['userId'][], media: Media[]) => void;
   initialValue?: string;
   getUsersForMentions: (search: string) => Promise<UserForMention[]>;
@@ -61,7 +60,6 @@ export class Container extends React.Component<Properties> {
 
     return (
       <MessageInputComponent
-        className={this.props.className}
         id={this.props.id}
         initialValue={this.props.initialValue}
         onSubmit={this.props.onSubmit}

--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -14,7 +14,6 @@ import { IconSend3 } from '@zero-tech/zui/icons';
 describe('MessageInput', () => {
   const subject = (props: Partial<Properties>, child: any = <div />) => {
     const allProps: Properties = {
-      className: '',
       placeholder: '',
       reply: null,
       onSubmit: () => undefined,
@@ -34,12 +33,6 @@ describe('MessageInput', () => {
     return shallow(<MessageInput {...allProps}>{child}</MessageInput>);
   };
 
-  it('adds className', () => {
-    const wrapper = subject({ className: 'message-input' });
-
-    expect(wrapper.hasClass('message-input')).toBeTrue();
-  });
-
   it('adds placeholder', () => {
     const wrapper = subject({ placeholder: 'Speak' });
     const dropzone = wrapper.find(Dropzone).shallow();
@@ -47,15 +40,9 @@ describe('MessageInput', () => {
     expect(dropzone.find(MentionsInput).prop('placeholder')).toEqual('Speak');
   });
 
-  it('it renders the messageInput', function () {
-    const wrapper = subject({ className: 'chat' });
-
-    expect(wrapper.find('.message-input').exists()).toBe(true);
-  });
-
   it('should call editActions', function () {
     const renderAfterInput = jest.fn();
-    const wrapper = subject({ renderAfterInput, className: 'chat' });
+    const wrapper = subject({ renderAfterInput });
     const _dropzone = wrapper.find(Dropzone).shallow();
 
     expect(renderAfterInput).toHaveBeenCalled();

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -328,7 +328,7 @@ export class MessageInput extends React.Component<Properties, State> {
           )}
         </div>
         <div
-          className={classNames(c('input-row'), this.props.className, {
+          className={classNames(c('input-row'), {
             'message-input__container--editing': this.props.isEditing,
           })}
         >
@@ -467,7 +467,7 @@ export class MessageInput extends React.Component<Properties, State> {
   render() {
     return (
       <div
-        className={classNames('message-input', this.props.className, {
+        className={classNames('message-input', {
           'message-input--editing': this.props.isEditing,
         })}
       >


### PR DESCRIPTION
### What does this do?
- removes unused `classname` prop from message input container / component.

### Why are we making this change?
- house keeping / no longer used.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
