### PR TITLE
feat: remove tooltip from conversation item

### DIFF
--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { ConversationItem, Properties } from '.';
-import moment from 'moment';
 import { ContentHighlighter } from '../../../content-highlighter';
 import { Avatar } from '@zero-tech/zui/components';
 import { bem } from '../../../../lib/bem';
-import Tooltip from '../../../tooltip';
 
 const c = bem('.conversation-item');
 
@@ -120,30 +118,6 @@ describe(ConversationItem, () => {
       });
 
       expect(wrapper.find(Avatar)).toHaveProp('statusType', 'active');
-    });
-  });
-
-  describe('tooltip', () => {
-    it('renders Online if single member is currently online', function () {
-      const wrapper = subject({ conversation: convoWith({ isOnline: true }) });
-
-      expect(wrapper.find(Tooltip)).toHaveProp('overlay', 'Online');
-    });
-
-    it('renders last seen time if single member has previously been online', function () {
-      const wrapper = subject({
-        conversation: convoWith({ lastSeenAt: moment().subtract(2, 'days').toISOString() }),
-      });
-
-      expect(wrapper.find(Tooltip)).toHaveProp('overlay', 'Last Seen: 2 days ago');
-    });
-
-    it('renders member names when multiple other members', function () {
-      const wrapper = subject({
-        conversation: convoWith({ firstName: 'Johnny', lastName: 'Cash' }, { firstName: 'Jackie', lastName: 'Chan' }),
-      });
-
-      expect(wrapper.find(Tooltip)).toHaveProp('overlay', 'Johnny Cash, Jackie Chan');
     });
   });
 });

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
-import { lastSeenText } from '../utils/utils';
 import { highlightFilter } from '../../lib/utils';
 import { Channel } from '../../../../store/channels';
 
@@ -63,14 +62,6 @@ export class ConversationItem extends React.Component<Properties, State> {
   closeContextMenu = () => {
     this.setState({ isContextMenuOpen: false });
   };
-
-  tooltipContent(conversation: Channel) {
-    if (conversation.otherMembers && conversation.otherMembers.length === 1) {
-      return lastSeenText(conversation.otherMembers[0]);
-    }
-
-    return otherMembersToString(conversation.otherMembers);
-  }
 
   get conversationStatus() {
     const isAnyUserOnline = this.props.conversation.otherMembers.some((user) => user.isOnline);

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -6,7 +6,6 @@ import { highlightFilter } from '../../lib/utils';
 import { Channel } from '../../../../store/channels';
 
 import { MoreMenu } from './more-menu';
-import Tooltip from '../../../tooltip';
 import { Avatar, Status } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 
@@ -138,46 +137,35 @@ export class ConversationItem extends React.Component<Properties, State> {
     const isActive = conversation.id === activeConversationId ? 'true' : 'false';
 
     return (
-      <Tooltip
-        placement='left'
-        overlay={this.tooltipContent(conversation)}
-        align={{
-          offset: [
-            10,
-            0,
-          ],
-        }}
+      <div
+        {...cn('')}
+        onClick={this.handleMemberClick}
+        onKeyDown={this.handleKeyDown}
+        tabIndex={0}
+        role='button'
+        is-active={isActive}
+        onContextMenu={this.openContextMenu}
       >
-        <div
-          {...cn('')}
-          onClick={this.handleMemberClick}
-          onKeyDown={this.handleKeyDown}
-          tabIndex={0}
-          role='button'
-          is-active={isActive}
-          onContextMenu={this.openContextMenu}
-        >
-          <div {...cn('avatar-with-menu-container')}>
-            {this.renderAvatar()}
-            {this.renderMoreMenu()}
-          </div>
+        <div {...cn('avatar-with-menu-container')}>
+          {this.renderAvatar()}
+          {this.renderMoreMenu()}
+        </div>
 
-          <div {...cn('summary')}>
-            <div {...cn('header')}>
-              <div {...cn('name')} is-unread={isUnread}>
-                {this.highlightedName()}
-              </div>
-              <div {...cn('timestamp')}>{previewDisplayDate}</div>
+        <div {...cn('summary')}>
+          <div {...cn('header')}>
+            <div {...cn('name')} is-unread={isUnread}>
+              {this.highlightedName()}
             </div>
-            <div {...cn('content')}>
-              <div {...cn('message')} is-unread={isUnread}>
-                <ContentHighlighter message={messagePreview} variant='negative' tabIndex={-1} />
-              </div>
-              {hasUnreadMessages && <div {...cn('unread-count')}>{conversation.unreadCount}</div>}
+            <div {...cn('timestamp')}>{previewDisplayDate}</div>
+          </div>
+          <div {...cn('content')}>
+            <div {...cn('message')} is-unread={isUnread}>
+              <ContentHighlighter message={messagePreview} variant='negative' tabIndex={-1} />
             </div>
+            {hasUnreadMessages && <div {...cn('unread-count')}>{conversation.unreadCount}</div>}
           </div>
         </div>
-      </Tooltip>
+      </div>
     );
   }
 }


### PR DESCRIPTION
### What does this do?
- removes tooltip from conversation item

### Why are we making this change?
- as requested from leadership.
- there is no need for tooltips when we already have status with avatars, names at top of conversations etc.

### How do I test this?
- run tests as usual.
- run ui and hover over conversation item.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="636" alt="Screenshot 2024-04-18 at 10 49 55" src="https://github.com/zer0-os/zOS/assets/39112648/4444c1df-7470-4890-9df2-e34ab36a13d3">

