### PR TITLE
Enable email registration by default

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -59,7 +59,7 @@ export class FeatureFlags {
   }
 
   get allowEmailRegistration() {
-    return this._getBoolean('allowEmailRegistration', false);
+    return this._getBoolean('allowEmailRegistration', true);
   }
 
   set allowEmailRegistration(value: boolean) {


### PR DESCRIPTION
### What does this do?

Enables users to register via emails (by default). 
