### PR TITLE
refactor(conversation-header): replace and add the avatar component to the conversation header

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.test.tsx
+++ b/src/components/messenger/chat/conversation-header/index.test.tsx
@@ -7,7 +7,7 @@ import { GroupManagementMenu } from '../../../group-management-menu';
 import { bem } from '../../../../lib/bem';
 import { stubUser } from '../../../../store/test/store';
 
-import { IconCurrencyEthereum, IconUsers1 } from '@zero-tech/zui/icons';
+import { Avatar } from '@zero-tech/zui/components';
 
 const c = bem('.conversation-header');
 
@@ -76,13 +76,13 @@ describe(ConversationHeader, () => {
     it('header renders avatar online status', function () {
       const wrapper = subject({ otherMembers: [stubUser({ isOnline: true })] });
 
-      expect(wrapper).toHaveElement(c('avatar--online'));
+      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'active');
     });
 
     it('header renders offline status', function () {
       const wrapper = subject({ otherMembers: [stubUser({ isOnline: false })] });
 
-      expect(wrapper).toHaveElement(c('avatar--offline'));
+      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'offline');
     });
 
     it('renders a formatted subtitle', function () {
@@ -98,26 +98,6 @@ describe(ConversationHeader, () => {
       const wrapper = subject({ isOneOnOne: true, otherMembers: [stubUser({ displaySubHandle: '' })] });
 
       expect(wrapper.find(c('subtitle'))).toHaveText('');
-    });
-
-    it('header renders users avatar when there is a avatar url', function () {
-      const wrapper = subject({ isOneOnOne: true, otherMembers: [stubUser({ profileImage: 'avatar-url' })] });
-
-      const headerAvatar = wrapper.find(c('avatar'));
-
-      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url(avatar-url)' });
-      expect(headerAvatar).not.toHaveElement(IconUsers1);
-      expect(headerAvatar).not.toHaveElement(IconCurrencyEthereum);
-    });
-
-    it('header renders avatar with eth icon when there is no avatar url', function () {
-      const wrapper = subject({ isOneOnOne: true, otherMembers: [stubUser({ profileImage: '' })] });
-
-      const headerAvatar = wrapper.find(c('avatar'));
-
-      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url()' });
-      expect(headerAvatar).not.toHaveElement(IconUsers1);
-      expect(headerAvatar).toHaveElement(IconCurrencyEthereum);
     });
   });
 
@@ -149,7 +129,7 @@ describe(ConversationHeader, () => {
         otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: true })],
       });
 
-      expect(wrapper).toHaveElement(c('avatar--online'));
+      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'active');
     });
 
     it('header renders offline status', function () {
@@ -158,33 +138,7 @@ describe(ConversationHeader, () => {
         otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: false })],
       });
 
