### PR TITLE
refactor(user-header): hard code current users presence status in header

### DIFF
--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -159,7 +159,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
               isActive={this.shouldAvatarHaveHighlight}
               size={'medium'}
               imageURL={this.props.userAvatarUrl}
-              statusType={this.props.userStatus}
+              statusType='active'
             />
           }
           itemSize='spacious'


### PR DESCRIPTION
### What does this do?
- sets current users Avatar status to active.

### Why are we making this change?
- Always display online status for current user. 

### How do I test this?
- run tests as usual.
- run ui and check current users Avatar in header as below. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="245" alt="Screenshot 2024-05-06 at 20 49 53" src="https://github.com/zer0-os/zOS/assets/39112648/4122a492-bbe1-4b99-be15-0b163a19bfe6">
