### PR TITLE
feat(dialog-manager): add rewards dialog

### DIFF
--- a/src/components/dialog-manager/container.test.tsx
+++ b/src/components/dialog-manager/container.test.tsx
@@ -5,14 +5,18 @@ import { RootState } from '../../store/reducer';
 import { SecureBackupContainer } from '../secure-backup/container';
 import { closeBackupDialog } from '../../store/matrix';
 import { LogoutConfirmationModalContainer } from '../logout-confirmation-modal/container';
+import { RewardsModalContainer } from '../rewards-modal/container';
+import { closeRewardsDialog } from '../../store/rewards';
 
 describe('DialogManager', () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
       displayLogoutModal: false,
       isBackupDialogOpen: false,
+      isRewardsDialogOpen: false,
 
       closeBackupDialog: () => null,
+      closeRewardsDialog: () => null,
       ...props,
     };
     return shallow(<Container {...allProps} />);
@@ -52,6 +56,18 @@ describe('DialogManager', () => {
     expect(wrapper).not.toHaveElement(LogoutConfirmationModalContainer);
   });
 
+  it('renders Rewards Modal when isRewardsDialogOpen is true', () => {
+    const wrapper = subject({ isRewardsDialogOpen: true });
+
+    expect(wrapper).toHaveElement(RewardsModalContainer);
+  });
+
+  it('does not render Rewards Modal when isRewardsDialogOpen is false', () => {
+    const wrapper = subject({ isRewardsDialogOpen: false });
+
+    expect(wrapper).not.toHaveElement(RewardsModalContainer);
+  });
+
   describe('mapState', () => {
     const stateMock: RootState = {
       authentication: {
@@ -59,6 +75,9 @@ describe('DialogManager', () => {
       },
       matrix: {
         isBackupDialogOpen: true,
+      },
+      rewards: {
+        showRewardsInPopup: false,
       },
     } as RootState;
 
@@ -73,6 +92,12 @@ describe('DialogManager', () => {
 
       expect(props.displayLogoutModal).toBe(true);
     });
+
+    it('returns isRewardsDialogOpen', () => {
+      const props = Container.mapState(stateMock);
+
+      expect(props.isRewardsDialogOpen).toBe(false);
+    });
   });
 
   describe('mapActions', () => {
@@ -81,6 +106,13 @@ describe('DialogManager', () => {
 
       expect(actions.closeBackupDialog).toBeDefined();
       expect(actions.closeBackupDialog).toEqual(closeBackupDialog);
+    });
+
+    it('returns closeRewardsDialog action', () => {
+      const actions = Container.mapActions({} as any);
+
+      expect(actions.closeRewardsDialog).toBeDefined();
+      expect(actions.closeRewardsDialog).toEqual(closeRewardsDialog);
     });
   });
 });

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -4,14 +4,18 @@ import { connectContainer } from '../../store/redux-container';
 import { SecureBackupContainer } from '../secure-backup/container';
 import { closeBackupDialog } from '../../store/matrix';
 import { LogoutConfirmationModalContainer } from '../logout-confirmation-modal/container';
+import { RewardsModalContainer } from '../rewards-modal/container';
+import { closeRewardsDialog } from '../../store/rewards';
 
 export interface PublicProperties {}
 
 export interface Properties extends PublicProperties {
   displayLogoutModal: boolean;
   isBackupDialogOpen: boolean;
+  isRewardsDialogOpen: boolean;
 
   closeBackupDialog: () => void;
+  closeRewardsDialog: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -19,20 +23,26 @@ export class Container extends React.Component<Properties> {
     const {
       authentication: { displayLogoutModal },
       matrix: { isBackupDialogOpen },
+      rewards,
     } = state;
 
     return {
       displayLogoutModal,
       isBackupDialogOpen,
+      isRewardsDialogOpen: rewards.showRewardsInPopup,
     };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { closeBackupDialog };
+    return { closeBackupDialog, closeRewardsDialog };
   }
 
   closeBackup = () => {
     this.props.closeBackupDialog();
+  };
+
+  closeRewards = () => {
+    this.props.closeRewardsDialog();
   };
 
   renderSecureBackupDialog = (): JSX.Element => {
@@ -43,11 +53,16 @@ export class Container extends React.Component<Properties> {
     return <LogoutConfirmationModalContainer />;
   };
 
+  renderRewardsDialog = (): JSX.Element => {
+    return <RewardsModalContainer onClose={this.closeRewards} />;
+  };
+
   render() {
     return (
       <>
         {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}
         {this.props.displayLogoutModal && this.renderLogoutDialog()}
+        {this.props.isRewardsDialogOpen && this.renderRewardsDialog()}
       </>
     );
   }


### PR DESCRIPTION
### What does this do?
- add rewards dialog to the manager

### Why are we making this change?
- ensures rewards dialog can render from a higher level by calling saga actions.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
