### PR TITLE
fix(gifs): use correct giphy image url when creating optimistic message object

### DIFF
--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -18,7 +18,7 @@ export function createOptimisticMessageObject(
   messageText: string,
   user: User,
   parentMessage: ParentMessage = null,
-  file?: { name: string; url: string; mediaType: MediaType },
+  file?: { name: string; url: string; mediaType: MediaType; giphy: any },
   rootMessageId?: string
 ): Message {
   const id = uuidv4();
@@ -26,7 +26,7 @@ export function createOptimisticMessageObject(
   if (file) {
     media = {
       type: file.mediaType,
-      url: file.url,
+      url: file.giphy ? file.giphy.images.downsized.url : file.url,
       name: file.name,
       // Not sure why these are in our types as I don't think we use them at all
       // I'm guessing this is for rendering a loaded message when the image hasn't downloaded yet


### PR DESCRIPTION
### What does this do?
- uses the correct image url when creating optimistic message object.

### Why are we making this change?
- before these changes, the url being used for the optimistic message was the preview_gif url which causes flickering of image sizes as shown in the before and after below. By using the same image url here as what we use when uploading the image, the size and quality will remain consistent for better UI/UX.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Before:


https://github.com/zer0-os/zOS/assets/39112648/e3ebc99e-646e-4807-b89d-2f5dff5415ee

After:


https://github.com/zer0-os/zOS/assets/39112648/154b52da-f069-44fe-ad8b-256e45fb0919

