### PR TITLE
feat(inverted-scroll): hide scrollbar when secondary sidekick is open

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -273,6 +273,9 @@ describe('ChannelViewContainer', () => {
         chat: {
           activeConversationId: '1',
         },
+        groupManagement: {
+          isSecondarySidekickOpen: false,
+        },
       } as RootState);
 
     test('channel', () => {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -24,6 +24,7 @@ export interface Properties extends PublicProperties {
   context: {
     isAuthenticated: boolean;
   };
+  isSecondarySidekickOpen: boolean;
 }
 
 interface PublicProperties {
@@ -46,12 +47,14 @@ export class Container extends React.Component<Properties> {
     const {
       authentication: { user },
       chat: { activeConversationId },
+      groupManagement: { isSecondarySidekickOpen },
     } = state;
 
     return {
       channel,
       user,
       activeConversationId,
+      isSecondarySidekickOpen,
     };
   }
 
@@ -211,6 +214,7 @@ export class Container extends React.Component<Properties> {
           conversationErrorMessage={this.conversationErrorMessage}
           onHiddenMessageInfoClick={this.props.openBackupDialog}
           ref={this.chatViewRef}
+          isSecondarySidekickOpen={this.props.isSecondarySidekickOpen}
         />
       </>
     );

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -45,6 +45,8 @@ describe('ChatView', () => {
       sendDisabledMessage: '',
       conversationErrorMessage: '',
       onHiddenMessageInfoClick: () => null,
+      isSecondarySidekickOpen: false,
+
       ...props,
     };
 

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -49,6 +49,7 @@ export interface Properties {
   showSenderAvatar?: boolean;
   isOneOnOne: boolean;
   conversationErrorMessage: string;
+  isSecondarySidekickOpen: boolean;
 }
 
 export interface State {
@@ -239,7 +240,11 @@ export class ChatView extends React.Component<Properties, State> {
             onClose={this.closeLightBox}
           />
         )}
-        <InvertedScroll className='channel-view__inverted-scroll' ref={this.scrollContainerRef}>
+        <InvertedScroll
+          className='channel-view__inverted-scroll'
+          isScrollbarHidden={this.props.isSecondarySidekickOpen}
+          ref={this.scrollContainerRef}
+        >
           <div className='channel-view__main'>
             {this.props.hasLoadedMessages && this.props.messagesFetchStatus === MessagesFetchState.MORE_IN_PROGRESS && (
               <div {...cn('scroll-skeleton')}>

--- a/src/components/inverted-scroll/index.test.tsx
+++ b/src/components/inverted-scroll/index.test.tsx
@@ -24,4 +24,16 @@ describe('inverted-scroll', () => {
 
     expect(wrapper.hasClass('coffee-list')).toBe(true);
   });
+
+  it('applies scrollbar-hidden class if isScrollbarHidden', function () {
+    const wrapper = subject({ isScrollbarHidden: true });
+
+    expect(wrapper.hasClass('scrollbar-hidden')).toBe(true);
+  });
+
+  it('does not apply scrollbar-hidden class if isScrollbarHidden is false', function () {
+    const wrapper = subject({ isScrollbarHidden: false });
+
+    expect(wrapper.hasClass('scrollbar-hidden')).toBe(false);
+  });
 });

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -8,6 +8,7 @@ const cn = bemClassName('inverted-scroll');
 
 export interface Properties {
   className?: string;
+  isScrollbarHidden?: boolean;
 }
 
 interface State {
@@ -47,7 +48,11 @@ export class InvertedScroll extends React.Component<Properties, State> {
     return (
       <div
         id='invert-scroll'
-        className={classNames('scroll-container', this.props.className)}
+        className={classNames(
+          'scroll-container',
+          this.props.className,
+          this.props.isScrollbarHidden && 'scrollbar-hidden'
+        )}
         ref={this.setScrollWrapper}
       >
         <Waypoint onEnter={this.preventHigherScroll} />

--- a/src/components/inverted-scroll/styles.scss
+++ b/src/components/inverted-scroll/styles.scss
@@ -1,6 +1,16 @@
 .scroll-container {
   overflow-y: scroll;
   overflow-x: hidden;
+
+  &.scrollbar-hidden {
+    &::-webkit-scrollbar {
+      width: 0;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: none;
+    }
+  }
 }
 
 .inverted-scroll {


### PR DESCRIPTION
### What does this do?
- hides scrollbar when sidekick is open.

### Why are we making this change?
- per request.

### How do I test this?
- runs tests as usual.
- run the UI > check scrollbar on the right side > open sidekick > check for scrollbar.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/753697ab-0758-4620-ae75-d698216ba870


