### PR TITLE
feat(mentions): add truncation and ellipsis to suggestions display handle

### DIFF
--- a/src/components/message-input/mentions/styles.scss
+++ b/src/components/message-input/mentions/styles.scss
@@ -93,16 +93,17 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-size: 14px;
-    font-weight: 400;
     line-height: 20px;
 
     @include glass-text-primary-color;
   }
 
   &__suggestions-handle {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     font-size: 10px;
-    font-weight: 400;
-    display: flex;
+    line-height: 13px;
 
     @include glass-text-tertiary-color;
   }

--- a/src/components/message-input/mentions/styles.scss
+++ b/src/components/message-input/mentions/styles.scss
@@ -118,8 +118,12 @@
     padding: 2px;
 
     &__list {
+      display: flex;
+      flex-direction: column;
+
+      gap: 4px;
       padding: 6px !important;
-      max-height: 240px;
+      max-height: 262px;
       min-width: 128px;
       max-width: 256px;
       overflow-y: auto;


### PR DESCRIPTION
### What does this do?
-  adds truncation and ellipsis to suggestions display handle
- minor style changes

### Why are we making this change?
- as per design / improved ui

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="515" alt="Screenshot 2024-04-05 at 13 14 02" src="https://github.com/zer0-os/zOS/assets/39112648/88287bac-eaba-4bc3-b3b3-82c228c9a9a6">
