### PR TITLE
feat(view-members): enable view members for all conversations

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.test.tsx
+++ b/src/components/messenger/chat/conversation-header/index.test.tsx
@@ -152,12 +152,6 @@ describe(ConversationHeader, () => {
       expect(wrapper.find(c('subtitle'))).toHaveText('Offline');
     });
 
-    it('renders group button', function () {
-      const wrapper = subject({ isOneOnOne: false });
-
-      expect(wrapper).toHaveElement(c('group-button'));
-    });
-
     it('fires toggleSecondarySidekick', function () {
       const toggleSecondarySidekick = jest.fn();
 

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -158,14 +158,12 @@ export class ConversationHeader extends React.Component<Properties> {
             onViewGroupInformation={this.viewGroupInformation}
           />
 
-          {!this.isOneOnOne() && (
-            <IconButton
-              {...cn('group-button', this.props.isSecondarySidekickOpen && 'is-active')}
-              Icon={IconUsers1}
-              size={32}
-              onClick={this.toggleSidekick}
-            />
-          )}
+          <IconButton
+            {...cn('group-button', this.props.isSecondarySidekickOpen && 'is-active')}
+            Icon={IconUsers1}
+            size={32}
+            onClick={this.toggleSidekick}
+          />
         </div>
       </div>
     );

--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -87,7 +87,7 @@ export class Container extends React.Component<Properties> {
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,
-      canAddMembers: isCurrentUserRoomAdmin,
+      canAddMembers: isCurrentUserRoomAdmin && conversation?.otherMembers?.length > 1,
       canEditGroup: isCurrentUserRoomAdmin,
       canLeaveGroup: !isCurrentUserRoomAdmin && conversation?.otherMembers?.length > 1,
       conversationAdminIds,

--- a/src/components/messenger/group-management/view-members-panel/index.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.tsx
@@ -49,7 +49,7 @@ export class ViewMembersPanel extends React.Component<Properties> {
           <ScrollbarContainer>
             <CitizenListItem
               user={this.props.currentUser}
-              tag={this.getTagForUser(this.props.currentUser)}
+              tag={otherMembers.length > 1 ? this.getTagForUser(this.props.currentUser) : null}
             ></CitizenListItem>
             {sortedOtherMembers.map((u) => (
               <CitizenListItem key={u.userId} user={u} tag={this.getTagForUser(u)}></CitizenListItem>


### PR DESCRIPTION
### What does this do?
- enables users to open view members panel on all conversations.

### Why are we making this change?
- as requested.

### How do I test this?
- run tests as usual.
- run ui and check view members panel can be opened on each conversation

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
