### PR TITLE
refactor(message-input): extract mentions functionality into a standalone mentions component

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { MentionsInput } from 'react-mentions';
 import { shallow } from 'enzyme';
 
 import { MessageInput, Properties } from '.';
@@ -10,6 +9,7 @@ import { config } from '../../config';
 import ReplyCard from '../reply-card/reply-card';
 import { ViewModes } from '../../shared-components/theme-engine';
 import { IconSend3 } from '@zero-tech/zui/icons';
+import { Mentions } from './mentions';
 
 describe('MessageInput', () => {
   const subject = (props: Partial<Properties>, child: any = <div />) => {
@@ -37,7 +37,7 @@ describe('MessageInput', () => {
     const wrapper = subject({ placeholder: 'Speak' });
     const dropzone = wrapper.find(Dropzone).shallow();
 
-    expect(dropzone.find(MentionsInput).prop('placeholder')).toEqual('Speak');
+    expect(dropzone.find(Mentions).prop('placeholder')).toEqual('Speak');
   });
 
   it('should call editActions', function () {
@@ -53,7 +53,7 @@ describe('MessageInput', () => {
     const wrapper = subject({ onSubmit, placeholder: 'Speak' });
     const dropzone = wrapper.find(Dropzone).shallow();
 
-    const input = dropzone.find(MentionsInput);
+    const input = dropzone.find(Mentions);
     input.simulate('keydown', { preventDefault() {}, key: Key.Enter, ctrlKey: true });
 
     expect(onSubmit).not.toHaveBeenCalled();
@@ -64,7 +64,7 @@ describe('MessageInput', () => {
     const wrapper = subject({ onSubmit, placeholder: 'Speak' });
     const dropzone = wrapper.find(Dropzone).shallow();
 
-    const input = dropzone.find(MentionsInput);
+    const input = dropzone.find(Mentions);
     input.simulate('change', { target: { value: 'Hello' } });
     input.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
 
@@ -78,7 +78,7 @@ describe('MessageInput', () => {
     const wrapper = subject({ onSubmit, dropzoneToMedia });
     const dropzone = wrapper.find(Dropzone).shallow();
 
-    const input = dropzone.find(MentionsInput);
+    const input = dropzone.find(Mentions);
     wrapper.find(Dropzone).simulate('drop', [{ name: 'file1' }]);
     input.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
 
@@ -132,7 +132,7 @@ describe('MessageInput', () => {
     const wrapper = subject({ onSubmit, placeholder: 'Speak' });
     const dropzone = wrapper.find(Dropzone).shallow();
 
-    const input = dropzone.find(MentionsInput);
+    const input = dropzone.find(Mentions);
     input.simulate('change', { target: { value: 'Hello' } });
     input.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
 
@@ -256,7 +256,7 @@ describe('MessageInput', () => {
       const dropzone = wrapper.find(Dropzone).shallow();
 
       const message = 'Message with :smile:';
-      dropzone.find(MentionsInput).simulate('change', { target: { value: message } });
+      dropzone.find(Mentions).simulate('change', { target: { value: message } });
       wrapper.find('.message-input__icon--end-action').simulate('click');
 
       expect(onSubmit).toHaveBeenCalledWith('Message with 😄', [], []);
@@ -267,7 +267,7 @@ describe('MessageInput', () => {
     const userMentionHandler = wrapper
       .find(Dropzone)
       .shallow()
-      .find(MentionsInput)
+      .find(Mentions)
       .shallow()
       .find('Mention')
       .findWhere((n) => n.prop('trigger') === '@');
@@ -282,5 +282,5 @@ describe('MessageInput', () => {
 
 function setInput(wrapper, input) {
   const dropzone = wrapper.find(Dropzone).shallow();
-  dropzone.find(MentionsInput).simulate('change', { target: { value: input } });
+  dropzone.find(Mentions).simulate('change', { target: { value: input } });
 }

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -1,12 +1,11 @@
 import React, { RefObject } from 'react';
-import { MentionsInput, Mention } from 'react-mentions';
 import Dropzone from 'react-dropzone';
 
 import { config } from '../../config';
 import { Key } from '../../lib/keyboard-search';
 import { MediaType } from '../../store/messages';
-import { emojiMentionsConfig, userMentionsConfig } from './mentions-config';
-import { UserForMention, Media, dropzoneToMedia, addImagePreview, windowClipboard } from './utils';
+import { userMentionsConfig } from './mentions-config';
+import { Media, dropzoneToMedia, addImagePreview, windowClipboard } from './utils';
 
 import Menu from './menu/menu';
 import { EmojiPicker } from './emoji-picker/emoji-picker';
@@ -18,9 +17,10 @@ import ImageCards from '../../platform-apps/channels/image-cards';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
 import { PublicProperties as PublicPropertiesContainer } from './container';
 import { IconFaceSmile, IconSend3, IconStickerCircle } from '@zero-tech/zui/icons';
-import { Avatar, IconButton, Tooltip } from '@zero-tech/zui/components';
+import { IconButton, Tooltip } from '@zero-tech/zui/components';
 import { textToPlainEmojis } from '../content-highlighter/text-to-emojis';
 import { bemClassName } from '../../lib/bem';
+import { Mentions } from './mentions';
 
 import './styles.scss';
 
@@ -182,51 +182,6 @@ export class MessageInput extends React.Component<Properties, State> {
     this.props.onMessageInputRendered(this.textareaRef);
   };
 
-  searchMentionable = async (search: string, callback) => {
-    const fetchedUsers = await this.props.getUsersForMentions(search);
-    callback(fetchedUsers.sort(this.byIndexOf(search)));
-  };
-
-  byIndexOf(search: string): (a: UserForMention, b: UserForMention) => number {
-    const getIndex = (user) => user.display.toLowerCase().indexOf(search.toLowerCase());
-    return (a, b) => getIndex(a) - getIndex(b);
-  }
-
-  renderMentionTypes() {
-    const mentions = [
-      <Mention
-        trigger='@'
-        data={this.searchMentionable}
-        key='user'
-        appendSpaceOnAdd
-        markup={userMentionsConfig.markup}
-        displayTransform={userMentionsConfig.displayTransform}
-        renderSuggestion={(suggestion) => (
-          <>
-            <Avatar size={'small'} type={'circle'} imageURL={suggestion.profileImage} />
-            <div>
-              <div {...cn('mentions-text-area-wrap__suggestions__item-name')}>{suggestion.display}</div>
-              <div {...cn('mentions-text-area-wrap__suggestions__item-zid')}>{suggestion.displayHandle}</div>
-            </div>
-          </>
-        )}
-      />,
-      <Mention
-        trigger=':'
-        data={[]}
-        key='emoji'
-        markup={emojiMentionsConfig.markup}
-        regex={emojiMentionsConfig.regex}
-        displayTransform={emojiMentionsConfig.displayTransform}
-        style={{
-          visibility: 'hidden',
-        }}
-      />,
-    ];
-
-    return mentions;
-  }
-
   mediaSelected = (newMedia: Media[]): void => {
     this.setState({ media: [...this.state.media, ...newMedia] });
     this.props.onMessageInputRendered(this.textareaRef);
@@ -373,20 +328,16 @@ export class MessageInput extends React.Component<Properties, State> {
                       </div>
                       {this.state.isGiphyActive && <Giphy onClickGif={this.onInsertGiphy} onClose={this.closeGiphy} />}
 
-                      <MentionsInput
-                        inputRef={this.textareaRef}
-                        {...cn('mentions-text-area-wrap')}
+                      <Mentions
                         id={this.props.id}
-                        placeholder={this.props.placeholder}
-                        onKeyDown={this.onKeyDown}
-                        onChange={this.contentChanged}
-                        onBlur={this._handleBlur}
                         value={this.state.value}
-                        allowSuggestionsAboveCursor
-                        suggestionsPortalHost={document.body}
-                      >
-                        {this.renderMentionTypes()}
-                      </MentionsInput>
+                        onBlur={this._handleBlur}
+                        onChange={this.contentChanged}
+                        onKeyDown={this.onKeyDown}
+                        placeholder={this.props.placeholder}
+                        textareaRef={this.textareaRef}
+                        getUsersForMentions={this.props.getUsersForMentions}
+                      />
                     </div>
                   )}
                 </Dropzone>

--- a/src/components/message-input/mentions/index.tsx
+++ b/src/components/message-input/mentions/index.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import { UserForMention } from '../utils';
+import { bemClassName } from '../../../lib/bem';
+import { emojiMentionsConfig, userMentionsConfig } from '../mentions-config';
+
+import { Mention, MentionsInput } from 'react-mentions';
+import { Avatar } from '@zero-tech/zui/components';
+
+const cn = bemClassName('mentions');
+
+import './styles.scss';
+
+interface Properties {
+  id: string;
+  value: string;
+  placeholder?: string;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+
+  onBlur: (event: any, clickedSuggestion: any) => void;
+  onChange: (event: any) => void;
+  onKeyDown: (event: any) => void;
+  getUsersForMentions: (search: string) => Promise<UserForMention[]>;
+}
+
+export class Mentions extends React.Component<Properties> {
+  searchMentionable = async (search: string, callback) => {
+    const fetchedUsers = await this.props.getUsersForMentions(search);
+    callback(fetchedUsers.sort(this.byIndexOf(search)));
+  };
+
+  byIndexOf(search: string): (a: UserForMention, b: UserForMention) => number {
+    const getIndex = (user) => user.display.toLowerCase().indexOf(search.toLowerCase());
+    return (a, b) => getIndex(a) - getIndex(b);
+  }
+
+  renderMentionTypes() {
+    const mentions = [
+      <Mention
+        trigger='@'
+        data={this.searchMentionable}
+        key='user'
+        appendSpaceOnAdd
+        markup={userMentionsConfig.markup}
+        displayTransform={userMentionsConfig.displayTransform}
+        renderSuggestion={(suggestion) => (
+          <>
+            <Avatar size={'small'} type={'circle'} imageURL={suggestion.profileImage} />
+            <div>
+              <div {...cn('text-area-wrap__suggestions__item-name')}>{suggestion.display}</div>
+              <div {...cn('text-area-wrap__suggestions__item-zid')}>{suggestion.displayHandle}</div>
+            </div>
+          </>
+        )}
+      />,
+      <Mention
+        trigger=':'
+        data={[]}
+        key='emoji'
+        markup={emojiMentionsConfig.markup}
+        regex={emojiMentionsConfig.regex}
+        displayTransform={emojiMentionsConfig.displayTransform}
+        style={{
+          visibility: 'hidden',
+        }}
+      />,
+    ];
+
+    return mentions;
+  }
+
+  render() {
+    return (
+      <MentionsInput
+        {...cn('text-area-wrap')}
+        id={this.props.id}
+        inputRef={this.props.textareaRef}
+        placeholder={this.props.placeholder}
+        onKeyDown={this.props.onKeyDown}
+        onChange={this.props.onChange}
+        onBlur={this.props.onBlur}
+        value={this.props.value}
+        allowSuggestionsAboveCursor
+        suggestionsPortalHost={document.body}
+      >
+        {this.renderMentionTypes()}
+      </MentionsInput>
+    );
+  }
+}

--- a/src/components/message-input/mentions/index.tsx
+++ b/src/components/message-input/mentions/index.tsx
@@ -7,9 +7,9 @@ import { emojiMentionsConfig, userMentionsConfig } from '../mentions-config';
 import { Mention, MentionsInput } from 'react-mentions';
 import { Avatar } from '@zero-tech/zui/components';
 
-const cn = bemClassName('message-input');
-
 import '../styles.scss';
+
+const cn = bemClassName('message-input');
 
 interface Properties {
   id: string;

--- a/src/components/message-input/mentions/index.tsx
+++ b/src/components/message-input/mentions/index.tsx
@@ -7,9 +7,9 @@ import { emojiMentionsConfig, userMentionsConfig } from '../mentions-config';
 import { Mention, MentionsInput } from 'react-mentions';
 import { Avatar } from '@zero-tech/zui/components';
 
-const cn = bemClassName('mentions');
+const cn = bemClassName('message-input');
 
-import './styles.scss';
+import '../styles.scss';
 
 interface Properties {
   id: string;
@@ -47,8 +47,8 @@ export class Mentions extends React.Component<Properties> {
           <>
             <Avatar size={'small'} type={'circle'} imageURL={suggestion.profileImage} />
             <div>
-              <div {...cn('text-area-wrap__suggestions__item-name')}>{suggestion.display}</div>
-              <div {...cn('text-area-wrap__suggestions__item-zid')}>{suggestion.displayHandle}</div>
+              <div {...cn('mentions-text-area-wrap__suggestions__item-name')}>{suggestion.display}</div>
+              <div {...cn('mentions-text-area-wrap__suggestions__item-zid')}>{suggestion.displayHandle}</div>
             </div>
           </>
         )}
@@ -72,7 +72,7 @@ export class Mentions extends React.Component<Properties> {
   render() {
     return (
       <MentionsInput
-        {...cn('text-area-wrap')}
+        {...cn('mentions-text-area-wrap')}
         id={this.props.id}
         inputRef={this.props.textareaRef}
         placeholder={this.props.placeholder}


### PR DESCRIPTION
### What does this do?
- extracts mentions functionality from message input into a standalone mentions component.
- updates the message input test to reflect changes - basically just replacing mentions input import with mentions component import.

### Why are we making this change?
- tidy up the message input file to make working on mentions in follow up tasks far easier.

### How do I test this?
- run tests as usual.
- run ui and manually test mentions as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
