### PR TITLE
chore: bump ZUI version (`1.9.2`) -> (`1.9.3`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@web3-react/network-connector": "^6.1.9",
         "@web3-react/walletlink-connector": "^6.2.13",
         "@zer0-os/zos-component-library": "0.18.9",
-        "@zero-tech/zui": "1.9.2",
+        "@zero-tech/zui": "1.9.3",
         "assert": "^2.1.0",
         "buffer": "^6.0.3",
         "classnames": "^2.3.1",
@@ -9887,9 +9887,9 @@
       }
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.9.2.tgz",
-      "integrity": "sha512-6I/mj7cx4gwyOrZzeEXFSC6q6FYO4+N5smFAvRhcPgo22+6TOog72SZeCgtmsUsyT4HBb4Xi1sxfOfI7ZMa+xA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.9.3.tgz",
+      "integrity": "sha512-Uahm3XLhy8lF+fJi/9QdovxYn3ON6F95CxZUKOfNyWzBqSgjDgHZocSWODMVzxrzRJ50kVpE/gdI8MRQcabarA==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -42039,9 +42039,9 @@
       }
     },
     "@zero-tech/zui": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.9.2.tgz",
-      "integrity": "sha512-6I/mj7cx4gwyOrZzeEXFSC6q6FYO4+N5smFAvRhcPgo22+6TOog72SZeCgtmsUsyT4HBb4Xi1sxfOfI7ZMa+xA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.9.3.tgz",
+      "integrity": "sha512-Uahm3XLhy8lF+fJi/9QdovxYn3ON6F95CxZUKOfNyWzBqSgjDgHZocSWODMVzxrzRJ50kVpE/gdI8MRQcabarA==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.0.0",
         "@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@web3-react/network-connector": "^6.1.9",
     "@web3-react/walletlink-connector": "^6.2.13",
     "@zer0-os/zos-component-library": "0.18.9",
-    "@zero-tech/zui": "1.9.2",
+    "@zero-tech/zui": "1.9.3",
     "assert": "^2.1.0",
     "buffer": "^6.0.3",
     "classnames": "^2.3.1",


### PR DESCRIPTION
### What does this do?
- bumps ZUI version (`1.9.2`) -> (`1.9.3`)

### Why are we making this change?
- to import the latest style changes to the Skeleton loader.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
