### PR TITLE
feat(messages): enable right click

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -134,21 +134,18 @@ describe('message', () => {
   });
 
   it('renders message menu of items', () => {
-    const wrapper = subject({
-      message: 'the message',
-    });
+    const wrapper = subject({ message: 'the message' });
+
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.simulate('contextmenu', mockEvent);
 
     expect(wrapper.find('.message__menu-item').exists()).toBe(true);
   });
 
-  it('renders message input', () => {
-    const wrapper = subject({
-      message: 'the message',
-    });
+  it('should not renders message input', () => {
+    const wrapper = subject({ message: 'the message' });
 
-    wrapper.find(MessageMenu).first().prop('onEdit')();
-
-    expect(wrapper.find(MessageInput).exists()).toBe(true);
+    expect(wrapper.find(MessageInput).exists()).toBe(false);
   });
 
   it('disables all menu abilities when in progress', () => {
@@ -158,11 +155,15 @@ describe('message', () => {
       sendStatus: MessageSendStatus.IN_PROGRESS,
     });
 
-    const props = wrapper.find(MessageMenu).props();
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.simulate('contextmenu', mockEvent);
 
-    expect(props.canEdit).toBe(false);
-    expect(props.canReply).toBe(false);
-    expect(props.canDelete).toBe(false);
+    expect(wrapper.find(MessageMenu).exists()).toBe(true);
+
+    const messageMenuProps = wrapper.find(MessageMenu).props();
+    expect(messageMenuProps.canEdit).toBe(false);
+    expect(messageMenuProps.canReply).toBe(false);
+    expect(messageMenuProps.canDelete).toBe(false);
   });
 
   it('allows only delete when message send failed', () => {
@@ -172,11 +173,15 @@ describe('message', () => {
       sendStatus: MessageSendStatus.FAILED,
     });
 
-    const props = wrapper.find(MessageMenu).props();
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.find('.message').simulate('contextmenu', mockEvent);
 
-    expect(props.canEdit).toBe(false);
-    expect(props.canReply).toBe(false);
-    expect(props.canDelete).toBe(true);
+    expect(wrapper.find(MessageMenu).exists()).toBe(true);
+
+    const messageMenuProps = wrapper.find(MessageMenu).first().props();
+    expect(messageMenuProps.canEdit).toBe(false);
+    expect(messageMenuProps.canReply).toBe(false);
+    expect(messageMenuProps.canDelete).toBe(true);
   });
 
   it('displays the menu when message send failed', () => {
@@ -186,7 +191,10 @@ describe('message', () => {
       sendStatus: MessageSendStatus.FAILED,
     });
 
-    expect(wrapper).toHaveElement('.menu--force-visible');
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.find('.message').simulate('contextmenu', mockEvent);
+
+    expect(wrapper.find('.menu--force-visible').exists()).toBe(true);
   });
 
   it('renders edited indicator', () => {
@@ -238,6 +246,9 @@ describe('message', () => {
       onReply,
     });
 
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.simulate('contextmenu', mockEvent);
+
     wrapper.find(MessageMenu).simulate('reply');
 
     expect(onReply).toHaveBeenCalledWith({ reply: replyMessage });
@@ -252,13 +263,16 @@ describe('message', () => {
     expect(wrapper.find('.message__block-edited').exists()).toBe(false);
   });
 
-  it('should not renders edited indicator when onEdit clicked', () => {
+  it('should not render the edited indicator when onEdit is clicked', () => {
     const wrapper = subject({
       message: 'the message',
       updatedAt: 86276372,
     });
 
-    wrapper.find(MessageMenu).first().prop('onEdit')();
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.simulate('contextmenu', mockEvent);
+
+    wrapper.find(MessageMenu).props().onEdit();
 
     expect(wrapper.find('.message__block-edited').exists()).toBe(false);
   });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -69,35 +69,16 @@ export class Message extends React.Component<Properties, State> {
 
   wrapperRef = React.createRef<HTMLDivElement>();
 
-  componentDidMount() {
-    document.addEventListener('mousedown', this.handleClickOutside);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickOutside);
-  }
-
-  handleClickOutside = (event: MouseEvent) => {
-    if (this.wrapperRef.current && !this.wrapperRef.current.contains(event.target as Node)) {
-      this.handleCloseMenu();
-    }
-  };
-
   handleContextMenu = (event) => {
     if (event.button === 2) {
       event.preventDefault();
       event.stopPropagation();
       const { pageX, pageY } = event;
-      this.setState(
-        {
-          isDropdownMenuOpen: true,
-          menuX: pageX,
-          menuY: pageY,
-        },
-        () => {
-          document.addEventListener('mousedown', this.handleClickOutside);
-        }
-      );
+      this.setState({
+        isDropdownMenuOpen: true,
+        menuX: pageX,
+        menuY: pageY,
+      });
     }
   };
 
@@ -266,9 +247,7 @@ export class Message extends React.Component<Properties, State> {
   };
 
   handleCloseMenu = () => {
-    this.setState({ isMessageMenuOpen: false, isDropdownMenuOpen: false }, () => {
-      document.removeEventListener('mousedown', this.handleClickOutside);
-    });
+    this.setState({ isMessageMenuOpen: false, isDropdownMenuOpen: false });
   };
 
   canReply = () => {
@@ -285,7 +264,6 @@ export class Message extends React.Component<Properties, State> {
 
   renderMenu(): React.ReactElement {
     const { menuX, menuY, isDropdownMenuOpen, isMessageMenuOpen } = this.state;
-    // if (!isDropdownMenuOpen) return null;
 
     const menuProps = {
       canEdit: this.canEditMessage(),
@@ -298,6 +276,7 @@ export class Message extends React.Component<Properties, State> {
       isMenuOpen: isDropdownMenuOpen || isMessageMenuOpen,
       onOpenChange: this.handleOpenMenu,
       onCloseMenu: this.handleCloseMenu,
+      isMenuFlying: isDropdownMenuOpen,
     };
 
     const style: React.CSSProperties = isDropdownMenuOpen

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -15,6 +15,7 @@ export interface Properties {
   canReply?: boolean;
   isMediaMessage?: boolean;
   isMenuOpen?: boolean;
+  isMenuFlying?: boolean;
 
   onOpenChange?: (isOpen: boolean) => void;
   onCloseMenu?: () => void;
@@ -135,13 +136,15 @@ export class MessageMenu extends React.Component<Properties, State> {
           open={this.props.isMenuOpen}
           showArrow
           trigger={
-            <div
-              className={classNames('dropdown-menu-trigger', {
-                'dropdown-menu-trigger--open': this.props.isMenuOpen,
-              })}
-            >
-              <IconDotsHorizontal size={24} isFilled />
-            </div>
+            !this.props.isMenuFlying ? (
+              <div
+                className={classNames('dropdown-menu-trigger', {
+                  'dropdown-menu-trigger--open': this.props.isMenuOpen,
+                })}
+              >
+                <IconDotsHorizontal size={24} isFilled />
+              </div>
+            ) : null
           }
         />
         {this.renderDeleteModal()}

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -132,6 +132,7 @@ export class MessageMenu extends React.Component<Properties, State> {
           side='bottom'
           alignMenu='center'
           onOpenChange={this.props.onOpenChange}
+          open={this.props.isMenuOpen}
           showArrow
           trigger={
             <div


### PR DESCRIPTION
### What does this do?
- right click on menssage box 
- refactory renderMenssage()

### Why are we making this change?

### How do I test this?

https://github.com/zer0-os/zOS/assets/57037080/30ba4897-0792-4458-a7c9-596c31066380



### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security? noops
  1. How will this affect performance? noops
  1. Does this change any APIs? noops
