### PR TITLE
feat(authentication): close user profile on terminate

### DIFF
--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -33,6 +33,7 @@ import { Connectors } from '../../lib/web3';
 import { completePendingUserProfile } from '../registration/saga';
 import { StoreBuilder } from '../test/store';
 import { throwError } from 'redux-saga-test-plan/providers';
+import { closeUserProfile } from '../edit-profile/saga';
 
 describe(nonceOrAuthorize, () => {
   const signedWeb3Token = '0x000000000000000000000000000000000000000A';
@@ -219,6 +220,7 @@ describe('clearUserState', () => {
       .call(clearChannelsAndConversations)
       .call(clearMessages)
       .call(clearUsers)
+      .call(closeUserProfile)
       .withReducer(rootReducer)
       .run();
   });

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -15,6 +15,7 @@ import { Connectors } from '../../lib/web3';
 import { Events, getAuthChannel } from './channels';
 import { getHistory } from '../../lib/browser';
 import { completePendingUserProfile } from '../registration/saga';
+import { closeUserProfile } from '../edit-profile/saga';
 
 export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
@@ -89,6 +90,7 @@ export function* clearUserState() {
     call(clearChannelsAndConversations),
     call(clearMessages),
     call(clearUsers),
+    call(closeUserProfile),
   ]);
 }
 


### PR DESCRIPTION
### What does this do?
- ensures the users profile panel is closed on logout / termination.

### Why are we making this change?
- so when the user logs back in the user profile doesn't remain open.

### How do I test this?
- run test as usual.
- run ui > open profile > logout > log back in.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
