### PR TITLE
refactor(view-members): hide admin tags when one on one conversation

### DIFF
--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -86,4 +86,15 @@ describe(ViewMembersPanel, () => {
     expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Admin');
     expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
   });
+
+  it('does not assign admin tags if conversation is one on one', () => {
+    const wrapper = subject({
+      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-current' } as User,
+      otherMembers: [{ userId: 'otherUser1', matrixId: 'matrix-id-1' }] as User[],
+      conversationAdminIds: ['matrix-id-1'],
+    });
+
+    expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null);
+    expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', null);
+  });
 });

--- a/src/components/messenger/group-management/view-members-panel/index.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.tsx
@@ -23,6 +23,7 @@ export interface Properties {
 
 export class ViewMembersPanel extends React.Component<Properties> {
   getTagForUser(user: User) {
+    if (this.props.otherMembers.length <= 1) return null;
     return isUserAdmin(user, this.props.conversationAdminIds) ? 'Admin' : null;
   }
 
@@ -49,7 +50,7 @@ export class ViewMembersPanel extends React.Component<Properties> {
           <ScrollbarContainer>
             <CitizenListItem
               user={this.props.currentUser}
-              tag={otherMembers.length > 1 ? this.getTagForUser(this.props.currentUser) : null}
+              tag={this.getTagForUser(this.props.currentUser)}
             ></CitizenListItem>
             {sortedOtherMembers.map((u) => (
               <CitizenListItem key={u.userId} user={u} tag={this.getTagForUser(u)}></CitizenListItem>


### PR DESCRIPTION
### What does this do?
- Hiding admin tags when one on one conversation on the View Members panel.

### Why are we making this change?
- Improved UI
- Improved code quality.

### How do I test this?
- run tests as usual.
- run ui and open view members panel for one on one conversations

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
