### PR TITLE
Remove internal global network management functionality

### DIFF
--- a/src/components/edit-profile/container.test.tsx
+++ b/src/components/edit-profile/container.test.tsx
@@ -17,8 +17,6 @@ describe('Container', () => {
       loadingZIDs: false,
       editProfile: () => null,
       startProfileEdit: () => null,
-      leaveGlobalNetwork: () => null,
-      joinGlobalNetwork: () => null,
       fetchOwnedZIDs: () => null,
       ...props,
     };

--- a/src/components/edit-profile/container.tsx
+++ b/src/components/edit-profile/container.tsx
@@ -2,14 +2,7 @@ import * as React from 'react';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { EditProfile } from '.';
-import {
-  State,
-  editProfile,
-  joinGlobalNetwork,
-  leaveGlobalNetwork,
-  startProfileEdit,
-  fetchOwnedZIDs,
-} from '../../store/edit-profile';
+import { State, editProfile, startProfileEdit, fetchOwnedZIDs } from '../../store/edit-profile';
 import { Container as RegistrationContainer } from '../../authentication/create-account-details/container';
 export interface PublicProperties {
   onClose?: () => void;
@@ -29,8 +22,6 @@ export interface Properties extends PublicProperties {
   loadingZIDs: boolean;
   editProfile: (data: { name: string; image: File; primaryZID: string }) => void;
   startProfileEdit: () => void;
-  leaveGlobalNetwork: () => void;
-  joinGlobalNetwork: () => void;
   fetchOwnedZIDs: () => void;
 }
 
@@ -52,7 +43,7 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { editProfile, startProfileEdit, joinGlobalNetwork, leaveGlobalNetwork, fetchOwnedZIDs };
+    return { editProfile, startProfileEdit, fetchOwnedZIDs };
   }
 
   componentDidMount(): void {
@@ -72,8 +63,6 @@ export class Container extends React.Component<Properties> {
         currentPrimaryZID={this.props.currentPrimaryZID}
         ownedZIDs={this.props.ownedZIDs}
         loadingZIDs={this.props.loadingZIDs}
-        onLeaveGlobal={this.props.leaveGlobalNetwork}
-        onJoinGlobal={this.props.joinGlobalNetwork}
       />
     );
   }

--- a/src/components/edit-profile/index.test.tsx
+++ b/src/components/edit-profile/index.test.tsx
@@ -7,7 +7,7 @@ import { ImageUpload } from '../../components/image-upload';
 import { State as EditProfileState } from '../../store/edit-profile';
 import { buttonLabelled } from '../../test/utils';
 
-const featureFlags = { internalUsage: false, allowEditPrimaryZID: false };
+const featureFlags = { allowEditPrimaryZID: false };
 jest.mock('../../lib/feature-flags', () => ({
   featureFlags: featureFlags,
 }));
@@ -24,8 +24,6 @@ describe('EditProfile', () => {
       loadingZIDs: false,
       onEdit: () => null,
       onClose: () => null,
-      onLeaveGlobal: () => null,
-      onJoinGlobal: () => null,
       ...props,
     };
 
@@ -204,45 +202,8 @@ describe('EditProfile', () => {
 
     expect(wrapper.find(Alert).exists()).toBe(false);
   });
-
-  describe('internal features', () => {
-    it('calls onLeaveGlobal when Leave Global pressed', () => {
-      featureFlags.internalUsage = true;
-      const onLeaveGlobal = jest.fn();
-      const wrapper = subject({ onLeaveGlobal });
-
-      leaveGlobalButton(wrapper).simulate('press');
-      expect(onLeaveGlobal).toHaveBeenCalledWith();
-    });
-
-    it('calls onJoinGlobal when Join Global pressed', () => {
-      featureFlags.internalUsage = true;
-      const onJoinGlobal = jest.fn();
-      const wrapper = subject({ onJoinGlobal });
-
-      joinGlobalButton(wrapper).simulate('press');
-      expect(onJoinGlobal).toHaveBeenCalledWith();
-    });
-
-    it('hides Global buttons if feature flag is disabled', () => {
-      featureFlags.internalUsage = false;
-      const onLeaveGlobal = jest.fn();
-      const wrapper = subject({ onLeaveGlobal });
-
-      expect(leaveGlobalButton(wrapper).exists()).toBe(false);
-      expect(joinGlobalButton(wrapper).exists()).toBe(false);
-    });
-  });
 });
 
 function saveButton(wrapper) {
   return buttonLabelled(wrapper, 'Save Changes');
-}
-
-function leaveGlobalButton(wrapper) {
-  return buttonLabelled(wrapper, 'Leave Global');
-}
-
-function joinGlobalButton(wrapper) {
-  return buttonLabelled(wrapper, 'Join Global');
 }

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -26,9 +26,6 @@ export interface Properties {
   loadingZIDs: boolean;
   onEdit: (data: { name: string; image: File; primaryZID: string }) => void;
   onClose?: () => void;
-
-  onLeaveGlobal: () => void;
-  onJoinGlobal: () => void;
 }
 
 interface State {
@@ -228,17 +225,6 @@ export class EditProfile extends React.Component<Properties, State> {
         )}
 
         <div className={c('footer')}>
