### PR TITLE
feat(get-access-page): redesign and auto focus to input on render

### DIFF
--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -75,18 +75,15 @@ export class Invite extends React.Component<Properties, State> {
 
     return (
       <div className={c('')}>
-        <div className={c('heading-container')}>
-          <h3 className={c('heading')}>Add invite code</h3>
-          <div className={c('sub-heading')}>6 digit code you received in your invite</div>
-        </div>
         <form className={c('form')} onSubmit={this.submitForm}>
           <div className={c('input-container')}>
             <Input
               onChange={this.onInviteCodeChanged}
-              placeholder='e.g 123456'
+              placeholder='Invite Code'
               value={this.state.inviteCode}
               type='text'
               error={isError}
+              autoFocus
             />
 
             {isError && this.renderAlert(this.props.inviteCodeStatus)}

--- a/src/authentication/validate-invite/styles.scss
+++ b/src/authentication/validate-invite/styles.scss
@@ -6,25 +6,7 @@
 
   @include base();
 
-  &__heading-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 0 24px;
-    gap: 8px;
-  }
-
-  &__heading {
-    @include heading();
-  }
-
-  &__sub-heading {
-    @include sub-heading();
-  }
-
   &__form {
-    gap: 32px !important;
-
     @include form();
   }
 


### PR DESCRIPTION
### What does this do?
- removes header and subtitle from `/get-access` page components.
- copy changes to placeholder.
- adds focus on input, on page load.

### Why are we making this change?
- as per design.

### How do I test this?
- run tests as usual.
- run UI > visit `/get-access` route.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="992" alt="Screenshot 2024-05-15 at 20 44 00" src="https://github.com/zer0-os/zOS/assets/39112648/3e5217c4-74ff-4764-9544-bbd940f0375f">
