### PR TITLE
feat(content-highlighter): add additional variant for parent message/reply card highlighted text

### DIFF
--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -10,7 +10,7 @@ import { bemClassName } from '../../lib/bem';
 
 export interface Properties {
   message: string;
-  variant?: 'negative';
+  variant?: 'negative' | 'tertiary';
   tabIndex?: number;
   isHidden?: boolean;
   onHiddenMessageInfoClick?: () => void;
@@ -37,7 +37,7 @@ export class ContentHighlighter extends React.Component<Properties> {
 
         return (
           <span data-variant={this.props.variant} {...props}>
-            {this.props.variant && '@'}
+            {this.props.variant === 'negative' && '@'}
             {mention}
           </span>
         );

--- a/src/components/content-highlighter/styles.scss
+++ b/src/components/content-highlighter/styles.scss
@@ -17,6 +17,10 @@
       font-weight: 400;
       color: theme.$color-greyscale-11;
     }
+
+    &[data-variant='tertiary'] {
+      font-size: 12px;
+    }
   }
 
   &__hidden-message-block {

--- a/src/components/message/parent-message/index.tsx
+++ b/src/components/message/parent-message/index.tsx
@@ -35,7 +35,7 @@ export class ParentMessage extends React.PureComponent<Properties> {
         <div {...cn('content')}>
           <div {...cn('header')}>{this.name}</div>
           <span>
-            <ContentHighlighter message={this.props.message} />
+            <ContentHighlighter variant='tertiary' message={this.props.message} />
           </span>
         </div>
       </div>

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -41,7 +41,7 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
         <div {...cn('content')}>
           <div {...cn('header')}>{this.name}</div>
           <div {...cn('message')}>
-            <ContentHighlighter message={message} />
+            <ContentHighlighter variant='tertiary' message={message} />
           </div>
         </div>
         <IconButton Icon={IconXClose} size={24} onClick={this.itemRemoved} />


### PR DESCRIPTION
### What does this do?
- adds variant to content highlighter user mentions

### Why are we making this change?
- handles font size of highlighted text in parent messages and reply cards.

Before:
<img width="815" alt="Screenshot 2024-04-04 at 15 52 21" src="https://github.com/zer0-os/zOS/assets/39112648/66ae1db0-9a96-4522-8f3d-81ad5e10e018">


After:
<img width="815" alt="Screenshot 2024-04-04 at 15 52 04" src="https://github.com/zer0-os/zOS/assets/39112648/b1787768-5a56-4447-95d0-2861616cbe88">

