### PR TITLE
Update `Edit Group` Flow: Show 3 dot menu instead of `x` icon to remove member

### DIFF
--- a/src/components/citizen-list-item/index.test.tsx
+++ b/src/components/citizen-list-item/index.test.tsx
@@ -42,15 +42,6 @@ describe(CitizenListItem, () => {
     expect(avatar).toHaveProp('statusType', 'offline');
   });
 
-  it('publishes remove event', function () {
-    const onRemove = jest.fn();
-    const wrapper = subject({ onRemove, user: { userId: 'user-id' } as any });
-
-    wrapper.find(IconButton).simulate('click');
-
-    expect(onRemove).toHaveBeenCalledWith('user-id');
-  });
-
   it('does not render remove icon if no handler provided', function () {
     const wrapper = subject({});
 

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -2,30 +2,36 @@ import * as React from 'react';
 
 import { User } from '../../store/channels';
 import { bemClassName } from '../../lib/bem';
-import { Avatar, IconButton } from '@zero-tech/zui/components';
-import { IconXClose } from '@zero-tech/zui/icons';
+import { Avatar } from '@zero-tech/zui/components';
 import { displayName } from '../../lib/user';
 
 import './styles.scss';
+import { MemberManagementMenuContainer } from '../messenger/group-management/member-management-menu/container';
+import classNames from 'classnames';
 
 const cn = bemClassName('citizen-list-item');
 
 export interface Properties {
   user: User;
   tag?: string;
+  canRemove?: boolean;
+  showMemberManagementMenu?: boolean;
 
-  onRemove?: (userId: string) => void;
   onSelected?: (userId: string) => void;
 }
 
-export class CitizenListItem extends React.Component<Properties> {
+interface State {
+  isMenuOpen: boolean;
+}
+
+export class CitizenListItem extends React.Component<Properties, State> {
+  state: State = {
+    isMenuOpen: false,
+  };
+
   get statusType() {
     return this.props.user.isOnline ? 'active' : 'offline';
   }
-
-  publishRemove = () => {
-    this.props.onRemove(this.props.user.userId);
-  };
 
   publishMemberClick = () => {
     if (this.props.onSelected) {
@@ -37,6 +43,10 @@ export class CitizenListItem extends React.Component<Properties> {
     if (event.key === 'Enter' && this.props.onSelected) {
       this.props.onSelected(this.props.user.userId);
     }
+  };
+
+  onIsMenuOpenChange = (isOpen: boolean) => {
+    this.setState({ isMenuOpen: isOpen });
   };
 
   render() {
@@ -56,9 +66,20 @@ export class CitizenListItem extends React.Component<Properties> {
         </div>
 
         {this.props.tag && <div {...cn('tag')}>{this.props.tag}</div>}
-        {this.props.onRemove && (
-          <div {...cn('remove')}>
-            <IconButton Icon={IconXClose} size={24} onClick={this.publishRemove} />
+        {this.props.showMemberManagementMenu && (
+          <div
+            className={classNames('citizen-list-item__remove', {
+              'citizen-list-item__remove--menu-open': this.state.isMenuOpen,
+            })}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <MemberManagementMenuContainer
+              user={this.props.user}
+              onOpenChange={this.onIsMenuOpenChange}
+              canRemove={this.props.canRemove}
+            />
           </div>
         )}
       </div>

--- a/src/components/citizen-list-item/styles.scss
+++ b/src/components/citizen-list-item/styles.scss
@@ -57,6 +57,10 @@
 
   &__remove {
     display: none;
+
+    &--menu-open {
+      display: block;
+    }
   }
 
   &:hover &__remove {

--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -8,7 +8,6 @@ import {
   MembersSelectedPayload,
   editConversationNameAndIcon,
   EditConversationPayload,
-  openRemoveMember,
   startEditConversation,
   startAddGroupMember,
   LeaveGroupDialogStatus,
@@ -110,7 +109,6 @@ export class Container extends React.Component<Properties> {
       back,
       addSelectedMembers,
       editConversationNameAndIcon,
-      openRemoveMember,
       startEditConversation,
       startAddGroupMember,
       setLeaveGroupStatus,
@@ -133,10 +131,6 @@ export class Container extends React.Component<Properties> {
 
   onAddMembers = async (selectedOptions: Option[]) => {
     this.props.addSelectedMembers({ roomId: this.props.activeConversationId, users: selectedOptions });
-  };
-
-  openRemoveMember = (userId: string) => {
-    this.props.openRemoveMember({ roomId: this.props.activeConversationId, userId });
   };
 
   onEditConversation = async (name: string, image: File | null) => {
@@ -178,7 +172,6 @@ export class Container extends React.Component<Properties> {
           isOneOnOne={this.props.isOneOnOne}
           onEditConversation={this.onEditConversation}
           editConversationState={this.props.editConversationState}
-          onRemoveMember={this.openRemoveMember}
           canAddMembers={this.props.canAddMembers}
           canEditGroup={this.props.canEditGroup}
           canLeaveGroup={this.props.canLeaveGroup}

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -19,7 +19,6 @@ describe(EditConversationPanel, () => {
       errors: {},
       name: '',
       icon: '',
-      onRemoveMember: () => null,
       conversationAdminIds: [],
       onMemberSelected: () => null,
       openUserProfile: () => null,
@@ -130,20 +129,38 @@ describe(EditConversationPanel, () => {
       ]);
     });
 
-    it('pubishes remove event', function () {
-      const onRemoveMember = jest.fn();
+    it('passes canRemoveMembers as false to CitizenListItem if only 2 members in group', function () {
       const wrapper = subject({
-        onRemoveMember,
+        currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
         otherMembers: [
           { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
-          { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
         ] as User[],
       });
 
-      const item = wrapper.find(CitizenListItem).findWhere((c) => c.prop('user').userId === 'otherMember1');
-      item.simulate('remove', 'otherMember1');
+      expect(wrapper.find(CitizenListItem).at(1).prop('canRemove')).toEqual(false);
+    });
 
-      expect(onRemoveMember).toHaveBeenCalledWith('otherMember1');
+    it('passes canRemoveMembers as true to CitizenListItem if more than 2 members in group', function () {
+      const wrapper = subject({
+        currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
+        otherMembers: [
+          { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+          { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+          { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Eve' },
+        ] as User[],
+      });
+
+      expect(wrapper.find(CitizenListItem).at(1).prop('canRemove')).toEqual(true);
+    });
+
+    it('passes showMemberManagementMenu as true to CitizenListItem', function () {
+      const wrapper = subject({
+        otherMembers: [
+          { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+        ] as User[],
+      });
+
+      expect(wrapper.find(CitizenListItem).at(1).prop('showMemberManagementMenu')).toEqual(true);
     });
 
     it('publishes onMemberSelected event', () => {

--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -26,7 +26,6 @@ export interface Properties {
   conversationAdminIds: string[];
 
   onBack: () => void;
-  onRemoveMember: (userId: string) => void;
   onEdit: (name: string, image: File | null) => void;
   onMemberSelected: (userId: string) => void;
   openUserProfile: () => void;
@@ -67,15 +66,9 @@ export class EditConversationPanel extends React.Component<Properties, State> {
     return this.props.state === EditConversationState.SUCCESS;
   }
 
-  get removeMember() {
-    if (this.props.otherMembers.length < 2) return null;
-
-    return this.publishRemove;
+  get canRemoveMembers() {
+    return this.props.otherMembers.length > 1;
   }
-
-  publishRemove = (userId: string) => {
-    this.props.onRemoveMember(userId);
-  };
 
   memberSelected = (userId: string) => {
     this.props.onMemberSelected(userId);
@@ -147,8 +140,9 @@ export class EditConversationPanel extends React.Component<Properties, State> {
               <CitizenListItem
                 key={u.userId}
                 user={u}
-                onRemove={this.removeMember}
+                canRemove={this.canRemoveMembers}
                 onSelected={this.memberSelected}
+                showMemberManagementMenu
               ></CitizenListItem>
             ))}
           </ScrollbarContainer>

--- a/src/components/messenger/group-management/index.test.tsx
+++ b/src/components/messenger/group-management/index.test.tsx
@@ -27,7 +27,6 @@ describe(GroupManagement, () => {
       onBack: () => null,
       searchUsers: () => null,
       onAddMembers: () => null,
-      onRemoveMember: () => null,
       onEditConversation: () => null,
       startEditConversation: () => null,
       startAddGroupMember: () => null,

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -29,7 +29,6 @@ export interface Properties {
   onAddMembers: (options: Option[]) => void;
   onEditConversation: (name: string, image: File | null) => void;
   searchUsers: (search: string) => Promise<any>;
-  onRemoveMember: (userId: string) => void;
   startEditConversation: () => void;
   startAddGroupMember: () => void;
   setLeaveGroupStatus: (status: LeaveGroupDialogStatus) => void;
@@ -59,7 +58,6 @@ export class GroupManagement extends React.PureComponent<Properties> {
             conversationAdminIds={this.props.conversationAdminIds}
             errors={this.props.errors.editConversationErrors}
             onBack={this.props.onBack}
-            onRemoveMember={this.props.onRemoveMember}
             onEdit={this.props.onEditConversation}
             state={this.props.editConversationState}
             onMemberSelected={this.props.onMemberClick}

--- a/src/components/messenger/group-management/member-management-menu/container.test.tsx
+++ b/src/components/messenger/group-management/member-management-menu/container.test.tsx
@@ -1,0 +1,12 @@
+import { Container } from './container';
+import { StoreBuilder } from '../../../../store/test/store';
+
+describe(Container, () => {
+  describe('mapState', () => {
+    test('gets activeConversationId', () => {
+      const state = new StoreBuilder().withActiveConversationId('id');
+
+      expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ activeConversationId: 'id' }));
+    });
+  });
+});

--- a/src/components/messenger/group-management/member-management-menu/container.tsx
+++ b/src/components/messenger/group-management/member-management-menu/container.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { RootState } from '../../../../store/reducer';
+import { connectContainer } from '../../../../store/redux-container';
+import { openRemoveMember } from '../../../../store/group-management';
+
+import { MemberManagementMenu } from '.';
+
+export interface PublicProperties {
+  user?: any;
+  canRemove?: boolean;
+
+  onOpenChange: (isOpen: boolean) => void;
+}
+
+export interface Properties extends PublicProperties {
+  activeConversationId: string;
+
+  openRemoveMember: (params: { roomId: string; userId: string }) => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState) {
+    const {
+      chat: { activeConversationId },
+    } = state;
+
+    return {
+      activeConversationId,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { openRemoveMember };
+  }
+
+  openRemoveMember = () => {
+    const { activeConversationId, user } = this.props;
+    this.props.openRemoveMember({ roomId: activeConversationId, userId: user.userId });
+  };
+
+  render() {
+    return (
+      <MemberManagementMenu
+        onRemoveMember={this.openRemoveMember}
+        onOpenChange={this.props.onOpenChange}
+        canRemove={this.props.canRemove}
+      />
+    );
+  }
+}
+
+export const MemberManagementMenuContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/group-management/member-management-menu/index.test.tsx
+++ b/src/components/messenger/group-management/member-management-menu/index.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Properties, MemberManagementMenu } from '.';
+import { DropdownMenu } from '@zero-tech/zui/components';
+
+describe(MemberManagementMenu, () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      canRemove: true,
+      onOpenChange: () => {},
+      onRemoveMember: () => {},
+      ...props,
+    };
+
+    return shallow(<MemberManagementMenu {...allProps} />);
+  };
+
+  it('does not render the menu if user cannot do anything', function () {
+    const wrapper = subject({
+      canRemove: false,
+    });
+
+    expect(wrapper).not.toHaveElement(DropdownMenu);
+  });
+
+  describe('Remove', () => {
+    it('publishes onRemoveMember event when Remove member is clicked', () => {
+      const onRemoveMember = jest.fn();
+      const wrapper = subject({ onRemoveMember, canRemove: true });
+
+      selectItem(wrapper, 'remove-member');
+
+      expect(onRemoveMember).toHaveBeenCalled();
+    });
+  });
+});
+
+function selectItem(wrapper, id) {
+  menuItem(wrapper, id).onSelect();
+}
+
+function menuItem(menu, id) {
+  const dropdownMenu = menu.find(DropdownMenu);
+  return dropdownMenu.prop('items').find((i) => i.id === id);
+}

--- a/src/components/messenger/group-management/member-management-menu/index.tsx
+++ b/src/components/messenger/group-management/member-management-menu/index.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { IconDotsHorizontal, IconUserX1 } from '@zero-tech/zui/icons';
+import { DropdownMenu } from '@zero-tech/zui/components';
+
+import './styles.scss';
+
+export interface Properties {
+  canRemove?: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+
+  onRemoveMember: () => void;
+}
+
+export class MemberManagementMenu extends React.Component<Properties> {
+  handleOpenChange = (open) => {
+    this.props.onOpenChange(open);
+  };
+
+  onRemoveMember = () => {
+    this.props.onRemoveMember();
+  };
+
+  renderMenuItem(icon, label) {
+    return (
+      <div className={'menu-item'}>
+        {icon} {label}
+      </div>
+    );
+  }
+
+  get dropdownMenuItems() {
+    const menuItems = [];
+
+    if (this.props.canRemove) {
+      menuItems.push({
+        id: 'remove-member',
+        className: 'remove-member',
+        label: this.renderMenuItem(<IconUserX1 size={20} />, 'Remove'),
+        onSelect: this.onRemoveMember,
+      });
+    }
+
+    return menuItems;
+  }
+
+  render() {
+    const items = this.dropdownMenuItems;
+    if (items.length === 0) {
+      return null;
+    }
+
+    return (
+      <DropdownMenu
+        menuClassName={'member-management-menu'}
+        items={items}
+        side='bottom'
+        alignMenu='end'
+        onOpenChange={this.handleOpenChange}
+        className={'member-management-trigger'}
+        trigger={<IconDotsHorizontal size={24} isFilled />}
+      />
+    );
+  }
+}

--- a/src/components/messenger/group-management/member-management-menu/styles.scss
+++ b/src/components/messenger/group-management/member-management-menu/styles.scss
@@ -1,0 +1,25 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.member-management-menu {
+  .remove-member {
+    color: theme.$color-failure-11;
+  }
+
+  .menu-item {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.member-management-trigger {
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background-color: theme.$color-greyscale-transparency-3;
+  }
+}


### PR DESCRIPTION
### What does this do?

Updates the members list in the **edit group panel** to use `3 dot` menu instead of the `x` icon. This is to allow more options to manage the members of the group. The admin can now either
a) Remove a member from the group
b) Set/Remove a member as a "moderator" from the group

Part b) is currently in implementation.

Before:

https://github.com/zer0-os/zOS/assets/33264364/abf855ce-2578-4919-ab17-ca3473beb6a7

After:

https://github.com/zer0-os/zOS/assets/33264364/36578d9c-5b24-44dc-b87a-a650b2bd6751



