### PR TITLE
feat(autocomplete-member): implement onSearchChange callback for search state updates

### DIFF
--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -181,6 +181,48 @@ describe('autocomplete-members', () => {
 
     expect(wrapper.state('results')).toEqual(null);
   });
+
+  it('calls onSearchChange with true when search begins', async () => {
+    const onSearchChange = jest.fn();
+    const search = jest.fn().mockResolvedValue([]);
+    const wrapper = subject({ search, onSearchChange });
+
+    await searchFor(wrapper, 'name');
+
+    expect(onSearchChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onSearchChange with false when search is cleared', async () => {
+    const onSearchChange = jest.fn();
+    const search = jest.fn().mockResolvedValue([]);
+    const wrapper = subject({ search, onSearchChange });
+
+    await searchFor(wrapper, 'name');
+    await searchFor(wrapper, '');
+
+    expect(onSearchChange).toHaveBeenCalledWith(false);
+  });
+
+  it('calls onSearchChange with false when an item is selected', async () => {
+    const onSearchChange = jest.fn();
+    const search = jest.fn();
+    when(search).mockResolvedValue([
+      { name: 'Member 1', id: 'member-1' },
+      { name: 'Member 2', id: 'member-2' },
+    ]);
+    const onSelect = jest.fn();
+    const wrapper = subject({ search, onSelect, onSearchChange });
+
+    await searchFor(wrapper, 'Member 1');
+    wrapper
+      .find('.autocomplete-members__search-results > div')
+      .first()
+      .simulate('click', {
+        currentTarget: { dataset: { id: 'member-1' } },
+      });
+
+    expect(onSearchChange).toHaveBeenLastCalledWith(false);
+  });
 });
 
 async function searchFor(wrapper, searchString) {

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -12,6 +12,7 @@ export interface Properties {
   search: (query: string) => Promise<Item[]>;
   selectedOptions?: Option[];
   onSelect: (selected: Option) => void;
+  onSearchChange?: (isSearching: boolean) => void;
 }
 
 interface State {
@@ -24,6 +25,8 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
 
   searchChanged = async (searchString: string) => {
     this.setState({ searchString });
+
+    this.props.onSearchChange && this.props.onSearchChange?.(!!searchString);
 
     if (!searchString) {
       return this.setState({ results: null });
@@ -43,6 +46,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     if (selectedUser) {
       this.props.onSelect(selectedUser);
       this.setState({ results: null, searchString: '' });
+      this.props.onSearchChange && this.props.onSearchChange(false);
     }
   };
 


### PR DESCRIPTION
### What does this do?
- implements an onSearchChange callback to manage the search active state within the autocomplete component, ensuring the UI responds correctly to user search interactions.

### Why are we making this change?
- to improve the user experience by providing immediate visual feedback when a search is being performed and to support better state management within the component.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
