### PR TITLE
feat(electron-titlebar): implement css draggale titlebar region for electron window app

### DIFF
--- a/src/components/electron-titlebar/index.tsx
+++ b/src/components/electron-titlebar/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { bemClassName } from '../../lib/bem';
+
+import './styles.scss';
+
+const cn = bemClassName('electron-titlebar');
+
+export class ElectronTitlebar extends React.Component {
+  render() {
+    return <div {...cn('')}></div>;
+  }
+}

--- a/src/components/electron-titlebar/styles.scss
+++ b/src/components/electron-titlebar/styles.scss
@@ -1,0 +1,10 @@
+.electron-titlebar {
+  -webkit-app-region: drag;
+  height: 22px;
+  width: 100%;
+  background: transparent;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
 import { Router, Redirect, Route, Switch } from 'react-router-dom';
 import { ContextProvider as Web3ReactContextProvider } from './lib/web3/web3-react';
-import { showReleaseVersionInConsole, initializeErrorBoundary } from './utils';
+import { showReleaseVersionInConsole, initializeErrorBoundary, isElectron } from './utils';
 import { ErrorBoundary } from './components/error-boundary/';
 import BodyClassManager from './components/body-class-manager';
 
@@ -19,6 +19,7 @@ import { ResetPassword } from './reset-password';
 import { LoginPage } from './pages';
 import { Web3Connect } from './components/web3-connect';
 import { getHistory } from './lib/browser';
+import { ElectronTitlebar } from './components/electron-titlebar';
 
 runSagas();
 
@@ -38,6 +39,7 @@ ReactDOM.render(
           <Router history={history}>
             <Web3ReactContextProvider>
               <Web3Connect>
+                {isElectron() && <ElectronTitlebar />}
                 <BodyClassManager />
                 <Switch>
                   <Route path='/get-access' exact component={Invite} />


### PR DESCRIPTION
### What does this do?
- introduces a transparent, draggable titlebar to the Electron application, enabling window movement without a visible interface disruption.

### Why are we making this change?
- to reposition the Electron window using a dedicated draggable region that aligns with macOS traffic light controls.

### How do I test this?
- this will need to be tested in the electron environment.
- in terms of ensuring no breaking changes, run tests and ui as usual. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

The titlebar is transparent but for demo purposes I have filled it red here.
<img width="1385" alt="Screenshot 2024-04-30 at 12 05 33" src="https://github.com/zer0-os/zOS/assets/39112648/c034a148-40c1-48e0-8529-e26bac11ffb4">
