### PR TITLE
fix(message): browser context menu on when highlighting text

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -71,6 +71,13 @@ export class Message extends React.Component<Properties, State> {
   wrapperRef = React.createRef<HTMLDivElement>();
 
   handleContextMenu = (event) => {
+    if (typeof window !== 'undefined' && window.getSelection) {
+      const selectedText = window.getSelection().toString();
+      if (selectedText.length > 0) {
+        return;
+      }
+    }
+
     if (event.button === 2) {
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
### What does this do?
- ensures browser context menu can be opened when highlighting text.

### Why are we making this change?
- accessibility.

### How do I test this?
- run tests as usual.
- run the UI, send a message, highlight text, and right click for browser context menu.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/zer0-os/zOS/assets/39112648/9600eac1-1e28-4afe-b6f8-a62721ac86ca

