### PR TITLE
Remove references to old Sendbird chat access token

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -11,7 +11,6 @@ export interface RealtimeChatEvents {
   onMessageUpdated: (channelId: string, message: Message) => void;
   receiveUnreadCount: (channelId: string, unreadCount: number) => void;
   onUserJoinedChannel: (conversation) => void;
-  invalidChatAccessToken: () => void;
   onUserLeft: (channelId: string, userId: string) => void;
   onUserPresenceChanged: (matrixId: string, isOnline: boolean, lastSeenAt: string) => void;
   onRoomNameChanged: (channelId: string, name: string) => void;

--- a/src/store/authentication/api.ts
+++ b/src/store/authentication/api.ts
@@ -42,12 +42,6 @@ export async function getSSOToken(): Promise<{ token: string }> {
   return body;
 }
 
-export async function fetchChatAccessToken(): Promise<{ chatAccessToken: string }> {
-  const { body } = await get('/accounts/chatAccessToken');
-
-  return body;
-}
-
 export async function emailLogin({ email, password }: { email: string; password: string }) {
   try {
     const response = await post('/api/v2/accounts/login').send({ email, password });

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -14,7 +14,6 @@ import {
   publishUserLogin,
   publishUserLogout,
   authenticateByEmail,
-  setAuthentication,
   logoutRequest,
 } from './saga';
 import {
@@ -24,7 +23,6 @@ import {
   emailLogin,
 } from './api';
 import { reducer } from '.';
-import { setChatAccessToken } from '../chat';
 import { receive } from '../channels-list';
 import { rootReducer } from '../reducer';
 import { clearChannelsAndConversations } from '../channels-list/saga';
@@ -40,7 +38,6 @@ describe(nonceOrAuthorize, () => {
   const signedWeb3Token = '0x000000000000000000000000000000000000000A';
   const authorizationResponse = {
     accessToken: 'eyJh-access-token',
-    chatAccessToken: 'chat-access-token',
   };
 
   const nonceResponse = {
@@ -59,7 +56,6 @@ describe(nonceOrAuthorize, () => {
           null,
         ],
       ])
-      .put(setChatAccessToken({ value: authorizationResponse.chatAccessToken, isLoading: false }))
       .call(completeUserLogin)
       .run();
   });
@@ -267,13 +263,11 @@ describe(authenticateByEmail, () => {
   it('completes the whole auth process', async () => {
     const email = 'valid email';
     const password = 'valid password';
-    const chatAccessToken = 'token';
     const { returnValue } = await expectSaga(authenticateByEmail, email, password)
       .provide([
-        stubResponse(call(emailLogin, { email, password }), { success: true, response: { chatAccessToken } }),
+        stubResponse(call(emailLogin, { email, password }), { success: true, response: {} }),
         ...successResponses(),
       ])
-      .call(setAuthentication, { chatAccessToken })
       .call(completeUserLogin)
       .run();
 
@@ -295,10 +289,6 @@ describe(authenticateByEmail, () => {
       [
         matchers.call.fn(emailLogin),
         { success: true },
-      ],
-      [
-        matchers.call.fn(setAuthentication),
-        null,
       ],
       [
         matchers.call.fn(completeUserLogin),

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -27,11 +27,10 @@ export function* setAuthentication({ chatAccessToken } = { chatAccessToken: '' }
 
 export function* nonceOrAuthorize(action) {
   const { signedWeb3Token } = action.payload;
-  const { nonceToken: nonce = undefined, chatAccessToken } = yield call(nonceOrAuthorizeApi, signedWeb3Token);
+  const { nonceToken: nonce = undefined } = yield call(nonceOrAuthorizeApi, signedWeb3Token);
   if (nonce) {
     yield put(setUser({ nonce, data: null }));
   } else {
-    yield setAuthentication({ chatAccessToken });
     yield call(completeUserLogin);
   }
 
@@ -86,7 +85,6 @@ export function* authenticateByEmail(email, password) {
   if (!result.success) {
     return result;
   }
-  yield call(setAuthentication, { chatAccessToken: result.response.chatAccessToken });
   yield call(completeUserLogin);
   return result;
 }

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -21,10 +21,6 @@ export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
 };
 
-export function* setAuthentication({ chatAccessToken } = { chatAccessToken: '' }) {
-  yield put(setChatAccessToken({ value: chatAccessToken, isLoading: false }));
-}
-
 export function* nonceOrAuthorize(action) {
   const { signedWeb3Token } = action.payload;
   const { nonceToken: nonce = undefined } = yield call(nonceOrAuthorizeApi, signedWeb3Token);

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -5,7 +5,6 @@ import {
   nonceOrAuthorize as nonceOrAuthorizeApi,
   fetchCurrentUser,
   clearSession as clearSessionApi,
-  fetchChatAccessToken,
   emailLogin as apiEmailLogin,
 } from './api';
 import { setChatAccessToken } from '../chat';
@@ -68,15 +67,13 @@ export function* terminate(isAccountChange = false) {
   yield call(publishUserLogout);
 }
 
-export function* getCurrentUserWithChatAccessToken() {
+export function* getCurrentUser() {
   try {
     const user = yield call(fetchCurrentUser);
     if (!user) {
       return false;
     }
 
-    const { chatAccessToken } = yield call(fetchChatAccessToken);
-    yield setAuthentication({ chatAccessToken });
     yield completeUserLogin(user);
     return true;
   } catch (e) {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -7,7 +7,6 @@ import {
   clearSession as clearSessionApi,
   emailLogin as apiEmailLogin,
 } from './api';
-import { setChatAccessToken } from '../chat';
 import { clearChannelsAndConversations } from '../channels-list/saga';
 import { clearUsers } from '../users/saga';
 import { clearMessages } from '../messages/saga';
@@ -49,7 +48,6 @@ export function* completeUserLogin(user = null) {
 
 export function* terminate(isAccountChange = false) {
   yield put(setUser({ data: null, nonce: null }));
-  yield put(setChatAccessToken({ value: null, isLoading: false }));
 
   try {
     yield call(clearSessionApi);

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -74,7 +74,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       emit({ type: Events.MessageDeleted, payload: { channelId, messageId } });
     const receiveUnreadCount = (channelId, unreadCount) =>
       emit({ type: Events.UnreadCountChanged, payload: { channelId, unreadCount } });
-    const invalidChatAccessToken = () => emit({ type: Events.InvalidToken, payload: {} });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
     const onUserPresenceChanged = (matrixId, isOnline, lastSeenAt) =>
@@ -94,7 +93,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       onMessageUpdated,
       receiveDeleteMessage,
       receiveUnreadCount,
-      invalidChatAccessToken,
       onUserLeft,
       onUserJoinedChannel,
       onUserPresenceChanged,

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -2,10 +2,6 @@ import { ChatState } from './types';
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 const initialState: ChatState = {
-  chatAccessToken: {
-    isLoading: false,
-    value: null,
-  },
   activeConversationId: null,
   joinRoomErrorContent: null,
   isJoiningConversation: false,
@@ -25,9 +21,6 @@ const slice = createSlice({
   name: 'chat',
   initialState,
   reducers: {
-    setChatAccessToken: (state, action: PayloadAction<ChatState['chatAccessToken']>) => {
-      state.chatAccessToken = action.payload;
-    },
     rawSetActiveConversationId: (state, action: PayloadAction<ChatState['activeConversationId']>) => {
       state.activeConversationId = action.payload;
     },
@@ -47,7 +40,6 @@ const slice = createSlice({
 });
 
 export const {
-  setChatAccessToken,
   rawSetActiveConversationId,
   setJoinRoomErrorContent,
   clearJoinRoomErrorContent,

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -23,8 +23,8 @@ import { translateJoinRoomApiError, parseAlias, isAlias, extractDomainFromAlias 
 import { joinRoom as apiJoinRoom } from './api';
 import { rawConversationsList } from '../channels-list/selectors';
 
-function* initChat(userId, chatAccessToken) {
-  const { chatConnection, connectionPromise, activate } = createChatConnection(userId, chatAccessToken, chat.get());
+function* initChat(userId, token) {
+  const { chatConnection, connectionPromise, activate } = createChatConnection(userId, token, chat.get());
   const id = yield connectionPromise;
   if (id !== userId) {
     yield call(saveUserMatrixCredentials, id, 'not-used');
@@ -67,9 +67,8 @@ function* connectOnLogin() {
   const user = yield select(currentUserSelector);
   const userId = user.matrixId;
   const token = yield call(getSSOToken);
-  const chatAccessToken = token.token;
 
-  yield initChat(userId, chatAccessToken);
+  yield initChat(userId, token.token);
 }
 
 function* closeConnectionOnLogout(chatConnection) {

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -6,10 +6,6 @@ export type ErrorDialogContent = {
 };
 
 export interface ChatState {
-  chatAccessToken: {
-    value: string;
-    isLoading: boolean;
-  };
   activeConversationId: string;
   joinRoomErrorContent: ErrorDialogContent;
   isJoiningConversation: boolean;

--- a/src/store/page-load/saga.test.ts
+++ b/src/store/page-load/saga.test.ts
@@ -1,7 +1,7 @@
 import { redirectOnUserLogin, redirectToEntryPath, saga } from './saga';
 import { getHistory, getNavigator } from '../../lib/browser';
 import { rootReducer } from '../reducer';
-import { getCurrentUserWithChatAccessToken } from '../authentication/saga';
+import { getCurrentUser } from '../authentication/saga';
 import { call, spawn } from 'redux-saga/effects';
 
 import { expectSaga } from '../../test/saga';
@@ -24,7 +24,7 @@ describe('page-load saga', () => {
   function subject(...args: Parameters<typeof expectSaga>) {
     return expectSaga(...args).provide([
       [call(getHistory), history],
-      [call(getCurrentUserWithChatAccessToken), true],
+      [call(getCurrentUser), true],
       [call(getNavigator), stubNavigator()],
       [spawn(redirectOnUserLogin), null],
     ]);
@@ -62,7 +62,7 @@ describe('page-load saga', () => {
       storeState: { pageload },
     } = await subject(saga)
       .withReducer(rootReducer, initialState as any)
-      .provide([[call(getCurrentUserWithChatAccessToken), false]])
+      .provide([[call(getCurrentUser), false]])
       .run();
 
     expect(pageload.isComplete).toBe(true);
@@ -74,7 +74,7 @@ describe('page-load saga', () => {
 
     history = new StubHistory('/');
     const { storeState } = await subject(saga)
-      .provide([[call(getCurrentUserWithChatAccessToken), false]])
+      .provide([[call(getCurrentUser), false]])
       .withReducer(rootReducer, initialState as any)
       .run();
 
@@ -85,7 +85,7 @@ describe('page-load saga', () => {
   it('saves the entry path when redirecting to the login page', async () => {
     history = new StubHistory('/some/path');
     const { storeState } = await subject(saga)
-      .provide([[call(getCurrentUserWithChatAccessToken), false]])
+      .provide([[call(getCurrentUser), false]])
       .withReducer(rootReducer)
       .run();
 
@@ -110,7 +110,7 @@ describe('page-load saga', () => {
     history = new StubHistory('/reset-password');
     const { storeState: resetPasswordStoreState } = await subject(saga)
       .withReducer(rootReducer, initialState as any)
-      .provide([[call(getCurrentUserWithChatAccessToken), false]])
+      .provide([[call(getCurrentUser), false]])
       .run();
 
     expect(resetPasswordStoreState.pageload.isComplete).toBe(true);
@@ -123,7 +123,7 @@ describe('page-load saga', () => {
       return expectSaga(saga)
         .provide([
           [call(getHistory), new StubHistory(path)],
-          [call(getCurrentUserWithChatAccessToken), false],
+          [call(getCurrentUser), false],
           [call(getNavigator), stubNavigator(userAgent)],
           [spawn(redirectOnUserLogin), null],
         ])

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -1,7 +1,7 @@
 import { call, put, select, spawn, take } from 'redux-saga/effects';
 import { setEntryPath, setIsComplete, setShowAndroidDownload } from '.';
 import { getHistory, getNavigator } from '../../lib/browser';
-import { getCurrentUserWithChatAccessToken } from '../authentication/saga';
+import { getCurrentUser } from '../authentication/saga';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 
 const anonymousPaths = [
@@ -13,7 +13,7 @@ const anonymousPaths = [
 export function* saga() {
   const history = yield call(getHistory);
 
-  const success = yield call(getCurrentUserWithChatAccessToken);
+  const success = yield call(getCurrentUser);
   if (success) {
     yield handleAuthenticatedUser(history);
   } else {

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -25,7 +25,7 @@ import { nonce as nonceApi } from '../authentication/api';
 import { isPasswordValid } from '../../lib/password';
 import { getSignedTokenForConnector } from '../web3/saga';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
-import { completeUserLogin, setAuthentication } from '../authentication/saga';
+import { completeUserLogin } from '../authentication/saga';
 import { getHistory } from '../../lib/browser';
 import { setIsComplete as setPageLoadComplete } from '../page-load';
 import { createConversation } from '../channels-list/saga';
@@ -74,7 +74,6 @@ export function* createAccount(action) {
     });
 
     if (result.success) {
-      yield setAuthentication({ chatAccessToken: result.response.chatAccessToken });
       const userFetch = yield call(fetchCurrentUser);
       if (userFetch) {
         yield put(setUserId(userFetch.id));
@@ -108,7 +107,6 @@ export function* authorizeAndCreateWeb3Account(action) {
     const inviteCode = yield select((state) => state.registration.inviteCode);
     result = yield call(apiCreateWeb3Account, { inviteCode, web3Token: result.token });
     if (result.success) {
-      yield setAuthentication({ chatAccessToken: result.response.chatAccessToken });
       const userFetch = yield call(fetchCurrentUser);
       if (userFetch) {
         yield put(setUserId(userFetch.id));


### PR DESCRIPTION
### What does this do?

Removes the old chatAccessToken from state

### Why are we making this change?

This state was previously used for Sendbird connections but we now don't use it for anything.

### How do I test this?

Login/Register/etc and verify that there are no errors and you can message as usual

