### PR TITLE
feat(create-conversation-panel): implement focus to input once member is selected

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -9,6 +9,7 @@ import '../list/styles.scss';
 import { highlightFilter, itemToOption } from '../lib/utils';
 import classNames from 'classnames';
 export interface Properties {
+  inputRef?: React.RefObject<HTMLInputElement>;
   search: (query: string) => Promise<Item[]>;
   selectedOptions?: Option[];
   onSelect: (selected: Option) => void;
@@ -47,6 +48,9 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
       this.props.onSelect(selectedUser);
       this.setState({ results: null, searchString: '' });
       this.props.onSearchChange && this.props.onSearchChange(false);
+      if (this.props.inputRef?.current) {
+        this.props.inputRef.current.focus();
+      }
     }
   };
 
@@ -64,6 +68,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     return (
       <div className='autocomplete-members'>
         <Input
+          ref={this.props.inputRef}
           autoFocus
           type='search'
           size={'small'}

--- a/src/components/messenger/list/create-conversation-panel/index.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.tsx
@@ -31,6 +31,8 @@ interface State {
 }
 
 export default class CreateConversationPanel extends React.Component<Properties, State> {
+  inputRef = React.createRef<HTMLInputElement>();
+
   constructor(props) {
     super(props);
     this.state = { selectedOptions: [...props.initialSelections], isInviteDialogOpen: false, isSearching: false };
@@ -125,6 +127,7 @@ export default class CreateConversationPanel extends React.Component<Properties,
         <PanelHeader title='New Conversation' onBack={this.props.onBack} />
         <div {...cn('search')}>
           <AutocompleteMembers
+            inputRef={this.inputRef}
             search={this.props.search}
             onSelect={this.selectOption}
             selectedOptions={selectedOptions}


### PR DESCRIPTION
### What does this do?
- implements focus back to search input once a member has been selected.

### Why are we making this change?
- improved ux.

### How do I test this?
- run tests as usual.
- run ui, search users, select member and check input is focussed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/c986dcba-c86c-4b5a-897d-ce521c09f427