-      expect(wrapper).toHaveElement(c('avatar--offline'));
-    });
-
-    it('header renders default icon when there is no avatar url', function () {
-      const wrapper = subject({ isOneOnOne: false });
-
-      const headerAvatar = wrapper.find(c('avatar'));
-
-      expect(headerAvatar).toHaveProp('style', { backgroundImage: 'url()' });
-      expect(headerAvatar).not.toHaveElement(IconCurrencyEthereum);
-      expect(headerAvatar).toHaveElement(IconUsers1);
-    });
-
-    it('header renders custom icon when there is an avatar url', function () {
-      const wrapper = subject({
-        isOneOnOne: false,
-        icon: 'https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg',
-      });
-
-      const headerAvatar = wrapper.find(c('avatar'));
-
-      expect(headerAvatar).toHaveProp('style', {
-        backgroundImage:
-          'url(https://res.cloudinary.com/fact0ry-dev/image/upload/v1691505978/mze88aeuxxdobzjd0lt6.jpg)',
-      });
-      expect(headerAvatar).not.toHaveElement(IconCurrencyEthereum);
-      expect(headerAvatar).not.toHaveElement(IconUsers1);
+      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'offline');
     });
 
     it('renders online status as subtitle ', function () {

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -3,11 +3,9 @@ import * as React from 'react';
 import { User } from '../../../../store/channels';
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import Tooltip from '../../../tooltip';
-import { getProvider } from '../../../../lib/cloudinary/provider';
 import { GroupManagementMenu } from '../../../group-management-menu';
 import { lastSeenText } from '../../list/utils/utils';
-
-import { IconCurrencyEthereum, IconUsers1 } from '@zero-tech/zui/icons';
+import { Avatar } from '@zero-tech/zui/components';
 
 import { bemClassName } from '../../../../lib/bem';
 import './styles.scss';
@@ -52,23 +50,28 @@ export class ConversationHeader extends React.Component<Properties> {
 
   avatarStatus() {
     if (!this.props.otherMembers) {
-      return 'unknown';
+      return 'offline';
     }
 
-    return this.anyOthersOnline() ? 'online' : 'offline';
+    return this.anyOthersOnline() ? 'active' : 'offline';
   }
 
   anyOthersOnline() {
     return this.props.otherMembers.some((m) => m.isOnline);
   }
 
-  renderIcon = () => {
-    return this.isOneOnOne() ? (
-      <IconCurrencyEthereum size={16} {...cn('avatar-icon', 'isOneOnOne')} />
-    ) : (
-      <IconUsers1 size={16} />
+  renderAvatar() {
+    return (
+      <Avatar
+        size={'medium'}
+        imageURL={this.avatarUrl()}
+        statusType={this.avatarStatus()}
+        tabIndex={-1}
+        isRaised
+        isGroup={!this.isOneOnOne()}
+      />
     );
-  };
+  }
 
   renderSubTitle() {
     if (!this.props.otherMembers || this.props.otherMembers.length === 0) {
@@ -113,16 +116,7 @@ export class ConversationHeader extends React.Component<Properties> {
   render() {
     return (
       <div {...cn('')}>
-        <span>
-          <div
-            style={{
-              backgroundImage: `url(${getProvider().getSourceUrl(this.avatarUrl())})`,
-            }}
-            {...cn('avatar', this.avatarStatus())}
-          >
-            {!this.avatarUrl() && this.renderIcon()}
-          </div>
-        </span>
+        <div {...cn('avatar')}>{this.renderAvatar()}</div>
 
         <span {...cn('description')}>
           <div {...cn('title')}>{this.renderTitle()}</div>

--- a/src/components/messenger/chat/conversation-header/styles.scss
+++ b/src/components/messenger/chat/conversation-header/styles.scss
@@ -20,59 +20,7 @@ $recent-indicator-size: 8px;
   }
 
   &__avatar {
-    @include glass-separator-primary;
-
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    position: relative;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-
-    &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      border-radius: inherit;
-
-      @include glass-materials-raised;
-    }
-
-    &::after {
-      content: '';
-      width: $recent-indicator-size;
-      height: $recent-indicator-size;
-      border: 2px solid theme.$color-primary-1;
-      border-radius: 50%;
-      position: absolute;
-      top: 22px;
-      left: 22px;
-    }
-
-    &--online::after {
-      background-color: theme.$color-secondary-11;
-    }
-
-    &--offline::after {
-      background-color: theme.$color-greyscale-9;
-    }
-
-    & > * {
-      position: absolute;
-      top: calc(50% - 8px);
-      line-height: 0px;
-      left: calc(50% - 8px);
-    }
-  }
-
-  &__avatar-icon {
-    &--isOneOnOne {
-      color: theme.$color-secondary-11;
-    }
+    pointer-events: none;
   }
 
   &__description {


### PR DESCRIPTION
### What does this do?
- replaces existing elements that render conversation icon with the Avatar component.

### Why are we making this change?
- consistency of using Avatars when profile/group images are required.

### How do I test this?
- run tests as usual.
- run UI and check conversation header for Avatar component.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
<img width="548" alt="Screenshot 2024-05-01 at 10 33 12" src="https://github.com/zer0-os/zOS/assets/39112648/8501d3cc-21e7-4926-8633-aae56fadb9b1">
