### PR TITLE
chore: bump version (`1.70.0`) -> (1.71.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ZERO",
-  "version": "1.70.0",
+  "version": "1.71.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ZERO",
-      "version": "1.70.0",
+      "version": "1.71.0",
       "dependencies": {
         "@craco/craco": "^7.1.0",
         "@ethersproject/bytes": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ZERO",
-  "version": "1.70.0",
+  "version": "1.71.0",
   "private": true,
   "main": "./public/electron.js",
   "engines": {


### PR DESCRIPTION
- chore: bump version (`1.70.0`) -> (1.71.0`)