### PR TITLE
refactor(current-user-presence): hardcode and set current user online status to active

### DIFF
--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -82,7 +82,7 @@ export class Container extends React.Component<Properties> {
         lastName: currentUser?.profileSummary.lastName,
         profileImage: currentUser?.profileSummary.profileImage,
         matrixId: currentUser?.matrixId,
-        isOnline: currentUser?.isOnline,
+        isOnline: currentUser?.isOnline || true,
         primaryZID: currentUser?.primaryZID,
         displaySubHandle: getUserSubHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
       } as User,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -105,7 +105,7 @@ export class Container extends React.Component<Properties, State> {
       userName: user?.data?.profileSummary?.firstName || '',
       userHandle,
       userAvatarUrl: user?.data?.profileSummary?.profileImage || '',
-      userIsOnline: !!user?.data?.isOnline,
+      userIsOnline: true,
       myUserId: user?.data?.id,
       joinRoomErrorContent,
       isBackupDialogOpen,

--- a/src/components/settings-menu/index.tsx
+++ b/src/components/settings-menu/index.tsx
@@ -159,7 +159,7 @@ export class SettingsMenu extends React.Component<Properties, State> {
               isActive={this.shouldAvatarHaveHighlight}
               size={'medium'}
               imageURL={this.props.userAvatarUrl}
-              statusType='active'
+              statusType={this.props.userStatus}
             />
           }
           itemSize='spacious'


### PR DESCRIPTION
### What does this do?
- hardcode current user status to active where we display users avatar (citizen list item).

### Why are we making this change?
- if the user is online, we can just set the status to active. there is currently an existing bug where we are not fetching the current users online status therefore it is undefined. This is essentially a quick fix for now.

### How do I test this?
- run tests as usual.
- run the ui and check your users online status on the avatars where displayed.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="245" alt="Screenshot 2024-05-06 at 22 28 23" src="https://github.com/zer0-os/zOS/assets/39112648/9e5aecd9-e9a4-44c5-8b58-66c3fcb8e6aa">
