### PR TITLE
feat: add right side kick panel, sub components, and wire up actions/state

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -39,6 +39,8 @@ export class Container extends React.Component<Properties> {
             <AppBar />
             <Sidekick />
             <MessengerChat />
+            <Sidekick variant='secondary' />
+
             <FeatureFlag featureFlag='enableDevPanel'>
               <DevPanelContainer />
             </FeatureFlag>

--- a/src/components/messenger/chat/conversation-header/index.test.tsx
+++ b/src/components/messenger/chat/conversation-header/index.test.tsx
@@ -22,10 +22,12 @@ describe(ConversationHeader, () => {
       canLeaveRoom: false,
       canEdit: false,
       canViewDetails: false,
+      isSecondarySidekickOpen: false,
       onAddMember: () => null,
       onEdit: () => null,
       onLeaveRoom: () => null,
       onViewDetails: () => null,
+      toggleSecondarySidekick: () => null,
 
       ...props,
     };
@@ -148,6 +150,20 @@ describe(ConversationHeader, () => {
       });
 
       expect(wrapper.find(c('subtitle'))).toHaveText('Offline');
+    });
+
+    it('renders group button', function () {
+      const wrapper = subject({ isOneOnOne: false });
+
+      expect(wrapper).toHaveElement(c('group-button'));
+    });
+
+    it('fires toggleSecondarySidekick', function () {
+      const toggleSecondarySidekick = jest.fn();
+
+      subject({ isOneOnOne: false, toggleSecondarySidekick }).find(c('group-button')).simulate('click');
+
+      expect(toggleSecondarySidekick).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -5,9 +5,10 @@ import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import Tooltip from '../../../tooltip';
 import { GroupManagementMenu } from '../../../group-management-menu';
 import { lastSeenText } from '../../list/utils/utils';
-import { Avatar } from '@zero-tech/zui/components';
-
+import { Avatar, IconButton } from '@zero-tech/zui/components';
+import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bemClassName } from '../../../../lib/bem';
+
 import './styles.scss';
 
 const cn = bemClassName('conversation-header');
@@ -21,13 +22,19 @@ export interface Properties {
   canLeaveRoom: boolean;
   canEdit: boolean;
   canViewDetails: boolean;
+  isSecondarySidekickOpen: boolean;
   onAddMember: () => void;
   onEdit: () => void;
   onLeaveRoom: () => void;
   onViewDetails: () => void;
+  toggleSecondarySidekick: () => void;
 }
 
 export class ConversationHeader extends React.Component<Properties> {
+  toggleSidekick = () => {
+    this.props.toggleSecondarySidekick();
+  };
+
   isOneOnOne() {
     return this.props.isOneOnOne;
   }
@@ -124,6 +131,15 @@ export class ConversationHeader extends React.Component<Properties> {
         </span>
 
         <div {...cn('group-management-menu-container')}>
+          {!this.isOneOnOne() && (
+            <IconButton
+              {...cn('group-button', this.props.isSecondarySidekickOpen && 'is-active')}
+              Icon={IconUsers1}
+              size={32}
+              onClick={this.toggleSidekick}
+            />
+          )}
+
           <GroupManagementMenu
             canAddMembers={this.props.canAddMembers}
             canLeaveRoom={this.props.canLeaveRoom}

--- a/src/components/messenger/chat/conversation-header/styles.scss
+++ b/src/components/messenger/chat/conversation-header/styles.scss
@@ -54,5 +54,12 @@ $recent-indicator-size: 8px;
 
   &__group-management-menu-container {
     display: flex;
+    gap: 8px;
+  }
+
+  &__group-button {
+    &--is-active {
+      background-color: theme.$color-greyscale-transparency-3;
+    }
   }
 }

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -31,6 +31,7 @@ describe(DirectMessageChat, () => {
       canEdit: false,
       canAddMembers: false,
       canViewDetails: false,
+      isSecondarySidekickOpen: false,
       sendMessage: () => null,
       onRemoveReply: () => null,
       isCurrentUserRoomAdmin: false,
@@ -39,6 +40,7 @@ describe(DirectMessageChat, () => {
       startEditConversation: () => null,
       setLeaveGroupStatus: () => null,
       viewGroupInformation: () => null,
+      toggleSecondarySidekick: () => null,
       ...props,
     };
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -13,6 +13,7 @@ import {
   setLeaveGroupStatus,
   startEditConversation,
   viewGroupInformation,
+  toggleSecondarySidekick,
 } from '../../../store/group-management';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
 import { JoiningConversationDialog } from '../../joining-conversation-dialog';
@@ -34,6 +35,7 @@ export interface Properties extends PublicProperties {
   canEdit: boolean;
   canAddMembers: boolean;
   canViewDetails: boolean;
+  isSecondarySidekickOpen: boolean;
   startAddGroupMember: () => void;
   startEditConversation: () => void;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
@@ -41,6 +43,7 @@ export interface Properties extends PublicProperties {
   sendMessage: (payload: PayloadSendMessage) => void;
   onRemoveReply: () => void;
   viewGroupInformation: () => void;
+  toggleSecondarySidekick: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -75,6 +78,7 @@ export class Container extends React.Component<Properties> {
       canEdit,
       canAddMembers,
       canViewDetails,
+      isSecondarySidekickOpen: groupManagement.isSecondarySidekickOpen,
     };
   }
 
@@ -86,6 +90,7 @@ export class Container extends React.Component<Properties> {
       onRemoveReply,
       sendMessage,
       viewGroupInformation,
+      toggleSecondarySidekick,
     };
   }
 
@@ -173,6 +178,8 @@ export class Container extends React.Component<Properties> {
                 onViewDetails={this.props.viewGroupInformation}
                 onAddMember={this.props.startAddGroupMember}
                 onEdit={this.props.startEditConversation}
+                toggleSecondarySidekick={this.props.toggleSecondarySidekick}
+                isSecondarySidekickOpen={this.props.isSecondarySidekickOpen}
               />
             )}
           </div>

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -14,7 +14,7 @@ export function lastSeenText(user): string {
 }
 
 export function isUserAdmin(user: User, adminIds: string[]) {
-  return adminIds.includes(user.matrixId);
+  return adminIds?.includes(user.matrixId);
 }
 
 export function sortMembers(members: User[], adminIds: string[]) {

--- a/src/components/messenger/secondary-sidekick-content/index.tsx
+++ b/src/components/messenger/secondary-sidekick-content/index.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { connectContainer } from '../../../store/redux-container';
+
+import { startAddGroupMember } from '../../../store/group-management';
+import { RootState } from '../../../store/reducer';
+import { User, denormalize as denormalizeChannel } from '../../../store/channels';
+import { currentUserSelector } from '../../../store/authentication/selectors';
+import { getUserSubHandle } from '../../../lib/user';
+import { ViewMembersPanel } from './view-members-panel';
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  currentUser: User;
+  otherMembers: User[];
+  conversationIcon: string;
+  canAddMembers: boolean;
+  conversationAdminIds: string[];
+
+  startAddGroupMember: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    const {
+      chat: { activeConversationId },
+    } = state;
+
+    const conversation = denormalizeChannel(activeConversationId, state);
+    const currentUser = currentUserSelector(state);
+    const conversationAdminIds = conversation?.adminMatrixIds;
+    const isCurrentUserRoomAdmin = conversationAdminIds?.includes(currentUser?.matrixId) ?? false;
+
+    return {
+      currentUser: {
+        firstName: currentUser?.profileSummary.firstName,
+        lastName: currentUser?.profileSummary.lastName,
+        profileImage: currentUser?.profileSummary.profileImage,
+        matrixId: currentUser?.matrixId,
+        isOnline: currentUser?.isOnline,
+        primaryZID: currentUser?.primaryZID,
+        displaySubHandle: getUserSubHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
+      } as User,
+      otherMembers: conversation ? conversation.otherMembers : [],
+      canAddMembers: isCurrentUserRoomAdmin,
+      conversationAdminIds,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {
+      startAddGroupMember,
+    };
+  }
+
+  render() {
+    return (
+      <>
+        <ViewMembersPanel
+          canAddMembers={this.props.canAddMembers}
+          otherMembers={this.props.otherMembers}
+          conversationAdminIds={this.props.conversationAdminIds}
+          currentUser={this.props.currentUser}
+          onAdd={this.props.startAddGroupMember}
+        />
+      </>
+    );
+  }
+}
+
+export const SecondarySidekickContent = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/secondary-sidekick-content/view-members-panel/index.test.tsx
+++ b/src/components/messenger/secondary-sidekick-content/view-members-panel/index.test.tsx
@@ -1,0 +1,89 @@
+import { shallow } from 'enzyme';
+
+import { ViewMembersPanel, Properties } from '.';
+import { CitizenListItem } from '../../../citizen-list-item';
+import { User } from '../../../../store/channels';
+
+import { bem } from '../../../../lib/bem';
+
+const c = bem('.view-members-panel');
+
+describe(ViewMembersPanel, () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      currentUser: { userId: 'current-user' } as User,
+      otherMembers: [],
+      conversationAdminIds: [],
+      canAddMembers: false,
+
+      onAdd: () => null,
+      ...props,
+    };
+
+    return shallow(<ViewMembersPanel {...allProps} />);
+  };
+
+  it('publishes onAdd event', () => {
+    const onAdd = jest.fn();
+    const wrapper = subject({ onAdd, canAddMembers: true });
+
+    wrapper.find(c('add-icon')).simulate('click');
+
+    expect(onAdd).toHaveBeenCalled();
+  });
+
+  it('renders add icon button when current user can add members', () => {
+    const wrapper = subject({ canAddMembers: true });
+    expect(wrapper).toHaveElement(c('add-icon'));
+  });
+
+  it('does not render add icon button when current user cannot add members', () => {
+    const wrapper = subject({ canAddMembers: false });
+    expect(wrapper).not.toHaveElement(c('add-icon'));
+  });
+
+  it('renders member header with correct count', () => {
+    const otherMembers = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+    ] as User[];
+    const wrapper = subject({ otherMembers });
+    expect(wrapper.find(c('member-header'))).toHaveText(`${otherMembers.length + 1} members`);
+  });
+
+  it('renders singular member when only one member is present', () => {
+    const wrapper = subject({ otherMembers: [] });
+    expect(wrapper.find(c('member-header'))).toHaveText('1 member');
+  });
+
+  it('renders the members of the conversation', function () {
+    const wrapper = subject({
+      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
+      otherMembers: [
+        { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+        { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+      ] as User[],
+    });
+
+    expect(wrapper.find(CitizenListItem).map((c) => c.prop('user'))).toEqual([
+      { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' },
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+      { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+    ]);
+  });
+
+  it('assigns admin tag to the user that is the conversation admin', () => {
+    const wrapper = subject({
+      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-current' } as User,
+      otherMembers: [
+        { userId: 'otherUser1', matrixId: 'matrix-id-1' },
+        { userId: 'otherUser2', matrixId: 'matrix-id-2' },
+      ] as User[],
+      conversationAdminIds: ['matrix-id-1'],
+    });
+
+    expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null);
+    expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Admin');
+    expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
+  });
+});

--- a/src/components/messenger/secondary-sidekick-content/view-members-panel/index.tsx
+++ b/src/components/messenger/secondary-sidekick-content/view-members-panel/index.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+
+import { IconButton } from '@zero-tech/zui/components';
+import { IconPlus } from '@zero-tech/zui/icons';
+import { User } from '../../../../store/channels';
+import { bemClassName } from '../../../../lib/bem';
+import { CitizenListItem } from '../../../citizen-list-item';
+import { ScrollbarContainer } from '../../../scrollbar-container';
+import { isUserAdmin, sortMembers } from '../../list/utils/utils';
+
+import './styles.scss';
+
+const cn = bemClassName('view-members-panel');
+
+export interface Properties {
+  currentUser: User;
+  otherMembers: User[];
+  canAddMembers: boolean;
+  conversationAdminIds: string[];
+
+  onAdd: () => void;
+}
+
+export class ViewMembersPanel extends React.Component<Properties> {
+  getTagForUser(user: User) {
+    return isUserAdmin(user, this.props.conversationAdminIds) ? 'Admin' : null;
+  }
+
+  addMember = () => {
+    this.props.onAdd();
+  };
+
+  renderMembers = () => {
+    const { otherMembers, conversationAdminIds } = this.props;
+    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds);
+
+    return (
+      <div {...cn('members')}>
+        <div {...cn('member-header')}>
+          <div {...cn('member-total')}>
+            <span>{otherMembers.length + 1}</span> member{otherMembers.length + 1 === 1 ? '' : 's'}
+          </div>
+          {this.props.canAddMembers && (
+            <IconButton {...cn('add-icon')} Icon={IconPlus} onClick={this.addMember} size={32} />
+          )}
+        </div>
+
+        <div {...cn('member-list')}>
+          <ScrollbarContainer>
+            <CitizenListItem
+              user={this.props.currentUser}
+              tag={this.getTagForUser(this.props.currentUser)}
+            ></CitizenListItem>
+            {sortedOtherMembers.map((u) => (
+              <CitizenListItem key={u.userId} user={u} tag={this.getTagForUser(u)}></CitizenListItem>
+            ))}
+          </ScrollbarContainer>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div {...cn()}>
+        <div {...cn('body')}>{this.renderMembers()}</div>
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/secondary-sidekick-content/view-members-panel/styles.scss
+++ b/src/components/messenger/secondary-sidekick-content/view-members-panel/styles.scss
@@ -1,0 +1,46 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../variables';
+@import '../../../../glass';
+
+.view-members-panel {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  &__body {
+    margin: 16px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  &__members {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  &__member-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__member-total {
+    @include glass-text-secondary-color;
+
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 14px;
+    text-transform: uppercase;
+  }
+
+  &__member-list {
+    padding-top: 8px;
+    flex-grow: 1;
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
+  }
+}

--- a/src/components/messenger/secondary-sidekick-content/view-members-panel/styles.scss
+++ b/src/components/messenger/secondary-sidekick-content/view-members-panel/styles.scss
@@ -26,6 +26,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    height: 32px;
   }
 
   &__member-total {

--- a/src/components/sidekick/index.test.tsx
+++ b/src/components/sidekick/index.test.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Container, Properties } from '.';
+import { Container, Properties, SidekickVariant } from '.';
 import { MessengerList } from '../messenger/list';
+import { Stage as GroupManagementStage } from '../../store/group-management';
 
 describe('Sidekick', () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps = {
       className: '',
-      isOpen: false,
+      variant: SidekickVariant.Primary,
+      groupManagementStage: GroupManagementStage.None,
+      isSecondarySidekickOpen: false,
       ...props,
     };
 

--- a/src/components/sidekick/index.tsx
+++ b/src/components/sidekick/index.tsx
@@ -1,34 +1,64 @@
 import React from 'react';
+import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { IfAuthenticated } from '../authentication/if-authenticated';
 import { MessengerList } from '../messenger/list';
+import { SecondarySidekickContent } from '../messenger/secondary-sidekick-content';
 
+import classNames from 'classnames';
+import { bemClassName } from '../../lib/bem';
 import './styles.scss';
+
+const cn = bemClassName('sidekick');
+
+export enum SidekickVariant {
+  Primary = 'primary',
+  Secondary = 'secondary',
+}
 
 interface PublicProperties {
   className?: string;
+  variant?: 'primary' | 'secondary';
 }
 
-export interface Properties extends PublicProperties {}
+export interface Properties extends PublicProperties {
+  isSecondarySidekickOpen: boolean;
+}
 
 export class Container extends React.Component<Properties> {
-  static mapState(): Partial<Properties> {
-    return {};
+  static mapState(state: RootState): Partial<Properties> {
+    const { groupManagement } = state;
+
+    return {
+      isSecondarySidekickOpen: groupManagement.isSecondarySidekickOpen,
+    };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {};
   }
 
+  get isSecondary() {
+    return this.props.variant === SidekickVariant.Secondary;
+  }
+
+  renderContent() {
+    if (this.isSecondary) {
+      return <SecondarySidekickContent />;
+    } else {
+      return <MessengerList />;
+    }
+  }
+
   render() {
+    const sidekickClass = classNames(this.props.variant, this.props.isSecondarySidekickOpen ? 'open' : 'close');
+
     return (
       <IfAuthenticated showChildren>
-        <div className='sidekick'>
-          <div className='sidekick__tab-content-outer'>
-            <div className='sidekick__tab-content'>
-              <div className='sidekick__tab-content--messages'>
-                <MessengerList />
-              </div>
+        <div {...cn('', sidekickClass)}>
+          <div {...cn('tab-content-outer', this.props.variant)}>
+            <div {...cn('tab-content')}>
+              <div {...cn('tab-content--messages')}>{this.renderContent()}</div>
             </div>
           </div>
         </div>

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -19,6 +19,27 @@
   flex-shrink: 0;
   padding: 16px 16px 16px 0px;
 
+  &--secondary {
+    justify-content: flex-end;
+    overflow-y: auto;
+    max-width: 0;
+    width: fit-content;
+
+    &.open {
+      transform: translateX(0);
+      max-width: 302px;
+      padding: 16px 16px 16px 0;
+    }
+
+    &.close {
+      transform: translateX(100%);
+      max-width: 0;
+      padding: 16px 0;
+    }
+
+    transition: transform 0.1s ease-out, max-width 0.1s ease-out, padding 0.1s ease-out;
+  }
+
   .scroll-container__gradient {
     background: linear-gradient(to bottom, transparent, theme.$background-color-tertiary-hover 100%);
   }
@@ -33,6 +54,10 @@
     flex-shrink: 0;
     pointer-events: auto;
     width: $width-sidekick;
+
+    &--secondary {
+      width: 220px;
+    }
 
     @include glass-outer;
   }

--- a/src/store/group-management/index.ts
+++ b/src/store/group-management/index.ts
@@ -24,6 +24,7 @@ export enum SagaActionTypes {
   RemoveMember = 'group-management/remove-member',
   EditConversationNameAndIcon = 'group-management/edit-conversation-name-and-icon',
   OpenViewGroupInformation = 'group-management/open-view-group-information',
+  ToggleSecondarySidekick = 'group-management/toggle-secondary-sidekick',
 }
 
 export enum Stage {
@@ -57,6 +58,7 @@ export const viewGroupInformation = createAction(SagaActionTypes.OpenViewGroupIn
 export const editConversationNameAndIcon = createAction<EditConversationPayload>(
   SagaActionTypes.EditConversationNameAndIcon
 );
+export const toggleSecondarySidekick = createAction(SagaActionTypes.ToggleSecondarySidekick);
 
 export type GroupManagementState = {
   stage: Stage;
@@ -71,6 +73,7 @@ export type GroupManagementState = {
   };
   errors: GroupManagementErrors;
   editConversationState: EditConversationState;
+  isSecondarySidekickOpen: boolean;
 };
 
 export const initialState: GroupManagementState = {
@@ -86,6 +89,7 @@ export const initialState: GroupManagementState = {
     stage: RemoveMemberDialogStage.CLOSED,
     error: '',
   },
+  isSecondarySidekickOpen: false,
 };
 
 const slice = createSlice({
@@ -128,6 +132,9 @@ const slice = createSlice({
     setRemoveMemberError: (state, action: PayloadAction<GroupManagementState['removeMember']['error']>) => {
       state.removeMember.error = action.payload;
     },
+    setSecondarySidekickOpen: (state, action: PayloadAction<GroupManagementState['isSecondarySidekickOpen']>) => {
+      state.isSecondarySidekickOpen = action.payload;
+    },
   },
 });
 
@@ -142,5 +149,6 @@ export const {
   setRemoveMember,
   setRemoveMemberStage,
   setRemoveMemberError,
+  setSecondarySidekickOpen,
 } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/group-management/saga.test.ts
+++ b/src/store/group-management/saga.test.ts
@@ -1,5 +1,11 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { removeMember, editConversationNameAndIcon, reset, roomMembersSelected } from './saga';
+import {
+  removeMember,
+  editConversationNameAndIcon,
+  reset,
+  roomMembersSelected,
+  toggleIsSecondarySidekick,
+} from './saga';
 import { StoreBuilder } from '../test/store';
 import {
   Stage,
@@ -9,6 +15,7 @@ import {
   setEditConversationGeneralError,
   setEditConversationImageError,
   RemoveMemberDialogStage,
+  setSecondarySidekickOpen,
 } from '.';
 import { expectSaga } from '../../test/saga';
 import { rootReducer } from '../reducer';
@@ -241,6 +248,30 @@ describe('Group Management Saga', () => {
         .put(setEditConversationGeneralError('An unknown error has occurred'))
         .put(setEditConversationState(EditConversationState.LOADED))
         .run();
+    });
+  });
+
+  describe('toggleSecondarySidekick', () => {
+    it('toggles the isSecondarySidekickOpen state to true', async () => {
+      const initialState = defaultState({ isSecondarySidekickOpen: false });
+
+      const { storeState } = await expectSaga(toggleIsSecondarySidekick)
+        .withReducer(rootReducer, initialState)
+        .put(setSecondarySidekickOpen(true))
+        .run();
+
+      expect(storeState.groupManagement.isSecondarySidekickOpen).toBe(true);
+    });
+
+    it('toggles the isSecondarySidekickOpen state to false', async () => {
+      const initialState = defaultState({ isSecondarySidekickOpen: true });
+
+      const { storeState } = await expectSaga(toggleIsSecondarySidekick)
+        .withReducer(rootReducer, initialState)
+        .put(setSecondarySidekickOpen(false))
+        .run();
+
+      expect(storeState.groupManagement.isSecondarySidekickOpen).toBe(false);
     });
   });
 });

--- a/src/store/group-management/saga.ts
+++ b/src/store/group-management/saga.ts
@@ -18,9 +18,11 @@ import {
   RemoveMemberDialogStage,
   setRemoveMemberStage,
   setRemoveMemberError,
+  setSecondarySidekickOpen,
 } from './index';
 import { EditConversationState } from './types';
 import { uploadImage } from '../registration/api';
+import { isSecondarySidekickOpenSelector } from './selectors';
 
 export function* reset() {
   yield put(setStage(Stage.None));
@@ -44,6 +46,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.CancelRemoveMember, cancelRemoveMember);
   yield takeLatest(SagaActionTypes.RemoveMember, removeMember);
   yield takeLatest(SagaActionTypes.OpenViewGroupInformation, openViewGroupInformation);
+  yield takeLatest(SagaActionTypes.ToggleSecondarySidekick, toggleIsSecondarySidekick);
 }
 
 export function* resetConversationManagement() {
@@ -175,4 +178,9 @@ export function* editConversationNameAndIcon(action) {
 
 export function* openViewGroupInformation() {
   yield put(setStage(Stage.ViewGroupInformation));
+}
+
+export function* toggleIsSecondarySidekick() {
+  const isOpen = yield select(isSecondarySidekickOpenSelector);
+  yield put(setSecondarySidekickOpen(!isOpen));
 }

--- a/src/store/group-management/selectors.ts
+++ b/src/store/group-management/selectors.ts
@@ -1,0 +1,3 @@
+import { RootState } from '../reducer';
+
+export const isSecondarySidekickOpenSelector = (state: RootState) => state.groupManagement.isSecondarySidekickOpen;


### PR DESCRIPTION
### What does this do?
- This PR introduces the Right Sidekick and functionality to open this and few the new `ViewMembersPanel`.
- Lays the foundations to move group management into the right side kick.

### Why are we making this change?
- as per design.

### How do I test this?
- run tests as usual.
- run the UI > open a group conversation > click group icon in conversation header > check panel slides gracefully in and out of view.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  

https://github.com/zer0-os/zOS/assets/39112648/a7bd2e2d-4e82-4e6a-941e-b19b595df569


