### PR TITLE
Send typing events to matrix homeserver  when user starts typing

### DIFF
--- a/src/components/message-input/container.tsx
+++ b/src/components/message-input/container.tsx
@@ -7,6 +7,7 @@ import { ViewModes } from '../../shared-components/theme-engine';
 import { MessageInput as MessageInputComponent } from './index';
 import { ParentMessage } from '../../lib/chat/types';
 import { currentUserSelector } from '../../store/authentication/saga';
+import { userTypingInRoom } from '../../store/channels';
 
 export interface PublicProperties {
   onSubmit: (message: string, mentionedUserIds: User['userId'][], media: Media[]) => void;
@@ -24,6 +25,8 @@ export interface PublicProperties {
 
 export interface Properties extends PublicProperties {
   viewMode: ViewModes;
+
+  userTypingInRoom: ({ roomId }: { roomId: string }) => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -42,7 +45,7 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return {};
+    return { userTypingInRoom };
   }
 
   onMessageInputRendered = (textareaRef: RefObject<HTMLTextAreaElement>) => {
@@ -72,6 +75,7 @@ export class Container extends React.Component<Properties> {
         replyIsCurrentUser={replyIsCurrentUser}
         isEditing={this.props.isEditing}
         sendDisabledMessage={this.props.sendDisabledMessage}
+        onUserTyping={this.props.userTypingInRoom}
       />
     );
   }

--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -20,6 +20,7 @@ describe('MessageInput', () => {
       getUsersForMentions: () => undefined,
       onMessageInputRendered: () => undefined,
       renderAfterInput: () => undefined,
+      onUserTyping: () => undefined,
       clipboard: {
         addPasteListener: (_) => {},
         removePasteListener: (_) => {},
@@ -38,6 +39,17 @@ describe('MessageInput', () => {
     const _dropzone = wrapper.find(Dropzone).shallow();
 
     expect(renderAfterInput).toHaveBeenCalled();
+  });
+
+  it('publishs onUserTyping when input value changes', () => {
+    const onUserTyping = jest.fn();
+    const wrapper = subject({ onUserTyping });
+    const dropzone = wrapper.find(Dropzone).shallow();
+
+    const input = dropzone.find(Mentions);
+    input.simulate('change', { target: { value: 'Hello' } });
+
+    expect(onUserTyping).toHaveBeenCalledTimes(1);
   });
 
   it('does not submit message when message state is empty', () => {

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -35,6 +35,7 @@ export interface Properties extends PublicPropertiesContainer {
     removePasteListener: (listener: EventListenerOrEventListenerObject) => void;
   };
   dropzoneToMedia?: (files: any[]) => Media[];
+  onUserTyping: ({ roomId }: { roomId: string }) => void;
 }
 
 interface State {
@@ -166,6 +167,8 @@ export class MessageInput extends React.Component<Properties, State> {
     let {
       target: { value },
     } = event;
+
+    this.props.onUserTyping({ roomId: this.props.id });
 
     value = textToPlainEmojis(value);
     const mentionedUserIds = this.extractUserIds(value);

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -300,3 +300,7 @@ export async function addRoomToFavorites(roomId: string) {
 export async function removeRoomFromFavorites(roomId: string) {
   return await chat.get().matrix.removeRoomFromFavorites(roomId);
 }
+
+export async function sendTypingEvent(roomId: string, isTyping: boolean) {
+  return await chat.get().matrix.sendTypingEvent(roomId, isTyping);
+}

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -42,6 +42,7 @@ import { encryptFile } from './matrix/media';
 import { uploadAttachment } from '../../store/messages/api';
 import { featureFlags } from '../feature-flags';
 import { logger } from 'matrix-js-sdk/lib/logger';
+import { USER_TYPING_TIMEOUT } from '../../store/channels/saga';
 
 export class MatrixClient implements IChatClient {
   private matrix: SDKMatrixClient = null;
@@ -685,6 +686,12 @@ export class MatrixClient implements IChatClient {
 
     const result = await this.matrix.getRoomTags(roomId);
     return !!result.tags?.[MatrixConstants.FAVORITE];
+  }
+
+  async sendTypingEvent(roomId: string, isTyping: boolean): Promise<void> {
+    await this.waitForConnection();
+
+    this.matrix.sendTyping(roomId, isTyping, USER_TYPING_TIMEOUT);
   }
 
   arraysMatch(a, b) {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -42,7 +42,8 @@ import { encryptFile } from './matrix/media';
 import { uploadAttachment } from '../../store/messages/api';
 import { featureFlags } from '../feature-flags';
 import { logger } from 'matrix-js-sdk/lib/logger';
-import { USER_TYPING_TIMEOUT } from '../../store/channels/saga';
+
+export const USER_TYPING_TIMEOUT = 5000; // 5s
 
 export class MatrixClient implements IChatClient {
   private matrix: SDKMatrixClient = null;

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -54,7 +54,6 @@ export interface Channel {
   adminMatrixIds: string[];
   reply?: ParentMessage;
   isFavorite: boolean;
-  currentUserLastTypingEventPublishedAt?: number;
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -74,7 +73,6 @@ export const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   isFavorite: false,
-  currentUserLastTypingEventPublishedAt: null,
 };
 
 export enum SagaActionTypes {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -54,6 +54,7 @@ export interface Channel {
   adminMatrixIds: string[];
   reply?: ParentMessage;
   isFavorite: boolean;
+  currentUserLastTypingEventPublishedAt?: number;
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -73,6 +74,7 @@ export const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   isFavorite: false,
+  currentUserLastTypingEventPublishedAt: null,
 };
 
 export enum SagaActionTypes {
@@ -82,6 +84,7 @@ export enum SagaActionTypes {
   OnRemoveReply = 'channels/saga/onRemoveReply',
   OnFavoriteRoom = 'channels/saga/onFavoriteRoom',
   OnUnfavoriteRoom = 'channels/saga/onUnfavoriteRoom',
+  UserTypingInRoom = 'channels/saga/userTypingInRoom',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
@@ -90,6 +93,7 @@ const onReply = createAction<{ reply: ParentMessage }>(SagaActionTypes.OnReply);
 const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
 const onFavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnFavoriteRoom);
 const onUnfavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnfavoriteRoom);
+const userTypingInRoom = createAction<{ roomId: string }>(SagaActionTypes.UserTypingInRoom);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -102,4 +106,13 @@ const slice = createNormalizedSlice({
 
 export const { receive: rawReceive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { unreadCountUpdated, removeAll, openConversation, onReply, onRemoveReply, onFavoriteRoom, onUnfavoriteRoom };
+export {
+  unreadCountUpdated,
+  removeAll,
+  openConversation,
+  onReply,
+  onRemoveReply,
+  onFavoriteRoom,
+  onUnfavoriteRoom,
+  userTypingInRoom,
+};

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -1,15 +1,24 @@
 import getDeepProperty from 'lodash.get';
-import { takeLatest, put, call, select, spawn } from 'redux-saga/effects';
+import { takeLatest, put, call, select, spawn, delay, takeLeading, race, take } from 'redux-saga/effects';
 import { SagaActionTypes, rawReceive, schema, removeAll, Channel, CHANNEL_DEFAULTS } from '.';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
-import { addRoomToFavorites, removeRoomFromFavorites, chat } from '../../lib/chat';
+import {
+  addRoomToFavorites,
+  removeRoomFromFavorites,
+  chat,
+  sendTypingEvent as matrixSendUserTypingEvent,
+} from '../../lib/chat';
 import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
 import { ParentMessage } from '../../lib/chat/types';
 import { rawSetActiveConversationId } from '../chat';
 import { resetConversationManagement } from '../group-management/saga';
+import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
+import { ChatMessageEvents, getChatMessageBus } from '../messages/messages';
+
+export const USER_TYPING_TIMEOUT = 5000; // 5s
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -136,7 +145,63 @@ export function* roomUnfavorited(action) {
   }
 }
 
+export function* publishUserTypingEvent(roomId) {
+  try {
+    const channel = yield select(rawChannelSelector(roomId));
+    if (!channel) {
+      return;
+    }
+
+    const currentUserLastTypingEventPublishedAt = channel.currentUserLastTypingEventPublishedAt;
+    const now = Date.now();
+    if (currentUserLastTypingEventPublishedAt && now - currentUserLastTypingEventPublishedAt <= USER_TYPING_TIMEOUT) {
+      // not enough time has passed since last typing event
+      return;
+    }
+
+    yield call(matrixSendUserTypingEvent, roomId, true);
+    yield call(receiveChannel, { id: roomId, currentUserLastTypingEventPublishedAt: now });
+  } catch (error) {
+    console.error(`Failed to publish user is typing event in room ${roomId}:`, error);
+  }
+}
+
+export function* publishUserStoppedTypingEvent(roomId) {
+  try {
+    yield call(matrixSendUserTypingEvent, roomId, false);
+    yield call(receiveChannel, { id: roomId, currentUserLastTypingEventPublishedAt: null });
+  } catch (error) {
+    console.error(`Failed to publish user stopped typing event in room ${roomId}:`, error);
+  }
+}
+
+export function* onUserTypingInRoom(action) {
+  const { roomId } = action.payload;
+
+  yield call(publishUserTypingEvent, roomId);
+
+  // Start a race between the next typing event, timeout, room change, user logout, and message sending
+  const { nextAction, timeout, roomChanged, onLogout, messageSent } = yield race({
+    nextAction: take(SagaActionTypes.UserTypingInRoom),
+    timeout: delay(USER_TYPING_TIMEOUT),
+    roomChanged: take(SagaActionTypes.OpenConversation),
+    onLogout: take(yield call(getAuthChannel), AuthEvents.UserLogout),
+    messageSent: take(yield call(getChatMessageBus), ChatMessageEvents.Sent),
+  });
+
+  // Check if the timeout occurred or other events happened
+  if (timeout || roomChanged || onLogout || messageSent) {
+    yield call(publishUserStoppedTypingEvent, roomId);
+    return;
+  }
+
+  // Recursively call the saga to process the next typing event
+  yield call(onUserTypingInRoom, nextAction);
+}
+
 export function* saga() {
+  yield takeLeading(SagaActionTypes.UserTypingInRoom, onUserTypingInRoom);
+
   yield takeLatest(SagaActionTypes.OpenConversation, ({ payload }: any) => openConversation(payload.conversationId));
   yield takeLatest(SagaActionTypes.OnReply, ({ payload }: any) => onReply(payload.reply));
   yield takeLatest(SagaActionTypes.OnRemoveReply, onRemoveReply);

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -46,6 +46,7 @@ describe(send, () => {
       .next({ id: 'message-id' })
       .next()
       .next()
+      .next()
       .isDone();
   });
 
@@ -63,6 +64,7 @@ describe(send, () => {
       .call(uploadFileMessages, channelId, '', [uploadableFile])
       .next()
       .next()
+      .next()
       .isDone();
   });
 
@@ -77,6 +79,7 @@ describe(send, () => {
       .next()
       .next({ id: 'root-id' })
       .call(uploadFileMessages, channelId, 'root-id', [uploadableFile])
+      .next()
       .next()
       .next()
       .isDone();
@@ -102,6 +105,7 @@ describe(send, () => {
       .call(uploadFileMessages, channelId, '', [uploadableFile2])
       .next()
       .next()
+      .next()
       .isDone();
   });
 
@@ -113,6 +117,7 @@ describe(send, () => {
       .next({ id: 'message-id' })
       .next()
       .call(publishMessageSent)
+      .next()
       .next()
       .isDone();
   });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -4,7 +4,12 @@ import { takeLatest, put, call, select, delay, spawn } from 'redux-saga/effects'
 import { EditMessageOptions, SagaActionTypes, schema, removeAll, denormalize, MediaType, MessageSendStatus } from '.';
 import { receive as receiveMessage } from './';
 import { ConversationStatus, MessagesFetchState } from '../channels';
-import { markConversationAsRead, rawChannelSelector, receiveChannel } from '../channels/saga';
+import {
+  markConversationAsRead,
+  publishUserStoppedTypingEvent,
+  rawChannelSelector,
+  receiveChannel,
+} from '../channels/saga';
 import uniqBy from 'lodash.uniqby';
 
 import { getLinkPreviews } from './api';
@@ -196,6 +201,7 @@ export function* send(action) {
 
   yield call(uploadFileMessages, channelId, rootMessageId, uploadableFiles);
   yield call(publishMessageSent);
+  yield call(publishUserStoppedTypingEvent, channelId);
 }
 
 export function* publishMessageSent() {


### PR DESCRIPTION
### What does this do?

Implements the following logic:

- As soon as you start typing in the <MessageInput/> component, we start publishing a "typing" event (which we'll later process on the client side)
- the above is built into a race saga condition, as we need to publish "stopped typing" when: 
  - it has been 5s & the user hasn't typed anymore
  - the users "sends" a message in chat
  - the user changes the room (opens another conversation). in this case we should publish stop typing event for the previous room.
  - users logs out of the app

- We also store `currentUserLastTypingEventPublishedAt` in redux for each `Channel`, to ensure we only send the next typing event AFTER the timeout (which is 5s). Since the API is rate-limited.

Doc reference: [https://spec.matrix.org/v1.10/client-server-api/#typing-notifications](https://spec.matrix.org/v1.10/client-server-api/#typing-notifications)