### PR TITLE
refactor(channels-saga): keep sidekick panel open when switching conversations

### DIFF
--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -9,8 +9,7 @@ import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
 import { ParentMessage } from '../../lib/chat/types';
 import { rawSetActiveConversationId } from '../chat';
-import { isSecondarySidekickOpenSelector } from '../group-management/selectors';
-import { toggleIsSecondarySidekick } from '../group-management/saga';
+import { resetConversationManagement } from '../group-management/saga';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -54,11 +53,7 @@ export function* openConversation(conversationId) {
 
   yield call(setActiveConversation, conversationId);
   yield spawn(markConversationAsRead, conversationId);
-
-  const isSidekickOpen = yield select(isSecondarySidekickOpenSelector);
-  if (isSidekickOpen) {
-    yield spawn(toggleIsSecondarySidekick);
-  }
+  yield call(resetConversationManagement);
 }
 
 export function* unreadCountUpdated(action) {


### PR DESCRIPTION
### What does this do?
- keeps sidekick open and resets conversation management when switching conversations (opening a different conversation).

### Why are we making this change?
- per request.

### How do I test this?
- run tests as usual.
- run UI and follow the demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/9b6b6bb1-dcb9-4ce5-ad6c-8a7075a37f29

