### PR TITLE
feat(content-highlighter): viewing mentions redesign updates

### DIFF
--- a/src/components/content-highlighter/styles.scss
+++ b/src/components/content-highlighter/styles.scss
@@ -16,11 +16,6 @@
     &[data-variant='negative'] {
       font-size: 12px;
       font-weight: 400;
-      padding: 0;
-      margin: 0;
-      border-radius: unset;
-      border: unset;
-      background-color: unset;
       color: theme.$color-greyscale-11;
     }
   }

--- a/src/components/content-highlighter/styles.scss
+++ b/src/components/content-highlighter/styles.scss
@@ -7,16 +7,15 @@
 
   &__user-mention {
     display: inline-block;
-    padding: 2px 4px;
-
-    font-size: 12px;
+    font-size: 14px;
+    font-weight: 700;
     line-height: 14px;
 
-    border-radius: 4px;
-    background-color: theme.$color-primary-7;
-    color: theme.$color-greyscale-12;
+    color: theme.$color-secondary-11;
 
     &[data-variant='negative'] {
+      font-size: 12px;
+      font-weight: 400;
       padding: 0;
       margin: 0;
       border-radius: unset;


### PR DESCRIPTION
### What does this do?
- viewing mentions redesign as shown below in screenshots.

### Why are we making this change?
- as per design.

### How do I test this?
- When composing a message, mention a user and send the message. When the message is displayed in the chat view check the mentions in the body of the message (compare with figma/below screenshot).

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Before
<img width="1430" alt="Screenshot 2024-04-04 at 09 38 06" src="https://github.com/zer0-os/zOS/assets/39112648/67c016ce-2921-40a5-90cc-bb9611edfba9">


After
<img width="1430" alt="Screenshot 2024-04-04 at 09 36 15" src="https://github.com/zer0-os/zOS/assets/39112648/afb89200-381c-4cbb-8023-9058221ab35f">

