### PR TITLE
feat(sidekick): close right sidekick when opening a different conversation

### DIFF
--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -9,6 +9,8 @@ import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
 import { ParentMessage } from '../../lib/chat/types';
 import { rawSetActiveConversationId } from '../chat';
+import { isSecondarySidekickOpenSelector } from '../group-management/selectors';
+import { toggleIsSecondarySidekick } from '../group-management/saga';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -52,6 +54,11 @@ export function* openConversation(conversationId) {
 
   yield call(setActiveConversation, conversationId);
   yield spawn(markConversationAsRead, conversationId);
+
+  const isSidekickOpen = yield select(isSecondarySidekickOpenSelector);
+  if (isSidekickOpen) {
+    yield spawn(toggleIsSecondarySidekick);
+  }
 }
 
 export function* unreadCountUpdated(action) {


### PR DESCRIPTION
### What does this do?
- closes right sidekick when opening a different conversations.

### Why are we making this change?
- prevents panels being open when they shouldn't be.

### How do I test this?
- run tests as usual.
- run ui and switch conversations whilst the right side kick is open

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
