### PR TITLE
[Fix] When sending an image message, the text and image position jump around for a split second

### DIFF
--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -271,36 +271,6 @@ describe(performSend, () => {
     expect(returnValue).toEqual({ id: 'new-id' });
   });
 
-  it('replaces the optimistic message', async () => {
-    const channelId = 'channel-id';
-    const message = 'test message';
-
-    const initialState = new StoreBuilder().withConversationList({
-      id: channelId,
-      messages: [
-        { id: 'message-1' },
-        { id: 'optimistic-id' },
-      ] as any,
-    });
-
-    const { storeState } = await expectSaga(performSend, channelId, message, [], null, 'optimistic-id')
-      .provide([
-        stubResponse(matchers.call.fn(chat.get), chatClient),
-        stubResponse(matchers.call.fn(chatClient.sendMessagesByChannelId), {
-          id: 'new-id',
-          optimisticId: 'optimistic-id',
-        }),
-      ])
-      .withReducer(rootReducer, initialState.build())
-      .run();
-
-    const channel = denormalizeChannel(channelId, storeState);
-    expect(channel.messages).toEqual([
-      { id: 'message-1' },
-      { id: 'new-id', optimisticId: 'optimistic-id', sendStatus: MessageSendStatus.SUCCESS },
-    ]);
-  });
-
   it('handles send failure', async () => {
     const channelId = 'channel-id';
     const optimisticId = 'optimistic-id';

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -270,15 +270,12 @@ export function* performSend(channelId, message, mentionedUserIds, parentMessage
   return yield sendMessage(messageCall, channelId, optimisticId);
 }
 
+// note: we're not replacing the optimistic message with the real message here anymore
+// because we're now relying on receiving the real-time message event from matrix,
+// which will replace the optimistic message
 export function* sendMessage(apiCall, channelId, optimisticId) {
   try {
-    const createdMessage = yield apiCall;
-    const existingMessageIds = yield select(rawMessagesSelector(channelId));
-    const messages = yield call(replaceOptimisticMessage, existingMessageIds, createdMessage);
-    if (messages) {
-      yield call(receiveChannel, { id: channelId, messages: messages });
-    }
-    return createdMessage;
+    return yield apiCall;
   } catch (e) {
     yield call(messageSendFailed, optimisticId);
     return null;

--- a/src/store/messages/saga.uploadFileMessage.test.ts
+++ b/src/store/messages/saga.uploadFileMessage.test.ts
@@ -24,7 +24,7 @@ describe(uploadFileMessages, () => {
 
     const channel = denormalizeChannel(channelId, storeState);
     expect(channel.messages).toHaveLength(1);
-    expect(channel.messages[0].id).toEqual('image-message-id');
+    expect(channel.messages[0].id).toEqual('optimistic-id'); // we'll get the real id later (from matrix event)
   });
 
   it('first media file sets its rootMessageId', async () => {


### PR DESCRIPTION
### What does this do?

https://github.com/zer0-os/zOS/assets/33264364/8914e9ce-5a10-4580-a1bf-f0dc471c9af3

