### PR TITLE
feat(create-account): redesign create account options

### DIFF
--- a/src/authentication/create-account-method/styles.scss
+++ b/src/authentication/create-account-method/styles.scss
@@ -1,6 +1,9 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .create-account-method {
+  width: 256px;
+  margin-top: 52px;
+
   &--is-connecting {
     margin: auto;
   }
@@ -16,17 +19,20 @@
 
   &__toggle-group {
     height: 40px;
-    background: theme.$color-primary-transparency-1;
-    width: 280px;
+    background: unset;
+    width: 256px;
     margin-bottom: 32px;
+    border: 1px solid rgba(163, 162, 163, 0.1);
+    border-radius: 9999px;
 
     > * {
       border-left: none !important;
+      border-radius: 9999px !important;
     }
 
     [data-state='on'] {
-      font-weight: 700;
-      background: theme.$color-primary-transparency-2 !important;
+      font-weight: 600;
+      background: rgba(163, 162, 163, 0.1) !important;
     }
   }
 }

--- a/src/authentication/create-email-account/index.tsx
+++ b/src/authentication/create-email-account/index.tsx
@@ -115,6 +115,7 @@ export class CreateEmailAccount extends React.Component<Properties, State> {
               onChange={this.trackEmail}
               error={!!this.emailError}
               alert={this.emailError}
+              autoFocus
             />
             <PasswordInput
               {...cn('input')}

--- a/src/authentication/create-email-account/styles.scss
+++ b/src/authentication/create-email-account/styles.scss
@@ -7,7 +7,11 @@
   @include base();
 
   &__form {
-    @include form();
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    margin: 0 auto;
   }
 
   &__input-container {
@@ -22,7 +26,7 @@
   }
 
   &__input-alert {
-    font-size: 14px;
+    font-size: 12px;
     margin-top: 4px;
     padding: 4px 8px;
     line-height: 17px;
@@ -41,7 +45,7 @@
 
   &__error {
     padding: 4px 8px;
-    font-size: 14px;
+    font-size: 12px;
     line-height: 17px;
   }
 }

--- a/src/authentication/create-wallet-account/index.tsx
+++ b/src/authentication/create-wallet-account/index.tsx
@@ -23,15 +23,11 @@ export class CreateWalletAccount extends React.Component<Properties> {
     return (
       <div {...cn('')}>
         <div {...cn('main')}>
-          <div {...cn('select-wallet')}>
-            <WalletSelect isConnecting={this.props.isConnecting} onSelect={this.props.onSelect} />
-          </div>
+          <WalletSelect isConnecting={this.props.isConnecting} onSelect={this.props.onSelect} />
           {this.showError && (
-            <div {...cn('error-container')}>
-              <Alert {...cn('error')} variant='error' isFilled>
-                {this.props.error}
-              </Alert>
-            </div>
+            <Alert {...cn('error')} variant='error' isFilled>
+              {this.props.error}
+            </Alert>
           )}
         </div>
       </div>

--- a/src/authentication/create-wallet-account/styles.scss
+++ b/src/authentication/create-wallet-account/styles.scss
@@ -1,23 +1,21 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../styles';
+@import '../../glass';
 
 .create-wallet-account {
+  display: flex;
   margin: 0 0 auto;
 
+  background: rgba(11, 7, 7, 0.75);
+  border-radius: 8px;
+
+  @include glass-shadow-and-blur;
   @include base();
 
   &__main {
     box-sizing: border-box;
-    width: 280px;
-    margin-bottom: 8px;
-  }
-
-  &__select-wallet {
-    margin-bottom: 8px;
-  }
-
-  &__error-container {
-    padding-top: 4px;
+    width: 100%;
+    padding: 8px;
   }
 
   &__error {

--- a/src/authentication/email-login/styles.scss
+++ b/src/authentication/email-login/styles.scss
@@ -25,9 +25,10 @@
   }
 
   &__input-alert {
-    font-size: 14px;
+    font-size: 12px;
     margin-top: 4px;
     padding: 4px 8px;
+    line-height: 17px;
   }
 
   &__submit-button {
@@ -42,7 +43,7 @@
 
   &__error {
     padding: 4px 8px;
-    font-size: 14px;
-    line-height: 24px;
+    font-size: 12px;
+    line-height: 17px;
   }
 }


### PR DESCRIPTION
### What does this do?
- redesigns the create account options - web3 and email

### Why are we making this change?
- as per design

### How do I test this?
- run tests as usual
- run ui and visit the create account page. you will need an invite code to pass through acces.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/3529e0ae-e9d7-47c5-a3f3-2c448e8ca452


