### PR TITLE
feat(citizen-list-item): handle member click / key down

### DIFF
--- a/src/components/citizen-list-item/index.test.tsx
+++ b/src/components/citizen-list-item/index.test.tsx
@@ -11,7 +11,7 @@ describe(CitizenListItem, () => {
     const allProps: Properties = {
       user: { userId: 'stub' } as any,
 
-      onMemberClick: () => null,
+      onMemberSelected: () => null,
       ...props,
     };
 
@@ -70,20 +70,20 @@ describe(CitizenListItem, () => {
   });
 
   it('publishes member click event when clicked', function () {
-    const onMemberClick = jest.fn();
-    const wrapper = subject({ onMemberClick, user: { userId: 'user-id' } as any });
+    const onMemberSelected = jest.fn();
+    const wrapper = subject({ onMemberSelected, user: { userId: 'user-id' } as any });
 
     wrapper.find(c('')).simulate('click');
 
-    expect(onMemberClick).toHaveBeenCalledWith('user-id');
+    expect(onMemberSelected).toHaveBeenCalledWith('user-id');
   });
 
   it('publishes member click event on "Enter" key press', function () {
-    const onMemberClick = jest.fn();
-    const wrapper = subject({ onMemberClick, user: { userId: 'user-id' } as any });
+    const onMemberSelected = jest.fn();
+    const wrapper = subject({ onMemberSelected, user: { userId: 'user-id' } as any });
 
     wrapper.find(c('')).simulate('keydown', { key: 'Enter' });
 
-    expect(onMemberClick).toHaveBeenCalledWith('user-id');
+    expect(onMemberSelected).toHaveBeenCalledWith('user-id');
   });
 });

--- a/src/components/citizen-list-item/index.test.tsx
+++ b/src/components/citizen-list-item/index.test.tsx
@@ -10,6 +10,8 @@ describe(CitizenListItem, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       user: { userId: 'stub' } as any,
+
+      onMemberClick: () => null,
       ...props,
     };
 
@@ -65,5 +67,23 @@ describe(CitizenListItem, () => {
     const wrapper = subject({});
 
     expect(wrapper).not.toHaveElement(c('tag'));
+  });
+
+  it('publishes member click event when clicked', function () {
+    const onMemberClick = jest.fn();
+    const wrapper = subject({ onMemberClick, user: { userId: 'user-id' } as any });
+
+    wrapper.find(c('')).simulate('click');
+
+    expect(onMemberClick).toHaveBeenCalledWith('user-id');
+  });
+
+  it('publishes member click event on "Enter" key press', function () {
+    const onMemberClick = jest.fn();
+    const wrapper = subject({ onMemberClick, user: { userId: 'user-id' } as any });
+
+    wrapper.find(c('')).simulate('keydown', { key: 'Enter' });
+
+    expect(onMemberClick).toHaveBeenCalledWith('user-id');
   });
 });

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { User } from '../../store/channels';
 import { bemClassName } from '../../lib/bem';
 import { Avatar, IconButton } from '@zero-tech/zui/components';
-
-import './styles.scss';
 import { IconXClose } from '@zero-tech/zui/icons';
 import { displayName } from '../../lib/user';
+
+import './styles.scss';
+
 const cn = bemClassName('citizen-list-item');
 
 export interface Properties {

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -14,6 +14,7 @@ export interface Properties {
   tag?: string;
 
   onRemove?: (userId: string) => void;
+  onMemberClick?: (userId: string) => void;
 }
 
 export class CitizenListItem extends React.Component<Properties> {
@@ -25,9 +26,26 @@ export class CitizenListItem extends React.Component<Properties> {
     this.props.onRemove(this.props.user.userId);
   };
 
+  publishMemberClick = () => {
+    if (this.props.onMemberClick) {
+      this.props.onMemberClick(this.props.user.userId);
+    }
+  };
+
+  publishMemberKeyDown = (event) => {
+    if (event.key === 'Enter' && this.props.onMemberClick) {
+      this.props.onMemberClick(this.props.user.userId);
+    }
+  };
+
   render() {
     return (
-      <div {...cn()}>
+      <div
+        {...cn('', this.props.onMemberClick && 'clickable')}
+        onClick={this.publishMemberClick}
+        onKeyDown={this.publishMemberKeyDown}
+        tabIndex={0}
+      >
         <div {...cn('details')}>
           <Avatar size={'small'} imageURL={this.props.user.profileImage} tabIndex={-1} statusType={this.statusType} />
           <div {...cn('text-container')}>

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -15,7 +15,7 @@ export interface Properties {
   tag?: string;
 
   onRemove?: (userId: string) => void;
-  onMemberClick?: (userId: string) => void;
+  onMemberSelected?: (userId: string) => void;
 }
 
 export class CitizenListItem extends React.Component<Properties> {
@@ -28,21 +28,21 @@ export class CitizenListItem extends React.Component<Properties> {
   };
 
   publishMemberClick = () => {
-    if (this.props.onMemberClick) {
-      this.props.onMemberClick(this.props.user.userId);
+    if (this.props.onMemberSelected) {
+      this.props.onMemberSelected(this.props.user.userId);
     }
   };
 
   publishMemberKeyDown = (event) => {
-    if (event.key === 'Enter' && this.props.onMemberClick) {
-      this.props.onMemberClick(this.props.user.userId);
+    if (event.key === 'Enter' && this.props.onMemberSelected) {
+      this.props.onMemberSelected(this.props.user.userId);
     }
   };
 
   render() {
     return (
       <div
-        {...cn('', this.props.onMemberClick && 'clickable')}
+        {...cn('', this.props.onMemberSelected && 'clickable')}
         onClick={this.publishMemberClick}
         onKeyDown={this.publishMemberKeyDown}
         tabIndex={0}

--- a/src/components/citizen-list-item/styles.scss
+++ b/src/components/citizen-list-item/styles.scss
@@ -11,6 +11,15 @@
   align-items: center;
   border-radius: 8px;
   overflow: hidden;
+  outline: none;
+
+  &--clickable {
+    cursor: pointer;
+
+    &:focus {
+      @include glass-state-hover-color;
+    }
+  }
 
   &:hover {
     @include glass-state-hover-color;


### PR DESCRIPTION
### What does this do?
- handle member click in the citizen list item component.
- handle member key down.

### Why are we making this change?
- this allows us to add an action/event when clicking the citizen list item, the follow ups to this will create or open a conversation with the selected member.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

https://github.com/zer0-os/zOS/assets/39112648/d37a1449-bf3c-4840-b3b1-7e908f54001a


