### PR TITLE
feat: implement adding favorite room tags

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -19,7 +19,7 @@ export interface RealtimeChatEvents {
   onOtherUserJoinedChannel: (channelId: string, user: UserModel) => void;
   onOtherUserLeftChannel: (channelId: string, user: UserModel) => void;
   receiveLiveRoomEvent: (eventData) => void;
-  onFavoriteTagChange: (roomId: string, isFavorite: boolean) => void;
+  roomFavorited: (roomId: string) => void;
 }
 
 export interface MatrixKeyBackupInfo {
@@ -283,6 +283,6 @@ export async function getSecureBackup() {
   return await chat.get().matrix.getSecureBackup();
 }
 
-export async function addFavoriteRoomTag(roomId: string) {
-  return await chat.get().matrix.addFavoriteRoomTag(roomId);
+export async function addRoomToFavorites(roomId: string) {
+  return await chat.get().matrix.addRoomToFavorites(roomId);
 }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -19,6 +19,7 @@ export interface RealtimeChatEvents {
   onOtherUserJoinedChannel: (channelId: string, user: UserModel) => void;
   onOtherUserLeftChannel: (channelId: string, user: UserModel) => void;
   receiveLiveRoomEvent: (eventData) => void;
+  onFavoriteTagChange: (roomId: string, isFavorite: boolean) => void;
 }
 
 export interface MatrixKeyBackupInfo {
@@ -280,4 +281,8 @@ export async function isRoomMember(userId: string, roomId: string) {
 
 export async function getSecureBackup() {
   return await chat.get().matrix.getSecureBackup();
+}
+
+export async function addFavoriteRoomTag(roomId: string) {
+  return await chat.get().matrix.addFavoriteRoomTag(roomId);
 }

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -69,6 +69,7 @@ const getSdkClient = (sdkClient = {}) => ({
   paginateEventTimeline: () => true,
   isRoomEncrypted: () => true,
   invite: jest.fn().mockResolvedValue({}),
+  setRoomTag: jest.fn().mockResolvedValue({}),
   ...sdkClient,
 });
 
@@ -792,8 +793,8 @@ describe('matrix client', () => {
     });
   });
 
-  describe('addFavoriteRoomTag', () => {
-    it('sets "favorite" tag on room', async () => {
+  describe('addRoomToFavorites', () => {
+    it('sets room tag with "m.favorite"', async () => {
       const roomId = '!testRoomId';
       const setRoomTag = jest.fn().mockResolvedValue({});
 
@@ -802,7 +803,7 @@ describe('matrix client', () => {
       });
 
       await client.connect(null, 'token');
-      await client.addFavoriteRoomTag(roomId);
+      await client.addRoomToFavorites(roomId);
 
       expect(setRoomTag).toHaveBeenCalledWith(roomId, 'm.favorite');
     });

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -791,4 +791,20 @@ describe('matrix client', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('addFavoriteRoomTag', () => {
+    it('sets "favorite" tag on room', async () => {
+      const roomId = '!testRoomId';
+      const setRoomTag = jest.fn().mockResolvedValue({});
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ setRoomTag })),
+      });
+
+      await client.connect(null, 'token');
+      await client.addFavoriteRoomTag(roomId);
+
+      expect(setRoomTag).toHaveBeenCalledWith(roomId, 'm.favorite');
+    });
+  });
 });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -653,6 +653,16 @@ export class MatrixClient implements IChatClient {
     return await Promise.all(matches.map((r) => this.mapConversation(r)));
   }
 
+  async addFavoriteRoomTag(roomId: string): Promise<void> {
+    await this.waitForConnection();
+
+    try {
+      await this.matrix.setRoomTag(roomId, MatrixConstants.FAVORITE);
+    } catch (error) {
+      console.error(`Error adding favorite tag for room ${roomId}:`, error);
+    }
+  }
+
   arraysMatch(a, b) {
     if (a.length !== b.length) {
       return false;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -54,6 +54,7 @@ export class MatrixClient implements IChatClient {
   private connectionResolver: () => void;
   private connectionAwaiter: Promise<void>;
   private unreadNotificationHandlers = [];
+  private roomTagHandlers = [];
   private initializationTimestamp: number;
   private secretStorageKey: string;
 
@@ -656,11 +657,7 @@ export class MatrixClient implements IChatClient {
   async addRoomToFavorites(roomId: string): Promise<void> {
     await this.waitForConnection();
 
-    try {
-      await this.matrix.setRoomTag(roomId, MatrixConstants.FAVORITE);
-    } catch (error) {
-      console.error(`Error adding favorite tag for room ${roomId}:`, error);
-    }
+    await this.matrix.setRoomTag(roomId, MatrixConstants.FAVORITE);
   }
 
   arraysMatch(a, b) {
@@ -719,9 +716,16 @@ export class MatrixClient implements IChatClient {
       return;
     }
 
+    if (this.roomTagHandlers[room.roomId]) {
+      return;
+    }
+
     this.unreadNotificationHandlers[room.roomId] = (unreadNotification) =>
       this.handleUnreadNotifications(room.roomId, unreadNotification);
     room.on(RoomEvent.UnreadNotifications, this.unreadNotificationHandlers[room.roomId]);
+
+    this.roomTagHandlers[room.roomId] = (event) => this.publishRoomTagChange(event, room.roomId);
+    room.on(RoomEvent.Tags, this.roomTagHandlers[room.roomId]);
   }
 
   private handleUnreadNotifications = (roomId, unreadNotifications) => {
@@ -746,10 +750,6 @@ export class MatrixClient implements IChatClient {
       }
       if (event.type === EventType.RoomRedaction) {
         this.receiveDeleteMessage(event);
-      }
-
-      if (event.type === EventType.Tag) {
-        this.publishRoomTagUpdate(event);
       }
 
       this.processMessageEvent(event);
@@ -930,13 +930,13 @@ export class MatrixClient implements IChatClient {
     }
   };
 
-  private publishRoomTagUpdate(event) {
-    const roomId = event.room_id;
-
-    const isFavoriteTagAdded = !!event.content?.tags?.[MatrixConstants.FAVORITE];
+  private publishRoomTagChange(event, roomId) {
+    const isFavoriteTagAdded = !!event.getContent().tags?.[MatrixConstants.FAVORITE];
 
     if (isFavoriteTagAdded) {
       this.events.roomFavorited(roomId);
+    } else {
+      console.log('room unfavorited');
     }
   }
 

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -20,6 +20,7 @@ export enum MatrixConstants {
   NEW_CONTENT = 'm.new_content',
   REPLACE = 'm.replace',
   BAD_ENCRYPTED_MSGTYPE = 'm.bad.encrypted',
+  FAVORITE = 'm.favorite',
 }
 
 export enum CustomEventType {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -80,12 +80,14 @@ export enum SagaActionTypes {
   OpenConversation = 'channels/saga/openConversation',
   OnReply = 'channels/saga/onReply',
   OnRemoveReply = 'channels/saga/onRemoveReply',
+  OnToggleFavoriteTag = 'channels/saga/onToggleFavoriteTag',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
 const onReply = createAction<{ reply: ParentMessage }>(SagaActionTypes.OnReply);
 const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
+const onToggleFavoriteTag = createAction<{ roomId: string }>(SagaActionTypes.OnToggleFavoriteTag);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -98,4 +100,4 @@ const slice = createNormalizedSlice({
 
 export const { receive: rawReceive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply };
+export { unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply, onToggleFavoriteTag };

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -80,14 +80,14 @@ export enum SagaActionTypes {
   OpenConversation = 'channels/saga/openConversation',
   OnReply = 'channels/saga/onReply',
   OnRemoveReply = 'channels/saga/onRemoveReply',
-  OnToggleFavoriteTag = 'channels/saga/onToggleFavoriteTag',
+  OnFavoriteRoom = 'channels/saga/onFavoriteRoom',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
 const onReply = createAction<{ reply: ParentMessage }>(SagaActionTypes.OnReply);
 const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
-const onToggleFavoriteTag = createAction<{ roomId: string }>(SagaActionTypes.OnToggleFavoriteTag);
+const onFavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnFavoriteRoom);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -100,4 +100,4 @@ const slice = createNormalizedSlice({
 
 export const { receive: rawReceive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply, onToggleFavoriteTag };
+export { unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply, onFavoriteRoom };

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -131,7 +131,7 @@ describe(roomFavoriteUpdated, () => {
 });
 
 describe(onFavoriteRoom, () => {
-  it('calls addFavoriteRoomTag when channel is not already favorite', async () => {
+  it('calls addRoomToFavorites when channel is not already favorite', async () => {
     const initialState = new StoreBuilder().withConversationList({ id: 'channel-id', isFavorite: false }).build();
 
     await expectSaga(onFavoriteRoom, { payload: { roomId: 'channel-id' } })

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -1,20 +1,19 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { call, delay } from 'redux-saga/effects';
 
 import {
-  favouriteTagUpdated,
+  roomFavoriteUpdated,
   markAllMessagesAsRead,
   markConversationAsRead,
   receiveChannel,
-  toggleFavoriteRoomTag,
+  onFavoriteRoom,
   unreadCountUpdated,
 } from './saga';
 
 import { rootReducer } from '../reducer';
 import { ConversationStatus, denormalize as denormalizeChannel } from '../channels';
 import { StoreBuilder } from '../test/store';
-import { addFavoriteRoomTag, chat } from '../../lib/chat';
+import { addRoomToFavorites, chat } from '../../lib/chat';
 
 const userId = 'user-id';
 
@@ -117,30 +116,30 @@ describe(receiveChannel, () => {
   });
 });
 
-describe(favouriteTagUpdated, () => {
-  it('updates favorite tag for channel', async () => {
-    const initialState = new StoreBuilder().withConversationList({ id: 'channel-id', isFavorite: false }).build();
-    const { storeState } = await expectSaga(favouriteTagUpdated, {
-      payload: { roomId: 'channel-id', isFavorite: true },
+describe(roomFavoriteUpdated, () => {
+  it('updates favorites for room', async () => {
+    const initialState = new StoreBuilder().withConversationList({ id: 'room-id', isFavorite: false }).build();
+    const { storeState } = await expectSaga(roomFavoriteUpdated, {
+      payload: { roomId: 'room-id' },
     })
       .withReducer(rootReducer, initialState)
       .run();
 
-    const channel = denormalizeChannel('channel-id', storeState);
+    const channel = denormalizeChannel('room-id', storeState);
     expect(channel.isFavorite).toEqual(true);
   });
 });
 
-describe(toggleFavoriteRoomTag, () => {
+describe(onFavoriteRoom, () => {
   it('calls addFavoriteRoomTag when channel is not already favorite', async () => {
     const initialState = new StoreBuilder().withConversationList({ id: 'channel-id', isFavorite: false }).build();
 
-    await expectSaga(toggleFavoriteRoomTag, { payload: { roomId: 'channel-id' } })
+    await expectSaga(onFavoriteRoom, { payload: { roomId: 'channel-id' } })
       .withReducer(rootReducer, initialState)
       .provide([
-        [matchers.call.fn(addFavoriteRoomTag), undefined],
+        [matchers.call.fn(addRoomToFavorites), undefined],
       ])
-      .call(addFavoriteRoomTag, 'channel-id')
+      .call(addRoomToFavorites, 'channel-id')
       .run();
   });
 });

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -4,7 +4,7 @@ import { SagaActionTypes, rawReceive, schema, removeAll, Channel, CHANNEL_DEFAUL
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
-import { addFavoriteRoomTag, chat } from '../../lib/chat';
+import { addRoomToFavorites, chat } from '../../lib/chat';
 import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
 import { ParentMessage } from '../../lib/chat/types';
@@ -98,7 +98,7 @@ export function* receiveChannel(channel: Partial<Channel>) {
   yield put(rawReceive(data));
 }
 
-export function* toggleFavoriteRoomTag(action) {
+export function* onFavoriteRoom(action) {
   const { roomId } = action.payload;
 
   const channel = yield select(rawChannelSelector(roomId));
@@ -107,30 +107,27 @@ export function* toggleFavoriteRoomTag(action) {
     return;
   }
 
-  if (channel.isFavorite) {
-    console.log('removeFavoriteRoomTag', roomId);
-  } else {
-    yield call(addFavoriteRoomTag, roomId);
-  }
+  yield call(addRoomToFavorites, roomId);
 }
 
-export function* favouriteTagUpdated(action) {
-  const { roomId, isFavorite } = action.payload;
+export function* roomFavoriteUpdated(action) {
+  const { roomId } = action.payload;
 
   const channel = yield select(rawChannelSelector(roomId));
 
   if (!channel) {
     return;
   }
-  yield call(receiveChannel, { id: roomId, isFavorite: isFavorite });
+
+  yield call(receiveChannel, { id: roomId, isFavorite: true });
 }
 
 export function* saga() {
   yield takeLatest(SagaActionTypes.OpenConversation, ({ payload }: any) => openConversation(payload.conversationId));
   yield takeLatest(SagaActionTypes.OnReply, ({ payload }: any) => onReply(payload.reply));
   yield takeLatest(SagaActionTypes.OnRemoveReply, onRemoveReply);
-  yield takeLatest(SagaActionTypes.OnToggleFavoriteTag, toggleFavoriteRoomTag);
+  yield takeLatest(SagaActionTypes.OnFavoriteRoom, onFavoriteRoom);
 
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.UnreadCountChanged, unreadCountUpdated);
-  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.FavoriteTagChanged, favouriteTagUpdated);
+  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomFavorited, roomFavoriteUpdated);
 }

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -18,7 +18,7 @@ export enum Events {
   OtherUserLeftChannel = 'chat/channel/otherUserLeft',
   LiveRoomEventReceived = 'chat/message/liveRoomEventReceived',
   ChatConnectionComplete = 'chat/connection/complete',
-  FavoriteTagChanged = 'chat/favoriteTagChanged',
+  RoomFavorited = 'chat/channel/roomFavorited',
 }
 
 let theBus;
@@ -85,8 +85,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const onOtherUserLeftChannel = (channelId, user) =>
       emit({ type: Events.OtherUserLeftChannel, payload: { channelId, user } });
     const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
-    const onFavoriteTagChange = (roomId, isFavorite) =>
-      emit({ type: Events.FavoriteTagChanged, payload: { roomId, isFavorite } });
+    const roomFavorited = (roomId) => emit({ type: Events.RoomFavorited, payload: { roomId } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -102,7 +101,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       onOtherUserJoinedChannel,
       onOtherUserLeftChannel,
       receiveLiveRoomEvent,
-      onFavoriteTagChange,
+      roomFavorited,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -18,6 +18,7 @@ export enum Events {
   OtherUserLeftChannel = 'chat/channel/otherUserLeft',
   LiveRoomEventReceived = 'chat/message/liveRoomEventReceived',
   ChatConnectionComplete = 'chat/connection/complete',
+  FavoriteTagChanged = 'chat/favoriteTagChanged',
 }
 
 let theBus;
@@ -84,6 +85,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const onOtherUserLeftChannel = (channelId, user) =>
       emit({ type: Events.OtherUserLeftChannel, payload: { channelId, user } });
     const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
+    const onFavoriteTagChange = (roomId, isFavorite) =>
+      emit({ type: Events.FavoriteTagChanged, payload: { roomId, isFavorite } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -99,6 +102,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       onOtherUserJoinedChannel,
       onOtherUserLeftChannel,
       receiveLiveRoomEvent,
+      onFavoriteTagChange,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);


### PR DESCRIPTION
### What does this do?
- adds room to favorites (matrix)
- publishes room tag event updates
- handles room favorite updates (saga)
- adds and handles action for favoriting room

### Why are we making this change?
- to be able to mark rooms (conversations) as favorites for an enhanced user experience

### How do I test this?
- run tests as usual.
- alternatively, you could call the `addRoomToFavorites` and check the tag event is logged and the event content tags contains the `m.favorite` tag.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

ADD Favorite Demo (once wired up) with rough three dot menu

https://github.com/zer0-os/zOS/assets/39112648/0d8cd48b-1e5d-4bb8-880c-bcd3393737b8

