### PR TITLE
Remove references to the api endpoint chatChannels as we no longer need them

### DIFF
--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -3,15 +3,6 @@ import { get } from '../../lib/api/rest';
 import { User } from '../channels';
 import { rawUserToDomainUser } from './utils';
 
-export async function fetchChannels(id: string) {
-  try {
-    const channels = await get<any>(`/api/networks/${id}/chatChannels`);
-    return await channels.body;
-  } catch (error: any) {
-    console.log('Error occured while fetching chatChannels ', error?.response ?? error); // eg. error.code = ENOTFOUND
-  }
-}
-
 interface ImageApiUploadResponse {
   apiUrl: string;
   query: string;

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -1,48 +1,9 @@
 import { AttachmentResponse } from '../../lib/api/attachment';
-import { get, post } from '../../lib/api/rest';
-import { ParentMessage } from '../../lib/chat/types';
+import { get } from '../../lib/api/rest';
 import { LinkPreview } from '../../lib/link-preview';
 import { AttachmentUploadResult } from './index';
-import { FileUploadResult, SendPayload } from './saga';
 
 import axios from 'axios';
-
-export async function sendFileMessage(channelId: string, file: FileUploadResult, optimisticId?: string): Promise<any> {
-  return sendMessagesByChannelId(channelId, null, null, null, file, optimisticId);
-}
-
-export async function sendMessagesByChannelId(
-  channelId: string,
-  message: string,
-  mentionedUserIds: string[],
-  parentMessage?: ParentMessage,
-  file?: FileUploadResult,
-  optimisticId?: string
-): Promise<any> {
-  const data: SendPayload = { message, mentionedUserIds, optimisticId };
-
-  if (parentMessage) {
-    data.parentMessageId = parentMessage.messageId;
-    data.parentMessageUserId = parentMessage.userId;
-  }
-
-  if (file) {
-    data.file = file;
-  }
-
-  const response = await post<any>(`/chatChannels/${channelId}/message`).send(data);
-
-  return response.body;
-}
-
-export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = '', optimisticId = '') {
-  const response = await post<any>(`/upload/chatChannels/${channelId}/message`)
-    .field('rootMessageId', rootMessageId)
-    .field('optimisticId', optimisticId)
-    .attach('file', media);
-
-  return response.body;
-}
 
 export async function uploadAttachment(file: File): Promise<AttachmentUploadResult> {
   const response = await get<any>('/api/feedItems/getAttachmentUploadInfo', undefined, {

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -2,7 +2,7 @@ import { call } from 'redux-saga/effects';
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { getLinkPreviews, sendMessagesByChannelId } from './api';
+import { getLinkPreviews } from './api';
 import {
   createOptimisticMessage,
   createOptimisticMessages,
@@ -241,7 +241,6 @@ describe(performSend, () => {
       .provide([
         stubResponse(matchers.call.fn(chat.get), chatClient),
         stubResponse(matchers.call.fn(chatClient.sendMessagesByChannelId), {}),
-        ...successResponses(),
       ])
       .call.like({
         fn: chatClient.sendMessagesByChannelId,
@@ -287,7 +286,6 @@ describe(performSend, () => {
           id: 'new-id',
           optimisticId: 'optimistic-id',
         }),
-        ...successResponses(),
       ])
       .withReducer(rootReducer, initialState.build())
       .run();
@@ -335,9 +333,3 @@ describe(messageSendFailed, () => {
     expect(channel.messages[1].sendStatus).toEqual(MessageSendStatus.FAILED);
   });
 });
-
-function successResponses() {
-  return [
-    stubResponse(matchers.call.fn(sendMessagesByChannelId), { id: 'message 1', message: {} }),
-  ];
-}

--- a/src/store/messages/uploadable.test.ts
+++ b/src/store/messages/uploadable.test.ts
@@ -1,12 +1,8 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import { call } from 'redux-saga/effects';
-import { FileUploadResult } from './saga';
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { chat } from '../../lib/chat';
 
-import { sendFileMessage, uploadAttachment } from './api';
-import { stubResponse } from '../../test/saga';
-import { UploadableAttachment, UploadableGiphy, UploadableMedia } from './uploadable';
+import { UploadableMedia } from './uploadable';
 
 const chatClient = {
   uploadFileMessage: () => {},
@@ -23,52 +19,6 @@ describe(UploadableMedia, () => {
       .provide([
         [matchers.call.fn(chat.get), chatClient],
         [matchers.call.fn(chatClient.uploadFileMessage), { id: 'new-id' }],
-      ])
-      .run();
-
-    expect(returnValue).toEqual({ id: 'new-id' });
-  });
-});
-
-describe(UploadableAttachment, () => {
-  it('uploads an attachment', async () => {
-    const channelId = 'channel-id';
-    const pdfFile = { nativeFile: { type: 'application/pdf' } } as any;
-    const fileUploadResult = {
-      name: 'filename',
-      key: 'file-key',
-      url: 'file-url',
-      type: 'file',
-    } as FileUploadResult;
-    const messageSendResponse = { id: 'new-id' };
-    const uploadable = new UploadableAttachment(pdfFile);
-    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
-
-    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, ''))
-      .provide([
-        stubResponse(call(uploadAttachment, pdfFile.nativeFile), fileUploadResult),
-        stubResponse(call(sendFileMessage, channelId, fileUploadResult, 'optimistic-id'), messageSendResponse),
-      ])
-      .run();
-
-    expect(returnValue).toEqual({ id: 'new-id' });
-  });
-});
-
-describe(UploadableGiphy, () => {
-  it('creates a giphy message', async () => {
-    const channelId = 'channel-id';
-    const giphy = {
-      name: 'giphy-file',
-      giphy: { images: { original: { url: 'url_giphy' } }, type: 'gif' },
-    };
-    const expectedFileToSend = { url: 'url_giphy', name: 'giphy-file', type: 'gif' };
-    const uploadable = new UploadableGiphy(giphy);
-    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
-
-    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, ''))
-      .provide([
-        stubResponse(call(sendFileMessage, channelId, expectedFileToSend as any, 'optimistic-id'), { id: 'new-id' }),
       ])
       .run();
 

--- a/src/store/messages/uploadable.ts
+++ b/src/store/messages/uploadable.ts
@@ -1,7 +1,6 @@
 import { CallEffect, call } from 'redux-saga/effects';
 
 import { FileType, getFileType } from './utils';
-import { sendFileMessage, uploadAttachment } from './api';
 import { Message } from '.';
 import { chat } from '../../lib/chat';
 
@@ -44,18 +43,17 @@ export class UploadableMedia implements Uploadable {
 export class UploadableGiphy implements Uploadable {
   public optimisticMessage: Message;
   constructor(public file) {}
-  *upload(channelId, _rootMessageId) {
-    const original = this.file.giphy.images.original;
-    const giphyFile = { url: original.url, name: this.file.name, type: this.file.giphy.type };
-    return yield call(sendFileMessage, channelId, giphyFile, this.optimisticMessage?.id?.toString());
+  *upload(_channelId, _rootMessageId) {
+    yield;
+    throw new Error('Giphy upload is not supported yet.');
   }
 }
 
 export class UploadableAttachment implements Uploadable {
   public optimisticMessage: Message;
   constructor(public file) {}
-  *upload(channelId, _rootMessageId) {
-    const uploadResponse = yield call(uploadAttachment, this.file.nativeFile);
-    return yield call(sendFileMessage, channelId, uploadResponse, this.optimisticMessage?.id?.toString());
+  *upload(_channelId, _rootMessageId) {
+    yield;
+    throw new Error('Attachment upload is not supported yet.');
   }
 }


### PR DESCRIPTION
### What does this do?

We no longer get chat information from zero-api. This removes some of the helpers that were referencing zero-api endpoints.

