### PR TITLE
Remove enableAppBar feature flag

### DIFF
--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { WorldPanelItem } from './world-panel-item';
 import { IconDotsGrid, IconMessageSquare2 } from '@zero-tech/zui/icons';
-import { featureFlags } from '../../lib/feature-flags';
 import { MoreAppsModal } from './more-apps-modal';
 
 import { bemClassName } from '../../lib/bem';
@@ -26,7 +25,7 @@ export class AppBar extends React.Component<Properties, State> {
   render() {
     return (
       <>
-        <div {...cn('', !featureFlags.enableAppBar && 'disabled')}>
+        <div {...cn('')}>
           <WorldPanelItem Icon={IconMessageSquare2} label='Messenger' isActive />
           <WorldPanelItem Icon={IconDotsGrid} label='More Apps' isActive={false} onClick={this.openModal} />
         </div>

--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -15,14 +15,4 @@
   pointer-events: all;
 
   @include main-background;
-
-  // Allow the sidekick to render properly until
-  // feature is enabled
-  &--disabled {
-    width: 16px;
-
-    > * {
-      display: none;
-    }
-  }
 }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -58,14 +58,6 @@ export class FeatureFlags {
     this._setBoolean('enableFavorites', value);
   }
 
-  get enableAppBar() {
-    return this._getBoolean('enableAppBar', true);
-  }
-
-  set enableAppBar(value: boolean) {
-    this._setBoolean('enableAppBar', value);
-  }
-
   get enableMatrix() {
     return this._getBoolean('enableMatrix', true);
   }


### PR DESCRIPTION
### What does this do?

Removes the app bar feature flag as it has been enabled in production for nearly a week now
