### PR TITLE
feat(group-details/edit-group panels): wire up clickable members to process opening existing conversation or creating conversation

### DIFF
--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -21,6 +21,7 @@ describe(EditConversationPanel, () => {
       icon: '',
       onRemoveMember: () => null,
       conversationAdminIds: [],
+      onMemberSelected: () => null,
       ...props,
     };
 

--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -28,6 +28,7 @@ export interface Properties {
   onBack: () => void;
   onRemoveMember: (userId: string) => void;
   onEdit: (name: string, image: File | null) => void;
+  onMemberSelected: (userId: string) => void;
 }
 
 interface State {
@@ -73,6 +74,10 @@ export class EditConversationPanel extends React.Component<Properties, State> {
 
   publishRemove = (userId: string) => {
     this.props.onRemoveMember(userId);
+  };
+
+  memberSelected = (userId: string) => {
+    this.props.onMemberSelected(userId);
   };
 
   renderEditImageAndIcon = () => {
@@ -134,7 +139,12 @@ export class EditConversationPanel extends React.Component<Properties, State> {
           <ScrollbarContainer>
             <CitizenListItem user={this.props.currentUser} tag='Admin'></CitizenListItem>
             {sortedOtherMembers.map((u) => (
-              <CitizenListItem key={u.userId} user={u} onRemove={this.removeMember}></CitizenListItem>
+              <CitizenListItem
+                key={u.userId}
+                user={u}
+                onRemove={this.removeMember}
+                onMemberSelected={this.memberSelected}
+              ></CitizenListItem>
             ))}
           </ScrollbarContainer>
         </div>

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -61,6 +61,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             onRemoveMember={this.props.onRemoveMember}
             onEdit={this.props.onEditConversation}
             state={this.props.editConversationState}
+            onMemberSelected={this.props.onMemberClick}
           />
         )}
         {this.props.stage === Stage.ViewGroupInformation && (
@@ -77,6 +78,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             onLeave={this.props.setLeaveGroupStatus}
             onEdit={this.props.startEditConversation}
             onBack={this.props.onBack}
+            onMemberSelected={this.props.onMemberClick}
           />
         )}
         {this.props.stage === Stage.None && (

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -27,6 +27,7 @@ describe(ViewGroupInformationPanel, () => {
       onLeave: () => null,
       onEdit: () => null,
       onBack: () => null,
+      onMemberSelected: () => null,
       ...props,
     };
 

--- a/src/components/messenger/group-management/view-group-information-panel/index.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.tsx
@@ -29,6 +29,7 @@ export interface Properties {
   onLeave: (status: LeaveGroupDialogStatus) => void;
   onEdit: () => void;
   onBack: () => void;
+  onMemberSelected: (userId: string) => void;
 }
 
 export class ViewGroupInformationPanel extends React.Component<Properties> {
@@ -50,6 +51,10 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
 
   openLeaveGroup = () => {
     this.props.onLeave(LeaveGroupDialogStatus.OPEN);
+  };
+
+  memberSelected = (userId: string) => {
+    this.props.onMemberSelected(userId);
   };
 
   renderDetails = () => {
@@ -98,7 +103,12 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
               tag={this.getTagForUser(this.props.currentUser)}
             ></CitizenListItem>
             {sortedOtherMembers.map((u) => (
-              <CitizenListItem key={u.userId} user={u} tag={this.getTagForUser(u)}></CitizenListItem>
+              <CitizenListItem
+                key={u.userId}
+                user={u}
+                tag={this.getTagForUser(u)}
+                onMemberSelected={this.memberSelected}
+              ></CitizenListItem>
             ))}
           </ScrollbarContainer>
         </div>


### PR DESCRIPTION
### What does this do?
- wires up clickable members to process opening existing conversation or creating conversation on the Group Details and Edit Group panels of the right sidekick.

### Why are we making this change?
- as requested.

### How do I test this?
- run tests as usual.
- run the UI and attempt to click members when in the group management flow on the right side kick.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/abaa69d7-5172-4a29-ad6c-c5c159fbcf7f

