### PR TITLE
feat(alerts): apply isFilled flag to component where required

### DIFF
--- a/src/authentication/confirm-password-reset/index.tsx
+++ b/src/authentication/confirm-password-reset/index.tsx
@@ -132,7 +132,7 @@ export class ConfirmPasswordReset extends React.Component<Properties, State> {
         </div>
         {this.generalError && (
           <div {...cn('error-container')}>
-            <Alert {...cn('error')} variant='error'>
+            <Alert isFilled {...cn('error')} variant='error'>
               {this.generalError}
             </Alert>
           </div>

--- a/src/authentication/create-account-details/index.tsx
+++ b/src/authentication/create-account-details/index.tsx
@@ -73,7 +73,11 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
               errorMessage={this.props.errors.image}
             />
           </div>
-          {this.imageError && <Alert variant='error'>{this.imageError}</Alert>}
+          {this.imageError && (
+            <Alert isFilled variant='error'>
+              {this.imageError}
+            </Alert>
+          )}
           <Input
             {...cn('input')}
             label='Display Name'
@@ -87,7 +91,11 @@ export class CreateAccountDetails extends React.Component<Properties, State> {
             error={!!this.nameError}
             alert={this.nameError}
           />
-          {this.generalError && <Alert variant='error'>{this.generalError}</Alert>}
+          {this.generalError && (
+            <Alert isFilled variant='error'>
+              {this.generalError}
+            </Alert>
+          )}
           <Button {...cn('submit-button')} isLoading={this.props.isLoading} isSubmit>
             Create Account
           </Button>

--- a/src/authentication/create-email-account/index.tsx
+++ b/src/authentication/create-email-account/index.tsx
@@ -143,7 +143,7 @@ export class CreateEmailAccount extends React.Component<Properties, State> {
           </div>
           {this.generalError && (
             <div {...cn('error-container')}>
-              <Alert {...cn('error')} variant='error'>
+              <Alert {...cn('error')} variant='error' isFilled>
                 {this.generalError}
               </Alert>
             </div>

--- a/src/authentication/create-wallet-account/index.tsx
+++ b/src/authentication/create-wallet-account/index.tsx
@@ -28,7 +28,7 @@ export class CreateWalletAccount extends React.Component<Properties> {
           </div>
           {this.showError && (
             <div {...cn('error-container')}>
-              <Alert {...cn('error')} variant='error'>
+              <Alert {...cn('error')} variant='error' isFilled>
                 {this.props.error}
               </Alert>
             </div>

--- a/src/authentication/email-login/index.tsx
+++ b/src/authentication/email-login/index.tsx
@@ -83,7 +83,7 @@ export class EmailLogin extends React.Component<Properties, State> {
           </div>
           {this.generalError && (
             <div {...cn('error-container')}>
-              <Alert {...cn('error')} variant='error'>
+              <Alert {...cn('error')} variant='error' isFilled>
                 {this.generalError}
               </Alert>
             </div>

--- a/src/authentication/request-password-reset/index.tsx
+++ b/src/authentication/request-password-reset/index.tsx
@@ -77,7 +77,7 @@ export class RequestPasswordReset extends React.Component<Properties, State> {
 
         {this.generalError && (
           <div {...cn('error-container')}>
-            <Alert {...cn('error')} variant='error'>
+            <Alert {...cn('error')} variant='error' isFilled>
               {this.generalError}
             </Alert>
           </div>

--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -64,7 +64,7 @@ export class Invite extends React.Component<Properties, State> {
     }
 
     return (
-      <Alert className={c('alert')} variant='error'>
+      <Alert className={c('alert')} variant='error' isFilled>
         {errorMessage}
       </Alert>
     );

--- a/src/authentication/web3-login/index.tsx
+++ b/src/authentication/web3-login/index.tsx
@@ -34,7 +34,7 @@ export class Web3Login extends React.Component<Web3LoginProperties, Web3LoginSta
           </div>
           {error && (
             <div {...cn('error-container')}>
-              <Alert {...cn('error')} variant='error'>
+              <Alert {...cn('error')} variant='error' isFilled>
                 {errorText}
               </Alert>
             </div>

--- a/src/components/group-management/remove-member-dialog/index.tsx
+++ b/src/components/group-management/remove-member-dialog/index.tsx
@@ -49,7 +49,11 @@ export class RemoveMemberDialog extends React.Component<Properties> {
       >
         <div {...cn()}>
           <div>{this.props.inProgress ? this.progressMessage : this.message}</div>
-          {this.props.error && <Alert variant='error'>{this.props.error}</Alert>}
+          {this.props.error && (
+            <Alert variant='error' isFilled>
+              {this.props.error}
+            </Alert>
+          )}
         </div>
       </ModalConfirmation>
     );

--- a/src/components/messenger/list/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/list/edit-conversation-panel/index.tsx
@@ -98,12 +98,12 @@ export class EditConversationPanel extends React.Component<Properties, State> {
         />
 
         {this.generalError && (
-          <Alert {...cn('alert')} variant='error'>
+          <Alert {...cn('alert')} variant='error' isFilled>
             {this.generalError}
           </Alert>
         )}
         {this.changesSaved && (
-          <Alert {...cn('alert')} variant='success'>
+          <Alert {...cn('alert')} variant='success' isFilled>
             Changes saved
           </Alert>
         )}

--- a/src/components/secure-backup/restore-backup/index.tsx
+++ b/src/components/secure-backup/restore-backup/index.tsx
@@ -49,7 +49,7 @@ export class RestoreBackup extends React.Component<Properties, State> {
             />
 
             {this.props.errorMessage && (
-              <Alert {...cn('alert')} variant='error'>
+              <Alert {...cn('alert')} variant='error' isFilled>
                 {this.props.errorMessage}
               </Alert>
             )}

--- a/src/components/secure-backup/verify-key-phrase/index.tsx
+++ b/src/components/secure-backup/verify-key-phrase/index.tsx
@@ -46,7 +46,7 @@ export class VerifyKeyPhrase extends React.Component<Properties, State> {
             />
 
             {this.props.errorMessage && (
-              <Alert {...cn('alert')} variant='error'>
+              <Alert {...cn('alert')} variant='error' isFilled>
                 {this.props.errorMessage}
               </Alert>
             )}


### PR DESCRIPTION
### What does this do?
- applies `isFilled` flag to alert component where required.

### Why are we making this change?
- filled background has been made optional in zui and set to false by default, as a result, the `isFilled` flag should be added to uses of `Alert` where the design still requires a filled background. 

### How do I test this?
- run tests as usual.
- run the UI and check the alert backgrounds.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="628" alt="Screenshot 2024-04-26 at 13 19 55" src="https://github.com/zer0-os/zOS/assets/39112648/10380b3a-c3fc-4455-936c-d07b5d9e94b2">
<img width="628" alt="Screenshot 2024-04-26 at 13 19 28" src="https://github.com/zer0-os/zOS/assets/39112648/78bc0af0-83e9-452c-be5c-40924af9ee9a">

