### PR TITLE
Update Backup Flow to have "highlight blue text" instead of "Success Green"

### DIFF
--- a/src/components/secure-backup/styles.scss
+++ b/src/components/secure-backup/styles.scss
@@ -85,7 +85,7 @@
     align-self: stretch;
 
     &--success {
-      color: theme.$color-success-11;
+      color: theme.$color-secondary-11;
     }
 
     &--warning {
@@ -119,7 +119,7 @@
 
   &__success-message {
     text-align: center;
-    color: theme.$color-success-11;
+    color: theme.$color-secondary-11;
 
     margin: 0;
     font-size: 18px;


### PR DESCRIPTION
### What does this do?

Before:
<img width="675" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/70b5ea93-4f43-4cb3-9105-d6e70d6a63e4">

<img width="685" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/bef074db-5762-4db3-a1b3-abe3445ffd4c">


After:
<img width="677" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/c59d7e23-a65c-42fc-8e5b-3247a5e27b2e">


<img width="682" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/c5d4b801-56ff-4870-a33b-fa0f6440e96b">
