### PR TITLE
Implement core logic for `setting a new moderator` (by admin) [Feature flagged]

### DIFF
--- a/src/components/group-management/member-management-dialog/container.test.tsx
+++ b/src/components/group-management/member-management-dialog/container.test.tsx
@@ -7,7 +7,7 @@ describe(Container, () => {
     test('gets the member management type', () => {
       const state = new StoreBuilder()
         .withUsers({ userId: 'user-id', firstName: 'Jack', lastName: 'Black' })
-        .managingGroup({ memberMangement: { type: MemberManagementAction.RemoveMember } as any });
+        .managingGroup({ memberManagement: { type: MemberManagementAction.RemoveMember } as any });
 
       expect(Container.mapState(state.build())).toEqual(
         expect.objectContaining({ type: MemberManagementAction.RemoveMember })
@@ -17,7 +17,7 @@ describe(Container, () => {
     test('gets the user name', () => {
       const state = new StoreBuilder()
         .withUsers({ userId: 'user-id', firstName: 'Jack', lastName: 'Black' })
-        .managingGroup({ memberMangement: { userId: 'user-id' } as any });
+        .managingGroup({ memberManagement: { userId: 'user-id' } as any });
 
       expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ userName: 'Jack Black' }));
     });
@@ -25,14 +25,14 @@ describe(Container, () => {
     test('gets the room name', () => {
       const state = new StoreBuilder()
         .withConversationList({ id: 'room-id', name: 'Fun Room' })
-        .managingGroup({ memberMangement: { roomId: 'room-id' } as any });
+        .managingGroup({ memberManagement: { roomId: 'room-id' } as any });
 
       expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ roomName: 'Fun Room' }));
     });
 
     test('gets the remove member stage', () => {
       const state = new StoreBuilder().managingGroup({
-        memberMangement: { stage: MemberManagementDialogStage.IN_PROGRESS } as any,
+        memberManagement: { stage: MemberManagementDialogStage.IN_PROGRESS } as any,
       });
 
       expect(Container.mapState(state.build())).toEqual(
@@ -41,7 +41,7 @@ describe(Container, () => {
     });
 
     test('gets the remove member error message', () => {
-      const state = new StoreBuilder().managingGroup({ memberMangement: { error: 'an error' } as any });
+      const state = new StoreBuilder().managingGroup({ memberManagement: { error: 'an error' } as any });
 
       expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ error: 'an error' }));
     });

--- a/src/components/group-management/member-management-dialog/container.tsx
+++ b/src/components/group-management/member-management-dialog/container.tsx
@@ -11,6 +11,7 @@ import {
   removeMember,
   MemberManagementDialogStage,
   MemberManagementAction,
+  setMemberAsModerator,
 } from '../../../store/group-management';
 
 export interface PublicProperties {}
@@ -26,22 +27,23 @@ export interface Properties extends PublicProperties {
 
   cancel: () => void;
   remove: (userId: string, roomId: string) => void;
+  setAsMod: (userId: string, roomId: string) => void;
 }
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const {
-      groupManagement: { memberMangement },
+      groupManagement: { memberManagement },
     } = state;
-    const user = denormalizeUser(memberMangement.userId, state);
-    const channel = denormalizeChannel(memberMangement.roomId, state);
+    const user = denormalizeUser(memberManagement.userId, state);
+    const channel = denormalizeChannel(memberManagement.roomId, state);
 
     return {
-      type: memberMangement.type,
-      userId: memberMangement.userId,
-      roomId: memberMangement.roomId,
-      stage: memberMangement.stage,
-      error: memberMangement.error,
+      type: memberManagement.type,
+      userId: memberManagement.userId,
+      roomId: memberManagement.roomId,
+      stage: memberManagement.stage,
+      error: memberManagement.error,
       userName: displayName(user),
       roomName: channel?.name,
     };
@@ -51,12 +53,17 @@ export class Container extends React.Component<Properties> {
     return {
       cancel: cancelMemberManagement,
       remove: (userId, roomId) => removeMember({ userId, roomId }),
+      setAsMod: (userId, roomId) => setMemberAsModerator({ userId, roomId }),
     };
   }
 
   onConfirm = (): void => {
     if (this.props.type === MemberManagementAction.RemoveMember) {
       this.props.remove(this.props.userId, this.props.roomId);
+    }
+
+    if (this.props.type === MemberManagementAction.MakeModerator) {
+      this.props.setAsMod(this.props.userId, this.props.roomId);
     }
   };
 

--- a/src/components/group-management/member-management-dialog/index.test.tsx
+++ b/src/components/group-management/member-management-dialog/index.test.tsx
@@ -25,20 +25,100 @@ describe(MemberManagementDialog, () => {
     return shallow(<MemberManagementDialog {...allProps} />);
   };
 
-  it('renders the message with NO room name', function () {
-    const wrapper = subject({ userName: 'Johnny Cash', roomName: '' });
+  describe('remove member', () => {
+    it('renders the message with NO room name', function () {
+      const wrapper = subject({ userName: 'Johnny Cash', roomName: '', type: MemberManagementAction.RemoveMember });
 
-    expect(wrapper.find(c('')).text()).toEqual(
-      'Are you sure you want to remove Johnny Cash from the group?Johnny Cash will lose access to the conversation and its history.'
-    );
+      expect(wrapper.find(c('')).text()).toEqual(
+        'Are you sure you want to remove Johnny Cash from the group?Johnny Cash will lose access to the conversation and its history.'
+      );
+    });
+
+    it('renders the message with a room name', function () {
+      const wrapper = subject({
+        userName: 'Johnny Cash',
+        roomName: 'Fun Room',
+        type: MemberManagementAction.RemoveMember,
+      });
+
+      expect(wrapper.find(c('')).text()).toEqual(
+        'Are you sure you want to remove Johnny Cash from Fun Room?Johnny Cash will lose access to the conversation and its history.'
+      );
+    });
+
+    it('renders loading text when isInProgress with NO room name', () => {
+      const wrapper = subject({
+        inProgress: true,
+        userName: 'Johnny Cash',
+        roomName: '',
+        type: MemberManagementAction.RemoveMember,
+      });
+
+      expect(wrapper.find(c('')).text()).toEqual('Removing Johnny Cash from the group.');
+    });
+
+    it('renders loading text when isInProgress with room name', () => {
+      const wrapper = subject({
+        inProgress: true,
+        userName: 'Johnny Cash',
+        roomName: 'Fun Room',
+        type: MemberManagementAction.RemoveMember,
+      });
+
+      expect(wrapper.find(c('')).text()).toEqual('Removing Johnny Cash from Fun Room.');
+    });
+
+    it('renders confirmation message when NOT isInProgress', () => {
+      const wrapper = subject({ inProgress: false, type: MemberManagementAction.RemoveMember });
+
+      expect(wrapper.find(ModalConfirmation).prop('confirmationLabel')).toEqual('Remove Member');
+    });
   });
 
-  it('renders the message with a room name', function () {
-    const wrapper = subject({ userName: 'Johnny Cash', roomName: 'Fun Room' });
+  describe('make moderator', () => {
+    it('renders the message with NO room name', function () {
+      const wrapper = subject({ userName: 'Johnny Cash', roomName: '', type: MemberManagementAction.MakeModerator });
 
-    expect(wrapper.find(c('')).text()).toEqual(
-      'Are you sure you want to remove Johnny Cash from Fun Room?Johnny Cash will lose access to the conversation and its history.'
-    );
+      expect(wrapper.find(c('')).text()).toEqual('Are you sure you want to make Johnny Cash moderator of the group?');
+    });
+
+    it('renders the message with a room name', function () {
+      const wrapper = subject({
+        userName: 'Johnny Cash',
+        roomName: 'Fun Room',
+        type: MemberManagementAction.MakeModerator,
+      });
+
+      expect(wrapper.find(c('')).text()).toEqual('Are you sure you want to make Johnny Cash moderator of Fun Room?');
+    });
+
+    it('renders loading text when isInProgress with NO room name', () => {
+      const wrapper = subject({
+        inProgress: true,
+        userName: 'Johnny Cash',
+        roomName: '',
+        type: MemberManagementAction.MakeModerator,
+      });
+
+      expect(wrapper.find(c('')).text()).toEqual('Making Johnny Cash moderator of the group.');
+    });
+
+    it('renders loading text when isInProgress with room name', () => {
+      const wrapper = subject({
+        inProgress: true,
+        userName: 'Johnny Cash',
+        roomName: 'Fun Room',
+        type: MemberManagementAction.MakeModerator,
+      });
+
+      expect(wrapper.find(c('')).text()).toEqual('Making Johnny Cash moderator of Fun Room.');
+    });
+
+    it('renders confirmation message when NOT isInProgress', () => {
+      const wrapper = subject({ inProgress: false, type: MemberManagementAction.MakeModerator });
+
+      expect(wrapper.find(ModalConfirmation).prop('confirmationLabel')).toEqual('Make Mod');
+    });
   });
 
   it('publishes close event when cancelled', function () {
@@ -51,30 +131,12 @@ describe(MemberManagementDialog, () => {
   });
 
   it('publishes onRemove event when confirmed', () => {
-    const onRemove = jest.fn();
-    const wrapper = subject({ onConfirm: onRemove });
+    const onConfirm = jest.fn();
+    const wrapper = subject({ onConfirm });
 
     wrapper.find(ModalConfirmation).simulate('confirm');
 
-    expect(onRemove).toHaveBeenCalled();
-  });
-
-  it('renders loading text when isInProgress with NO room name', () => {
-    const wrapper = subject({ inProgress: true, userName: 'Johnny Cash', roomName: '' });
-
-    expect(wrapper.find(c('')).text()).toEqual('Removing Johnny Cash from the group.');
-  });
-
-  it('renders loading text when isInProgress with room name', () => {
-    const wrapper = subject({ inProgress: true, userName: 'Johnny Cash', roomName: 'Fun Room' });
-
-    expect(wrapper.find(c('')).text()).toEqual('Removing Johnny Cash from Fun Room.');
-  });
-
-  it('renders confirmation message when NOT isInProgress', () => {
-    const wrapper = subject({ inProgress: false });
-
-    expect(wrapper.find(ModalConfirmation).prop('confirmationLabel')).toEqual('Remove Member');
+    expect(onConfirm).toHaveBeenCalled();
   });
 
   it('renders sets inProgress on Modal', () => {

--- a/src/components/group-management/member-management-dialog/index.tsx
+++ b/src/components/group-management/member-management-dialog/index.tsx
@@ -29,7 +29,7 @@ export class MemberManagementDialog extends React.Component<Properties> {
     if (this.props.type === MemberManagementAction.RemoveMember) {
       return `Removing ${this.props.userName} from ${this.roomLabel}.`;
     } else if (this.props.type === MemberManagementAction.MakeModerator) {
-      return `Making ${this.props.userName} a moderator of ${this.roomLabel}.`;
+      return `Making ${this.props.userName} moderator of ${this.roomLabel}.`;
     }
 
     return 'in progress';
@@ -48,7 +48,7 @@ export class MemberManagementDialog extends React.Component<Properties> {
     if (this.props.type === MemberManagementAction.MakeModerator) {
       return (
         <>
-          Are you sure you want to make <i>{this.props.userName}</i> a moderator of <i>{this.roomLabel}</i>?
+          Are you sure you want to make <i>{this.props.userName}</i> moderator of <i>{this.roomLabel}</i>?
         </>
       );
     }

--- a/src/components/group-management/member-management-dialog/index.tsx
+++ b/src/components/group-management/member-management-dialog/index.tsx
@@ -48,7 +48,7 @@ export class MemberManagementDialog extends React.Component<Properties> {
     if (this.props.type === MemberManagementAction.MakeModerator) {
       return (
         <>
-          Are you sure you want to make <i>{this.props.userName}</i> moderator of <i>{this.roomLabel}</i>?
+          Are you sure you want to make <b>{this.props.userName}</b> moderator of <i>{this.roomLabel}</i>?
         </>
       );
     }

--- a/src/components/group-management/member-management-dialog/index.tsx
+++ b/src/components/group-management/member-management-dialog/index.tsx
@@ -26,25 +26,55 @@ export class MemberManagementDialog extends React.Component<Properties> {
   }
 
   get progressMessage() {
-    return `Removing ${this.props.userName} from ${this.roomLabel}.`;
+    if (this.props.type === MemberManagementAction.RemoveMember) {
+      return `Removing ${this.props.userName} from ${this.roomLabel}.`;
+    } else if (this.props.type === MemberManagementAction.MakeModerator) {
+      return `Making ${this.props.userName} a moderator of ${this.roomLabel}.`;
+    }
+
+    return 'in progress';
   }
 
   get message() {
-    return (
-      <>
-        Are you sure you want to remove {this.props.userName} from {this.roomLabel}?<br />
-        {this.props.userName} will lose access to the conversation and its history.
-      </>
-    );
+    if (this.props.type === MemberManagementAction.RemoveMember) {
+      return (
+        <>
+          Are you sure you want to remove {this.props.userName} from {this.roomLabel}?<br />
+          {this.props.userName} will lose access to the conversation and its history.
+        </>
+      );
+    }
+
+    if (this.props.type === MemberManagementAction.MakeModerator) {
+      return (
+        <>
+          Are you sure you want to make <i>{this.props.userName}</i> a moderator of <i>{this.roomLabel}</i>?
+        </>
+      );
+    }
+
+    return 'Are you sure you want to perform this action?';
+  }
+
+  get title() {
+    if (this.props.type === MemberManagementAction.RemoveMember) {
+      return 'Remove Member';
+    }
+
+    if (this.props.type === MemberManagementAction.MakeModerator) {
+      return 'Make Mod';
+    }
+
+    return 'Member Management';
   }
 
   render() {
     return (
       <ModalConfirmation
         open
-        title='Remove Member'
+        title={this.title}
         cancelLabel='Cancel'
-        confirmationLabel='Remove Member'
+        confirmationLabel={this.title}
         onCancel={this.props.onClose}
         onConfirm={this.props.onConfirm}
         inProgress={this.props.inProgress}

--- a/src/components/messenger/group-management/container.test.tsx
+++ b/src/components/messenger/group-management/container.test.tsx
@@ -53,5 +53,15 @@ describe(Container, () => {
         expect.objectContaining({ editConversationState: EditConversationState.NONE })
       );
     });
+
+    test('gets conversationModeratorIds', () => {
+      const state = new StoreBuilder()
+        .managingGroup({})
+        .withActiveConversation({ id: 'user-id', moderatorIds: ['user-id'] });
+
+      expect(Container.mapState(state.build())).toEqual(
+        expect.objectContaining({ conversationModeratorIds: ['user-id'] })
+      );
+    });
   });
 });

--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -47,6 +47,7 @@ export interface Properties extends PublicProperties {
   canEditGroup: boolean;
   canLeaveGroup: boolean;
   conversationAdminIds: string[];
+  conversationModeratorIds: string[];
   isOneOnOne: boolean;
   existingConversations: Channel[];
 
@@ -73,6 +74,7 @@ export class Container extends React.Component<Properties> {
     const conversation = denormalizeChannel(activeConversationId, state);
     const currentUser = currentUserSelector(state);
     const conversationAdminIds = conversation?.adminMatrixIds;
+    const conversationModeratorIds = conversation?.moderatorIds;
     const isCurrentUserRoomAdmin = conversationAdminIds?.includes(currentUser?.matrixId) ?? false;
     const existingConversations = denormalizeConversations(state);
 
@@ -100,6 +102,7 @@ export class Container extends React.Component<Properties> {
       canEditGroup: isCurrentUserRoomAdmin,
       canLeaveGroup: !isCurrentUserRoomAdmin && conversation?.otherMembers?.length > 1,
       conversationAdminIds,
+      conversationModeratorIds,
       isOneOnOne: conversation?.isOneOnOne,
       existingConversations,
     };
@@ -177,6 +180,7 @@ export class Container extends React.Component<Properties> {
           canLeaveGroup={this.props.canLeaveGroup}
           startEditConversation={this.props.startEditConversation}
           conversationAdminIds={this.props.conversationAdminIds}
+          conversationModeratorIds={this.props.conversationModeratorIds}
           startAddGroupMember={this.props.startAddGroupMember}
           setLeaveGroupStatus={this.props.setLeaveGroupStatus}
           onMemberClick={this.processMemberConversation}

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -20,6 +20,7 @@ describe(EditConversationPanel, () => {
       name: '',
       icon: '',
       conversationAdminIds: [],
+      conversationModeratorIds: [],
       onMemberSelected: () => null,
       openUserProfile: () => null,
       ...props,
@@ -126,6 +127,26 @@ describe(EditConversationPanel, () => {
         { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' },
         { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
         { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+      ]);
+    });
+
+    it('renders the members with appropriate tags', function () {
+      const wrapper = subject({
+        currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
+        otherMembers: [
+          { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
+          { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
+          { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Eve' },
+        ] as User[],
+        conversationAdminIds: ['currentUser'],
+        conversationModeratorIds: ['otherMember2'],
+      });
+
+      expect(wrapper.find(CitizenListItem).map((c) => c.prop('tag'))).toEqual([
+        'Admin',
+        '',
+        'Mod',
+        '',
       ]);
     });
 

--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -24,6 +24,7 @@ export interface Properties {
   errors: EditConversationErrors;
   state: EditConversationState;
   conversationAdminIds: string[];
+  conversationModeratorIds: string[];
 
   onBack: () => void;
   onEdit: (name: string, image: File | null) => void;
@@ -124,6 +125,13 @@ export class EditConversationPanel extends React.Component<Properties, State> {
     );
   };
 
+  getMemberTag = (userId: string) => {
+    if (this.props.conversationModeratorIds.includes(userId)) {
+      return 'Mod';
+    }
+    return '';
+  };
+
   renderMembers = () => {
     const { conversationAdminIds, otherMembers } = this.props;
     const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds);
@@ -142,6 +150,7 @@ export class EditConversationPanel extends React.Component<Properties, State> {
                 user={u}
                 canRemove={this.canRemoveMembers}
                 onSelected={this.memberSelected}
+                tag={this.getMemberTag(u.userId)}
                 showMemberManagementMenu
               ></CitizenListItem>
             ))}

--- a/src/components/messenger/group-management/index.test.tsx
+++ b/src/components/messenger/group-management/index.test.tsx
@@ -21,6 +21,7 @@ describe(GroupManagement, () => {
       errors: {},
       editConversationState: EditConversationState.NONE,
       conversationAdminIds: [],
+      conversationModeratorIds: [],
       canAddMembers: false,
       canEditGroup: false,
       canLeaveGroup: false,

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -24,6 +24,7 @@ export interface Properties {
   canEditGroup: boolean;
   canLeaveGroup: boolean;
   conversationAdminIds: string[];
+  conversationModeratorIds: string[];
 
   onBack: () => void;
   onAddMembers: (options: Option[]) => void;
@@ -56,6 +57,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             currentUser={this.props.currentUser}
             otherMembers={this.props.otherMembers}
             conversationAdminIds={this.props.conversationAdminIds}
+            conversationModeratorIds={this.props.conversationModeratorIds}
             errors={this.props.errors.editConversationErrors}
             onBack={this.props.onBack}
             onEdit={this.props.onEditConversation}

--- a/src/components/messenger/group-management/member-management-menu/index.tsx
+++ b/src/components/messenger/group-management/member-management-menu/index.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
-import { IconDotsHorizontal, IconUserX1 } from '@zero-tech/zui/icons';
+import { IconDotsHorizontal, IconUserCheck1, IconUserX1 } from '@zero-tech/zui/icons';
 import { DropdownMenu } from '@zero-tech/zui/components';
 
 import './styles.scss';
 import { MemberManagementAction } from '../../../../store/group-management';
+import { featureFlags } from '../../../../lib/feature-flags';
 
 export interface Properties {
   canRemove?: boolean;
@@ -22,6 +23,10 @@ export class MemberManagementMenu extends React.Component<Properties> {
     this.props.onOpenMemberManagement(MemberManagementAction.RemoveMember);
   };
 
+  onMakeMod = () => {
+    this.props.onOpenMemberManagement(MemberManagementAction.MakeModerator);
+  };
+
   renderMenuItem(icon, label) {
     return (
       <div className={'menu-item'}>
@@ -32,6 +37,15 @@ export class MemberManagementMenu extends React.Component<Properties> {
 
   get dropdownMenuItems() {
     const menuItems = [];
+
+    if (featureFlags.allowModeratorActions) {
+      menuItems.push({
+        id: 'make-mod',
+        className: 'make-mod',
+        label: this.renderMenuItem(<IconUserCheck1 size={20} />, 'Make Mod'),
+        onSelect: this.onMakeMod,
+      });
+    }
 
     if (this.props.canRemove) {
       menuItems.push({

--- a/src/components/messenger/group-management/member-management-menu/styles.scss
+++ b/src/components/messenger/group-management/member-management-menu/styles.scss
@@ -18,6 +18,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-left: 4px;
 
   &:hover {
     background-color: theme.$color-greyscale-transparency-3;

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -21,6 +21,7 @@ export interface RealtimeChatEvents {
   roomFavorited: (roomId: string) => void;
   roomUnfavorited: (roomId: string) => void;
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
+  roomMemberPowerLevelChanged: (roomId: string, matrixId: string, powerLevel: number) => void;
 }
 
 export interface MatrixKeyBackupInfo {
@@ -316,4 +317,8 @@ export async function uploadImageUrl(
 
 export async function sendTypingEvent(roomId: string, isTyping: boolean) {
   return await chat.get().matrix.sendTypingEvent(roomId, isTyping);
+}
+
+export async function setUserAsModerator(roomId: string, userId: string) {
+  return await chat.get().matrix.setUserAsModerator(roomId, userId);
 }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -81,6 +81,14 @@ export class FeatureFlags {
   set allowEditPrimaryZID(value: boolean) {
     this._setBoolean('allowEditPrimaryZID', value);
   }
+
+  get allowModeratorActions() {
+    return this._getBoolean('allowModeratorActions', false);
+  }
+
+  set allowModeratorActions(value: boolean) {
+    this._setBoolean('allowModeratorActions', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -302,6 +302,7 @@ describe('channels list saga', () => {
           { matrixId: 'matrix-id-2', userId: 'matrix-id-2' },
         ],
         messages: [],
+        moderatorIds: [],
       },
       {
         id: 'room-2',
@@ -310,6 +311,7 @@ describe('channels list saga', () => {
           { matrixId: 'matrix-id-3', userId: 'matrix-id-3' },
         ],
         messages: [],
+        moderatorIds: [],
       },
     ] as any;
 
@@ -476,6 +478,21 @@ describe('channels list saga', () => {
         primaryZID: '',
         displaySubHandle: '',
       });
+    });
+
+    it('maps moderatorIds of channels to ZERO Users and save normalized state', async () => {
+      rooms[0].moderatorIds = ['matrix-id-1', 'matrix-id-2'];
+      rooms[1].moderatorIds = ['matrix-id-3'];
+
+      const initialState = new StoreBuilder().withConversationList(rooms[0], rooms[1]);
+
+      await expectSaga(mapToZeroUsers, rooms)
+        .withReducer(rootReducer, initialState.build())
+        .provide([[call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers]])
+        .run();
+
+      expect(rooms[0].moderatorIds).toIncludeSameMembers(['user-1', 'user-2']);
+      expect(rooms[1].moderatorIds).toIncludeSameMembers(['user-3']);
     });
   });
 

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -27,6 +27,8 @@ export const mapChannelMembers = (channels: Channel[], zeroUsersMap: { [id: stri
     for (const member of channel.memberHistory) {
       replaceZOSUserFields(member as User, zeroUsersMap[member.matrixId]);
     }
+
+    channel.moderatorIds = channel.moderatorIds.map((matrixId) => zeroUsersMap[matrixId]?.userId || matrixId);
   }
 };
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -52,6 +52,7 @@ export interface Channel {
   conversationStatus: ConversationStatus;
   messagesFetchStatus: MessagesFetchState;
   adminMatrixIds: string[];
+  moderatorIds?: string[];
   reply?: ParentMessage;
   isFavorite: boolean;
   otherMembersTyping: string[];
@@ -73,6 +74,7 @@ export const CHANNEL_DEFAULTS = {
   conversationStatus: ConversationStatus.CREATED,
   messagesFetchStatus: null,
   adminMatrixIds: [],
+  moderatorIds: [],
   isFavorite: false,
   otherMembersTyping: [],
 };

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -21,6 +21,7 @@ export enum Events {
   RoomFavorited = 'chat/channel/roomFavorited',
   RoomUnfavorited = 'chat/channel/roomUnfavorited',
   RoomMemberTyping = 'chat/channel/roomMemberTyping',
+  RoomMemberPowerLevelChanged = 'chat/channel/roomMemberPowerLevelChanged',
 }
 
 let theBus;
@@ -89,6 +90,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const roomFavorited = (roomId) => emit({ type: Events.RoomFavorited, payload: { roomId } });
     const roomUnfavorited = (roomId) => emit({ type: Events.RoomUnfavorited, payload: { roomId } });
     const roomMemberTyping = (roomId, userIds) => emit({ type: Events.RoomMemberTyping, payload: { roomId, userIds } });
+    const roomMemberPowerLevelChanged = (roomId, matrixId, powerLevel) =>
+      emit({ type: Events.RoomMemberPowerLevelChanged, payload: { roomId, matrixId, powerLevel } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -106,6 +109,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       roomFavorited,
       roomUnfavorited,
       roomMemberTyping,
+      roomMemberPowerLevelChanged,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);

--- a/src/store/group-management/index.ts
+++ b/src/store/group-management/index.ts
@@ -22,6 +22,7 @@ export enum SagaActionTypes {
   OpenMemberManagement = 'group-management/open-member-management',
   CancelMemberManageMent = 'group-management/cancel-member-management',
   RemoveMember = 'group-management/remove-member',
+  SetMemberAsModerator = 'group-management/set-member-as-moderator',
   EditConversationNameAndIcon = 'group-management/edit-conversation-name-and-icon',
   OpenViewGroupInformation = 'group-management/open-view-group-information',
   ToggleSecondarySidekick = 'group-management/toggle-secondary-sidekick',
@@ -63,6 +64,9 @@ export const openMemberManagement = createAction<{ type: MemberManagementAction;
 );
 export const cancelMemberManagement = createAction(SagaActionTypes.CancelMemberManageMent);
 export const removeMember = createAction<{ roomId: string; userId: string }>(SagaActionTypes.RemoveMember);
+export const setMemberAsModerator = createAction<{ roomId: string; userId: string }>(
+  SagaActionTypes.SetMemberAsModerator
+);
 export const viewGroupInformation = createAction(SagaActionTypes.OpenViewGroupInformation);
 export const editConversationNameAndIcon = createAction<EditConversationPayload>(
   SagaActionTypes.EditConversationNameAndIcon
@@ -74,7 +78,7 @@ export type GroupManagementState = {
   isAddingMembers: boolean;
   addMemberError: string;
   leaveGroupDialogStatus: LeaveGroupDialogStatus;
-  memberMangement: {
+  memberManagement: {
     type: MemberManagementAction;
     stage: MemberManagementDialogStage;
     userId: string;
@@ -93,7 +97,7 @@ export const initialState: GroupManagementState = {
   leaveGroupDialogStatus: LeaveGroupDialogStatus.CLOSED,
   errors: { editConversationErrors: { image: '', general: '' } },
   editConversationState: EditConversationState.NONE,
-  memberMangement: {
+  memberManagement: {
     type: MemberManagementAction.None,
     userId: '',
     roomId: '',
@@ -134,14 +138,14 @@ const slice = createSlice({
     setEditConversationState: (state, action: PayloadAction<GroupManagementState['editConversationState']>) => {
       state.editConversationState = action.payload;
     },
-    setMemberManagement: (state, action: PayloadAction<GroupManagementState['memberMangement']>) => {
-      state.memberMangement = action.payload;
+    setMemberManagement: (state, action: PayloadAction<GroupManagementState['memberManagement']>) => {
+      state.memberManagement = action.payload;
     },
-    setMemberManagementStage: (state, action: PayloadAction<GroupManagementState['memberMangement']['stage']>) => {
-      state.memberMangement.stage = action.payload;
+    setMemberManagementStage: (state, action: PayloadAction<GroupManagementState['memberManagement']['stage']>) => {
+      state.memberManagement.stage = action.payload;
     },
-    setMemberManagementError: (state, action: PayloadAction<GroupManagementState['memberMangement']['error']>) => {
-      state.memberMangement.error = action.payload;
+    setMemberManagementError: (state, action: PayloadAction<GroupManagementState['memberManagement']['error']>) => {
+      state.memberManagement.error = action.payload;
     },
     setSecondarySidekickOpen: (state, action: PayloadAction<GroupManagementState['isSecondarySidekickOpen']>) => {
       state.isSecondarySidekickOpen = action.payload;

--- a/src/store/group-management/saga.ts
+++ b/src/store/group-management/saga.ts
@@ -1,5 +1,5 @@
 import { call, fork, put, take, select, takeLatest } from 'redux-saga/effects';
-import { Chat, chat } from '../../lib/chat';
+import { Chat, chat, setUserAsModerator as matrixSetUserAsModerator } from '../../lib/chat';
 import { Events, getAuthChannel } from '../authentication/channels';
 import { denormalize as denormalizeUsers } from '../users';
 import { currentUserSelector } from '../authentication/saga';
@@ -46,6 +46,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.OpenMemberManagement, openMemberManagementDialog);
   yield takeLatest(SagaActionTypes.CancelMemberManageMent, cancelMemberManageMent);
   yield takeLatest(SagaActionTypes.RemoveMember, removeMember);
+  yield takeLatest(SagaActionTypes.SetMemberAsModerator, setMemberAsModerator);
   yield takeLatest(SagaActionTypes.OpenViewGroupInformation, openViewGroupInformation);
   yield takeLatest(SagaActionTypes.ToggleSecondarySidekick, toggleIsSecondarySidekick);
 }
@@ -164,6 +165,25 @@ export function* removeMember(action) {
     yield resetMemberManagement();
   } catch (e) {
     yield put(setMemberManagementError('Failed to remove member, please try again'));
+    yield put(setMemberManagementStage(MemberManagementDialogStage.OPEN));
+  }
+}
+
+export function* setMemberAsModerator(action) {
+  const { userId, roomId } = action.payload;
+
+  yield put(setMemberManagementStage(MemberManagementDialogStage.IN_PROGRESS));
+
+  try {
+    const user = yield select((state) => denormalizeUsers(userId, state));
+    if (!user) {
+      return;
+    }
+
+    yield call(matrixSetUserAsModerator, roomId, user);
+    yield resetMemberManagement();
+  } catch (e) {
+    yield put(setMemberManagementError('Failed to set member as moderator, please try again'));
     yield put(setMemberManagementStage(MemberManagementDialogStage.OPEN));
   }
 }


### PR DESCRIPTION
### What does this do?

This PR covers the following updates:

- adds a new feature flag (`allowModeratorActions`)
- updates the `channel` state to add `moderatorIds` (this will store the channel's moderator id's). Also updated `matrix-client` to parse the `matrixIds` -> `zeroUserIds` (since the raw id's which we receive from matrix, for mods, are matrixIds)
- updates `matrix-client` (& sagas) to add core logic for setting a new moderator. It also publishes a real-time event (`publishRoomMemberPowerLevelChanged`), which we receive in the `saga`, and update the channel state accordingly.
- updated `MemberManagementDialog` to reflect UI for setting a member as moderator.



https://github.com/zer0-os/zOS/assets/33264364/5f3e30d0-6150-4dba-a092-d3137b493e69

