### PR TITLE
fix: use isOneOnOne to determine conversation type in group management

### DIFF
--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -44,6 +44,7 @@ export interface Properties extends PublicProperties {
   canEditGroup: boolean;
   canLeaveGroup: boolean;
   conversationAdminIds: string[];
+  isOneOnOne: boolean;
 
   back: () => void;
   addSelectedMembers: (payload: MembersSelectedPayload) => void;
@@ -87,10 +88,11 @@ export class Container extends React.Component<Properties> {
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,
-      canAddMembers: isCurrentUserRoomAdmin && conversation?.otherMembers?.length > 1,
+      canAddMembers: isCurrentUserRoomAdmin && !conversation?.isOneOnOne,
       canEditGroup: isCurrentUserRoomAdmin,
       canLeaveGroup: !isCurrentUserRoomAdmin && conversation?.otherMembers?.length > 1,
       conversationAdminIds,
+      isOneOnOne: conversation?.isOneOnOne,
     };
   }
   static mapActions(_props: Properties): Partial<Properties> {
@@ -143,6 +145,7 @@ export class Container extends React.Component<Properties> {
           errors={this.props.errors}
           name={this.props.name}
           icon={this.props.conversationIcon}
+          isOneOnOne={this.props.isOneOnOne}
           onEditConversation={this.onEditConversation}
           editConversationState={this.props.editConversationState}
           onRemoveMember={this.openRemoveMember}

--- a/src/components/messenger/group-management/index.test.tsx
+++ b/src/components/messenger/group-management/index.test.tsx
@@ -17,6 +17,7 @@ describe(GroupManagement, () => {
       addMemberError: '',
       name: '',
       icon: '',
+      isOneOnOne: false,
       errors: {},
       editConversationState: EditConversationState.NONE,
       conversationAdminIds: [],

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -16,6 +16,7 @@ export interface Properties {
   errors: GroupManagementErrors;
   name: string;
   icon: string;
+  isOneOnOne: boolean;
   currentUser: User;
   otherMembers: User[];
   editConversationState: EditConversationState;
@@ -79,6 +80,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
         )}
         {this.props.stage === Stage.None && (
           <ViewMembersPanel
+            isOneOnOne={this.props.isOneOnOne}
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
             canAddMembers={this.props.canAddMembers}

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -11,6 +11,7 @@ const c = bem('.view-members-panel');
 describe(ViewMembersPanel, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
+      isOneOnOne: false,
       currentUser: { userId: 'current-user' } as User,
       otherMembers: [],
       conversationAdminIds: [],
@@ -92,6 +93,7 @@ describe(ViewMembersPanel, () => {
       currentUser: { userId: 'currentUser', matrixId: 'matrix-id-current' } as User,
       otherMembers: [{ userId: 'otherUser1', matrixId: 'matrix-id-1' }] as User[],
       conversationAdminIds: ['matrix-id-1'],
+      isOneOnOne: true,
     });
 
     expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null);

--- a/src/components/messenger/group-management/view-members-panel/index.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.tsx
@@ -13,6 +13,7 @@ import './styles.scss';
 const cn = bemClassName('view-members-panel');
 
 export interface Properties {
+  isOneOnOne: boolean;
   currentUser: User;
   otherMembers: User[];
   canAddMembers: boolean;
@@ -23,7 +24,7 @@ export interface Properties {
 
 export class ViewMembersPanel extends React.Component<Properties> {
   getTagForUser(user: User) {
-    if (this.props.otherMembers.length <= 1) return null;
+    if (this.props.isOneOnOne) return null;
     return isUserAdmin(user, this.props.conversationAdminIds) ? 'Admin' : null;
   }
 


### PR DESCRIPTION
### What does this do?
- replaces otherMembers.length with isOneOnOne for condition within group management.

### Why are we making this change?
- using otherMembers.length > 1 doesn't necessarily mean the conversation is a one on one conversation as groups could go from i.e. 3 members to 2 members.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
