### PR TITLE
fix: fetching of room name and avatar when creating a group

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -38,6 +38,8 @@ export interface IChatClient {
   reconnect: () => void;
   supportsOptimisticCreateConversation: () => boolean;
   getUserPresence: (userId: string) => Promise<any>;
+  getRoomNameById: (id: string) => Promise<string>;
+  getRoomAvatarById: (id: string) => Promise<string>;
   getChannels: (id: string) => Promise<Partial<Channel>[]>;
   getConversations: () => Promise<Partial<Channel>[]>;
   searchMyNetworksByName: (filter: string) => Promise<MemberNetworks[] | any>;
@@ -102,6 +104,14 @@ export class Chat {
 
   async getUserPresence(userId: string) {
     return this.client.getUserPresence(userId);
+  }
+
+  async getRoomNameById(roomId: string) {
+    return this.client.getRoomNameById(roomId);
+  }
+
+  async getRoomAvatarById(roomId: string) {
+    return this.client.getRoomAvatarById(roomId);
   }
 
   async getConversations() {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -117,6 +117,20 @@ export class MatrixClient implements IChatClient {
     }
   }
 
+  async getRoomNameById(roomId: string) {
+    await this.waitForConnection();
+
+    const room = this.matrix.getRoom(roomId);
+    return this.getRoomName(room);
+  }
+
+  async getRoomAvatarById(roomId: string) {
+    await this.waitForConnection();
+
+    const room = this.matrix.getRoom(roomId);
+    return this.getRoomAvatar(room);
+  }
+
   async getChannels(_id: string) {
     return [];
   }

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -13,6 +13,10 @@ import {
   otherUserLeftChannel,
   mapToZeroUsers,
   fetchUserPresence,
+  fetchRoomName,
+  roomNameChanged,
+  fetchRoomAvatar,
+  roomAvatarChanged,
 } from './saga';
 
 import { RootState, rootReducer } from '../reducer';
@@ -40,6 +44,8 @@ const MOCK_CONVERSATIONS = [mockConversation('0001'), mockConversation('0002')];
 const chatClient = {
   getConversations: () => MOCK_CONVERSATIONS,
   getUserPresence: () => {},
+  getRoomNameById: () => {},
+  getRoomAvatarById: () => {},
 };
 
 describe('channels list saga', () => {
@@ -561,6 +567,66 @@ describe('channels list saga', () => {
             isOnline: mockPresenceData1.isOnline,
           })
         )
+        .next()
+        .isDone();
+    });
+  });
+
+  describe(fetchRoomName, () => {
+    function subject(roomId: string, provide = []) {
+      return expectSaga(fetchRoomName, roomId).provide([
+        [matchers.call.fn(chat.get), chatClient],
+        ...provide,
+      ]);
+    }
+
+    const mockRoomName = 'some-room-name';
+
+    it('fetches and updates room name data', async () => {
+      await subject('room-id', [[matchers.call([chatClient, chatClient.getRoomNameById], 'room-id'), mockRoomName]])
+        .call(chat.get)
+        .call([chatClient, chatClient.getRoomNameById], 'room-id')
+        .run();
+    });
+
+    it('calls roomNameChanged when name is fetched', () => {
+      testSaga(fetchRoomName, 'room-id')
+        .next()
+        .call(chat.get)
+        .next(chatClient)
+        .call([chatClient, chatClient.getRoomNameById], 'room-id')
+        .next(mockRoomName)
+        .call(roomNameChanged, 'room-id', mockRoomName)
+        .next()
+        .isDone();
+    });
+  });
+
+  describe(fetchRoomAvatar, () => {
+    function subject(roomId: string, provide = []) {
+      return expectSaga(fetchRoomAvatar, roomId).provide([
+        [matchers.call.fn(chat.get), chatClient],
+        ...provide,
+      ]);
+    }
+
+    const mockRoomAvatar = 'some-room-avatar';
+
+    it('fetches and updates room avatar data', async () => {
+      await subject('room-id', [[matchers.call([chatClient, chatClient.getRoomAvatarById], 'room-id'), mockRoomAvatar]])
+        .call(chat.get)
+        .call([chatClient, chatClient.getRoomAvatarById], 'room-id')
+        .run();
+    });
+
+    it('calls roomAvatarChanged when avatar is fetched', () => {
+      testSaga(fetchRoomAvatar, 'room-id')
+        .next()
+        .call(chat.get)
+        .next(chatClient)
+        .call([chatClient, chatClient.getRoomAvatarById], 'room-id')
+        .next(mockRoomAvatar)
+        .call(roomAvatarChanged, 'room-id', mockRoomAvatar)
         .next()
         .isDone();
     });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -56,6 +56,18 @@ export function* fetchUserPresence(users) {
   }
 }
 
+export function* fetchRoomName(roomId) {
+  const chatClient = yield call(chat.get);
+  const roomName = yield call([chatClient, chatClient.getRoomNameById], roomId);
+  yield call(roomNameChanged, roomId, roomName);
+}
+
+export function* fetchRoomAvatar(roomId) {
+  const chatClient = yield call(chat.get);
+  const roomAvatar = yield call([chatClient, chatClient.getRoomAvatarById], roomId);
+  yield call(roomAvatarChanged, roomId, roomAvatar);
+}
+
 export function* fetchConversations() {
   yield put(setStatus(AsyncListStatus.Fetching));
   const chatClient = yield call(chat.get);
@@ -304,6 +316,8 @@ export function* addChannel(channel) {
   const conversationsList = yield select(rawConversationsList);
   yield call(mapToZeroUsers, [channel]);
   yield fork(fetchUserPresence, channel.otherMembers);
+  yield fork(fetchRoomName, channel.id);
+  yield fork(fetchRoomAvatar, channel.id);
 
   yield put(receive(uniqNormalizedList([...conversationsList, channel])));
 }


### PR DESCRIPTION
### What does this do?
- fixes issue where room name and avatar are not updated in the conversation item (conversation list) when the current user creates a group conversation.

### Why are we making this change?
- the `addChannel` function appeared to be overriding the group name due to the event not being registered. this change ensures that the name and avatar are fetched at the appropriate time.

### How do I test this?
- run tests as usual.
- run the ui and create a group conversation > check the name and avatar get updated.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
