### PR TITLE
refactor(group-management): add test coverage for onMemberSelect events

### DIFF
--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -145,6 +145,19 @@ describe(EditConversationPanel, () => {
       expect(onRemoveMember).toHaveBeenCalledWith('otherMember1');
     });
 
+    it('publishes onMemberSelected event', () => {
+      const onMemberSelected = jest.fn();
+      const otherMembers = [
+        { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+      ] as User[];
+
+      const wrapper = subject({ onMemberSelected, otherMembers });
+
+      wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+
+      expect(onMemberSelected).toHaveBeenCalled();
+    });
+
     it('does not allow remove if there are only 2 people in the room', function () {
       const wrapper = subject({
         otherMembers: [

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -61,6 +61,19 @@ describe(ViewGroupInformationPanel, () => {
     expect(onAdd).toHaveBeenCalled();
   });
 
+  it('publishes onMemberSelected event', () => {
+    const onMemberSelected = jest.fn();
+    const otherMembers = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+    ] as User[];
+
+    const wrapper = subject({ onMemberSelected, otherMembers });
+
+    wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+
+    expect(onMemberSelected).toHaveBeenCalled();
+  });
+
   it('publishes onLeave event', () => {
     const onLeave = jest.fn();
     const wrapper = subject({

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -34,6 +34,19 @@ describe(ViewMembersPanel, () => {
     expect(onAdd).toHaveBeenCalled();
   });
 
+  it('publishes onMemberSelected event', () => {
+    const onMemberSelected = jest.fn();
+    const otherMembers = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+    ] as User[];
+
+    const wrapper = subject({ onMemberSelected, otherMembers });
+
+    wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+
+    expect(onMemberSelected).toHaveBeenCalled();
+  });
+
   it('renders add icon button when current user can add members', () => {
     const wrapper = subject({ canAddMembers: true });
     expect(wrapper).toHaveElement(c('add-icon'));


### PR DESCRIPTION
### What does this do?
- adds tests to group management panels using onMemberSelect event to ensure it is published

### Why are we making this change?
- add test coverage

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
