### PR TITLE
feat(user-profile): add open and close user profile actions / state

### DIFF
--- a/src/store/edit-profile/index.ts
+++ b/src/store/edit-profile/index.ts
@@ -3,6 +3,8 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 export enum SagaActionTypes {
   EditProfile = 'profile/edit',
   FetchOwnedZIDs = 'profile/edit/fetchOwnedZIDs',
+  OpenUserProfile = 'profile/edit/openUserProfile',
+  CloseUserProfile = 'profile/edit/closeUserProfile',
 }
 
 export enum State {
@@ -17,6 +19,7 @@ export type EditProfileState = {
   state: State;
   ownedZIDs: string[];
   loadingZIDs: boolean;
+  isUserProfileOpen: boolean;
 };
 
 export const initialState: EditProfileState = {
@@ -24,6 +27,7 @@ export const initialState: EditProfileState = {
   state: State.NONE,
   ownedZIDs: [],
   loadingZIDs: false,
+  isUserProfileOpen: false,
 };
 
 export const editProfile = createAction<{
@@ -33,6 +37,8 @@ export const editProfile = createAction<{
 }>(SagaActionTypes.EditProfile);
 
 export const fetchOwnedZIDs = createAction(SagaActionTypes.FetchOwnedZIDs);
+export const openUserProfile = createAction(SagaActionTypes.OpenUserProfile);
+export const closeUserProfile = createAction(SagaActionTypes.CloseUserProfile);
 
 const slice = createSlice({
   name: 'edit-profile',
@@ -55,8 +61,12 @@ const slice = createSlice({
     setLoadingZIDs: (state, action: PayloadAction<EditProfileState['loadingZIDs']>) => {
       state.loadingZIDs = action.payload;
     },
+    setIsUserProfileOpen: (state, action: PayloadAction<EditProfileState['isUserProfileOpen']>) => {
+      state.isUserProfileOpen = action.payload;
+    },
   },
 });
 
-export const { setErrors, startProfileEdit, setState, setOwnedZIDs, setLoadingZIDs } = slice.actions;
+export const { setErrors, startProfileEdit, setState, setOwnedZIDs, setLoadingZIDs, setIsUserProfileOpen } =
+  slice.actions;
 export const { reducer } = slice;

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -1,9 +1,21 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
-import { editProfile as editProfileSaga, updateUserProfile, fetchOwnedZIDs } from './saga';
+import {
+  editProfile as editProfileSaga,
+  updateUserProfile,
+  fetchOwnedZIDs,
+  openUserProfile,
+  closeUserProfile,
+} from './saga';
 import { editUserProfile as apiEditUserProfile, fetchOwnedZIDs as apiFetchOwnedZIDs } from './api';
 import { uploadImage } from '../registration/api';
-import { EditProfileState, State, initialState as initialEditProfileState, setLoadingZIDs } from '.';
+import {
+  EditProfileState,
+  State,
+  initialState as initialEditProfileState,
+  setIsUserProfileOpen,
+  setLoadingZIDs,
+} from '.';
 import { rootReducer } from '../reducer';
 import { User } from '../authentication/types';
 import { ProfileDetailsErrors } from '../registration';
@@ -153,6 +165,36 @@ describe('fetchOwnedZIDs', () => {
 
     expect(editProfile.ownedZIDs).toEqual(ownedZIDs);
     expect(editProfile.loadingZIDs).toEqual(false);
+  });
+});
+
+describe('openUserProfile', () => {
+  it('should set isUserProfileOpen to true', async () => {
+    const { storeState } = await expectSaga(openUserProfile)
+      .withReducer(rootReducer, initialState())
+      .put(setIsUserProfileOpen(true))
+      .run();
+
+    expect(storeState.editProfile.isUserProfileOpen).toEqual(true);
+  });
+});
+
+describe('closeUserProfile', () => {
+  it('should set isUserProfileOpen to false', async () => {
+    const initialStateWithOpenProfile = {
+      ...initialState(),
+      editProfile: {
+        ...initialState().editProfile,
+        isUserProfileOpen: true,
+      },
+    };
+
+    const { storeState } = await expectSaga(closeUserProfile)
+      .withReducer(rootReducer, initialStateWithOpenProfile)
+      .put(setIsUserProfileOpen(false))
+      .run();
+
+    expect(storeState.editProfile.isUserProfileOpen).toEqual(false);
   });
 });
 

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects';
-import { SagaActionTypes, State, setErrors, setLoadingZIDs, setOwnedZIDs, setState } from '.';
+import { SagaActionTypes, State, setErrors, setIsUserProfileOpen, setLoadingZIDs, setOwnedZIDs, setState } from '.';
 import {
   editUserProfile as apiEditUserProfile,
   saveUserMatrixCredentials as apiSaveUserMatrixCredentials,
@@ -83,7 +83,17 @@ export function* fetchOwnedZIDs() {
   yield put(setLoadingZIDs(false));
 }
 
+export function* openUserProfile() {
+  yield put(setIsUserProfileOpen(true));
+}
+
+export function* closeUserProfile() {
+  yield put(setIsUserProfileOpen(false));
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.EditProfile, editProfile);
   yield takeLatest(SagaActionTypes.FetchOwnedZIDs, fetchOwnedZIDs);
+  yield takeLatest(SagaActionTypes.OpenUserProfile, openUserProfile);
+  yield takeLatest(SagaActionTypes.CloseUserProfile, closeUserProfile);
 }


### PR DESCRIPTION
### What does this do?
- adds open and close user profile actions / state

### Why are we making this change?
- to continue work on updating the edit profile panel (redesign)

### How do I test this?
- run tests as usual - no UI implemented yet.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
