### PR TITLE
refactor(citizen-list-item): rename onMemberSelect to onSelect

### DIFF
--- a/src/components/citizen-list-item/index.test.tsx
+++ b/src/components/citizen-list-item/index.test.tsx
@@ -11,7 +11,7 @@ describe(CitizenListItem, () => {
     const allProps: Properties = {
       user: { userId: 'stub' } as any,
 
-      onMemberSelected: () => null,
+      onSelected: () => null,
       ...props,
     };
 
@@ -71,7 +71,7 @@ describe(CitizenListItem, () => {
 
   it('publishes member click event when clicked', function () {
     const onMemberSelected = jest.fn();
-    const wrapper = subject({ onMemberSelected, user: { userId: 'user-id' } as any });
+    const wrapper = subject({ onSelected: onMemberSelected, user: { userId: 'user-id' } as any });
 
     wrapper.find(c('')).simulate('click');
 
@@ -80,7 +80,7 @@ describe(CitizenListItem, () => {
 
   it('publishes member click event on "Enter" key press', function () {
     const onMemberSelected = jest.fn();
-    const wrapper = subject({ onMemberSelected, user: { userId: 'user-id' } as any });
+    const wrapper = subject({ onSelected: onMemberSelected, user: { userId: 'user-id' } as any });
 
     wrapper.find(c('')).simulate('keydown', { key: 'Enter' });
 

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -15,7 +15,7 @@ export interface Properties {
   tag?: string;
 
   onRemove?: (userId: string) => void;
-  onMemberSelected?: (userId: string) => void;
+  onSelected?: (userId: string) => void;
 }
 
 export class CitizenListItem extends React.Component<Properties> {
@@ -28,21 +28,21 @@ export class CitizenListItem extends React.Component<Properties> {
   };
 
   publishMemberClick = () => {
-    if (this.props.onMemberSelected) {
-      this.props.onMemberSelected(this.props.user.userId);
+    if (this.props.onSelected) {
+      this.props.onSelected(this.props.user.userId);
     }
   };
 
   publishMemberKeyDown = (event) => {
-    if (event.key === 'Enter' && this.props.onMemberSelected) {
-      this.props.onMemberSelected(this.props.user.userId);
+    if (event.key === 'Enter' && this.props.onSelected) {
+      this.props.onSelected(this.props.user.userId);
     }
   };
 
   render() {
     return (
       <div
-        {...cn('', this.props.onMemberSelected && 'clickable')}
+        {...cn('', this.props.onSelected && 'clickable')}
         onClick={this.publishMemberClick}
         onKeyDown={this.publishMemberKeyDown}
         tabIndex={0}

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -153,7 +153,7 @@ describe(EditConversationPanel, () => {
 
       const wrapper = subject({ onMemberSelected, otherMembers });
 
-      wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+      wrapper.find(CitizenListItem).at(1).simulate('selected', 'otherMember1');
 
       expect(onMemberSelected).toHaveBeenCalled();
     });

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -145,6 +145,19 @@ describe(EditConversationPanel, () => {
       expect(onRemoveMember).toHaveBeenCalledWith('otherMember1');
     });
 
+    it('publishes onMemberSelected event', () => {
+      const onMemberSelected = jest.fn();
+      const otherMembers = [
+        { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+      ] as User[];
+
+      const wrapper = subject({ onMemberSelected, otherMembers });
+
+      wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+
+      expect(onMemberSelected).toHaveBeenCalled();
+    });
+
     it('does not allow remove if there are only 2 people in the room', function () {
       const wrapper = subject({
         otherMembers: [

--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -143,7 +143,7 @@ export class EditConversationPanel extends React.Component<Properties, State> {
                 key={u.userId}
                 user={u}
                 onRemove={this.removeMember}
-                onMemberSelected={this.memberSelected}
+                onSelected={this.memberSelected}
               ></CitizenListItem>
             ))}
           </ScrollbarContainer>

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -61,6 +61,19 @@ describe(ViewGroupInformationPanel, () => {
     expect(onAdd).toHaveBeenCalled();
   });
 
+  it('publishes onMemberSelected event', () => {
+    const onMemberSelected = jest.fn();
+    const otherMembers = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+    ] as User[];
+
+    const wrapper = subject({ onMemberSelected, otherMembers });
+
+    wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+
+    expect(onMemberSelected).toHaveBeenCalled();
+  });
+
   it('publishes onLeave event', () => {
     const onLeave = jest.fn();
     const wrapper = subject({

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -69,7 +69,7 @@ describe(ViewGroupInformationPanel, () => {
 
     const wrapper = subject({ onMemberSelected, otherMembers });
 
-    wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+    wrapper.find(CitizenListItem).at(1).simulate('selected', 'otherMember1');
 
     expect(onMemberSelected).toHaveBeenCalled();
   });

--- a/src/components/messenger/group-management/view-group-information-panel/index.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.tsx
@@ -107,7 +107,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
                 key={u.userId}
                 user={u}
                 tag={this.getTagForUser(u)}
-                onMemberSelected={this.memberSelected}
+                onSelected={this.memberSelected}
               ></CitizenListItem>
             ))}
           </ScrollbarContainer>

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -34,6 +34,19 @@ describe(ViewMembersPanel, () => {
     expect(onAdd).toHaveBeenCalled();
   });
 
+  it('publishes onMemberSelected event', () => {
+    const onMemberSelected = jest.fn();
+    const otherMembers = [
+      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+    ] as User[];
+
+    const wrapper = subject({ onMemberSelected, otherMembers });
+
+    wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+
+    expect(onMemberSelected).toHaveBeenCalled();
+  });
+
   it('renders add icon button when current user can add members', () => {
     const wrapper = subject({ canAddMembers: true });
     expect(wrapper).toHaveElement(c('add-icon'));

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -42,7 +42,7 @@ describe(ViewMembersPanel, () => {
 
     const wrapper = subject({ onMemberSelected, otherMembers });
 
-    wrapper.find(CitizenListItem).at(1).simulate('memberSelected', 'otherMember1');
+    wrapper.find(CitizenListItem).at(1).simulate('selected', 'otherMember1');
 
     expect(onMemberSelected).toHaveBeenCalled();
   });

--- a/src/components/messenger/group-management/view-members-panel/index.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.tsx
@@ -63,7 +63,7 @@ export class ViewMembersPanel extends React.Component<Properties> {
                 key={u.userId}
                 user={u}
                 tag={this.getTagForUser(u)}
-                onMemberSelected={this.memberSelected}
+                onSelected={this.memberSelected}
               ></CitizenListItem>
             ))}
           </ScrollbarContainer>


### PR DESCRIPTION
### What does this do?
- renaming of prop
- updates tests where necessary due to change

### Why are we making this change?
- improved naming within the context of the citizen list item

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
