### PR TITLE
[Fix] the initial conversation with my inviter does not render display name/ ZID /avatar until page refresh

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -23,6 +23,7 @@ import { getZEROUsers } from './api';
 import { union } from 'lodash';
 import { uniqNormalizedList } from '../utils';
 import { channelListStatus, rawConversationsList } from './selectors';
+import { setIsConversationsLoaded } from '../chat';
 
 export function* mapToZeroUsers(channels: any[]) {
   let allMatrixIds = [];
@@ -86,6 +87,9 @@ export function* fetchConversations() {
   // state but it does not mean _all_ current known conversations are in state
   // as there are often follow up events still to be processed which would add
   // new conversations to the state. You may prefer waitForChatConnectionCompletion
+
+  yield put(setIsConversationsLoaded(true));
+
   const channel = yield call(getConversationsBus);
   yield put(channel, { type: ConversationEvents.ConversationsLoaded });
 }

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -10,6 +10,7 @@ const initialState: ChatState = {
   joinRoomErrorContent: null,
   isJoiningConversation: false,
   isChatConnectionComplete: false,
+  isConversationsLoaded: false,
 };
 
 export enum SagaActionTypes {
@@ -43,6 +44,9 @@ const slice = createSlice({
     setIsChatConnectionComplete: (state, action: PayloadAction<ChatState['isChatConnectionComplete']>) => {
       state.isChatConnectionComplete = action.payload;
     },
+    setIsConversationsLoaded: (state, action: PayloadAction<ChatState['isConversationsLoaded']>) => {
+      state.isConversationsLoaded = action.payload;
+    },
   },
 });
 
@@ -53,6 +57,7 @@ export const {
   clearJoinRoomErrorContent,
   setIsJoiningConversation,
   setIsChatConnectionComplete,
+  setIsConversationsLoaded,
 } = slice.actions;
 export const { reducer } = slice;
 export { closeConversationErrorDialog };

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -32,7 +32,13 @@ function* initChat(userId, chatAccessToken) {
   yield takeEvery(chatConnection, convertToBusEvents);
 
   yield spawn(closeConnectionOnLogout, chatConnection);
-  yield spawn(activateWhenConversationsLoaded, activate);
+
+  const isFirstTimeLogin = yield select((state) => state.registration.isFirstTimeLogin);
+  if (isFirstTimeLogin) {
+    activate();
+  } else {
+    yield spawn(activateWhenConversationsLoaded, activate);
+  }
 }
 
 // This will wait until all the initial batch of "snapshot state" rooms

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -14,4 +14,5 @@ export interface ChatState {
   joinRoomErrorContent: ErrorDialogContent;
   isJoiningConversation: boolean;
   isChatConnectionComplete: boolean;
+  isConversationsLoaded: boolean;
 }


### PR DESCRIPTION
### What does this do?

Fixes the bug where the "initial conversation" with the person who invited me, does not render display name, ZID, and avatar (until page refresh).

The **issue** which i found is: We're creating the `welcomeConversation`, which calls `matrix-client's createConversation`. BUT, the chatConnection bus, is NOT activated. (i.e **the chatBus is not emitting real time events**, since it is not connected/initialized). When you create a conversation in matrix, it will create an empty room first, and then invite other people. Now we had created the room and saved that in our state during `createConversation`. But as soon as we get the next matrix event (`RoomMember.Joined` related to the invitee), we don't end up "emitting" it, as the `chatBus` wasn't connected, so, we don't end up processing it and saving it in our state. 

The **reason** that the chatBus is NOT initialized is that we're listening for the `ConversationsLoaded` event (in the race condition), **after** the conversations have been loaded. Since the user is logging into the app for the first time, the conversation load happens very fast, and we emit the `ConversationsLoaded` event BEFORE we're even listening for it in `activateWhenConversationsLoaded`. Which is why the `activate()` function is never called, and the chatBus is not connected.

The **solution** here is to add a global state in `saga/chat` (`isConversationsLoaded`) which we're setting to `true` before emitting the `ConversationsLoaded` event. Now, before the race condition in `activateWhenConversationsLoaded`, we first check in the global state whether the `isConversationsLoaded` is `true` or not. If it is, we directly `activate()` the chat bus connection. 

Before

https://github.com/zer0-os/zOS/assets/33264364/9c0352c0-8ca5-4f1c-9455-3673d2927b63

After

https://github.com/zer0-os/zOS/assets/33264364/db5520a4-cb8a-46e6-9b61-f60c9540df6d



