### PR TITLE
refactor(favorites-empty-state): update to american spelling for favorites

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -153,7 +153,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     if (this.state.selectedTab === Tab.Favorites) {
       return (
         <div {...cn('favorites-preview')}>
-          <span>Right click a conversation to add it to your favourites.</span>
+          <span>Right click a conversation to add it to your favorites.</span>
           <div {...cn('favorites-preview-image')}></div>
         </div>
       );


### PR DESCRIPTION
Figma design uses `favourites`: 

<img width="338" alt="Screenshot 2024-04-03 at 12 56 06" src="https://github.com/zer0-os/zOS/assets/39112648/09bf3136-b863-4dfd-917c-1877e2a8ed30">

but this should instead be consistent with other uses of `favorites` (american spelling):

<img width="338" alt="Screenshot 2024-04-03 at 12 59 15" src="https://github.com/zer0-os/zOS/assets/39112648/a8a762ad-1f21-426f-b270-0a70e29c1eb8">
