### PR TITLE
feat: add favorites error state

### DIFF
--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -16,6 +16,8 @@ import { bemClassName } from '../../../../lib/bem';
 import './conversation-item.scss';
 import '../styles.scss';
 
+import { FeatureFlag } from '../../../feature-flag';
+
 const cn = bemClassName('conversation-item');
 
 export interface Properties {
@@ -159,7 +161,7 @@ export class ConversationItem extends React.Component<Properties, State> {
         >
           <div {...cn('avatar-with-menu-container')}>
             {this.renderAvatar()}
-            {this.renderMoreMenu()}
+            <FeatureFlag featureFlag='enableFavorites'>{this.renderMoreMenu()}</FeatureFlag>
           </div>
 
           <div {...cn('summary')}>

--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -150,6 +150,11 @@ $side-padding: 16px;
     background-size: cover;
     background-repeat: no-repeat;
   }
+
+  &__favorites-error {
+    padding: 24px 16px;
+    font-size: 10px;
+  }
 }
 
 .messages-list__invite-button {

--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -151,9 +151,21 @@ $side-padding: 16px;
     background-repeat: no-repeat;
   }
 
-  &__favorites-error {
-    padding: 24px 16px;
-    font-size: 10px;
+  &__favorites-error-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px;
+    margin: 16px;
+    border-radius: 8px;
+
+    font-size: 12px;
+    background-color: theme.$color-failure-4;
+    color: theme.$color-failure-11;
+  }
+
+  &__favorites-error-close-icon {
+    color: theme.$color-failure-11;
   }
 }
 

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -11,6 +11,7 @@ describe('ConversationListPanel', () => {
       conversations: [],
       myUserId: '',
       activeConversationId: '',
+      isFavoritesError: false,
       search: () => undefined,
       onConversationClick: () => null,
       onCreateConversation: () => null,

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import { ConversationListPanel, Properties } from '.';
 import { Channel } from '../../../../store/channels';
 import { stubConversation } from '../../../../store/test/store';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+import { IconButton } from '@zero-tech/zui/components';
 
 describe('ConversationListPanel', () => {
   const subject = (props: Partial<Properties>) => {
@@ -17,6 +19,7 @@ describe('ConversationListPanel', () => {
       onCreateConversation: () => null,
       onFavoriteRoom: () => null,
       onUnfavoriteRoom: () => null,
+      closeFavoritesError: () => null,
       ...props,
     };
 
@@ -355,6 +358,21 @@ describe('ConversationListPanel', () => {
     // Simulate a search query change (from 'bob' to '')
     await searchFor(wrapper, '');
     expect(scrollContainerRef.current.scrollToTop).toHaveBeenCalled();
+  });
+
+  it('renders favorites error elements when isFavoritesError', function () {
+    const wrapper = subject({ isFavoritesError: true });
+
+    expect(wrapper).toHaveElement(IconAlertCircle);
+  });
+
+  it('fires closeFavoritesError', function () {
+    const closeFavoritesError = jest.fn();
+    const wrapper = subject({ closeFavoritesError, isFavoritesError: true });
+
+    wrapper.find(IconButton).simulate('click');
+
+    expect(closeFavoritesError).toHaveBeenCalled();
   });
 });
 

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { Channel } from '../../../../store/channels';
-import { IconUserPlus1 } from '@zero-tech/zui/icons';
+import { IconAlertCircle, IconUserPlus1, IconXClose } from '@zero-tech/zui/icons';
 import { ConversationItem } from '../conversation-item';
 import { InviteDialogContainer } from '../../../invite-dialog/container';
-import { Alert, Button, Input, Modal } from '@zero-tech/zui/components';
+import { Button, IconButton, Input, Modal } from '@zero-tech/zui/components';
 import { Item, Option } from '../../lib/types';
 import { UserSearchResults } from '../user-search-results';
 import { itemToOption } from '../../lib/utils';
@@ -29,6 +29,7 @@ export interface Properties {
   onConversationClick: (payload: { conversationId: string }) => void;
   onFavoriteRoom: (payload: { roomId: string }) => void;
   onUnfavoriteRoom: (payload: { roomId: string }) => void;
+  closeFavoritesError: () => void;
 }
 
 enum Tab {
@@ -162,10 +163,17 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     return null;
   };
 
-  renderFavoritesAlert() {
+  renderFavoritesError() {
     return (
-      <div {...cn('favorites-error')}>
-        <Alert variant='error'>Error updating favorites. Please try again.</Alert>
+      <div {...cn('favorites-error-container')}>
+        <IconAlertCircle size={16} />
+        Failed to update favorites.
+        <IconButton
+          {...cn('favorites-error-close-icon')}
+          Icon={IconXClose}
+          size={24}
+          onClick={this.props.closeFavoritesError}
+        />
       </div>
     );
   }
@@ -237,7 +245,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
           </ScrollbarContainer>
         </div>
 
-        {this.props.isFavoritesError && this.renderFavoritesAlert()}
+        {this.props.isFavoritesError && this.renderFavoritesError()}
 
         <Button
           {...cn('invite-button')}

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -4,7 +4,7 @@ import { Channel } from '../../../../store/channels';
 import { IconUserPlus1 } from '@zero-tech/zui/icons';
 import { ConversationItem } from '../conversation-item';
 import { InviteDialogContainer } from '../../../invite-dialog/container';
-import { Button, Input, Modal } from '@zero-tech/zui/components';
+import { Alert, Button, Input, Modal } from '@zero-tech/zui/components';
 import { Item, Option } from '../../lib/types';
 import { UserSearchResults } from '../user-search-results';
 import { itemToOption } from '../../lib/utils';
@@ -22,6 +22,7 @@ export interface Properties {
   conversations: Channel[];
   myUserId: string;
   activeConversationId: string;
+  isFavoritesError: boolean;
 
   search: (input: string) => any;
   onCreateConversation: (userId: string) => void;
@@ -161,6 +162,14 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     return null;
   };
 
+  renderFavoritesAlert() {
+    return (
+      <div {...cn('favorites-error')}>
+        <Alert variant='error'>Error updating favorites. Please try again.</Alert>
+      </div>
+    );
+  }
+
   render() {
     return (
       <>
@@ -227,6 +236,9 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             </div>
           </ScrollbarContainer>
         </div>
+
+        {this.props.isFavoritesError && this.renderFavoritesAlert()}
+
         <Button
           {...cn('invite-button')}
           variant={'text'}

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -43,6 +43,7 @@ describe('messenger-list', () => {
       isBackupDialogOpen: false,
       isRewardsDialogOpen: false,
       displayLogoutModal: false,
+      isFavoritesError: false,
       closeConversationErrorDialog: () => null,
       startCreateConversation: () => null,
       membersSelected: () => null,

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -55,7 +55,7 @@ describe('messenger-list', () => {
       closeRewardsDialog: () => null,
       onFavoriteRoom: () => null,
       onUnfavoriteRoom: () => null,
-
+      closeFavoritesError: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -65,6 +65,7 @@ export interface Properties extends PublicProperties {
   isBackupDialogOpen: boolean;
   isRewardsDialogOpen: boolean;
   displayLogoutModal: boolean;
+  isFavoritesError: boolean;
 
   startCreateConversation: () => void;
   startGroup: () => void;
@@ -91,7 +92,7 @@ export class Container extends React.Component<Properties, State> {
       createConversation,
       registration,
       authentication: { user, displayLogoutModal },
-      chat: { activeConversationId, joinRoomErrorContent },
+      chat: { activeConversationId, joinRoomErrorContent, isFavoritesError },
       groupManagement,
       matrix: { isBackupDialogOpen },
       rewards,
@@ -116,6 +117,7 @@ export class Container extends React.Component<Properties, State> {
       isBackupDialogOpen,
       isRewardsDialogOpen: rewards.showRewardsInPopup,
       displayLogoutModal,
+      isFavoritesError,
     };
   }
 
@@ -253,6 +255,7 @@ export class Container extends React.Component<Properties, State> {
             activeConversationId={this.props.activeConversationId}
             onFavoriteRoom={this.props.onFavoriteRoom}
             onUnfavoriteRoom={this.props.onUnfavoriteRoom}
+            isFavoritesError={this.props.isFavoritesError}
           />
         )}
         {this.props.stage === SagaStage.CreateOneOnOne && (

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../store/create-conversation';
 import { logout } from '../../../store/authentication';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
-import { closeConversationErrorDialog } from '../../../store/chat';
+import { closeConversationErrorDialog, closeFavoritesError } from '../../../store/chat';
 
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
@@ -80,6 +80,7 @@ export interface Properties extends PublicProperties {
   closeRewardsDialog: () => void;
   onFavoriteRoom: (payload: { roomId: string }) => void;
   onUnfavoriteRoom: (payload: { roomId: string }) => void;
+  closeFavoritesError: () => void;
 }
 
 interface State {
@@ -136,6 +137,7 @@ export class Container extends React.Component<Properties, State> {
       closeRewardsDialog,
       onFavoriteRoom,
       onUnfavoriteRoom,
+      closeFavoritesError,
     };
   }
 
@@ -256,6 +258,7 @@ export class Container extends React.Component<Properties, State> {
             onFavoriteRoom={this.props.onFavoriteRoom}
             onUnfavoriteRoom={this.props.onUnfavoriteRoom}
             isFavoritesError={this.props.isFavoritesError}
+            closeFavoritesError={this.props.closeFavoritesError}
           />
         )}
         {this.props.stage === SagaStage.CreateOneOnOne && (

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -8,7 +8,7 @@ import { addRoomToFavorites, removeRoomFromFavorites, chat } from '../../lib/cha
 import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
 import { ParentMessage } from '../../lib/chat/types';
-import { rawSetActiveConversationId } from '../chat';
+import { rawSetActiveConversationId, setIsFavoritesError } from '../chat';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -99,19 +99,26 @@ export function* receiveChannel(channel: Partial<Channel>) {
 }
 
 export function* onFavoriteRoom(action) {
+  yield put(setIsFavoritesError(false));
+
   const { roomId } = action.payload;
   try {
+    throw new Error('Mock error for addRoomToFavorites');
     yield call(addRoomToFavorites, roomId);
   } catch (error) {
+    yield put(setIsFavoritesError(true));
     console.error(`Failed to add room ${roomId} to favorites:`, error);
   }
 }
 
 export function* onUnfavoriteRoom(action) {
+  yield put(setIsFavoritesError(false));
+
   const { roomId } = action.payload;
   try {
     yield call(removeRoomFromFavorites, roomId);
   } catch (error) {
+    yield put(setIsFavoritesError(true));
     console.error(`Failed to remove room ${roomId} from favorites:`, error);
   }
 }

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -103,11 +103,9 @@ export function* onFavoriteRoom(action) {
 
   const { roomId } = action.payload;
   try {
-    throw new Error('Mock error for addRoomToFavorites');
     yield call(addRoomToFavorites, roomId);
   } catch (error) {
     yield put(setIsFavoritesError(true));
-    console.error(`Failed to add room ${roomId} to favorites:`, error);
   }
 }
 
@@ -119,7 +117,6 @@ export function* onUnfavoriteRoom(action) {
     yield call(removeRoomFromFavorites, roomId);
   } catch (error) {
     yield put(setIsFavoritesError(true));
-    console.error(`Failed to remove room ${roomId} from favorites:`, error);
   }
 }
 

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -10,6 +10,7 @@ const initialState: ChatState = {
   joinRoomErrorContent: null,
   isJoiningConversation: false,
   isChatConnectionComplete: false,
+  isFavoritesError: false,
 };
 
 export enum SagaActionTypes {
@@ -43,6 +44,9 @@ const slice = createSlice({
     setIsChatConnectionComplete: (state, action: PayloadAction<ChatState['isChatConnectionComplete']>) => {
       state.isChatConnectionComplete = action.payload;
     },
+    setIsFavoritesError: (state, action: PayloadAction<ChatState['isFavoritesError']>) => {
+      state.isFavoritesError = action.payload;
+    },
   },
 });
 
@@ -53,6 +57,7 @@ export const {
   clearJoinRoomErrorContent,
   setIsJoiningConversation,
   setIsChatConnectionComplete,
+  setIsFavoritesError,
 } = slice.actions;
 export const { reducer } = slice;
 export { closeConversationErrorDialog };

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -17,10 +17,12 @@ export enum SagaActionTypes {
   CloseConversationErrorDialog = 'chat/saga/closeConversationErrorDialog',
   setActiveConversationId = 'chat/saga/setActiveConversationId',
   SetIsJoiningConversation = 'chat/saga/setIsJoiningConversation',
+  CloseFavoritesError = 'chat/saga/closeFavoritesError',
 }
 
 const closeConversationErrorDialog = createAction(SagaActionTypes.CloseConversationErrorDialog);
 export const setActiveConversationId = createAction<{ id: string }>(SagaActionTypes.setActiveConversationId);
+const closeFavoritesError = createAction(SagaActionTypes.CloseFavoritesError);
 
 const slice = createSlice({
   name: 'chat',
@@ -60,4 +62,4 @@ export const {
   setIsFavoritesError,
 } = slice.actions;
 export const { reducer } = slice;
-export { closeConversationErrorDialog };
+export { closeConversationErrorDialog, closeFavoritesError };

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -8,6 +8,7 @@ import {
   clearJoinRoomErrorContent,
   setIsJoiningConversation,
   setIsChatConnectionComplete,
+  setIsFavoritesError,
 } from '.';
 import { Events as ChatEvents, createChatConnection, getChatBus } from './bus';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
@@ -194,6 +195,10 @@ export function* closeErrorDialog() {
   yield call(openFirstConversation);
 }
 
+export function* closeFavoritesError() {
+  yield put(setIsFavoritesError(false));
+}
+
 export function* saga() {
   yield spawn(connectOnLogin);
   yield takeLatest(SagaActionTypes.setActiveConversationId, ({ payload }: any) =>
@@ -205,4 +210,5 @@ export function* saga() {
   yield takeEveryFromBus(authBus, AuthEvents.UserLogin, addAdminUser);
 
   yield takeLatest(SagaActionTypes.CloseConversationErrorDialog, closeErrorDialog);
+  yield takeLatest(SagaActionTypes.CloseFavoritesError, closeFavoritesError);
 }

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -14,4 +14,5 @@ export interface ChatState {
   joinRoomErrorContent: ErrorDialogContent;
   isJoiningConversation: boolean;
   isChatConnectionComplete: boolean;
+  isFavoritesError: boolean;
 }


### PR DESCRIPTION
### What does this do?
- adds a basic error alert if favorited room or unfavorited room fails.

### Why are we making this change?
- handle errors gracefully / inform user favorite update failed.

### How do I test this?
- run tests as usual.
- throw error when favoriting or unfavoriting.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/d12ff873-6fb7-4f83-94e7-891d0a1e480c

