### PR TITLE
refactor(conversation-item): improve default group avatar icon

### DIFF
--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -123,50 +123,6 @@
     width: 100%;
   }
 
-  &__group-icon {
-    position: relative;
-    width: 40px;
-    height: 40px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 9999px;
-
-    @include glass-separator-primary;
-    @include glass-shadow-low;
-
-    &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      border-radius: inherit;
-      z-index: -1;
-
-      // custom raised background for group icon
-      background: linear-gradient(
-        153.33deg,
-        rgba(255, 255, 255, 0.55) 0%,
-        rgba(255, 255, 255, 0) 24.43%,
-        rgba(255, 255, 255, 0.01) 79.12%,
-        rgba(255, 255, 255, 0.75) 100%
-      );
-    }
-
-    & > * {
-      margin: auto;
-      position: relative;
-    }
-  }
-
-  &__group-status {
-    position: absolute;
-    top: 32px;
-    left: 32px;
-  }
-
   &__avatar-with-menu-container {
     position: relative;
     display: flex;

--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -40,12 +40,6 @@ describe(ConversationItem, () => {
     expect(wrapper.find(Avatar)).toHaveProp('imageURL', 'custom-image-url');
   });
 
-  it('renders default group icon if group conversation has no image', function () {
-    const wrapper = subject({ conversation: { ...convoWith({ firstName: 'one' }, { firstName: 'two' }) } });
-
-    expect(wrapper).toHaveElement(c('group-icon'));
-  });
-
   it('renders conversation title for one on one', function () {
     const wrapper = subject({ conversation: convoWith({ firstName: 'Johnny', lastName: 'Cash' }) });
 

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -81,13 +81,6 @@ export class ConversationItem extends React.Component<Properties, State> {
       imageUrl = this.props.conversation.icon;
     } else if (this.props.conversation.isOneOnOne && this.props.conversation.otherMembers[0]?.profileImage) {
       imageUrl = this.props.conversation.otherMembers[0].profileImage;
-    } else if (!this.props.conversation.isOneOnOne) {
-      return (
-        <div {...cn('group-icon')}>
-          <IconUsers1 size={25} />
-          <Status {...cn('group-status')} type={this.conversationStatus} />
-        </div>
-      );
     }
 
     return (
@@ -98,6 +91,7 @@ export class ConversationItem extends React.Component<Properties, State> {
         statusType={this.conversationStatus}
         tabIndex={-1}
         isRaised
+        isGroup={!this.props.conversation.isOneOnOne}
       />
     );
   }


### PR DESCRIPTION
### What does this do?
- removes custom group icon and uses Avatar components default group icon

### Why are we making this change?
- improve code quality

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
