### PR TITLE
fix(mentions): highlight filter on subsequent mention suggestions

### DIFF
--- a/src/components/message-input/mentions/index.tsx
+++ b/src/components/message-input/mentions/index.tsx
@@ -34,9 +34,15 @@ export class Mentions extends React.Component<Properties> {
     return (a, b) => getIndex(a) - getIndex(b);
   }
 
-  highlightedText(text, filter) {
-    const processedFilter = filter.slice(1);
-    return highlightFilter(text, processedFilter);
+  getCurrentMentionText() {
+    const regex = /@([^)]+)$/;
+    const matches = this.props.value.match(regex);
+    return matches ? matches[1] : '';
+  }
+
+  highlightedText(text: string) {
+    const currentMentionsText = this.getCurrentMentionText();
+    return highlightFilter(text, currentMentionsText);
   }
 
   renderMentionTypes() {
@@ -52,7 +58,7 @@ export class Mentions extends React.Component<Properties> {
           <>
             <Avatar size={'small'} type={'circle'} imageURL={suggestion.profileImage} />
             <div {...cn('suggestions-user-details')}>
-              <div {...cn('suggestions-name')}>{this.highlightedText(suggestion.display, this.props.value)}</div>
+              <div {...cn('suggestions-name')}>{this.highlightedText(suggestion.display)}</div>
               <div {...cn('suggestions-handle')}>{suggestion.displayHandle}</div>
             </div>
           </>


### PR DESCRIPTION
### What does this do?
- ensures the highlight filter is applied to subsequent mentions

### Why are we making this change?
- the highlight filter was applied to only the first mention suggestion list 

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
