### PR TITLE
feat(dialog-manager): add and handle secure backup dialog in manager

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -11,6 +11,7 @@ import { MessengerChat } from './components/messenger/chat';
 import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
 import { AppBar } from './components/app-bar';
+import { DialogManager } from './components/dialog-manager/container';
 
 export interface Properties {
   context: {
@@ -37,6 +38,7 @@ export class Container extends React.Component<Properties> {
       <div className={mainClassName}>
         {this.props.context.isAuthenticated && (
           <>
+            <DialogManager />
             <AppBar />
             <Sidekick />
             <MessengerChat />

--- a/src/components/dialog-manager/container.test.tsx
+++ b/src/components/dialog-manager/container.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Container, Properties } from './container';
+import { RootState } from '../../store/reducer';
+import { SecureBackupContainer } from '../secure-backup/container';
+import { closeBackupDialog } from '../../store/matrix';
+
+describe('DialogContainer', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      isBackupDialogOpen: false,
+
+      closeBackupDialog: () => null,
+      ...props,
+    };
+    return shallow(<Container {...allProps} />);
+  };
+
+  it('renders SecureBackupContainer when isBackupDialogOpen is true', () => {
+    const wrapper = subject({ isBackupDialogOpen: true });
+
+    expect(wrapper).toHaveElement(SecureBackupContainer);
+  });
+
+  it('does not render SecureBackupContainer when isBackupDialogOpen is false', () => {
+    const wrapper = subject({ isBackupDialogOpen: false });
+
+    expect(wrapper).not.toHaveElement(SecureBackupContainer);
+  });
+
+  it('calls closeBackupDialog on closeBackup method', () => {
+    const closeBackupDialogMock = jest.fn();
+    const wrapper = subject({ closeBackupDialog: closeBackupDialogMock });
+
+    const instance = wrapper.instance() as Container;
+    instance.closeBackup();
+
+    expect(closeBackupDialogMock).toHaveBeenCalled();
+  });
+
+  describe('mapState', () => {
+    const stateMock: RootState = {
+      matrix: {
+        isBackupDialogOpen: true,
+      },
+    } as RootState;
+
+    it('returns isBackupDialogOpen', () => {
+      const props = Container.mapState(stateMock);
+
+      expect(props.isBackupDialogOpen).toBe(true);
+    });
+  });
+
+  describe('mapActions', () => {
+    it('returns closeBackupDialog action', () => {
+      const actions = Container.mapActions({} as any);
+
+      expect(actions.closeBackupDialog).toBeDefined();
+      expect(actions.closeBackupDialog).toEqual(closeBackupDialog);
+    });
+  });
+});

--- a/src/components/dialog-manager/container.test.tsx
+++ b/src/components/dialog-manager/container.test.tsx
@@ -5,7 +5,7 @@ import { RootState } from '../../store/reducer';
 import { SecureBackupContainer } from '../secure-backup/container';
 import { closeBackupDialog } from '../../store/matrix';
 
-describe('DialogContainer', () => {
+describe('DialogManager', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       isBackupDialogOpen: false,

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -40,4 +40,4 @@ export class Container extends React.Component<Properties> {
   }
 }
 
-export const DialogContainer = connectContainer<PublicProperties>(Container);
+export const DialogManager = connectContainer<PublicProperties>(Container);

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
+import { SecureBackupContainer } from '../secure-backup/container';
+import { closeBackupDialog } from '../../store/matrix';
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  isBackupDialogOpen: boolean;
+
+  closeBackupDialog: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState) {
+    const {
+      matrix: { isBackupDialogOpen },
+    } = state;
+
+    return {
+      isBackupDialogOpen,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { closeBackupDialog };
+  }
+
+  closeBackup = () => {
+    this.props.closeBackupDialog();
+  };
+
+  renderSecureBackupDialog = (): JSX.Element => {
+    return <SecureBackupContainer onClose={this.closeBackup} />;
+  };
+
+  render() {
+    return <>{this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}</>;
+  }
+}
+
+export const DialogContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -13,7 +13,6 @@ import { RegistrationState } from '../../../store/registration';
 import { previewDisplayDate } from '../../../lib/chat/chat-message';
 import { UserHeader } from './user-header';
 import { ErrorDialog } from '../../error-dialog';
-import { SecureBackupContainer } from '../../secure-backup/container';
 import { bem } from '../../../lib/bem';
 
 const c = bem('.direct-message-members');
@@ -39,7 +38,6 @@ describe('messenger-list', () => {
       joinRoomErrorContent: null,
       onConversationClick: jest.fn(),
       createConversation: jest.fn(),
-      isBackupDialogOpen: false,
       isRewardsDialogOpen: false,
       displayLogoutModal: false,
       showRewardsTooltip: false,
@@ -49,7 +47,6 @@ describe('messenger-list', () => {
       back: () => null,
       receiveSearchResults: () => null,
       logout: () => null,
-      closeBackupDialog: () => null,
       closeRewardsDialog: () => null,
       onFavoriteRoom: () => null,
       onUnfavoriteRoom: () => null,
@@ -185,12 +182,6 @@ describe('messenger-list', () => {
     });
 
     expect(wrapper).toHaveElement(ErrorDialog);
-  });
-
-  it('renders Secure Backup Dialog if isBackupDialogOpen', function () {
-    const wrapper = subject({ isBackupDialogOpen: true });
-
-    expect(wrapper).toHaveElement(SecureBackupContainer);
   });
 
   it('calls closeConversationErrorDialog when error dialog is closed', function () {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -31,8 +31,6 @@ import { receiveSearchResults } from '../../../store/users';
 import { UserHeader } from './user-header';
 import { getUserSubHandle } from '../../../lib/user';
 import { VerifyIdDialog } from '../../verify-id-dialog';
-import { closeBackupDialog } from '../../../store/matrix';
-import { SecureBackupContainer } from '../../secure-backup/container';
 import { LogoutConfirmationModalContainer } from '../../logout-confirmation-modal/container';
 import { RewardsModalContainer } from '../../rewards-modal/container';
 import { closeRewardsDialog } from '../../../store/rewards';
@@ -58,7 +56,6 @@ export interface Properties extends PublicProperties {
   myUserId: string;
   activeConversationId?: string;
   joinRoomErrorContent: ErrorDialogContent;
-  isBackupDialogOpen: boolean;
   isRewardsDialogOpen: boolean;
   displayLogoutModal: boolean;
   showRewardsTooltip: boolean;
@@ -71,7 +68,6 @@ export interface Properties extends PublicProperties {
   logout: () => void;
   receiveSearchResults: (data) => void;
   closeConversationErrorDialog: () => void;
-  closeBackupDialog: () => void;
   closeRewardsDialog: () => void;
   onFavoriteRoom: (payload: { roomId: string }) => void;
   onUnfavoriteRoom: (payload: { roomId: string }) => void;
@@ -89,7 +85,6 @@ export class Container extends React.Component<Properties, State> {
       registration,
       authentication: { user, displayLogoutModal },
       chat: { activeConversationId, joinRoomErrorContent },
-      matrix: { isBackupDialogOpen },
       rewards,
     } = state;
 
@@ -108,7 +103,6 @@ export class Container extends React.Component<Properties, State> {
       userIsOnline: true,
       myUserId: user?.data?.id,
       joinRoomErrorContent,
-      isBackupDialogOpen,
       isRewardsDialogOpen: rewards.showRewardsInPopup,
       showRewardsTooltip: rewards.showRewardsInTooltip,
       displayLogoutModal,
@@ -125,7 +119,6 @@ export class Container extends React.Component<Properties, State> {
       logout,
       receiveSearchResults,
       closeConversationErrorDialog,
-      closeBackupDialog,
       closeRewardsDialog,
       onFavoriteRoom,
       onUnfavoriteRoom,
@@ -188,10 +181,6 @@ export class Container extends React.Component<Properties, State> {
     this.props.closeConversationErrorDialog();
   };
 
-  closeBackupDialog = () => {
-    this.props.closeBackupDialog();
-  };
-
   get userStatus(): 'active' | 'offline' {
     return this.props.userIsOnline ? 'active' : 'offline';
   }
@@ -228,10 +217,6 @@ export class Container extends React.Component<Properties, State> {
         <InviteDialogContainer onClose={this.closeInviteDialog} />
       </Modal>
     );
-  };
-
-  renderSecureBackupDialog = (): JSX.Element => {
-    return <SecureBackupContainer onClose={this.closeBackupDialog} />;
   };
 
   renderRewardsDialog = (): JSX.Element => {
@@ -303,7 +288,6 @@ export class Container extends React.Component<Properties, State> {
           {this.renderCreateConversation()}
           {this.state.isVerifyIdDialogOpen && this.renderVerifyIdDialog()}
           {this.props.joinRoomErrorContent && this.renderErrorDialog()}
-          {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}
           {this.props.displayLogoutModal && <LogoutConfirmationModalContainer />}
           {this.props.isRewardsDialogOpen && this.renderRewardsDialog()}
         </div>


### PR DESCRIPTION
### What does this do?
- adds dialog manager container
- moves secure backup dialog from messenger/list component level to the dialog manager
- adds test coverage

### Why are we making this change?
- tidy up the managing of dialogs to ensure expected functionality and more than one dialog rendering

### How do I test this?
- run tests as usual.
- you can open the secure backup dialog via the usual flow.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
