### PR TITLE
chore(tab-badge): change tab badge to visible

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -58,7 +58,7 @@ $side-padding: 16px;
       }
 
       .messages-list__tab-badge {
-        display: none;
+        display: block;
       }
     }
   }


### PR DESCRIPTION
### What does this do?

show the badge notification when you have conversations that have not been read in another chat