### PR TITLE
Remove the animation attribute on the conversation container

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -55,15 +55,20 @@ export interface State {
   lightboxMedia: any[];
   lightboxStartIndex: number;
   isLightboxOpen: boolean;
+  rendered: boolean;
 }
 
 export class ChatView extends React.Component<Properties, State> {
   scrollContainerRef: React.RefObject<InvertedScroll>;
-  state = { lightboxMedia: [], lightboxStartIndex: 0, isLightboxOpen: false };
+  state = { lightboxMedia: [], lightboxStartIndex: 0, isLightboxOpen: false, rendered: false };
 
   constructor(props) {
     super(props);
     this.scrollContainerRef = React.createRef();
+  }
+
+  componentDidMount(): void {
+    this.setState({ rendered: true });
   }
 
   scrollToBottom = () => {
@@ -186,9 +191,10 @@ export class ChatView extends React.Component<Properties, State> {
   renderMessages() {
     const messagesByDay = this.getMessagesByDay();
     const filteredMessagesByDay = filterAdminMessages(messagesByDay);
+    const cn = bemClassName('messages');
 
     return (
-      <div className='messages__container'>
+      <div {...cn('container', this.state.rendered && 'rendered')}>
         {Object.keys(filteredMessagesByDay)
           .sort((a, b) => (a > b ? 1 : -1))
           .map((day) => {

--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -117,9 +117,17 @@
 }
 
 .messages__container {
-  animation: fadein 200ms ease-out forwards;
   padding-right: 16px;
   padding-top: 100px;
+
+  // Use transition because nested elements can't background blur
+  // if a parent element has an animation attribute
+  // Note: background blur does not work during the `transition`
+  opacity: 0;
+  transition: opacity 200ms ease-out;
+  &--rendered {
+    opacity: 1;
+  }
 
   .message__header {
     display: flex;


### PR DESCRIPTION
### What does this do?

Converts the css `animation` property to a transition when fading in the message container. This is to allow background blur to work on all the child elements

