### PR TITLE
refactor(matrix-client): make read receipts private

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1,4 +1,4 @@
-import { EventType, GuestAccess, Preset, Visibility } from 'matrix-js-sdk';
+import { EventType, GuestAccess, Preset, ReceiptType, Visibility } from 'matrix-js-sdk';
 import { MatrixClient } from './matrix-client';
 import { setAsDM } from './matrix/utils';
 import { uploadImage as _uploadImage } from '../../store/channels-list/api';
@@ -828,7 +828,7 @@ describe('matrix client', () => {
       await client.connect(null, 'token');
       await client.markRoomAsRead(roomId);
 
-      expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent);
+      expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent, ReceiptType.ReadPrivate);
       expect(setRoomReadMarkers).toHaveBeenCalledWith(roomId, latestEventId);
     });
   });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -18,6 +18,7 @@ import {
   NotificationCountType,
   IRoomTimelineData,
   RoomMember,
+  ReceiptType,
 } from 'matrix-js-sdk';
 import { RealtimeChatEvents, IChatClient } from './';
 import { mapEventToAdminMessage, mapMatrixMessage, mapToLiveRoomEvent } from './matrix/chat-message';
@@ -689,7 +690,7 @@ export class MatrixClient implements IChatClient {
       return;
     }
 
-    await this.matrix.sendReadReceipt(latestEvent);
+    await this.matrix.sendReadReceipt(latestEvent, ReceiptType.ReadPrivate);
     await this.matrix.setRoomReadMarkers(roomId, latestEvent.event.event_id);
   }
 


### PR DESCRIPTION
### What does this do?
- makes read receipts private!

### Why are we making this change?
- these should be private by default

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
