### PR TITLE
refactor(messenger-list): update and enhance create conversation flow

### DIFF
--- a/src/components/messenger/list/create-conversation-panel/create-conversation-panel.scss
+++ b/src/components/messenger/list/create-conversation-panel/create-conversation-panel.scss
@@ -1,42 +1,40 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../../../variables';
 
 .create-conversation {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  align-content: center;
-  align-items: center;
-  flex-wrap: nowrap;
-  overflow: initial;
+  &__selected-users {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+    padding-top: 18px;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__selected-number {
+    color: theme.$color-greyscale-12;
+  }
+
+  &__content {
+    flex-grow: 99;
+
+    display: flex;
+    flex-direction: column;
+  }
 
   &__search {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    width: 100%;
-    text-align: center;
   }
 
-  &__group-button {
-    display: flex;
-    align-items: center;
-    margin-top: 16px;
-    gap: 8px;
-    cursor: pointer;
-  }
-
-  &__group-icon {
-    width: 40px;
-    height: 40px;
+  &__button-container {
     display: flex;
     justify-content: center;
-    align-items: center;
+    margin: 16px 16px 0;
+  }
 
-    background: linear-gradient(223deg, #421349 14.62%, #0d0416 36.73%, #0b060e 59.58%, #2b0659 85.38%);
-    border-radius: 9999px;
-
-    & > * {
-      margin: auto;
-    }
+  &__submit-button {
+    width: 100%;
   }
 }

--- a/src/components/messenger/list/create-conversation-panel/index.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.test.tsx
@@ -14,7 +14,7 @@ describe(CreateConversationPanel, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       initialSelections: [],
-      isContinuing: false,
+      isSubmitting: false,
 
       onBack: () => {},
       search: () => {},
@@ -96,9 +96,9 @@ describe(CreateConversationPanel, () => {
     expect(wrapper).not.toHaveElement(Button);
   });
 
-  it('sets isLoading on button when isContinuing is true', () => {
+  it('sets isLoading on button when isSubmitting is true', () => {
     const onCreateOneOnOne = jest.fn();
-    const wrapper = subject({ isContinuing: true, onCreateOneOnOne });
+    const wrapper = subject({ isSubmitting: true, onCreateOneOnOne });
 
     wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-one' });
 

--- a/src/components/messenger/list/create-conversation-panel/index.test.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.test.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import CreateConversationPanel, { Properties } from '.';
+import { PanelHeader } from '../panel-header';
+import { AutocompleteMembers } from '../../autocomplete-members';
+import { Button } from '@zero-tech/zui/components/Button';
+import { SelectedUserTag } from '../selected-user-tag';
+import { bem } from '../../../../lib/bem';
 
-jest.mock('../../autocomplete-members');
+const c = bem('.create-conversation');
 
-describe('CreateConversationPanel', () => {
+describe(CreateConversationPanel, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
+      initialSelections: [],
+      isContinuing: false,
+
       onBack: () => {},
       search: () => {},
-      onCreate: () => {},
-      onStartGroupChat: () => {},
+      onCreateOneOnOne: () => {},
+      onStartGroup: () => {},
       ...props,
     };
 
@@ -20,35 +28,96 @@ describe('CreateConversationPanel', () => {
 
   it('forwards search function to Autocomplete', function () {
     const search = jest.fn();
-    const wrapper = subject({ search: search });
+    const wrapper = subject({ search });
 
-    expect(wrapper.find('AutocompleteMembers').prop('search')).toBe(search);
+    expect(wrapper.find(AutocompleteMembers)).toHaveProp('search', search);
   });
 
-  it('fires onCreate when a user is selected', function () {
-    const onCreate = jest.fn();
-    const wrapper = subject({ onCreate: onCreate });
+  it('fires onCreateOneOnOne when a single user is selected', function () {
+    const onCreateOneOnOne = jest.fn();
+    const onStartGroup = jest.fn();
+    const wrapper = subject({ onCreateOneOnOne, onStartGroup });
 
-    wrapper.find('AutocompleteMembers').simulate('select', { value: 'selected-user-id' });
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-one' });
+    wrapper.find(Button).simulate('press');
 
-    expect(onCreate).toHaveBeenCalledWith('selected-user-id');
+    expect(onCreateOneOnOne).toHaveBeenCalledWith('user-one');
+    expect(onStartGroup).not.toHaveBeenCalled();
+  });
+
+  it('fires onStartGroup when multiple users are selected', () => {
+    const onCreateOneOnOne = jest.fn();
+    const onStartGroup = jest.fn();
+    const wrapper = subject({ onStartGroup, onCreateOneOnOne });
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-one' });
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-two' });
+    wrapper.find(Button).simulate('press');
+
+    expect(onStartGroup).toHaveBeenCalledWith([{ value: 'user-one' }, { value: 'user-two' }]);
+    expect(onCreateOneOnOne).not.toHaveBeenCalled();
   });
 
   it('fires onBack when back icon clicked', function () {
     const onBack = jest.fn();
     const wrapper = subject({ onBack: onBack });
 
-    wrapper.find('PanelHeader').simulate('back');
+    wrapper.find(PanelHeader).simulate('back');
 
     expect(onBack).toHaveBeenCalledOnce();
   });
 
-  it('fires onStartGroupChat when the action is clicked', function () {
-    const onStartGroupChat = jest.fn();
-    const wrapper = subject({ onStartGroupChat });
+  it('initializes with provided initial selections', () => {
+    const initialUsers = [
+      { value: 'user-one', label: 'User One' },
+      { value: 'user-two', label: 'User Two' },
+    ];
 
-    wrapper.find('.create-conversation__group-button').simulate('click');
+    const wrapper = subject({ initialSelections: initialUsers });
 
-    expect(onStartGroupChat).toHaveBeenCalledOnce();
+    expect(wrapper.find(SelectedUserTag)).toHaveLength(initialUsers.length);
+    expect(wrapper.find(SelectedUserTag).at(0).prop('userOption')).toEqual(initialUsers[0]);
+    expect(wrapper.find(SelectedUserTag).at(1).prop('userOption')).toEqual(initialUsers[1]);
+  });
+
+  it('redners the submit button if users are selected', () => {
+    const wrapper = subject({});
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-one' });
+
+    expect(wrapper).toHaveElement(Button);
+  });
+
+  it('does not render the submit button if no users are selected', () => {
+    const wrapper = subject({ initialSelections: [{ value: 'user-one', label: 'UserOne' }] });
+
+    wrapper.find(SelectedUserTag).simulate('remove', 'user-one');
+
+    expect(wrapper).not.toHaveElement(Button);
+  });
+
+  it('sets isLoading on button when isContinuing is true', () => {
+    const onCreateOneOnOne = jest.fn();
+    const wrapper = subject({ isContinuing: true, onCreateOneOnOne });
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-one' });
+
+    expect(wrapper.find(Button)).toHaveProp('isLoading', true);
+  });
+
+  it('renders selected users if users are selected', () => {
+    const wrapper = subject({});
+
+    wrapper.find(AutocompleteMembers).simulate('select', { value: 'user-one' });
+
+    expect(wrapper).toHaveElement(c('selected-users'));
+  });
+
+  it('does not render selected users if no users are selected', () => {
+    const wrapper = subject({ initialSelections: [{ value: 'user-one', label: 'UserOne' }] });
+
+    wrapper.find(SelectedUserTag).simulate('remove', 'user-one');
+
+    expect(wrapper).not.toHaveElement(c('selected-users'));
   });
 });

--- a/src/components/messenger/list/create-conversation-panel/index.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.tsx
@@ -14,7 +14,7 @@ const cn = bemClassName('create-conversation');
 
 export interface Properties {
   initialSelections: Option[];
-  isContinuing: boolean;
+  isSubmitting: boolean;
 
   search: (input: string) => any;
   onBack: () => void;
@@ -54,7 +54,7 @@ export default class CreateConversationPanel extends React.Component<Properties,
       : this.props.onStartGroup(selectedOptions);
   };
 
-  get isContinueDisabled() {
+  get isSubmitDisabled() {
     return this.state.selectedOptions.length === 0;
   }
 
@@ -84,8 +84,8 @@ export default class CreateConversationPanel extends React.Component<Properties,
         <Button
           {...cn('submit-button')}
           onPress={this.submitSelectedOptions}
-          isDisabled={this.isContinueDisabled}
-          isLoading={this.props.isContinuing}
+          isDisabled={this.isSubmitDisabled}
+          isLoading={this.props.isSubmitting}
         >
           {this.submitButtonText}
         </Button>

--- a/src/components/messenger/list/create-conversation-panel/index.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.tsx
@@ -2,47 +2,115 @@ import * as React from 'react';
 
 import { AutocompleteMembers } from '../../autocomplete-members';
 import { PanelHeader } from '../panel-header';
-import { IconUsersPlus } from '@zero-tech/zui/icons';
+import { SelectedUserTag } from '../selected-user-tag';
+import { Button } from '@zero-tech/zui/components/Button';
 
+import { Option } from '../../lib/types';
 import { bemClassName } from '../../../../lib/bem';
+
 import './create-conversation-panel.scss';
 
 const cn = bemClassName('create-conversation');
 
 export interface Properties {
-  search: (input: string) => any;
+  initialSelections: Option[];
+  isContinuing: boolean;
 
+  search: (input: string) => any;
   onBack: () => void;
-  onCreate: (id: string) => void;
-  onStartGroupChat: () => void;
+  onCreateOneOnOne: (id: string) => void;
+  onStartGroup: (options: Option[]) => void;
 }
 
-export default class CreateConversationPanel extends React.Component<Properties> {
-  userSelected = (option) => {
-    this.props.onCreate(option.value);
+interface State {
+  selectedOptions: Option[];
+}
+
+export default class CreateConversationPanel extends React.Component<Properties, State> {
+  state = { selectedOptions: [] };
+
+  constructor(props) {
+    super(props);
+    this.state = { selectedOptions: [...props.initialSelections] };
+  }
+
+  selectOption = (selectedOption) => {
+    const { selectedOptions } = this.state;
+    if (!selectedOptions.some((option) => option.value === selectedOption.value)) {
+      this.setState({ selectedOptions: [...selectedOptions, selectedOption] });
+    }
   };
 
-  startGroupChat = (_e) => {
-    this.props.onStartGroupChat();
+  unselectOption = (value) => {
+    this.setState((prevState) => ({
+      selectedOptions: prevState.selectedOptions.filter((option) => option.value !== value),
+    }));
   };
+
+  submitSelectedOptions = () => {
+    const { selectedOptions } = this.state;
+    selectedOptions.length === 1
+      ? this.props.onCreateOneOnOne(selectedOptions[0].value)
+      : this.props.onStartGroup(selectedOptions);
+  };
+
+  get isContinueDisabled() {
+    return this.state.selectedOptions.length === 0;
+  }
+
+  get submitButtonText() {
+    return this.state.selectedOptions.length === 1 ? 'Create Conversation' : 'Next';
+  }
+
+  renderSelectedUserTags(selectedOptions) {
+    return (
+      <>
+        <div {...cn('selected-users')}>
+          <span {...cn('selected-number')}>{selectedOptions.length}</span> member
+          {selectedOptions.length === 1 ? '' : 's'} selected
+        </div>
+        <div>
+          {selectedOptions.map((option) => (
+            <SelectedUserTag key={option.value} userOption={option} onRemove={this.unselectOption} />
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  renderButton() {
+    return (
+      <div {...cn('button-container')}>
+        <Button
+          {...cn('submit-button')}
+          onPress={this.submitSelectedOptions}
+          isDisabled={this.isContinueDisabled}
+          isLoading={this.props.isContinuing}
+        >
+          {this.submitButtonText}
+        </Button>
+      </div>
+    );
+  }
 
   render() {
+    const { selectedOptions } = this.state;
+    const hasSelectedOptions = selectedOptions.length > 0;
+
     return (
       <>
         <PanelHeader title='New Conversation' onBack={this.props.onBack} />
-
-        <div {...cn('')}>
-          <div {...cn('search')}>
-            <AutocompleteMembers search={this.props.search} onSelect={this.userSelected}>
-              <div {...cn('group-button')} onClick={this.startGroupChat}>
-                <div {...cn('group-icon')}>
-                  <IconUsersPlus size={25} />
-                </div>
-                Start a group chat
-              </div>
-            </AutocompleteMembers>
-          </div>
+        <div {...cn('search')}>
+          <AutocompleteMembers
+            search={this.props.search}
+            onSelect={this.selectOption}
+            selectedOptions={selectedOptions}
+          >
+            {hasSelectedOptions && this.renderSelectedUserTags(selectedOptions)}
+          </AutocompleteMembers>
         </div>
+
+        {hasSelectedOptions && this.renderButton()}
       </>
     );
   }

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -150,10 +150,10 @@ describe('messenger-list', () => {
     expect(back).toHaveBeenCalledOnce();
   });
 
-  it('sets CreateConversationPanel to Continuing while data is loading', async function () {
+  it('sets CreateConversationPanel to submitting while data is loading', async function () {
     const wrapper = subject({ stage: Stage.InitiateConversation, isFetchingExistingConversations: true });
 
-    expect(wrapper.find(CreateConversationPanel).prop('isContinuing')).toBeTrue();
+    expect(wrapper.find(CreateConversationPanel).prop('isSubmitting')).toBeTrue();
   });
 
   it('creates a group conversation when details submitted', async function () {

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -7,7 +7,6 @@ import moment from 'moment';
 import { when } from 'jest-when';
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
-import { StartGroupPanel } from './start-group-panel';
 import { GroupDetailsPanel } from './group-details-panel';
 import { Stage } from '../../../store/create-conversation';
 import { Stage as GroupManagementStage } from '../../../store/group-management';
@@ -47,7 +46,6 @@ describe('messenger-list', () => {
       closeConversationErrorDialog: () => null,
       startCreateConversation: () => null,
       membersSelected: () => null,
-      startGroup: () => null,
       back: () => null,
       receiveSearchResults: () => null,
       logout: () => null,
@@ -84,26 +82,16 @@ describe('messenger-list', () => {
   });
 
   it('does not render UserHeader when stage is not equal to none', function () {
-    const wrapper = subject({ stage: Stage.CreateOneOnOne });
+    const wrapper = subject({ stage: Stage.InitiateConversation });
 
     expect(wrapper).not.toHaveElement(UserHeader);
   });
 
   it('renders CreateConversationPanel', function () {
-    const wrapper = subject({ stage: Stage.CreateOneOnOne });
+    const wrapper = subject({ stage: Stage.InitiateConversation });
 
     expect(wrapper).not.toHaveElement(ConversationListPanel);
     expect(wrapper).toHaveElement(CreateConversationPanel);
-    expect(wrapper).not.toHaveElement(StartGroupPanel);
-    expect(wrapper).not.toHaveElement(GroupDetailsPanel);
-  });
-
-  it('renders StartGroupPanel', function () {
-    const wrapper = subject({ stage: Stage.StartGroupChat });
-
-    expect(wrapper).not.toHaveElement(ConversationListPanel);
-    expect(wrapper).not.toHaveElement(CreateConversationPanel);
-    expect(wrapper).toHaveElement(StartGroupPanel);
     expect(wrapper).not.toHaveElement(GroupDetailsPanel);
   });
 
@@ -112,33 +100,14 @@ describe('messenger-list', () => {
 
     expect(wrapper).not.toHaveElement(ConversationListPanel);
     expect(wrapper).not.toHaveElement(CreateConversationPanel);
-    expect(wrapper).not.toHaveElement(StartGroupPanel);
     expect(wrapper).toHaveElement(GroupDetailsPanel);
-  });
-
-  it('moves starts group when group chat started', async function () {
-    const startGroup = jest.fn();
-    const wrapper = subject({ stage: Stage.CreateOneOnOne, startGroup });
-
-    wrapper.find(CreateConversationPanel).simulate('startGroupChat');
-
-    expect(startGroup).toHaveBeenCalledOnce();
   });
 
   it('moves back from CreateConversationPanel', async function () {
     const back = jest.fn();
-    const wrapper = subject({ stage: Stage.CreateOneOnOne, back });
+    const wrapper = subject({ stage: Stage.InitiateConversation, back });
 
     await wrapper.find(CreateConversationPanel).simulate('back');
-
-    expect(back).toHaveBeenCalledOnce();
-  });
-
-  it('moves back from StartGroupPanel', async function () {
-    const back = jest.fn();
-    const wrapper = subject({ stage: Stage.StartGroupChat, back });
-
-    await wrapper.find(StartGroupPanel).simulate('back');
 
     expect(back).toHaveBeenCalledOnce();
   });
@@ -156,7 +125,7 @@ describe('messenger-list', () => {
     when(mockSearchMyNetworksByName)
       .calledWith('jac')
       .mockResolvedValue([{ id: 'user-id', profileImage: 'image-url' }]);
-    const wrapper = subject({ stage: Stage.CreateOneOnOne });
+    const wrapper = subject({ stage: Stage.InitiateConversation });
 
     const searchResults = await wrapper.find(CreateConversationPanel).prop('search')('jac');
 
@@ -165,32 +134,32 @@ describe('messenger-list', () => {
 
   it('creates a one on one conversation when user selected', async function () {
     const createConversation = jest.fn();
-    const wrapper = subject({ createConversation, stage: Stage.CreateOneOnOne });
+    const wrapper = subject({ createConversation, stage: Stage.InitiateConversation });
 
-    wrapper.find(CreateConversationPanel).prop('onCreate')('selected-user-id');
+    wrapper.find(CreateConversationPanel).prop('onCreateOneOnOne')('selected-user-id');
 
     expect(createConversation).toHaveBeenCalledWith({ userIds: ['selected-user-id'] });
   });
 
   it('returns to conversation list if back button pressed', async function () {
     const back = jest.fn();
-    const wrapper = subject({ stage: Stage.CreateOneOnOne, back });
+    const wrapper = subject({ stage: Stage.InitiateConversation, back });
 
     wrapper.find(CreateConversationPanel).prop('onBack')();
 
     expect(back).toHaveBeenCalledOnce();
   });
 
-  it('sets StartGroupPanel to Continuing while data is loading', async function () {
-    const wrapper = subject({ stage: Stage.StartGroupChat, isFetchingExistingConversations: true });
+  it('sets CreateConversationPanel to Continuing while data is loading', async function () {
+    const wrapper = subject({ stage: Stage.InitiateConversation, isFetchingExistingConversations: true });
 
-    expect(wrapper.find(StartGroupPanel).prop('isContinuing')).toBeTrue();
+    expect(wrapper.find(CreateConversationPanel).prop('isContinuing')).toBeTrue();
   });
 
   it('creates a group conversation when details submitted', async function () {
     const createConversation = jest.fn();
-    const wrapper = subject({ createConversation, stage: Stage.StartGroupChat });
-    await wrapper.find(StartGroupPanel).prop('onContinue')([{ value: 'id-1' } as any]);
+    const wrapper = subject({ createConversation, stage: Stage.InitiateConversation });
+    await wrapper.find(CreateConversationPanel).prop('onStartGroup')([{ value: 'id-1' } as any]);
     wrapper.setProps({ stage: Stage.GroupDetails });
 
     wrapper
@@ -205,9 +174,9 @@ describe('messenger-list', () => {
   });
 
   it('sets the start group props', async function () {
-    const wrapper = subject({ stage: Stage.StartGroupChat, groupUsers: [{ value: 'user-id' } as any] });
+    const wrapper = subject({ stage: Stage.InitiateConversation, groupUsers: [{ value: 'user-id' } as any] });
 
-    expect(wrapper.find(StartGroupPanel).prop('initialSelections')).toEqual([{ value: 'user-id' }]);
+    expect(wrapper.find(CreateConversationPanel).prop('initialSelections')).toEqual([{ value: 'user-id' }]);
   });
 
   it('renders GroupManagement if group management stage is NOT none', function () {
@@ -258,8 +227,7 @@ describe('messenger-list', () => {
 
     const stages = [
       { stage: Stage.None, component: ConversationListPanel, searchProp: 'search' },
-      { stage: Stage.CreateOneOnOne, component: CreateConversationPanel, searchProp: 'search' },
-      { stage: Stage.StartGroupChat, component: StartGroupPanel, searchProp: 'searchUsers' },
+      { stage: Stage.InitiateConversation, component: CreateConversationPanel, searchProp: 'search' },
     ];
 
     stages.forEach(({ stage, component, searchProp }) => {
@@ -432,7 +400,7 @@ describe('messenger-list', () => {
       expect(state.groupUsers).toEqual([{ value: 'a-thing' }]);
     });
 
-    test('start group chat', () => {
+    test('isFetchingExistingConversations', () => {
       const state = subject([], {
         startGroupChat: {
           isLoading: true,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -11,7 +11,6 @@ import {
   Stage as SagaStage,
   back,
   createConversation,
-  startGroup,
   membersSelected,
   startCreateConversation,
 } from '../../../store/create-conversation';
@@ -21,7 +20,6 @@ import { closeConversationErrorDialog } from '../../../store/chat';
 
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
-import { StartGroupPanel } from './start-group-panel';
 import { GroupDetailsPanel } from './group-details-panel';
 import { Option } from '../lib/types';
 import { MembersSelectedPayload } from '../../../store/create-conversation/types';
@@ -36,13 +34,13 @@ import { UserHeader } from './user-header';
 import { getUserSubHandle } from '../../../lib/user';
 import { VerifyIdDialog } from '../../verify-id-dialog';
 import { closeBackupDialog } from '../../../store/matrix';
-
-import { bemClassName } from '../../../lib/bem';
-import './styles.scss';
 import { SecureBackupContainer } from '../../secure-backup/container';
 import { LogoutConfirmationModalContainer } from '../../logout-confirmation-modal/container';
 import { RewardsModalContainer } from '../../rewards-modal/container';
 import { closeRewardsDialog } from '../../../store/rewards';
+
+import { bemClassName } from '../../../lib/bem';
+import './styles.scss';
 
 const cn = bemClassName('direct-message-members');
 
@@ -68,7 +66,6 @@ export interface Properties extends PublicProperties {
   showRewardsTooltip: boolean;
 
   startCreateConversation: () => void;
-  startGroup: () => void;
   back: () => void;
   membersSelected: (payload: MembersSelectedPayload) => void;
   createConversation: (payload: CreateMessengerConversation) => void;
@@ -127,7 +124,6 @@ export class Container extends React.Component<Properties, State> {
       createConversation,
       startCreateConversation,
       back,
-      startGroup,
       membersSelected,
       logout,
       receiveSearchResults,
@@ -258,21 +254,14 @@ export class Container extends React.Component<Properties, State> {
             onUnfavoriteRoom={this.props.onUnfavoriteRoom}
           />
         )}
-        {this.props.stage === SagaStage.CreateOneOnOne && (
+        {this.props.stage === SagaStage.InitiateConversation && (
           <CreateConversationPanel
-            onBack={this.props.back}
-            search={this.usersInMyNetworks}
-            onCreate={this.createOneOnOneConversation}
-            onStartGroupChat={this.props.startGroup}
-          />
-        )}
-        {this.props.stage === SagaStage.StartGroupChat && (
-          <StartGroupPanel
             initialSelections={this.props.groupUsers}
             isContinuing={this.props.isFetchingExistingConversations}
             onBack={this.props.back}
-            onContinue={this.groupMembersSelected}
-            searchUsers={this.usersInMyNetworks}
+            search={this.usersInMyNetworks}
+            onCreateOneOnOne={this.createOneOnOneConversation}
+            onStartGroup={this.groupMembersSelected}
           />
         )}
         {this.props.stage === SagaStage.GroupDetails && (

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -257,7 +257,7 @@ export class Container extends React.Component<Properties, State> {
         {this.props.stage === SagaStage.InitiateConversation && (
           <CreateConversationPanel
             initialSelections={this.props.groupUsers}
-            isContinuing={this.props.isFetchingExistingConversations}
+            isSubmitting={this.props.isFetchingExistingConversations}
             onBack={this.props.back}
             search={this.usersInMyNetworks}
             onCreateOneOnOne={this.createOneOnOneConversation}

--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -6,21 +6,18 @@ export enum SagaActionTypes {
   Start = 'create-conversation/start',
   Back = 'create-conversation/back',
   Cancel = 'create-conversation/cancel',
-  StartGroup = 'create-conversation/start-group',
   MembersSelected = 'create-conversation/members-selected',
   CreateConversation = 'create-conversation/create',
 }
 
 export const startCreateConversation = createAction(SagaActionTypes.Start);
-export const startGroup = createAction(SagaActionTypes.StartGroup);
 export const back = createAction(SagaActionTypes.Back);
 export const membersSelected = createAction<MembersSelectedPayload>(SagaActionTypes.MembersSelected);
 export const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
 
 export enum Stage {
   None = 'none',
-  CreateOneOnOne = 'one_on_one',
-  StartGroupChat = 'start_group',
+  InitiateConversation = 'initiate_conversation',
   GroupDetails = 'group_details',
 }
 

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -24,10 +24,7 @@ describe('create conversation saga', () => {
         .next()
         .call(reset)
         .next()
-        .put(setStage(Stage.CreateOneOnOne))
-        .next()
-        .next({ handlerResult: Stage.StartGroupChat })
-        .put(setStage(Stage.StartGroupChat))
+        .put(setStage(Stage.InitiateConversation))
         .next()
         .next({ handlerResult: Stage.GroupDetails })
         .put(setStage(Stage.GroupDetails));
@@ -36,10 +33,8 @@ describe('create conversation saga', () => {
     it('finishes when the next stage is None', async () => {
       testSaga(startConversation)
         .next()
-        .next()
-        .next()
-        .next({ handlerResult: Stage.StartGroupChat })
-        .put(setStage(Stage.StartGroupChat))
+        .next({ handlerResult: Stage.InitiateConversation })
+        .put(setStage(Stage.InitiateConversation))
         .next()
         .next({ handlerResult: Stage.None })
         .put(setStage(Stage.None))
@@ -56,7 +51,7 @@ describe('create conversation saga', () => {
         .next()
         .next()
         .next()
-        .next({ handlerResult: Stage.StartGroupChat })
+        .next({ handlerResult: Stage.InitiateConversation })
         .throw(new Error('Stub error'))
         .call(reset);
     });
@@ -117,7 +112,7 @@ describe('create conversation saga', () => {
     });
 
     it('returns to initial state when existing conversation selected', async () => {
-      const initialState = defaultState({ stage: Stage.StartGroupChat });
+      const initialState = defaultState({ stage: Stage.InitiateConversation });
 
       const { returnValue } = await subject(performGroupMembersSelected, [])
         .provide([[matchers.call.fn(fetchConversationsWithUsers), [{ id: 'convo-1' }]]])
@@ -129,7 +124,7 @@ describe('create conversation saga', () => {
 
     it('moves to group details stage if no existing conversations found', async () => {
       const users = [{ value: 'user-1' }, { value: 'user-2' }];
-      const initialState = defaultState({ stage: Stage.StartGroupChat });
+      const initialState = defaultState({ stage: Stage.InitiateConversation });
 
       const { returnValue, storeState } = await subject(performGroupMembersSelected, users)
         .provide([[matchers.call.fn(fetchConversationsWithUsers), []]])


### PR DESCRIPTION
### What does this do?
- removes `StartGroupChat` stage.
- renaming to reflect changes to create conversation flow.
- `CreateConversationPanel` updates to handle both creating one on one conversation and starts a group conversation.
- updates tests to reflect changes to flow/sagas.

### Why are we making this change?
- as per figma designs - removes use of the `StartGroupPanel` and the start group chat stage

### How do I test this?
- run tests as usual.
- run the UI and test the updated flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


DEMO

https://github.com/zer0-os/zOS/assets/39112648/08abef89-9e6a-4136-a3ec-75d082fea974

