### PR TITLE
Send typing events correctly when you're editing a message

### DIFF
--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -188,6 +188,18 @@ describe(publishUserTypingEvent, () => {
       .call(sendTypingEvent, 'room-id', true)
       .run();
   });
+
+  it('uses activeConversationId if roomId is not provided', async () => {
+    const initialState = new StoreBuilder().withActiveConversation({ id: 'room-id' }).build();
+
+    await expectSaga(publishUserTypingEvent, { payload: {} })
+      .withReducer(rootReducer, initialState)
+      .provide([
+        [matchers.call.fn(sendTypingEvent), undefined],
+      ])
+      .call(sendTypingEvent, 'room-id', true)
+      .run();
+  });
 });
 
 describe(receivedRoomMembersTyping, () => {

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -165,7 +165,7 @@ export function* receivedRoomMembersTyping(action) {
 }
 
 export function* publishUserTypingEvent(action) {
-  const { roomId } = action.payload;
+  const roomId = action.payload.roomId || (yield select((state) => state.chat.activeConversationId));
 
   try {
     yield call(matrixSendUserTypingEvent, roomId, true);


### PR DESCRIPTION
### What does this do?

Previously editing a message got broken on local (and logged an error on prod). This was due to the fact that the typing events were * not * going through while edit. 

Reason: The `channelId` is an optional parameter to the `<MessageInput>` component, & while editing a message, it was not being sent (which i had missed). Fixed now.

<img width="799" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/5c977d5c-5be4-47ac-8b54-043ef60a7f56">
