### PR TITLE
Remove unused user fields

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -269,7 +269,7 @@ describe('messenger-list', () => {
     const subject = (
       channels,
       createConversationState = {},
-      currentUser = [{ userId: '', firstName: '', isAMemberOfWorlds: true }],
+      currentUser = [{ userId: '', firstName: '' }],
       chat = { activeConversationId: '', joinRoomErrorContent: null }
     ) => {
       return DirectMessageChat.mapState(getState(channels, createConversationState, currentUser, chat));
@@ -278,7 +278,7 @@ describe('messenger-list', () => {
     const getState = (
       channels,
       createConversationState = {},
-      users = [{ userId: '', isAMemberOfWorlds: true }],
+      users = [{ userId: '' }],
       chat = { activeConversationId: '' }
     ) => {
       const channelData = normalize(channels);
@@ -288,7 +288,6 @@ describe('messenger-list', () => {
           user: {
             data: {
               id: users[0].userId,
-              isAMemberOfWorlds: users[0].isAMemberOfWorlds,
             },
           },
         },

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -27,8 +27,6 @@ export interface User {
   id: string;
   createdAt: string;
   handle: string;
-  isANetworkAdmin: boolean;
-  isAMemberOfWorlds: boolean;
   isOnline: boolean;
   lastActiveAt: string;
   profileId: string;


### PR DESCRIPTION
### What does this do?

Removes some fields that are no longer used in the app

### Why are we making this change?

Because these fields are being removed from the api side and they're meaningless now.

