### PR TITLE
fix(message-menu): rendering of delete message modal when right clicking and selecting delete option

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -12,9 +12,10 @@ import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
-import { IconAlertCircle } from '@zero-tech/zui/icons';
-import { Avatar } from '@zero-tech/zui/components';
+import { IconAlertCircle, IconXClose } from '@zero-tech/zui/icons';
+import { Avatar, IconButton, Modal } from '@zero-tech/zui/components';
 import { ContentHighlighter } from '../content-highlighter';
+import { Button, Variant as ButtonVariant, Color as ButtonColor } from '@zero-tech/zui/components/Button';
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
@@ -56,6 +57,7 @@ export interface State {
   isDropdownMenuOpen: boolean;
   menuX: number;
   menuY: number;
+  deleteDialogIsOpen: boolean;
 }
 
 export class Message extends React.Component<Properties, State> {
@@ -66,6 +68,7 @@ export class Message extends React.Component<Properties, State> {
     isDropdownMenuOpen: false,
     menuX: 0,
     menuY: 0,
+    deleteDialogIsOpen: false,
   } as State;
 
   wrapperRef = React.createRef<HTMLDivElement>();
@@ -269,7 +272,7 @@ export class Message extends React.Component<Properties, State> {
       canEdit: this.canEditMessage(),
       canDelete: this.canDeleteMessage(),
       canReply: this.canReply(),
-      onDelete: this.deleteMessage,
+      onDelete: this.toggleDeleteDialog,
       onEdit: this.toggleEdit,
       onReply: this.onReply,
       isMediaMessage: this.isMediaMessage(),
@@ -301,7 +304,7 @@ export class Message extends React.Component<Properties, State> {
       canEdit: this.canEditMessage(),
       canDelete: this.canDeleteMessage(),
       canReply: this.canReply(),
-      onDelete: this.deleteMessage,
+      onDelete: this.toggleDeleteDialog,
       onEdit: this.toggleEdit,
       onReply: this.onReply,
       isMediaMessage: this.isMediaMessage(),
@@ -373,6 +376,46 @@ export class Message extends React.Component<Properties, State> {
     );
   }
 
+  handleDeleteMessage = () => {
+    this.setState({
+      deleteDialogIsOpen: false,
+    });
+    this.props.onDelete(this.props.messageId);
+  };
+
+  toggleDeleteDialog = () => {
+    this.setState({
+      deleteDialogIsOpen: !this.state.deleteDialogIsOpen,
+    });
+  };
+
+  get showDeleteModal(): boolean {
+    return this.state.deleteDialogIsOpen;
+  }
+
+  renderDeleteModal() {
+    return (
+      <Modal className='delete-message-modal' open={this.showDeleteModal} onOpenChange={this.toggleDeleteDialog}>
+        <div className='delete-message-modal__header'>
+          <h2>Delete message</h2>
+          <IconButton Icon={IconXClose} size='large' onClick={this.toggleDeleteDialog} />
+        </div>
+        <div className='delete-message-text-content'>
+          Are you sure you want to delete this message? This cannot be undone.
+        </div>
+        <div className='delete-message-modal__footer'>
+          <Button variant={ButtonVariant.Secondary} color={ButtonColor.Greyscale} onPress={this.toggleDeleteDialog}>
+            Cancel
+          </Button>
+
+          <Button color={ButtonColor.Red} onPress={this.handleDeleteMessage}>
+            Delete message
+          </Button>
+        </div>
+      </Modal>
+    );
+  }
+
   render() {
     const { message, media, preview, sender, isOwner } = this.props;
     return (
@@ -421,6 +464,7 @@ export class Message extends React.Component<Properties, State> {
         </div>
         {this.renderMenu()}
         {this.renderFloatMenu()}
+        {this.renderDeleteModal()}
       </div>
     );
   }

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -43,7 +43,7 @@ describe('Message Menu', () => {
       expect(deleteItem).toBeDefined();
     });
 
-    it('should open delete modal when delete button is clicked', () => {
+    it('should publish onDelete when delete button is clicked', () => {
       const onDelete = jest.fn();
       const wrapper = subject({ canDelete: true, onDelete });
 
@@ -53,8 +53,7 @@ describe('Message Menu', () => {
 
       deleteItem.onSelect();
 
-      const state = wrapper.state() as { deleteDialogIsOpen: boolean };
-      expect(state.deleteDialogIsOpen).toBe(true);
+      expect(onDelete).toHaveBeenCalled();
     });
   });
 

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -1,9 +1,8 @@
 import React, { createRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import { DropdownMenu, Modal, IconButton } from '@zero-tech/zui/components';
-import { Button, Variant as ButtonVariant, Color as ButtonColor } from '@zero-tech/zui/components/Button';
-import { IconDotsHorizontal, IconEdit5, IconFlipBackward, IconTrash4, IconXClose } from '@zero-tech/zui/icons';
+import { DropdownMenu } from '@zero-tech/zui/components';
+import { IconDotsHorizontal, IconEdit5, IconFlipBackward, IconTrash4 } from '@zero-tech/zui/icons';
 
 import classNames from 'classnames';
 import './styles.scss';
@@ -24,14 +23,8 @@ export interface Properties {
   onReply?: () => void;
 }
 
-export interface State {
-  deleteDialogIsOpen: boolean;
-}
-
-export class MessageMenu extends React.Component<Properties, State> {
+export class MessageMenu extends React.Component<Properties> {
   ref = createRef();
-
-  state = { deleteDialogIsOpen: false };
 
   renderMenuOption(icon, label) {
     return (
@@ -68,52 +61,12 @@ export class MessageMenu extends React.Component<Properties, State> {
       menuItems.push({
         id: 'delete',
         label: this.renderMenuOption(<IconTrash4 size={20} />, 'Delete'),
-        onSelect: this.toggleDeleteDialog,
+        onSelect: this.props.onDelete,
       });
     }
 
     return menuItems;
   };
-
-  handleDeleteMessage = () => {
-    this.setState({
-      deleteDialogIsOpen: false,
-    });
-    this.props.onDelete();
-  };
-
-  toggleDeleteDialog = () => {
-    this.setState({
-      deleteDialogIsOpen: !this.state.deleteDialogIsOpen,
-    });
-  };
-
-  get showDeleteModal(): boolean {
-    return this.state.deleteDialogIsOpen;
-  }
-
-  renderDeleteModal() {
-    return (
-      <Modal className='delete-message-modal' open={this.showDeleteModal} onOpenChange={this.toggleDeleteDialog}>
-        <div className='delete-message-modal__header'>
-          <h2>Delete message</h2>
-          <IconButton Icon={IconXClose} size='large' onClick={this.toggleDeleteDialog} />
-        </div>
-        <div className='delete-message-text-content'>
-          Are you sure you want to delete this message? This cannot be undone.
-        </div>
-        <div className='delete-message-modal__footer'>
-          <Button variant={ButtonVariant.Secondary} color={ButtonColor.Greyscale} onPress={this.toggleDeleteDialog}>
-            Cancel
-          </Button>
-
-          <Button color={ButtonColor.Red} onPress={this.handleDeleteMessage}>
-            Delete message
-          </Button>
-        </div>
-      </Modal>
-    );
-  }
 
   render() {
     const menuItems = this.renderItems();
@@ -149,7 +102,6 @@ export class MessageMenu extends React.Component<Properties, State> {
             )
           }
         />
-        {this.renderDeleteModal()}
       </div>
     );
   }


### PR DESCRIPTION
Note:: This PR simply fixes the bug. I will be refactoring this so the dialog is handled in the dialog manager, in a follow up PR.

### What does this do?
- fixes the rendering of the delete message confirmation modal when right clicking a message bubble and selecting the delete option.

### Why are we making this change?
- fix bug.

### How do I test this?
- run tests as usual.
- run UI, send a message, and then right click message bubble, select delete, check modal is rendered. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
  
  

https://github.com/zer0-os/zOS/assets/39112648/29053a73-3cb4-44a7-9883-860d736f92ff




