### PR TITLE
feat(message): enable reply on image content 

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -123,8 +123,8 @@ export class ChatView extends React.Component<Properties, State> {
   }
 
   isUserOwnerOfMessage(message: MessageModel) {
-    // eslint-disable-next-line eqeqeq
-    return this.props.user && message?.sender && this.props.user.id == message.sender.userId;
+    const { user } = this.props;
+    return user && message?.sender && user.id == message.sender.userId;
   }
 
   renderMessageGroup(groupMessages) {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -124,7 +124,7 @@ export class ChatView extends React.Component<Properties, State> {
 
   isUserOwnerOfMessage(message: MessageModel) {
     const { user } = this.props;
-    return user && message?.sender && user.id == message.sender.userId;
+    return user && message?.sender && user.id === message.sender.userId;
   }
 
   renderMessageGroup(groupMessages) {

--- a/src/components/content-highlighter/content-highlight.test.tsx
+++ b/src/components/content-highlighter/content-highlight.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import { ContentHighlighter, Properties } from './';
 import { textToPlainEmojis } from './text-to-emojis';
+import { IconButton } from '@zero-tech/zui/components';
 
 jest.mock('./text-to-emojis', () => ({
   textToPlainEmojis: jest.fn((text) => text),
@@ -18,46 +18,65 @@ describe('ContentHighlighter', () => {
   };
 
   it('renders without crashing', () => {
-    render({});
+    const wrapper = render({ message: 'Default message' });
+    expect(wrapper.isEmptyRender()).toBeFalsy();
   });
 
   it('renders content with plain emojis', () => {
     const message = 'Hello, world! :)';
     (textToPlainEmojis as jest.Mock).mockReturnValueOnce('Hello, world! 🙂');
 
-    const wrapper = render({
-      message,
-    });
-
+    const wrapper = render({ message });
     expect(wrapper.text()).toContain('Hello, world! 🙂');
   });
 
-  it('renders content with a user mention', () => {
-    const wrapper = render({
-      message: 'Hello, @[John Doe](user:123)!',
-    });
+  it('renders user mentions correctly', () => {
+    const message = 'Hello, @[John Doe](user:123)!';
+    const wrapper = render({ message });
     expect(wrapper.find('.content-highlighter__user-mention').text()).toEqual('John Doe');
+    expect(wrapper.find('.content-highlighter__user-mention').exists()).toBeTruthy();
   });
 
-  it('renders content with a different variant', () => {
-    const wrapper = render({
-      message: 'Hello, @[John Doe](user:123)!',
-      variant: 'negative',
-    });
-    expect(wrapper.find('.content-highlighter__user-mention').prop('data-variant')).toEqual('negative');
+  it('renders image with click handler', () => {
+    const onImageReply = jest.fn();
+    const message = 'Check this out! ![Image](img.jpg)';
+    const wrapper = render({ message, onImageReply });
+
+    wrapper.find('img').simulate('click');
+    expect(onImageReply).toHaveBeenCalledWith('img.jpg');
   });
 
-  it('renders content with hidden message', () => {
+  it('renders content with links', () => {
+    const message = 'Visit https://example.com for more info';
+    const wrapper = render({ message });
+
+    const link = wrapper.find('.text-message__link');
+    expect(link.exists()).toBeTruthy();
+    expect(link.prop('href')).toContain('https://example.com');
+  });
+
+  it('renders hidden message with action button', () => {
     const onHiddenMessageInfoClick = jest.fn();
     const wrapper = render({
-      message: 'Message hidden',
+      message: 'This message is hidden',
       isHidden: true,
       onHiddenMessageInfoClick,
     });
 
-    expect(wrapper.find('.content-highlighter__hidden-message-text')).toHaveText('Message hidden');
-
-    wrapper.find('IconButton').simulate('click');
+    expect(wrapper.find('.content-highlighter__hidden-message-text').text()).toEqual('This message is hidden');
+    wrapper.find(IconButton).simulate('click');
     expect(onHiddenMessageInfoClick).toHaveBeenCalled();
+  });
+
+  it('renders a pure image without text', () => {
+    const message = '![Pure Image](pure.jpg)';
+    const wrapper = render({ message });
+    expect(wrapper.find('img').prop('src')).toEqual('pure.jpg');
+    expect(wrapper.find('img').exists()).toBeTruthy();
+  });
+
+  it('handles absence of text and image', () => {
+    const wrapper = render({ message: '' });
+    expect(wrapper.isEmptyRender()).toBeTruthy();
   });
 });

--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -72,7 +72,7 @@ export class ContentHighlighter extends React.Component<Properties> {
         </Linkify>
       );
     } else {
-      return <div>{this.renderContent(message)}</div>;
+      return <div className='content-highlighter'>{this.renderContent(message)}</div>;
     }
   }
 

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -265,12 +265,12 @@ export class MessageInput extends React.Component<Properties, State> {
 
   renderInput() {
     const reply = this.props.reply;
-
     return (
       <div {...cn('container')}>
         <div {...cn('addon-row')}>
           {reply && (
             <ReplyCard
+              imageUrl={reply.imageUrl}
               message={reply.message}
               senderIsCurrentUser={this.props.replyIsCurrentUser}
               senderFirstName={reply?.sender?.firstName}

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -236,6 +236,7 @@ describe('message', () => {
     const messageId = '989887';
     const message = 'hello';
     const sender = { userId: '78676X67767' };
+    const image = { media: { url: 'https://image.com/image.png' } };
     const replyMessage = {
       messageId,
       message,
@@ -247,6 +248,7 @@ describe('message', () => {
       admin: {},
       optimisticId: '',
       rootMessageId: '',
+      imageUrl: image.media.url,
     };
     const wrapper = subject({
       message,
@@ -258,6 +260,7 @@ describe('message', () => {
       admin: {},
       optimisticId: '',
       rootMessageId: '',
+      image,
       onReply,
     });
 
@@ -266,7 +269,10 @@ describe('message', () => {
 
     wrapper.find(MessageMenu).simulate('reply');
 
-    expect(onReply).toHaveBeenCalledWith({ reply: replyMessage });
+    expect(onReply).toHaveBeenCalledWith({
+      ...replyMessage,
+      imageUrl: image.media.url,
+    });
   });
 
   it('should not renders edited indicator', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -227,6 +227,7 @@ export class Message extends React.Component<Properties, State> {
       admin: this.props.admin,
       optimisticId: this.props.optimisticId,
       rootMessageId: this.props.rootMessageId,
+      imageUrl: this.props.media.url,
     };
 
     this.props.onReply({ reply });
@@ -346,12 +347,13 @@ export class Message extends React.Component<Properties, State> {
   }
 
   renderBody() {
-    const { message, isHidden } = this.props;
+    const { message, isHidden, media } = this.props;
 
     return (
       <div {...cn('block-body')}>
         {message && (
           <ContentHighlighter
+            imageUrl={media && media.url}
             message={message}
             isHidden={isHidden}
             onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
@@ -363,39 +365,46 @@ export class Message extends React.Component<Properties, State> {
   }
 
   renderParentMessage() {
+    const { parentMessageText, parentSenderIsCurrentUser, parentSenderFirstName, parentSenderLastName } = this.props;
+
+    if (!parentMessageText) {
+      return null;
+    }
+
     return (
       <ParentMessage
-        message={this.props.parentMessageText}
-        senderIsCurrentUser={this.props.parentSenderIsCurrentUser}
-        senderFirstName={this.props.parentSenderFirstName}
-        senderLastName={this.props.parentSenderLastName}
+        message={parentMessageText}
+        senderIsCurrentUser={parentSenderIsCurrentUser}
+        senderFirstName={parentSenderFirstName}
+        senderLastName={parentSenderLastName}
       />
     );
   }
 
   render() {
-    const { message, media, preview, sender, isOwner } = this.props;
+    const { message, media, preview, sender, isOwner, showSenderAvatar, showAuthorName, className } = this.props;
+    const { isEditing } = this.state;
     return (
       <div
-        className={classNames('message', this.props.className, {
+        className={classNames('message', className, {
           'message--owner': isOwner,
         })}
         onContextMenu={this.handleContextMenu}
         ref={this.wrapperRef}
       >
-        {this.props.showSenderAvatar && (
+        {showSenderAvatar && (
           <div {...cn('left')}>
             <div {...cn('author-avatar')}>
               <Avatar size='medium' imageURL={`${getProvider().getSourceUrl(sender.profileImage)}`} tabIndex={-1} />
             </div>
           </div>
         )}
-        <div {...cn('block', this.state.isEditing && 'edit')}>
+        <div {...cn('block', isEditing && 'edit')}>
           {(message || media || preview) && (
             <>
-              {!this.state.isEditing && (
+              {!isEditing && (
                 <>
-                  {this.props.showAuthorName && this.renderAuthorName()}
+                  {showAuthorName && this.renderAuthorName()}
                   {media && this.renderMedia(media)}
                   {this.renderLinkPreview()}
                   {this.renderParentMessage()}
@@ -403,11 +412,11 @@ export class Message extends React.Component<Properties, State> {
                 </>
               )}
 
-              {this.state.isEditing && this.props.message && (
+              {isEditing && message && (
                 <>
                   <div {...cn('block-edit')}>
                     <MessageInput
-                      initialValue={this.props.message}
+                      initialValue={message}
                       onSubmit={this.editMessage}
                       getUsersForMentions={this.props.getUsersForMentions}
                       isEditing={this.state.isEditing}

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -227,7 +227,7 @@ export class Message extends React.Component<Properties, State> {
       admin: this.props.admin,
       optimisticId: this.props.optimisticId,
       rootMessageId: this.props.rootMessageId,
-      imageUrl: this.props.media.url,
+      imageUrl: this.isMediaMessage ? this.props.media?.url : '',
     };
 
     this.props.onReply({ reply });
@@ -353,7 +353,7 @@ export class Message extends React.Component<Properties, State> {
       <div {...cn('block-body')}>
         {message && (
           <ContentHighlighter
-            imageUrl={media && media.url}
+            imageUrl={media && media?.url}
             message={message}
             isHidden={isHidden}
             onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}

--- a/src/components/message/parent-message/index.tsx
+++ b/src/components/message/parent-message/index.tsx
@@ -25,17 +25,18 @@ export class ParentMessage extends React.PureComponent<Properties> {
   }
 
   render() {
-    if (!this.props.message) {
+    const { message } = this.props;
+
+    if (!message) {
       return null;
     }
-
     return (
       <div {...cn('')}>
         <IconCornerDownRight size={16} />
         <div {...cn('content')}>
           <div {...cn('header')}>{this.name}</div>
           <span>
-            <ContentHighlighter variant='tertiary' message={this.props.message} />
+            <ContentHighlighter variant='tertiary' message={message} />
           </span>
         </div>
       </div>

--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -26,4 +26,12 @@
   &__header {
     margin-bottom: 4px;
   }
+
+  &__reply-image {
+    img {
+      width: 48px;
+      height: 48px;
+      margin-left: 10px;
+    }
+  }
 }

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -13,6 +13,7 @@ export interface Properties {
   senderIsCurrentUser: boolean;
   senderFirstName: string;
   senderLastName: string;
+  imageUrl?: string;
 
   onRemove?: () => void;
 }
@@ -33,7 +34,7 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
   };
 
   render() {
-    const { message } = this.props;
+    const { message, imageUrl } = this.props;
 
     return (
       <div {...cn()}>
@@ -41,7 +42,12 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
         <div {...cn('content')}>
           <div {...cn('header')}>{this.name}</div>
           <div {...cn('message')}>
-            <ContentHighlighter variant='tertiary' message={message} />
+            <ContentHighlighter variant='tertiary' message={message} imageUrl={imageUrl} />
+            {imageUrl && (
+              <div {...cn('image')}>
+                <img src={imageUrl} alt={''} />
+              </div>
+            )}
           </div>
         </div>
         <IconButton Icon={IconXClose} size={24} onClick={this.itemRemoved} />

--- a/src/components/reply-card/styles.scss
+++ b/src/components/reply-card/styles.scss
@@ -32,14 +32,39 @@
     margin-bottom: 4px;
   }
 
+  .content-highlighter {
+    flex-grow: 1;
+
+    overflow: hidden;
+
+    text-overflow: ellipsis;
+
+    white-space: nowrap;
+  }
+
+  &__message {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
   &__image {
+    order: -1;
+
     width: 48px;
+
     height: 48px;
-    border-radius: 4px;
+
+    flex-shrink: 0;
+
+    border-radius: 8px;
+
+    overflow: hidden;
+
     img {
-      width: 48px;
-      height: 48px;
-      border-radius: 4px;
+      height: 100%;
+      /* make image fill the container */
+      width: auto;
     }
   }
 }

--- a/src/components/reply-card/styles.scss
+++ b/src/components/reply-card/styles.scss
@@ -31,4 +31,15 @@
   &__header {
     margin-bottom: 4px;
   }
+
+  &__image {
+    width: 48px;
+    height: 48px;
+    border-radius: 4px;
+    img {
+      width: 48px;
+      height: 48px;
+      border-radius: 4px;
+    }
+  }
 }

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -20,6 +20,7 @@ export interface ParentMessage {
   admin?: any;
   optimisticId?: string;
   rootMessageId?: string;
+  imageUrl?: string;
 }
 
 export interface User {

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -58,7 +58,7 @@ export class MessageMenu extends React.Component<Properties, State> {
         onSelect: this.onEdit,
       });
     }
-    if (onReply && canReply && isMediaMessage) {
+    if (onReply && canReply) {
       menuItems.push({
         id: 'reply',
         label: this.renderMenuOption(<IconFlipBackward size={20} />, 'Reply'),

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -57,7 +57,7 @@ export class MessageMenu extends React.Component<Properties, State> {
         onSelect: this.onEdit,
       });
     }
-    if (this.props.onReply && this.props.canReply && !this.props.isMediaMessage) {
+    if (this.props.onReply && this.props.canReply && this.props.isMediaMessage) {
       menuItems.push({
         id: 'reply',
         label: this.renderMenuOption(<IconFlipBackward size={20} />, 'Reply'),

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -49,22 +49,23 @@ export class MessageMenu extends React.Component<Properties, State> {
   onReply = () => this.delayEvent(this.props.onReply);
 
   renderItems = () => {
+    const { canEdit, onEdit, isMediaMessage, canReply, onReply, canDelete, onDelete } = this.props;
     const menuItems = [];
-    if (this.props.onEdit && this.props.canEdit && !this.props.isMediaMessage) {
+    if (onEdit && canEdit && !isMediaMessage) {
       menuItems.push({
         id: 'edit',
         label: this.renderMenuOption(<IconEdit5 size={20} />, 'Edit'),
         onSelect: this.onEdit,
       });
     }
-    if (this.props.onReply && this.props.canReply && this.props.isMediaMessage) {
+    if (onReply && canReply && isMediaMessage) {
       menuItems.push({
         id: 'reply',
         label: this.renderMenuOption(<IconFlipBackward size={20} />, 'Reply'),
         onSelect: this.onReply,
       });
     }
-    if (this.props.onDelete && this.props.canDelete) {
+    if (onDelete && canDelete) {
       menuItems.push({
         id: 'delete',
         label: this.renderMenuOption(<IconTrash4 size={20} />, 'Delete'),
@@ -117,29 +118,30 @@ export class MessageMenu extends React.Component<Properties, State> {
 
   render() {
     const menuItems = this.renderItems();
+    const { className, onCloseMenu, onOpenChange, isMenuOpen, isMenuFlying } = this.props;
 
     if (!menuItems.length) {
       return null;
     }
 
     return (
-      <div className={this.props.className}>
+      <div className={className}>
         {this.props.isMenuOpen &&
-          createPortal(<div className='dropdown-menu__underlay' onClick={this.props.onCloseMenu} />, document.body)}
+          createPortal(<div className='dropdown-menu__underlay' onClick={onCloseMenu} />, document.body)}
 
         <DropdownMenu
           menuClassName={'dropdown-menu'}
           items={menuItems}
           side='bottom'
           alignMenu='center'
-          onOpenChange={this.props.onOpenChange}
-          open={this.props.isMenuOpen}
+          onOpenChange={onOpenChange}
+          open={isMenuOpen}
           showArrow
           trigger={
-            !this.props.isMenuFlying ? (
+            !isMenuFlying ? (
               <div
                 className={classNames('dropdown-menu-trigger', {
-                  'dropdown-menu-trigger--open': this.props.isMenuOpen,
+                  'dropdown-menu-trigger--open': isMenuOpen,
                 })}
               >
                 <IconDotsHorizontal size={24} isFilled />


### PR DESCRIPTION
### What does this feature do?

This feature enables the reply function for image content within messages.

### Why are we making this change?

Currently, the reply functionality is only available for text-only message bubbles. By enabling replies to images, we enhance user interaction capabilities and align with common messaging features.

### How do I test this?

1. Start a conversation within the application.
2. Send an image in the chat.
3. Attempt to reply directly to the image sent.

### Key Decisions and Risk Assessment:
#### Things to Consider:
- **Security Impact**: There is no expected impact on security with this change.
- **Performance Impact**: There is no anticipated effect on performance due to this update.
- **API Changes**: This feature does not involve any changes to existing APIs.
