### PR TITLE
refactor(conversation-item/more-menu): handle unfavorite event

### DIFF
--- a/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
@@ -8,36 +8,43 @@ describe(MoreMenu, () => {
     const allProps: Properties = {
       isFavorite: false,
       onFavorite: () => {},
+      onUnfavorite: () => {},
       ...props,
     };
 
     return shallow(<MoreMenu {...allProps} />);
   };
 
-  describe('Favorite menu item', () => {
-    it('fires onFavorite event when selected', function () {
-      const onFavorite = jest.fn();
+  it('fires onFavorite event', function () {
+    const onFavorite = jest.fn();
 
-      selectItem(subject({ onFavorite }), 'favorite');
+    selectItem(subject({ onFavorite, isFavorite: false }), 'favorite');
 
-      expect(onFavorite).toHaveBeenCalled();
-    });
+    expect(onFavorite).toHaveBeenCalled();
+  });
 
-    it('should display "Unfavorite" label when isFavorite is true', () => {
-      const wrapper = subject({ isFavorite: true });
+  it('fires onUnfavorite event', function () {
+    const onUnfavorite = jest.fn();
 
-      const favoriteItem = menuItem(wrapper, 'favorite');
+    selectItem(subject({ onUnfavorite, isFavorite: true }), 'unfavorite');
 
-      expectLabelToContainText(favoriteItem, 'Unfavorite');
-    });
+    expect(onUnfavorite).toHaveBeenCalled();
+  });
 
-    it('should display "Favorite" label when isFavorite is false', () => {
-      const wrapper = subject({ isFavorite: false });
+  it('should display "Unfavorite" label when isFavorite is true', () => {
+    const wrapper = subject({ isFavorite: true });
 
-      const favoriteItem = menuItem(wrapper, 'favorite');
+    const favoriteItem = menuItem(wrapper, 'unfavorite');
 
-      expectLabelToContainText(favoriteItem, 'Favorite');
-    });
+    expectLabelToContainText(favoriteItem, 'Unfavorite');
+  });
+
+  it('should display "Favorite" label when isFavorite is false', () => {
+    const wrapper = subject({ isFavorite: false });
+
+    const favoriteItem = menuItem(wrapper, 'favorite');
+
+    expectLabelToContainText(favoriteItem, 'Favorite');
   });
 });
 

--- a/src/components/messenger/list/conversation-item/more-menu/index.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.tsx
@@ -7,12 +7,18 @@ import './styles.scss';
 
 export interface Properties {
   isFavorite: boolean;
+
   onFavorite: () => void;
+  onUnfavorite: () => void;
 }
 
 export class MoreMenu extends React.Component<Properties> {
   favorite = () => {
     this.props.onFavorite();
+  };
+
+  unfavorite = () => {
+    this.props.onUnfavorite();
   };
 
   renderMenuOption(icon, label) {
@@ -24,16 +30,24 @@ export class MoreMenu extends React.Component<Properties> {
   }
 
   get menuItems() {
-    return [
-      {
-        id: 'favorite',
-        label: this.props.isFavorite
-          ? this.renderMenuOption(<IconBookmarkX size={20} />, 'Unfavorite')
-          : this.renderMenuOption(<IconBookmark size={20} />, 'Favorite'),
+    const menuItems = [];
 
-        onSelect: this.props.onFavorite,
-      },
-    ];
+    if (!this.props.isFavorite) {
+      menuItems.push({
+        id: 'favorite',
+        label: this.renderMenuOption(<IconBookmark size={20} />, 'Favorite'),
+
+        onSelect: this.favorite,
+      });
+    } else {
+      menuItems.push({
+        id: 'unfavorite',
+        label: this.renderMenuOption(<IconBookmarkX size={20} />, 'Unfavorite'),
+        onSelect: this.unfavorite,
+      });
+    }
+
+    return menuItems;
   }
 
   render() {


### PR DESCRIPTION
### What does this do?
- adds unfavorite call/ to `MoreMenu` `unfavorite` menu item

### Why are we making this change?
- to fire the `onUnfavorite` event.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
