### PR TITLE
feat(group-details): prevent create group if no name is set - disable submit button

### DIFF
--- a/src/components/messenger/list/group-details-panel/index.test.tsx
+++ b/src/components/messenger/list/group-details-panel/index.test.tsx
@@ -67,6 +67,20 @@ describe('GroupDetailsPanel', () => {
     expect(wrapper.find(SelectedUserTag).at(1).prop('userOption').value).toEqual('user-2');
   });
 
+  it('disables create button when no name', function () {
+    const wrapper = subject({});
+
+    expect(wrapper.find('Button')).toHaveProp('isDisabled', true);
+  });
+
+  it('enables create button when name is present', function () {
+    const wrapper = subject({});
+
+    wrapper.find('Input').simulate('change', 'group name');
+
+    expect(wrapper.find('Button')).toHaveProp('isDisabled', false);
+  });
+
   it('fires onCreate when create group is clicked', function () {
     const onCreate = jest.fn();
     const users = [

--- a/src/components/messenger/list/group-details-panel/index.tsx
+++ b/src/components/messenger/list/group-details-panel/index.tsx
@@ -46,6 +46,8 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
   renderImageUploadIcon = (): JSX.Element => <IconImagePlus />;
 
   render() {
+    const isDisabled = !this.state.name || this.state.name.trim().length === 0;
+
     return (
       <div {...cn('')}>
         <PanelHeader title='Group Details' onBack={this.back} />
@@ -78,7 +80,7 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
         </div>
 
         <div {...cn('footer')}>
-          <Button {...cn('create-button')} onPress={this.createGroup} isDisabled={!this.state.name}>
+          <Button {...cn('create-button')} onPress={this.createGroup} isDisabled={isDisabled}>
             Create Group
           </Button>
         </div>

--- a/src/components/messenger/list/group-details-panel/index.tsx
+++ b/src/components/messenger/list/group-details-panel/index.tsx
@@ -78,7 +78,7 @@ export class GroupDetailsPanel extends React.Component<Properties, State> {
         </div>
 
         <div {...cn('footer')}>
-          <Button {...cn('create-button')} onPress={this.createGroup}>
+          <Button {...cn('create-button')} onPress={this.createGroup} isDisabled={!this.state.name}>
             Create Group
           </Button>
         </div>


### PR DESCRIPTION
### What does this do?
- prevents user creating group without a name set.
- disables the submit button if there is no name entered.

### Why are we making this change?
-as requested.

### How do I test this?
- run tests as usual.
- run ui > create group > try submitting.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/257f900f-f5cb-4b06-b25c-fb0e0fdf28e0

