### PR TITLE
feat(create-conversation-panel): implement focus to input once selected member is removed

### DIFF
--- a/src/components/messenger/list/create-conversation-panel/index.tsx
+++ b/src/components/messenger/list/create-conversation-panel/index.tsx
@@ -83,7 +83,13 @@ export default class CreateConversationPanel extends React.Component<Properties,
         </div>
         <div {...cn('selected-tags')}>
           {selectedOptions.map((option) => (
-            <SelectedUserTag key={option.value} userOption={option} onRemove={this.unselectOption} tagSize='spacious' />
+            <SelectedUserTag
+              key={option.value}
+              userOption={option}
+              onRemove={this.unselectOption}
+              tagSize='spacious'
+              inputRef={this.inputRef}
+            />
           ))}
         </div>
       </>

--- a/src/components/messenger/list/selected-user-tag/index.tsx
+++ b/src/components/messenger/list/selected-user-tag/index.tsx
@@ -16,6 +16,7 @@ type TagSizeType = 'compact' | 'spacious';
 export interface Properties {
   userOption: Option;
   tagSize?: TagSizeType;
+  inputRef?: React.RefObject<HTMLInputElement>;
 
   onRemove?: (id: string) => void;
 }
@@ -23,6 +24,10 @@ export interface Properties {
 export class SelectedUserTag extends React.Component<Properties> {
   publishRemove = () => {
     this.props.onRemove(this.props.userOption.value);
+
+    if (this.props.inputRef?.current) {
+      this.props.inputRef.current.focus();
+    }
   };
 
   render() {


### PR DESCRIPTION
### What does this do?
- implements focus back to search input once a member has been removed.

### Why are we making this change?
- improved ux.

### How do I test this?
- run tests as usual.
- run ui, search users, select member, remove member and check input is focussed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/9c946feb-7628-47a4-8efa-c72156a6fc48

