### PR TITLE
Add a function to lower minimum `invite` & `kick` levels for existing groups during initial load

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -168,30 +168,34 @@ export class MatrixClient implements IChatClient {
    */
   async lowerMinimumInviteAndKickLevels(rooms: Room[]) {
     for (const room of rooms) {
-      const powerLevels = this.getLatestEvent(room, EventType.RoomPowerLevels);
-      if (!powerLevels || this.userId !== room.getCreator() || room.getMembers().length <= 2) {
-        continue;
-      }
+      try {
+        const powerLevels = this.getLatestEvent(room, EventType.RoomPowerLevels);
+        if (!powerLevels || this.userId !== room.getCreator() || room.getMembers().length <= 2) {
+          continue;
+        }
 
-      const powerLevelsContent = powerLevels.getContent();
-      if (powerLevelsContent.invite === PowerLevels.Moderator && powerLevelsContent.kick === PowerLevels.Moderator) {
-        continue;
-      }
+        const powerLevelsContent = powerLevels.getContent();
+        if (powerLevelsContent.invite === PowerLevels.Moderator && powerLevelsContent.kick === PowerLevels.Moderator) {
+          continue;
+        }
 
-      // just to be safe, above we check if the user is the creator of the room
-      // but also check if this users has a power level of 100,
-      // otherwise sendStateEvent will fail
-      const users = powerLevelsContent.users || {};
-      if (users[this.userId] !== PowerLevels.Owner) {
-        continue;
-      }
+        // just to be safe, above we check if the user is the creator of the room
+        // but also check if this users has a power level of 100,
+        // otherwise sendStateEvent will fail
+        const users = powerLevelsContent.users || {};
+        if (users[this.userId] !== PowerLevels.Owner) {
+          continue;
+        }
 
-      const updatedRoomPowerLevels = {
-        ...powerLevelsContent,
-        invite: PowerLevels.Moderator,
-        kick: PowerLevels.Moderator,
-      };
-      await this.matrix.sendStateEvent(room.roomId, EventType.RoomPowerLevels, updatedRoomPowerLevels);
+        const updatedRoomPowerLevels = {
+          ...powerLevelsContent,
+          invite: PowerLevels.Moderator,
+          kick: PowerLevels.Moderator,
+        };
+        await this.matrix.sendStateEvent(room.roomId, EventType.RoomPowerLevels, updatedRoomPowerLevels);
+      } catch (error) {
+        console.error(`Error lowering minimum invite and kick levels for room ${room.roomId} `, error);
+      }
     }
   }
 

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -29,6 +29,6 @@ export interface User {
 
 export enum PowerLevels {
   Viewer = 0, // Default
-  Editor = 50, // "Moderator" or ~PL50
+  Moderator = 50, // "Moderator" or ~PL50
   Owner = 100, // "Admin" or PL100
 }


### PR DESCRIPTION
### What does this do?

We need to add a new feature: `Add Moderators`. 

Currently we have minimum `invite, kick` level set to 100 for all users. This means that only the room creator/admin (which has a `power_level` of 100) can invite and kick users. 

We need to bring this down to `50` for existing groups, so that the admins of that groups can set users as moderators (with a `power_level` of `50`), and they can `invite`/`kick` users. Additionally, admins will be able to add/remove moderators.
