### PR TITLE
fix(tab-badge/favorites-preview): fade in preview and tab badge display

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -58,7 +58,7 @@ $side-padding: 16px;
       }
 
       .messages-list__tab-badge {
-        display: block;
+        display: none;
       }
     }
   }
@@ -74,8 +74,8 @@ $side-padding: 16px;
     align-items: center;
     text-align: center;
 
-    height: 16px;
-    min-width: 16px;
+    height: 12px;
+    min-width: 12px;
     padding: 2px 4px;
 
     border-radius: 9999px;
@@ -123,9 +123,9 @@ $side-padding: 16px;
     // accounts for 4px scrollbar width on right side of container
     padding: 0 12px 0 16px;
 
-    &.fade-in {
-      animation: fadeInEffect 0.5s ease-in-out;
-    }
+    // &.fade-in {
+    //   animation: fadeInEffect 0.5s ease-in-out;
+    // }
   }
 
   &__empty {
@@ -155,6 +155,8 @@ $side-padding: 16px;
 
     align-items: center;
     text-align: center;
+
+    animation: fadeInEffect 0.3s ease-in-out;
   }
 
   &__favorites-preview-image {

--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -122,10 +122,6 @@ $side-padding: 16px;
     height: 1px;
     // accounts for 4px scrollbar width on right side of container
     padding: 0 12px 0 16px;
-
-    // &.fade-in {
-    //   animation: fadeInEffect 0.5s ease-in-out;
-    // }
   }
 
   &__empty {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -36,17 +36,11 @@ interface State {
   filter: string;
   userSearchResults: Option[];
   selectedTab: Tab;
-  fadeIn: boolean;
 }
 
 export class ConversationListPanel extends React.Component<Properties, State> {
   scrollContainerRef: React.RefObject<ScrollbarContainer>;
-  state = { filter: '', userSearchResults: [], selectedTab: Tab.All, fadeIn: false };
-
-  triggerFadeIn = () => {
-    this.setState({ fadeIn: true });
-    setTimeout(() => this.setState({ fadeIn: false }), 500);
-  };
+  state = { filter: '', userSearchResults: [], selectedTab: Tab.All };
 
   constructor(props) {
     super(props);
@@ -111,7 +105,6 @@ export class ConversationListPanel extends React.Component<Properties, State> {
 
   selectFavorites = () => {
     this.setState({ selectedTab: Tab.Favorites });
-    this.triggerFadeIn();
   };
 
   onFavoriteRoom = (roomId: string) => {
@@ -182,7 +175,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
           </div>
 
           <ScrollbarContainer variant='on-hover' ref={this.scrollContainerRef}>
-            <div {...cn('item-list', this.state.fadeIn ? 'fade-in' : '')}>
+            <div {...cn('item-list')}>
               {this.filteredConversations.length > 0 &&
                 this.filteredConversations.map((c) => (
                   <ConversationItem


### PR DESCRIPTION
### What does this do?
- fixes tab badge issues (screenshot). Only display tab badge on unselected tab.
- fixes broken fade in of favorites preview.

### Why are we making this change?
- improve ui.

### How do I test this?
- run tests as usual.
- run ui and tag favorite conversations / untag favorites > check preview and tab badge

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before fix:

https://github.com/zer0-os/zOS/assets/39112648/e870faed-2e9b-420b-bb01-f7c7a0a83571

After fix:

https://github.com/zer0-os/zOS/assets/39112648/816d0dc7-7e53-4d60-9874-3a23175eeef7

