### PR TITLE
refactor(conversation-header): flip header group-management buttons

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -131,15 +131,6 @@ export class ConversationHeader extends React.Component<Properties> {
         </span>
 
         <div {...cn('group-management-menu-container')}>
-          {!this.isOneOnOne() && (
-            <IconButton
-              {...cn('group-button', this.props.isSecondarySidekickOpen && 'is-active')}
-              Icon={IconUsers1}
-              size={32}
-              onClick={this.toggleSidekick}
-            />
-          )}
-
           <GroupManagementMenu
             canAddMembers={this.props.canAddMembers}
             canLeaveRoom={this.props.canLeaveRoom}
@@ -150,6 +141,15 @@ export class ConversationHeader extends React.Component<Properties> {
             onEdit={this.props.onEdit}
             onViewGroupInformation={this.props.onViewDetails}
           />
+
+          {!this.isOneOnOne() && (
+            <IconButton
+              {...cn('group-button', this.props.isSecondarySidekickOpen && 'is-active')}
+              Icon={IconUsers1}
+              size={32}
+              onClick={this.toggleSidekick}
+            />
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
### What does this do?
- Simply flips button positions in conversation header.

<img width="244" alt="Screenshot 2024-05-03 at 09 55 46" src="https://github.com/zer0-os/zOS/assets/39112648/cc315e72-ff1d-45bd-a796-384356bb7fcb">
