### PR TITLE
feat(add-members-panel): implement focus to input when selecting or removing members

### DIFF
--- a/src/components/messenger/list/add-members-panel/index.tsx
+++ b/src/components/messenger/list/add-members-panel/index.tsx
@@ -29,6 +29,8 @@ interface State {
 }
 
 export class AddMembersPanel extends React.Component<Properties, State> {
+  inputRef = React.createRef<HTMLInputElement>();
+
   state = { selectedOptions: [], isSearching: false };
 
   constructor(props) {
@@ -89,7 +91,13 @@ export class AddMembersPanel extends React.Component<Properties, State> {
     return (
       <div {...cn('selected-tags')}>
         {this.state.selectedOptions.map((option) => (
-          <SelectedUserTag key={option.value} userOption={option} onRemove={this.unselectOption} tagSize='spacious' />
+          <SelectedUserTag
+            key={option.value}
+            userOption={option}
+            onRemove={this.unselectOption}
+            tagSize='spacious'
+            inputRef={this.inputRef}
+          />
         ))}
       </div>
     );
@@ -123,6 +131,7 @@ export class AddMembersPanel extends React.Component<Properties, State> {
         <PanelHeader title={'Add Members'} onBack={this.props.onBack} />
         <div {...cn('search')}>
           <AutocompleteMembers
+            inputRef={this.inputRef}
             search={this.props.searchUsers}
             onSelect={this.selectOption}
             selectedOptions={this.state.selectedOptions}


### PR DESCRIPTION
### What does this do?
- implements focus to input when selecting or removing members on the add members panel.

### Why are we making this change?
- improved UX

### How do I test this?
- run tests as usual.
- go through the add member flow and add/remove members - check focus of input.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/63a76e36-a7c8-4e2e-849d-3df2d6ba0616

