### PR TITLE
feat(giphy): implement uploading image urls to handle sending gifs

### DIFF
--- a/src/components/message-input/giphy/styles.scss
+++ b/src/components/message-input/giphy/styles.scss
@@ -4,16 +4,12 @@
   width: 500px;
   position: absolute;
   bottom: 64px;
-  left: 169px;
+  left: 0;
   background-color: themeDeprecated.$background-color-tertiary;
   padding: 5px;
   border-radius: 5px;
   border: 1px solid themeDeprecated.$input-arrow-color;
   z-index: 12;
-
-  &--fullscreen {
-    left: 374px;
-  }
 
   &-grid {
     height: 440px;

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -245,8 +245,7 @@ export class MessageInput extends React.Component<Properties, State> {
   }
 
   get allowGiphy() {
-    // Feature not implemented in Matrix yet
-    return false && !this.props.isEditing;
+    return !this.props.isEditing;
   }
 
   get allowFileAttachment() {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -300,3 +300,15 @@ export async function addRoomToFavorites(roomId: string) {
 export async function removeRoomFromFavorites(roomId: string) {
   return await chat.get().matrix.removeRoomFromFavorites(roomId);
 }
+
+export async function uploadImageUrl(
+  channelId: string,
+  url: string,
+  width: number,
+  height: number,
+  size: number,
+  rootMessageId: string,
+  optimisticId: string
+) {
+  return await chat.get().matrix.uploadImageUrl(channelId, url, width, height, size, rootMessageId, optimisticId);
+}

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -525,6 +525,44 @@ export class MatrixClient implements IChatClient {
     } as unknown as Message;
   }
 
+  async uploadImageUrl(
+    roomId: string,
+    url: string,
+    width: number,
+    height: number,
+    size: number,
+    rootMessageId: string = '',
+    optimisticId = ''
+  ) {
+    if (!this.matrix.isRoomEncrypted(roomId)) {
+      console.warn('uploadGiphyMessage called for non-encrypted room', roomId);
+      return;
+    }
+
+    const content = {
+      body: null,
+      msgtype: MsgType.Image,
+      url: url,
+      info: {
+        mimetype: 'image/gif',
+        w: width,
+        h: height,
+        size: size,
+        optimisticId,
+        rootMessageId,
+      },
+      optimisticId,
+    };
+
+    const messageResult = await this.matrix.sendMessage(roomId, content);
+    this.recordMessageSent(roomId);
+
+    return {
+      id: messageResult.event_id,
+      optimisticId,
+    } as unknown as Message;
+  }
+
   async recordMessageSent(roomId: string): Promise<void> {
     const data = { roomId, sentAt: new Date().valueOf() };
 

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -10,17 +10,10 @@ async function parseMediaData(matrixMessage) {
   let media = null;
   try {
     if (content?.msgtype === MsgType.Image) {
-      const { file, info } = content;
-      const blob = await decryptFile(file, info);
-      media = {
-        url: URL.createObjectURL(blob),
-        type: 'image',
-        ...info,
-      };
+      media = await buildMediaObject(content);
     }
   } catch (e) {
-    // ingore for now
-    console.log('error ocurred while parsing media data: ', e);
+    console.error('error ocurred while parsing media data: ', e);
   }
 
   return {
@@ -28,6 +21,24 @@ async function parseMediaData(matrixMessage) {
     image: content?.msgtype === MsgType.Image ? media : undefined,
     rootMessageId: media?.rootMessageId || '',
   };
+}
+
+async function buildMediaObject(content) {
+  if (content.file && content.info) {
+    const blob = await decryptFile(content.file, content.info);
+    return {
+      url: URL.createObjectURL(blob),
+      type: 'image',
+      ...content.info,
+    };
+  } else if (content.url) {
+    return {
+      url: content.url,
+      type: 'image',
+      ...content.info,
+    };
+  }
+  return null;
 }
 
 export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient) {

--- a/src/store/messages/uploadable.test.ts
+++ b/src/store/messages/uploadable.test.ts
@@ -1,8 +1,8 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { chat } from '../../lib/chat';
+import { chat, uploadImageUrl } from '../../lib/chat';
 
-import { UploadableMedia } from './uploadable';
+import { UploadableGiphy, UploadableMedia } from './uploadable';
 
 const chatClient = {
   uploadFileMessage: () => {},
@@ -23,5 +23,33 @@ describe(UploadableMedia, () => {
       .run();
 
     expect(returnValue).toEqual({ id: 'new-id' });
+  });
+});
+
+describe(UploadableGiphy, () => {
+  it('uploads the giphy data correctly', async () => {
+    const channelId = 'channel-id';
+    const giphyFile = {
+      giphy: {
+        images: {
+          downsized: {
+            url: 'http://example.com/image.gif',
+            width: '500',
+            height: '300',
+            size: '4000',
+          },
+        },
+      },
+    };
+    const uploadable = new UploadableGiphy(giphyFile);
+    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
+
+    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, 'root-id'))
+      .provide([
+        [matchers.call.fn(uploadImageUrl), { id: 'uploaded-id' }],
+      ])
+      .run();
+
+    expect(returnValue).toEqual({ id: 'uploaded-id' });
   });
 });

--- a/src/store/messages/uploadable.ts
+++ b/src/store/messages/uploadable.ts
@@ -2,7 +2,7 @@ import { CallEffect, call } from 'redux-saga/effects';
 
 import { FileType, getFileType } from './utils';
 import { Message } from '.';
-import { chat } from '../../lib/chat';
+import { chat, uploadImageUrl } from '../../lib/chat';
 
 export const createUploadableFile = (file): Uploadable => {
   if (file.nativeFile && getFileType(file.nativeFile) === FileType.Media) {
@@ -42,10 +42,21 @@ export class UploadableMedia implements Uploadable {
 
 export class UploadableGiphy implements Uploadable {
   public optimisticMessage: Message;
+
   constructor(public file) {}
-  *upload(_channelId, _rootMessageId) {
-    yield;
-    throw new Error('Giphy upload is not supported yet.');
+  *upload(channelId, rootMessageId) {
+    const giphyData = this.file.giphy.images.downsized;
+
+    return yield call(
+      uploadImageUrl,
+      channelId,
+      giphyData.url,
+      parseInt(giphyData.width),
+      parseInt(giphyData.height),
+      parseInt(giphyData.size),
+      rootMessageId,
+      this.optimisticMessage?.id?.toString()
+    );
   }
 }
 


### PR DESCRIPTION
### What does this do?
- implements uploading image urls to handle sending gifs

### Why are we making this change?
- to enable sending gifs

### How do I test this?
- run tests as usual.
- run the UI > open gif container by clicking the icon > select gif and send

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/35f74d8e-5094-424b-8b4f-71d70be2d45f

