### PR TITLE
Render `typing indicators` in the UI 

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -124,37 +124,10 @@ describe(DirectMessageChat, () => {
     });
   });
 
-  describe('users typing', () => {
-    it('renders empty text when no users are typing', () => {
-      const wrapper = subject({ otherMembersTypingInRoom: [] });
+  it('renders users typing', function () {
+    const wrapper = subject({ otherMembersTypingInRoom: ['Johnny', 'Dale'] });
 
-      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toBe('');
-    });
-
-    it('displays single user typing', () => {
-      const wrapper = subject({ otherMembersTypingInRoom: ['Ratik'] });
-
-      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toContain('Ratik is typing...');
-    });
-
-    it('displays two users typing', () => {
-      const wrapper = subject({ otherMembersTypingInRoom: ['Ratik', 'Dale'] });
-
-      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toContain('Ratik and Dale are typing...');
-    });
-
-    it('displays multiple users typing', () => {
-      const wrapper = subject({
-        otherMembersTypingInRoom: [
-          'Dom',
-          'Ratik',
-          'Dale',
-          'John',
-        ],
-      });
-
-      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toContain('Dom and 3 others are typing...');
-    });
+    expect(wrapper.find('.direct-message-chat__typing-indicator')).toHaveText('Johnny and Dale are typing...');
   });
 
   describe('message input', () => {

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -41,6 +41,7 @@ describe(DirectMessageChat, () => {
       setLeaveGroupStatus: () => null,
       viewGroupInformation: () => null,
       toggleSecondarySidekick: () => null,
+      otherMembersTypingInRoom: [],
       ...props,
     };
 
@@ -120,6 +121,39 @@ describe(DirectMessageChat, () => {
 
       expect(leaveGroupDialog).toHaveProp('roomId', 'room-id');
       expect(leaveGroupDialog).toHaveProp('groupName', 'group-name');
+    });
+  });
+
+  describe('users typing', () => {
+    it('renders empty text when no users are typing', () => {
+      const wrapper = subject({ otherMembersTypingInRoom: [] });
+
+      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toBe('');
+    });
+
+    it('displays single user typing', () => {
+      const wrapper = subject({ otherMembersTypingInRoom: ['Ratik'] });
+
+      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toContain('Ratik is typing...');
+    });
+
+    it('displays two users typing', () => {
+      const wrapper = subject({ otherMembersTypingInRoom: ['Ratik', 'Dale'] });
+
+      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toContain('Ratik and Dale are typing...');
+    });
+
+    it('displays multiple users typing', () => {
+      const wrapper = subject({
+        otherMembersTypingInRoom: [
+          'Dom',
+          'Ratik',
+          'Dale',
+          'John',
+        ],
+      });
+
+      expect(wrapper.find('.direct-message-chat__typing-indicator').text()).toContain('Dom and 3 others are typing...');
     });
   });
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -24,6 +24,7 @@ import { ConversationHeader } from './conversation-header';
 
 import './styles.scss';
 import { rawChannelSelector } from '../../../store/channels/saga';
+import { getOtherMembersTypingDisplayText } from '../lib/utils';
 
 export interface PublicProperties {}
 
@@ -160,21 +161,7 @@ export class Container extends React.Component<Properties> {
 
   renderTypingIndicators = () => {
     const { otherMembersTypingInRoom } = this.props;
-    let text = null;
-
-    switch (otherMembersTypingInRoom.length) {
-      case 0:
-        break;
-      case 1:
-        text = `${otherMembersTypingInRoom[0]} is typing...`;
-        break;
-      case 2:
-        text = `${otherMembersTypingInRoom[0]} and ${otherMembersTypingInRoom[1]} are typing...`;
-        break;
-      default:
-        text = `${otherMembersTypingInRoom[0]} and ${otherMembersTypingInRoom.length - 1} others are typing...`;
-    }
-
+    const text = getOtherMembersTypingDisplayText(otherMembersTypingInRoom);
     return <div className='direct-message-chat__typing-indicator'>{text}</div>;
   };
 

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -93,6 +93,14 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     z-index: 2;
   }
 
+  &__typing-indicator {
+    font-size: 14px;
+    font-style: italic;
+    font-weight: 400;
+
+    @include glass-text-secondary-color;
+  }
+
   &__description {
     overflow: hidden;
   }

--- a/src/components/messenger/lib/utils.test.ts
+++ b/src/components/messenger/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { highlightFilter } from './utils';
+import { getOtherMembersTypingDisplayText, highlightFilter } from './utils';
 
 describe('highlightFilter', () => {
   it('returns unmodified text when filter is an empty string', () => {
@@ -56,5 +56,44 @@ describe('highlightFilter', () => {
     expect(result[1].type).toEqual('span');
     expect(result[1].props.children).toEqual('lo');
     expect(result[2]).toEqual(' World');
+  });
+});
+
+describe(getOtherMembersTypingDisplayText, () => {
+  it('returns null when no members are typing', () => {
+    const otherMembersTypingInRoom = [];
+
+    const result = getOtherMembersTypingDisplayText(otherMembersTypingInRoom);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns text when one member is typing', () => {
+    const otherMembersTypingInRoom = ['Ashneer'];
+
+    const result = getOtherMembersTypingDisplayText(otherMembersTypingInRoom);
+
+    expect(result).toEqual('Ashneer is typing...');
+  });
+
+  it('returns text when two members are typing', () => {
+    const otherMembersTypingInRoom = ['Ashneer', 'Aman'];
+
+    const result = getOtherMembersTypingDisplayText(otherMembersTypingInRoom);
+
+    expect(result).toEqual('Ashneer and Aman are typing...');
+  });
+
+  it('returns text when more than two members are typing', () => {
+    const otherMembersTypingInRoom = [
+      'Ashneer',
+      'Aman',
+      'Anupam',
+      'Ankit',
+    ];
+
+    const result = getOtherMembersTypingDisplayText(otherMembersTypingInRoom);
+
+    expect(result).toEqual('Ashneer and 3 others are typing...');
   });
 });

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -36,3 +36,22 @@ export const highlightFilter = (text, filter) => {
 
   return text;
 };
+
+export const getOtherMembersTypingDisplayText = (otherMembersTypingInRoom: string[]) => {
+  let text = null;
+
+  switch (otherMembersTypingInRoom.length) {
+    case 0:
+      break;
+    case 1:
+      text = `${otherMembersTypingInRoom[0]} is typing...`;
+      break;
+    case 2:
+      text = `${otherMembersTypingInRoom[0]} and ${otherMembersTypingInRoom[1]} are typing...`;
+      break;
+    default:
+      text = `${otherMembersTypingInRoom[0]} and ${otherMembersTypingInRoom.length - 1} others are typing...`;
+  }
+
+  return text;
+};

--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -82,6 +82,10 @@
       }
     }
 
+    &[is-typing='true'] {
+      font-style: italic;
+    }
+
     div {
       overflow: hidden;
       white-space: nowrap;

--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -91,6 +91,26 @@ describe(ConversationItem, () => {
     expect(wrapper.find(ContentHighlighter)).toHaveProp('message', 'I said something here');
   });
 
+  it('renders the otherMembersTyping', function () {
+    const wrapper = subject({
+      conversation: { otherMembersTyping: ['Johnny'], otherMembers: [] } as any,
+    });
+
+    expect(wrapper.find(ContentHighlighter)).toHaveProp('message', 'Johnny is typing...');
+  });
+
+  it('renders the otherMembersTyping instead of message preview if users are typing', function () {
+    const wrapper = subject({
+      conversation: {
+        messagePreview: 'I said something here',
+        otherMembersTyping: ['Dale', 'Dom'],
+        otherMembers: [],
+      } as any,
+    });
+
+    expect(wrapper.find(ContentHighlighter)).toHaveProp('message', 'Dale and Dom are typing...');
+  });
+
   it('renders the previewDisplayDate', function () {
     const wrapper = subject({ conversation: { previewDisplayDate: 'Aug 1, 2021', otherMembers: [] } as any });
 

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
-import { highlightFilter } from '../../lib/utils';
+import { getOtherMembersTypingDisplayText, highlightFilter } from '../../lib/utils';
 import { Channel } from '../../../../store/channels';
 
 import { MoreMenu } from './more-menu';
@@ -112,13 +112,24 @@ export class ConversationItem extends React.Component<Properties, State> {
     );
   }
 
+  getMessagePreview() {
+    const { conversation } = this.props;
+    const { messagePreview, otherMembersTyping } = conversation;
+
+    if ((otherMembersTyping || []).length === 0) {
+      return messagePreview;
+    } else {
+      return getOtherMembersTypingDisplayText(otherMembersTyping);
+    }
+  }
+
   render() {
     const { conversation, activeConversationId } = this.props;
-    const { messagePreview, previewDisplayDate } = conversation;
+    const { previewDisplayDate, otherMembersTyping } = conversation;
     const hasUnreadMessages = conversation.unreadCount !== 0;
     const isUnread = hasUnreadMessages ? 'true' : 'false';
     const isActive = conversation.id === activeConversationId ? 'true' : 'false';
-
+    const isTyping = (otherMembersTyping || []).length > 0 ? 'true' : 'false';
     return (
       <div
         {...cn('')}
@@ -142,8 +153,8 @@ export class ConversationItem extends React.Component<Properties, State> {
             <div {...cn('timestamp')}>{previewDisplayDate}</div>
           </div>
           <div {...cn('content')}>
-            <div {...cn('message')} is-unread={isUnread}>
-              <ContentHighlighter message={messagePreview} variant='negative' tabIndex={-1} />
+            <div {...cn('message')} is-unread={isUnread} is-typing={isTyping}>
+              <ContentHighlighter message={this.getMessagePreview()} variant='negative' tabIndex={-1} />
             </div>
             {hasUnreadMessages && <div {...cn('unread-count')}>{conversation.unreadCount}</div>}
           </div>

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -20,6 +20,7 @@ export interface RealtimeChatEvents {
   receiveLiveRoomEvent: (eventData) => void;
   roomFavorited: (roomId: string) => void;
   roomUnfavorited: (roomId: string) => void;
+  roomMemberTyping: (roomId: string, userIds: string[]) => void;
 }
 
 export interface MatrixKeyBackupInfo {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -43,7 +43,6 @@ import { encryptFile } from './matrix/media';
 import { uploadAttachment } from '../../store/messages/api';
 import { featureFlags } from '../feature-flags';
 import { logger } from 'matrix-js-sdk/lib/logger';
-import { USER_TYPING_TIMEOUT } from '../../store/channels/saga';
 
 export const USER_TYPING_TIMEOUT = 5000; // 5s
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -17,6 +17,7 @@ import {
   EventTimeline,
   NotificationCountType,
   IRoomTimelineData,
+  RoomMember,
 } from 'matrix-js-sdk';
 import { RealtimeChatEvents, IChatClient } from './';
 import { mapEventToAdminMessage, mapMatrixMessage, mapToLiveRoomEvent } from './matrix/chat-message';
@@ -838,9 +839,10 @@ export class MatrixClient implements IChatClient {
 
     this.matrix.on(ClientEvent.Event, this.publishUserPresenceChange);
     this.matrix.on(RoomEvent.Name, this.publishRoomNameChange);
+    this.matrix.on(RoomMemberEvent.Typing, this.publishRoomMemberTyping);
+
     //this.matrix.on(RoomStateEvent.Members, this.publishMembershipChange);
     this.matrix.on(RoomEvent.Timeline, this.processRoomTimelineEvent.bind(this));
-
     // Log events during development to help with understanding which events are happening
     Object.keys(ClientEvent).forEach((key) => {
       this.matrix.on(ClientEvent[key], this.debugEvent(`ClientEvent.${key}`));
@@ -965,6 +967,11 @@ export class MatrixClient implements IChatClient {
 
   private publishRoomAvatarChange = (event) => {
     this.events.onRoomAvatarChanged(event.room_id, event.content?.url);
+  };
+
+  private publishRoomMemberTyping = (event: MatrixEvent, member: RoomMember) => {
+    const content = event.getContent();
+    this.events.roomMemberTyping(member.roomId, content.user_ids || []);
   };
 
   private publishMembershipChange = async (event) => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -42,6 +42,7 @@ import { encryptFile } from './matrix/media';
 import { uploadAttachment } from '../../store/messages/api';
 import { featureFlags } from '../feature-flags';
 import { logger } from 'matrix-js-sdk/lib/logger';
+import { USER_TYPING_TIMEOUT } from '../../store/channels/saga';
 
 export const USER_TYPING_TIMEOUT = 5000; // 5s
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -55,6 +55,7 @@ export interface Channel {
   reply?: ParentMessage;
   isFavorite: boolean;
   currentUserLastTypingEventPublishedAt?: number;
+  otherMembersTyping: string[];
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -75,6 +76,7 @@ export const CHANNEL_DEFAULTS = {
   adminMatrixIds: [],
   isFavorite: false,
   currentUserLastTypingEventPublishedAt: null,
+  otherMembersTyping: [],
 };
 
 export enum SagaActionTypes {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -54,7 +54,6 @@ export interface Channel {
   adminMatrixIds: string[];
   reply?: ParentMessage;
   isFavorite: boolean;
-  currentUserLastTypingEventPublishedAt?: number;
   otherMembersTyping: string[];
 }
 
@@ -75,7 +74,6 @@ export const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   isFavorite: false,
-  currentUserLastTypingEventPublishedAt: null,
   otherMembersTyping: [],
 };
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -54,6 +54,7 @@ export interface Channel {
   adminMatrixIds: string[];
   reply?: ParentMessage;
   isFavorite: boolean;
+  currentUserLastTypingEventPublishedAt?: number;
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -73,6 +74,7 @@ export const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   isFavorite: false,
+  currentUserLastTypingEventPublishedAt: null,
 };
 
 export enum SagaActionTypes {

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -207,4 +207,5 @@ const CHANNEL_DEFAULTS = {
   adminMatrixIds: [],
   isFavorite: false,
   currentUserLastTypingEventPublishedAt: null,
+  otherMembersTyping: [],
 };

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -206,4 +206,5 @@ const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   isFavorite: false,
+  currentUserLastTypingEventPublishedAt: null,
 };

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -11,6 +11,7 @@ import {
   onUnfavoriteRoom,
   roomUnfavorited,
   publishUserTypingEvent,
+  receivedRoomMembersTyping,
 } from './saga';
 
 import { rootReducer } from '../reducer';
@@ -189,6 +190,48 @@ describe(publishUserTypingEvent, () => {
   });
 });
 
+describe(receivedRoomMembersTyping, () => {
+  it('updates otherMembersTyping for room', async () => {
+    const initialState = new StoreBuilder()
+      .withConversationList({ id: 'room-id' })
+      .withUsers(
+        { matrixId: 'matrix-id-1', firstName: 'Ashneer' },
+        { matrixId: 'matrix-id-2', firstName: 'Aman' },
+        { matrixId: 'matrix-id-3', firstName: 'Anupam' }
+      )
+      .build();
+
+    const { storeState } = await expectSaga(receivedRoomMembersTyping, {
+      payload: { roomId: 'room-id', userIds: ['matrix-id-1', 'matrix-id-2'] },
+    })
+      .withReducer(rootReducer, initialState)
+      .run();
+
+    const channel = denormalizeChannel('room-id', storeState);
+    expect(channel.otherMembersTyping).toEqual(['Ashneer', 'Aman']);
+  });
+
+  it('does not add current user to otherMembersTyping', async () => {
+    const initialState = new StoreBuilder()
+      .withCurrentUser({
+        id: 'currentUser-id',
+        matrixId: 'current-user-matrix-id',
+        profileSummary: { firstName: 'CurrentUser' },
+      } as any)
+      .withConversationList({ id: 'room-id' })
+      .build();
+
+    const { storeState } = await expectSaga(receivedRoomMembersTyping, {
+      payload: { roomId: 'room-id', userIds: ['current-user-matrix-id'] },
+    })
+      .withReducer(rootReducer, initialState)
+      .run();
+
+    const channel = denormalizeChannel('room-id', storeState);
+    expect(channel.otherMembersTyping).toEqual([]);
+  });
+});
+
 const CHANNEL_DEFAULTS = {
   optimisticId: '',
   name: '',
@@ -206,6 +249,5 @@ const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   isFavorite: false,
-  currentUserLastTypingEventPublishedAt: null,
   otherMembersTyping: [],
 };

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -164,7 +164,9 @@ export function* receivedRoomMembersTyping(action) {
   yield call(receiveChannel, { id: roomId, otherMembersTyping });
 }
 
-export function* publishUserTypingEvent(roomId) {
+export function* publishUserTypingEvent(action) {
+  const { roomId } = action.payload;
+
   try {
     yield call(matrixSendUserTypingEvent, roomId, true);
   } catch (error) {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -17,6 +17,7 @@ import { rawSetActiveConversationId } from '../chat';
 import { resetConversationManagement } from '../group-management/saga';
 import { leadingDebounce } from '../utils';
 import { ChatMessageEvents, getChatMessageBus } from '../messages/messages';
+import { getLocalZeroUsersMap } from '../messages/saga';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -143,9 +144,27 @@ export function* roomUnfavorited(action) {
   }
 }
 
-export function* publishUserTypingEvent(action) {
-  const { roomId } = action.payload;
+export function* receivedRoomMembersTyping(action) {
+  const { roomId, userIds: matrixIds } = action.payload;
 
+  const currentUser = yield select(currentUserSelector());
+  const zeroUsersByMatrixIds = yield call(getLocalZeroUsersMap);
+  const otherMembersTyping = [];
+  for (const matrixId of matrixIds) {
+    if (matrixId === currentUser.matrixId) {
+      continue;
+    }
+
+    const zeroUser = zeroUsersByMatrixIds[matrixId];
+    if (zeroUser) {
+      otherMembersTyping.push(zeroUser.firstName);
+    }
+  }
+
+  yield call(receiveChannel, { id: roomId, otherMembersTyping });
+}
+
+export function* publishUserTypingEvent(roomId) {
   try {
     yield call(matrixSendUserTypingEvent, roomId, true);
   } catch (error) {
@@ -183,4 +202,5 @@ export function* saga() {
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.UnreadCountChanged, unreadCountUpdated);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomFavorited, roomFavorited);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomUnfavorited, roomUnfavorited);
+  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomMemberTyping, receivedRoomMembersTyping);
 }

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -20,6 +20,7 @@ export enum Events {
   ChatConnectionComplete = 'chat/connection/complete',
   RoomFavorited = 'chat/channel/roomFavorited',
   RoomUnfavorited = 'chat/channel/roomUnfavorited',
+  RoomMemberTyping = 'chat/channel/roomMemberTyping',
 }
 
 let theBus;
@@ -87,6 +88,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
     const roomFavorited = (roomId) => emit({ type: Events.RoomFavorited, payload: { roomId } });
     const roomUnfavorited = (roomId) => emit({ type: Events.RoomUnfavorited, payload: { roomId } });
+    const roomMemberTyping = (roomId, userIds) => emit({ type: Events.RoomMemberTyping, payload: { roomId, userIds } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -103,6 +105,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       receiveLiveRoomEvent,
       roomFavorited,
       roomUnfavorited,
+      roomMemberTyping,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);


### PR DESCRIPTION
### What does this do?

In chat:
(single user typing)
<img width="448" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/097e2c6c-c295-4464-b0b0-054c4b36b8b2">

(two users typing)
<img width="785" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/c106838d-8fc7-43fb-a14f-56b7a502e896">

(more than two users typing)
<img width="649" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/74cf7de1-7c1a-43c9-880a-79818f830e4a">


In conversation list panel:
<img width="318" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/60eeb2c6-7ed5-4879-9df3-4b36b65a0580">
