### PR TITLE
Small tweaks to the typing indicator UI

### DIFF
--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -94,13 +94,18 @@ $title-bar-border-radius: 8px 8px 0px 0px;
   }
 
   &__typing-indicator {
-    font-size: 14px;
+    font-size: 13px;
     font-style: italic;
     font-weight: 400;
     margin-left: 100px;
-    padding-bottom: 8px;
+    margin-top: -6px;
+    padding-bottom: 2px;
 
     @include glass-text-secondary-color;
+
+    &:empty {
+      display: none;
+    }
   }
 
   &__description {


### PR DESCRIPTION
### What does this do?

Adds a `display: none` on empty & reduces padding
<img width="713" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2920e568-b21b-4687-940d-3bd9ad974afc">
