### PR TITLE
refactor: remove enable favorites feature flag

### DIFF
--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -16,8 +16,6 @@ import { bemClassName } from '../../../../lib/bem';
 import './conversation-item.scss';
 import '../styles.scss';
 
-import { FeatureFlag } from '../../../feature-flag';
-
 const cn = bemClassName('conversation-item');
 
 export interface Properties {
@@ -161,7 +159,7 @@ export class ConversationItem extends React.Component<Properties, State> {
         >
           <div {...cn('avatar-with-menu-container')}>
             {this.renderAvatar()}
-            <FeatureFlag featureFlag='enableFavorites'>{this.renderMoreMenu()}</FeatureFlag>
+            {this.renderMoreMenu()}
           </div>
 
           <div {...cn('summary')}>

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -12,7 +12,6 @@ import { getDirectMatches, getIndirectMatches } from './utils';
 
 import { bemClassName } from '../../../../lib/bem';
 import './conversation-list-panel.scss';
-import { FeatureFlag } from '../../../feature-flag';
 
 const cn = bemClassName('messages-list');
 
@@ -156,26 +155,24 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             />
           </div>
 
-          <FeatureFlag featureFlag='enableFavorites'>
-            <div {...cn('tab-list')}>
-              <div {...cn('tab', this.state.selectedTab === Tab.All && 'active')} onClick={this.selectAll}>
-                All
-                {!!this.allUnreadCount && (
-                  <div {...cn('tab-badge')}>
-                    <span>{this.allUnreadCount}</span>
-                  </div>
-                )}
-              </div>
-              <div {...cn('tab', this.state.selectedTab === Tab.Favorites && 'active')} onClick={this.selectFavorites}>
-                Favorites
-                {!!this.favoritesUnreadCount && (
-                  <div {...cn('tab-badge')}>
-                    <span>{this.favoritesUnreadCount}</span>
-                  </div>
-                )}
-              </div>
+          <div {...cn('tab-list')}>
+            <div {...cn('tab', this.state.selectedTab === Tab.All && 'active')} onClick={this.selectAll}>
+              All
+              {!!this.allUnreadCount && (
+                <div {...cn('tab-badge')}>
+                  <span>{this.allUnreadCount}</span>
+                </div>
+              )}
             </div>
-          </FeatureFlag>
+            <div {...cn('tab', this.state.selectedTab === Tab.Favorites && 'active')} onClick={this.selectFavorites}>
+              Favorites
+              {!!this.favoritesUnreadCount && (
+                <div {...cn('tab-badge')}>
+                  <span>{this.favoritesUnreadCount}</span>
+                </div>
+              )}
+            </div>
+          </div>
 
           <ScrollbarContainer variant='on-hover' ref={this.scrollContainerRef}>
             <div {...cn('item-list')}>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -50,14 +50,6 @@ export class FeatureFlags {
     this._setBoolean('enableRewards', value);
   }
 
-  get enableFavorites() {
-    return this._getBoolean('enableFavorites', true);
-  }
-
-  set enableFavorites(value: boolean) {
-    this._setBoolean('enableFavorites', value);
-  }
-
   get enableMatrix() {
     return this._getBoolean('enableMatrix', true);
   }


### PR DESCRIPTION
### What does this do?
- remove `enableFavorites` feature flag.

### Why are we making this change?
- no longer required as feature has been released.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
