### PR TITLE
refactor(parse-plain-body): improve parsing of quoted lines

### DIFF
--- a/src/lib/chat/matrix/utils.test.ts
+++ b/src/lib/chat/matrix/utils.test.ts
@@ -120,4 +120,34 @@ describe(parsePlainBody, () => {
     const body = '> Quoted line\n    \n> Another quoted line';
     expect(parsePlainBody(body)).toEqual('');
   });
+
+  it('preserves intentional formatting within the message', () => {
+    const body = '> Quoted line\n\nIntentionally formatted message\nWith multiple lines';
+    const expected = 'Intentionally formatted message\nWith multiple lines';
+    expect(parsePlainBody(body)).toEqual(expected);
+  });
+
+  it('removes leading and trailing whitespace around the message', () => {
+    const body = '\n\n> Quoted line\n\nMessage with leading and trailing whitespace\n\n';
+    const expected = 'Message with leading and trailing whitespace';
+    expect(parsePlainBody(body)).toEqual(expected);
+  });
+
+  it('preserves URLs that follow a quoted line', () => {
+    const body = '> Quoted text\nhttps://example.com';
+    const expected = 'https://example.com';
+    expect(parsePlainBody(body)).toEqual(expected);
+  });
+
+  it('handles messages with URLs surrounded by whitespace', () => {
+    const body = '\n\n https://example.com \n\n';
+    const expected = 'https://example.com';
+    expect(parsePlainBody(body)).toEqual(expected);
+  });
+
+  it('keeps URLs intact within complex messages', () => {
+    const body = '> Quoted line\n\nBefore URL text\nhttps://example.com\nAfter URL text';
+    const expected = 'Before URL text\nhttps://example.com\nAfter URL text';
+    expect(parsePlainBody(body)).toEqual(expected);
+  });
 });

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -75,9 +75,9 @@ export function parsePlainBody(body) {
 
   const parsedBody = body
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => !line.startsWith('> ') && line !== '')
-    .join('\n');
+    .filter((line) => !line.startsWith('> '))
+    .join('\n')
+    .trim();
 
   return parsedBody;
 }


### PR DESCRIPTION
### What does this do?
- enhances the message content parsing to ensure proper handling of URLs and text, preserving intended formatting.

### Why are we making this change?
-  improve the user experience by ensuring message content is displayed as intended.

### How do I test this?
- run tests as usual.
- run UI and reply to a message that contains text and a url. you could also test replying to messages with a mix of content and should see the expected format.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before
<img width="810" alt="Screenshot 2024-04-02 at 22 28 42" src="https://github.com/zer0-os/zOS/assets/39112648/93d5f274-8853-4bb6-8969-246afc94007f">

After
<img width="810" alt="Screenshot 2024-04-02 at 22 31 26" src="https://github.com/zer0-os/zOS/assets/39112648/52beac68-7b62-43db-9191-c5bca238a0bb">

