### PR TITLE
feat(conversation-header): toggle sidekick by clicking inner header

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -139,12 +139,14 @@ export class ConversationHeader extends React.Component<Properties> {
   render() {
     return (
       <div {...cn('')}>
-        <div {...cn('avatar')}>{this.renderAvatar()}</div>
+        <div {...cn('details-container')} onClick={this.toggleSidekick}>
+          <div {...cn('avatar')}>{this.renderAvatar()}</div>
 
-        <span {...cn('description')}>
-          <div {...cn('title')}>{this.renderTitle()}</div>
-          <div {...cn('subtitle')}>{this.renderSubTitle()}</div>
-        </span>
+          <span {...cn('description')}>
+            <div {...cn('title')}>{this.renderTitle()}</div>
+            <div {...cn('subtitle')}>{this.renderSubTitle()}</div>
+          </span>
+        </div>
 
         <div {...cn('group-management-menu-container')}>
           <GroupManagementMenu

--- a/src/components/messenger/chat/conversation-header/styles.scss
+++ b/src/components/messenger/chat/conversation-header/styles.scss
@@ -19,6 +19,14 @@ $recent-indicator-size: 8px;
     justify-content: flex-end;
   }
 
+  &__details-container {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    cursor: pointer;
+    width: 100%;
+  }
+
   &__avatar {
     pointer-events: none;
   }


### PR DESCRIPTION
### What does this do?
- toggles sidekick by clicking inner header

### Why are we making this change?
- as requested.

### How do I test this?
- run tests as usual.
- run ui and click conversation header > check right side kick opens

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
