### PR TITLE
feat: use a right-click interaction to add & remove conversations from favourites

### DIFF
--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -173,17 +173,4 @@
     align-items: center;
     justify-content: center;
   }
-
-  &__more-menu-container {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    opacity: 0;
-    visibility: hidden;
-  }
-
-  &:hover &__more-menu-container {
-    opacity: 1;
-    visibility: visible;
-  }
 }

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -117,7 +117,7 @@ export class ConversationItem extends React.Component<Properties, State> {
     };
 
     return (
-      <div {...cn('more-menu-container')} onClick={stopPropagation}>
+      <div onClick={stopPropagation}>
         <MoreMenu
           isFavorite={this.props.conversation.isFavorite}
           onFavorite={this.onFavorite}

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -111,6 +111,7 @@ export class ConversationItem extends React.Component<Properties, State> {
       />
     );
   }
+
   renderMoreMenu() {
     const stopPropagation = (e) => {
       e.stopPropagation();

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -29,7 +29,15 @@ export interface Properties {
   onUnfavoriteRoom: (roomId: string) => void;
 }
 
-export class ConversationItem extends React.Component<Properties> {
+export interface State {
+  isContextMenuOpen: boolean;
+}
+
+export class ConversationItem extends React.Component<Properties, State> {
+  state = {
+    isContextMenuOpen: false,
+  };
+
   handleMemberClick = () => {
     this.props.onClick(this.props.conversation.id);
   };
@@ -46,6 +54,15 @@ export class ConversationItem extends React.Component<Properties> {
 
   onUnfavorite = () => {
     this.props.onUnfavoriteRoom(this.props.conversation.id);
+  };
+
+  openContextMenu = (e) => {
+    e.preventDefault();
+    this.setState({ isContextMenuOpen: true });
+  };
+
+  closeContextMenu = () => {
+    this.setState({ isContextMenuOpen: false });
   };
 
   tooltipContent(conversation: Channel) {
@@ -105,6 +122,8 @@ export class ConversationItem extends React.Component<Properties> {
           isFavorite={this.props.conversation.isFavorite}
           onFavorite={this.onFavorite}
           onUnfavorite={this.onUnfavorite}
+          isOpen={this.state.isContextMenuOpen}
+          onClose={this.closeContextMenu}
         />
       </div>
     );
@@ -135,6 +154,7 @@ export class ConversationItem extends React.Component<Properties> {
           tabIndex={0}
           role='button'
           is-active={isActive}
+          onContextMenu={this.openContextMenu}
         >
           <div {...cn('avatar-with-menu-container')}>
             {this.renderAvatar()}

--- a/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
@@ -7,8 +7,10 @@ describe(MoreMenu, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
       isFavorite: false,
+      isOpen: false,
       onFavorite: () => {},
       onUnfavorite: () => {},
+      onClose: () => {},
       ...props,
     };
 

--- a/src/components/messenger/list/conversation-item/more-menu/index.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.tsx
@@ -69,7 +69,6 @@ export class MoreMenu extends React.Component<Properties> {
         items={items}
         side='bottom'
         alignMenu='start'
-        className={'more-menu-trigger'}
         trigger={<></>}
         open={this.props.isOpen}
         onOpenChange={this.onOpenChange}

--- a/src/components/messenger/list/conversation-item/more-menu/index.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 
 import { DropdownMenu } from '@zero-tech/zui/components';
-import { IconBookmark, IconBookmarkX, IconDotsHorizontal } from '@zero-tech/zui/icons';
+import { IconBookmark, IconBookmarkX } from '@zero-tech/zui/icons';
 
 import './styles.scss';
 
 export interface Properties {
   isFavorite: boolean;
+  isOpen: boolean;
 
   onFavorite: () => void;
   onUnfavorite: () => void;
+  onClose: (isOpen: boolean) => void;
 }
 
 export class MoreMenu extends React.Component<Properties> {
@@ -28,6 +30,12 @@ export class MoreMenu extends React.Component<Properties> {
       </div>
     );
   }
+
+  onOpenChange = (isOpening) => {
+    if (!isOpening) {
+      this.props.onClose(isOpening);
+    }
+  };
 
   get menuItems() {
     const menuItems = [];
@@ -62,7 +70,9 @@ export class MoreMenu extends React.Component<Properties> {
         side='bottom'
         alignMenu='start'
         className={'more-menu-trigger'}
-        trigger={<IconDotsHorizontal size={16} isFilled />}
+        trigger={<></>}
+        open={this.props.isOpen}
+        onOpenChange={this.onOpenChange}
       />
     );
   }

--- a/src/components/messenger/list/conversation-item/more-menu/styles.scss
+++ b/src/components/messenger/list/conversation-item/more-menu/styles.scss
@@ -1,17 +1,5 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
-.more-menu-trigger {
-  display: flex;
-  width: 24px;
-  height: 24px;
-  justify-content: center;
-  align-items: center;
-
-  border-radius: 50%;
-  border: 1px solid theme.$color-greyscale-3;
-  background-color: theme.$color-greyscale-3;
-}
-
 .menu-item {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
### What does this do?
- uses right click to open the more menu dropdown items
- removes the three dot menu trigger for the dropdown (in favor of right click)

### Why are we making this change?
- new requirement request

### How do I test this?
- run tests as usual.
- run branch and right click on conversation items to click either 'favorite' or 'unfavorite' menu items

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/5d88579d-edbb-4c87-bda6-ef5a7de77cb5