-          {featureFlags.internalUsage && (
-            <>
-              <Button className={c('zui-button-large')} onPress={this.props.onLeaveGlobal}>
-                Leave Global
-              </Button>
-              <Button className={c('zui-button-large')} onPress={this.props.onJoinGlobal}>
-                Join Global
-              </Button>
-            </>
-          )}
-
           <Button isLoading={this.isLoading} isSubmit isDisabled={this.isDisabled} onPress={this.handleEdit}>
             Save Changes
           </Button>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -74,14 +74,6 @@ export class FeatureFlags {
     this._setBoolean('verboseLogging', value);
   }
 
-  get internalUsage() {
-    return this._getBoolean('internalUsage', false);
-  }
-
-  set internalUsage(value: boolean) {
-    this._setBoolean('internalUsage', value);
-  }
-
   get allowEditPrimaryZID() {
     return this._getBoolean('allowEditPrimaryZID', true);
   }

--- a/src/store/edit-profile/api.ts
+++ b/src/store/edit-profile/api.ts
@@ -33,14 +33,6 @@ export async function saveUserMatrixCredentials({
   };
 }
 
-export async function leaveGlobalNetwork() {
-  await post('/networks/global/leave').send();
-}
-
-export async function joinGlobalNetwork() {
-  await post('/networks/global/join').send();
-}
-
 export async function fetchOwnedZIDs() {
   const response = await get('/api/v2/users/zids');
   return response.body;

--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -2,8 +2,6 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export enum SagaActionTypes {
   EditProfile = 'profile/edit',
-  LeaveGlobal = 'profile/edit/leaveGlobal',
-  JoinGlobal = 'profile/edit/joinGlobal',
   FetchOwnedZIDs = 'profile/edit/fetchOwnedZIDs',
 }
 
@@ -34,8 +32,6 @@ export const editProfile = createAction<{
   primaryZID: string;
 }>(SagaActionTypes.EditProfile);
 
-export const leaveGlobalNetwork = createAction(SagaActionTypes.LeaveGlobal);
-export const joinGlobalNetwork = createAction(SagaActionTypes.JoinGlobal);
 export const fetchOwnedZIDs = createAction(SagaActionTypes.FetchOwnedZIDs);
 
 const slice = createSlice({

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -3,8 +3,6 @@ import { SagaActionTypes, State, setErrors, setLoadingZIDs, setOwnedZIDs, setSta
 import {
   editUserProfile as apiEditUserProfile,
   saveUserMatrixCredentials as apiSaveUserMatrixCredentials,
-  joinGlobalNetwork as joinGlobalNetworkApi,
-  leaveGlobalNetwork as leaveGlobalNetworkApi,
   fetchOwnedZIDs as fetchOwnedZIDsApi,
 } from './api';
 import { ProfileDetailsErrors } from '../registration';
@@ -72,14 +70,6 @@ export function* updateUserProfile(payload) {
   yield put(setUser({ data: currentUser }));
 }
 
-export function* leaveGlobalNetwork() {
-  yield leaveGlobalNetworkApi();
-}
-
-export function* joinGlobalNetwork() {
-  yield joinGlobalNetworkApi();
-}
-
 export function* fetchOwnedZIDs() {
   yield put(setLoadingZIDs(true));
 
@@ -95,7 +85,5 @@ export function* fetchOwnedZIDs() {
 
 export function* saga() {
   yield takeLatest(SagaActionTypes.EditProfile, editProfile);
-  yield takeLatest(SagaActionTypes.LeaveGlobal, leaveGlobalNetwork);
-  yield takeLatest(SagaActionTypes.JoinGlobal, joinGlobalNetwork);
   yield takeLatest(SagaActionTypes.FetchOwnedZIDs, fetchOwnedZIDs);
 }


### PR DESCRIPTION
### What does this do?

Removes the internal functionality to join/leave the global network

### Why are we making this change?

We are removing the network concept completely from the api side so these are no longer valid

