### PR TITLE
Render Users with 'Mod' tags, for users who are moderators of group in various panels

### DIFF
--- a/src/components/group-management/member-management-dialog/index.test.tsx
+++ b/src/components/group-management/member-management-dialog/index.test.tsx
@@ -33,19 +33,11 @@ describe(MemberManagementDialog, () => {
       const wrapper = subject({
         definition: {
           ...mockConfirmitionDefinition,
-          getMessage: () => (
-            <>
-              Are you sure you want to remove Johnny Cash from Fun Room?
-              <br />
-              Johnny Cash will lose access to the conversation and its history.
-            </>
-          ),
+          getMessage: () => <>Test Message</>,
         },
       });
 
-      expect(wrapper.find(c('')).text()).toEqual(
-        'Are you sure you want to remove Johnny Cash from Fun Room?Johnny Cash will lose access to the conversation and its history.'
-      );
+      expect(wrapper.find(c('')).text()).toEqual('Test Message');
     });
 
     it('renders progress message', () => {

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -137,15 +137,17 @@ describe(EditConversationPanel, () => {
           { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
           { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
           { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Eve' },
+          { userId: 'otherMember4', matrixId: 'matrix-id-4', firstName: 'Frank' },
         ] as User[],
         conversationAdminIds: ['currentUser'],
-        conversationModeratorIds: ['otherMember2'],
+        conversationModeratorIds: ['otherMember2', 'otherMember4'],
       });
 
       expect(wrapper.find(CitizenListItem).map((c) => c.prop('tag'))).toEqual([
         'Admin',
-        '',
         'Mod',
+        'Mod',
+        '',
         '',
       ]);
     });

--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -133,8 +133,8 @@ export class EditConversationPanel extends React.Component<Properties, State> {
   };
 
   renderMembers = () => {
-    const { conversationAdminIds, otherMembers } = this.props;
-    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds);
+    const { conversationAdminIds, otherMembers, conversationModeratorIds } = this.props;
+    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds, conversationModeratorIds);
 
     return (
       <div {...cn('members')}>

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -76,6 +76,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             canEditGroup={this.props.canEditGroup}
             canLeaveGroup={this.props.canLeaveGroup}
             conversationAdminIds={this.props.conversationAdminIds}
+            conversationModeratorIds={this.props.conversationModeratorIds}
             onAdd={this.props.startAddGroupMember}
             onLeave={this.props.setLeaveGroupStatus}
             onEdit={this.props.startEditConversation}
@@ -91,6 +92,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             otherMembers={this.props.otherMembers}
             canAddMembers={this.props.canAddMembers}
             conversationAdminIds={this.props.conversationAdminIds}
+            conversationModeratorIds={this.props.conversationModeratorIds}
             onAdd={this.props.startAddGroupMember}
             onMemberSelected={this.props.onMemberClick}
             openUserProfile={this.props.openUserProfile}

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -19,6 +19,7 @@ describe(ViewGroupInformationPanel, () => {
       currentUser: { userId: 'current-user' } as User,
       otherMembers: [],
       conversationAdminIds: [],
+      conversationModeratorIds: [],
       canAddMembers: false,
       canEditGroup: false,
       canLeaveGroup: false,
@@ -198,6 +199,22 @@ describe(ViewGroupInformationPanel, () => {
 
     expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null);
     expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Admin');
+    expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
+  });
+
+  it('assigns moderator tag to the user that is the conversation moderator', () => {
+    const wrapper = subject({
+      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-current' } as User,
+      otherMembers: [
+        { userId: 'otherUser1', matrixId: 'matrix-id-1' },
+        { userId: 'otherUser2', matrixId: 'matrix-id-2' },
+      ] as User[],
+      conversationAdminIds: [],
+      conversationModeratorIds: ['otherUser1'],
+    });
+
+    expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null); // current user is displayed at top
+    expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Mod');
     expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
   });
 });

--- a/src/components/messenger/group-management/view-group-information-panel/index.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.tsx
@@ -9,7 +9,7 @@ import { bemClassName } from '../../../../lib/bem';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { LeaveGroupDialogStatus } from '../../../../store/group-management';
-import { isUserAdmin, sortMembers } from '../../list/utils/utils';
+import { getTagForUser, sortMembers } from '../../list/utils/utils';
 
 import './styles.scss';
 
@@ -24,6 +24,7 @@ export interface Properties {
   canEditGroup: boolean;
   canLeaveGroup: boolean;
   conversationAdminIds: string[];
+  conversationModeratorIds: string[];
 
   onAdd: () => void;
   onLeave: (status: LeaveGroupDialogStatus) => void;
@@ -34,8 +35,8 @@ export interface Properties {
 }
 
 export class ViewGroupInformationPanel extends React.Component<Properties> {
-  getTagForUser(user: User) {
-    return isUserAdmin(user, this.props.conversationAdminIds) ? 'Admin' : null;
+  getTag(user: User) {
+    return getTagForUser(user, this.props.conversationAdminIds, this.props.conversationModeratorIds);
   }
 
   navigateBack = () => {
@@ -87,8 +88,8 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
   };
 
   renderMembers = () => {
-    const { otherMembers, conversationAdminIds } = this.props;
-    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds);
+    const { otherMembers, conversationAdminIds, conversationModeratorIds } = this.props;
+    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds, conversationModeratorIds);
 
     return (
       <div {...cn('members')}>
@@ -105,14 +106,14 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
           <ScrollbarContainer>
             <CitizenListItem
               user={this.props.currentUser}
-              tag={this.getTagForUser(this.props.currentUser)}
+              tag={this.getTag(this.props.currentUser)}
               onSelected={this.openProfile}
             ></CitizenListItem>
             {sortedOtherMembers.map((u) => (
               <CitizenListItem
                 key={u.userId}
                 user={u}
-                tag={this.getTagForUser(u)}
+                tag={this.getTag(u)}
                 onSelected={this.memberSelected}
               ></CitizenListItem>
             ))}

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -16,6 +16,7 @@ describe(ViewMembersPanel, () => {
       otherMembers: [],
       conversationAdminIds: [],
       canAddMembers: false,
+      conversationModeratorIds: [],
 
       onAdd: () => null,
       onMemberSelected: () => null,
@@ -126,5 +127,21 @@ describe(ViewMembersPanel, () => {
 
     expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null);
     expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', null);
+  });
+
+  it('assigns moderator tag to the user that is the conversation moderator', () => {
+    const wrapper = subject({
+      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-current' } as User,
+      otherMembers: [
+        { userId: 'otherUser1', matrixId: 'matrix-id-1' },
+        { userId: 'otherUser2', matrixId: 'matrix-id-2' },
+      ] as User[],
+      conversationAdminIds: [],
+      conversationModeratorIds: ['otherUser1'],
+    });
+
+    expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null); // current user is displayed at top
+    expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Mod');
+    expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
   });
 });

--- a/src/components/messenger/group-management/view-members-panel/index.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.tsx
@@ -6,7 +6,7 @@ import { User } from '../../../../store/channels';
 import { bemClassName } from '../../../../lib/bem';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { ScrollbarContainer } from '../../../scrollbar-container';
-import { isUserAdmin, sortMembers } from '../../list/utils/utils';
+import { getTagForUser, sortMembers } from '../../list/utils/utils';
 
 import './styles.scss';
 
@@ -18,6 +18,7 @@ export interface Properties {
   otherMembers: User[];
   canAddMembers: boolean;
   conversationAdminIds: string[];
+  conversationModeratorIds: string[];
 
   onAdd: () => void;
   onMemberSelected: (userId: string) => void;
@@ -25,9 +26,10 @@ export interface Properties {
 }
 
 export class ViewMembersPanel extends React.Component<Properties> {
-  getTagForUser(user: User) {
+  getTag(user: User) {
     if (this.props.isOneOnOne) return null;
-    return isUserAdmin(user, this.props.conversationAdminIds) ? 'Admin' : null;
+
+    return getTagForUser(user, this.props.conversationAdminIds, this.props.conversationModeratorIds);
   }
 
   addMember = () => {
@@ -43,8 +45,8 @@ export class ViewMembersPanel extends React.Component<Properties> {
   };
 
   renderMembers = () => {
-    const { otherMembers, conversationAdminIds } = this.props;
-    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds);
+    const { otherMembers, conversationAdminIds, conversationModeratorIds } = this.props;
+    const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds, conversationModeratorIds);
 
     return (
       <div {...cn('members')}>
@@ -61,14 +63,14 @@ export class ViewMembersPanel extends React.Component<Properties> {
           <ScrollbarContainer>
             <CitizenListItem
               user={this.props.currentUser}
-              tag={this.getTagForUser(this.props.currentUser)}
+              tag={this.getTag(this.props.currentUser)}
               onSelected={this.openProfile}
             ></CitizenListItem>
             {sortedOtherMembers.map((u) => (
               <CitizenListItem
                 key={u.userId}
                 user={u}
-                tag={this.getTagForUser(u)}
+                tag={this.getTag(u)}
                 onSelected={this.memberSelected}
               ></CitizenListItem>
             ))}

--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -1,24 +1,32 @@
-import { isUserAdmin, lastSeenText, sortMembers } from './utils';
+import { getTagForUser, isUserAdmin, isUserModerator, lastSeenText, sortMembers } from './utils';
 import { User } from '../../../../store/channels';
 
 describe('sortMembers', () => {
-  it('sorts members correctly with admins first, then online status and alphabetically', () => {
+  it('sorts members correctly with admins first, then moderators, then online status and alphabetically', () => {
     const members = [
       { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam', isOnline: false },
       { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie', isOnline: true },
       { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda', isOnline: true },
+      { userId: 'otherMember4', matrixId: 'matrix-id-4', firstName: 'David', isOnline: false },
+      { userId: 'otherMember5', matrixId: 'matrix-id-5', firstName: 'Eve', isOnline: true },
+      { userId: 'otherMember6', matrixId: 'matrix-id-6', firstName: 'Frank', isOnline: false },
+      { userId: 'otherMember7', matrixId: 'matrix-id-7', firstName: 'Craig', isOnline: false },
     ] as any;
     const adminIds = ['matrix-id-2', 'matrix-id-3'];
+    const moderatorIds = ['otherMember5', 'otherMember6'];
 
-    const sortedMembers = sortMembers(members, adminIds);
-
+    const sortedMembers = sortMembers(members, adminIds, moderatorIds);
     const expectedOrder = [
       { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Brenda', isOnline: true },
       { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie', isOnline: true },
+      { userId: 'otherMember5', matrixId: 'matrix-id-5', firstName: 'Eve', isOnline: true },
+      { userId: 'otherMember6', matrixId: 'matrix-id-6', firstName: 'Frank', isOnline: false },
       { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam', isOnline: false },
+      { userId: 'otherMember7', matrixId: 'matrix-id-7', firstName: 'Craig', isOnline: false },
+      { userId: 'otherMember4', matrixId: 'matrix-id-4', firstName: 'David', isOnline: false },
     ];
 
-    expect(sortedMembers).toEqual(expectedOrder);
+    expect(sortedMembers).toStrictEqual(expectedOrder);
   });
 });
 
@@ -45,6 +53,29 @@ describe('isUserAdmin', () => {
   });
 });
 
+describe(isUserModerator, () => {
+  it('returns true if the user is a moderator', () => {
+    const user = { userId: 'user1' } as User;
+    const moderatorIds = ['user1', 'user2'];
+
+    expect(isUserModerator(user, moderatorIds)).toBe(true);
+  });
+
+  it('returns false if the user is not a moderator', () => {
+    const user = { userId: 'user3' } as User;
+    const moderatorIds = ['user1', 'user2'];
+
+    expect(isUserModerator(user, moderatorIds)).toBe(false);
+  });
+
+  it('handles empty moderatorIds array', () => {
+    const user = { userId: 'user1' } as User;
+    const moderatorIds: string[] = [];
+
+    expect(isUserModerator(user, moderatorIds)).toBe(false);
+  });
+});
+
 describe('lastSeenText', () => {
   it('returns "Online" if the user is currently online', () => {
     const user = { isOnline: true };
@@ -59,5 +90,28 @@ describe('lastSeenText', () => {
   it('returns an empty string if lastSeenAt is null', () => {
     const user = { isOnline: false, lastSeenAt: null };
     expect(lastSeenText(user)).toEqual('');
+  });
+});
+
+describe(getTagForUser, () => {
+  it('returns "Admin" if the user is an admin', () => {
+    const user = { userId: 'user1', matrixId: 'matrix-id-1' } as User;
+    const adminIds = ['matrix-id-1', 'matrix-id-2'];
+
+    expect(getTagForUser(user, adminIds)).toBe('Admin');
+  });
+
+  it('returns "Mod" if the user is a moderator', () => {
+    const user = { userId: 'user1' } as User;
+    const moderatorIds = ['user1', 'user2'];
+
+    expect(getTagForUser(user, [], moderatorIds)).toBe('Mod');
+  });
+
+  it('returns null if the user is not an admin or moderator', () => {
+    const user = { userId: 'user2', matrixId: 'matrix-id-3' } as User;
+    const adminIds = ['matrix-id-1', 'matrix-id-2'];
+
+    expect(getTagForUser(user, adminIds)).toBe(null);
   });
 });

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -17,7 +17,11 @@ export function isUserAdmin(user: User, adminIds: string[]) {
   return adminIds?.includes(user.matrixId);
 }
 
-export function sortMembers(members: User[], adminIds: string[]) {
+export function isUserModerator(user: User, moderatorIds: string[]) {
+  return moderatorIds?.includes(user.userId);
+}
+
+export function sortMembers(members: User[], adminIds: string[], conversationModeratorIds: string[]) {
   return members.sort((a, b) => {
     const aIsAdmin = isUserAdmin(a, adminIds);
     const bIsAdmin = isUserAdmin(b, adminIds);
@@ -26,6 +30,13 @@ export function sortMembers(members: User[], adminIds: string[]) {
     if (aIsAdmin && !bIsAdmin) return -1;
     if (!aIsAdmin && bIsAdmin) return 1;
 
+    // Sort moderators next
+    const aIsModerator = isUserModerator(a, conversationModeratorIds);
+    const bIsModerator = isUserModerator(b, conversationModeratorIds);
+
+    if (aIsModerator && !bIsModerator) return -1;
+    if (!aIsModerator && bIsModerator) return 1;
+
     // Then sort by online status
     if (a.isOnline && !b.isOnline) return -1;
     if (!a.isOnline && b.isOnline) return 1;
@@ -33,4 +44,16 @@ export function sortMembers(members: User[], adminIds: string[]) {
     // Finally sort alphabetically by firstName
     return a.firstName!.localeCompare(b.firstName);
   });
+}
+
+export function getTagForUser(user: User, conversationAdminIds: string[], conversationModeratorIds: string[] = []) {
+  let tag = null;
+  if (isUserAdmin(user, conversationAdminIds)) {
+    tag = 'Admin';
+  }
+  if (isUserModerator(user, conversationModeratorIds)) {
+    tag = 'Mod';
+  }
+
+  return tag;
 }


### PR DESCRIPTION
### What does this do?

Renders '`Mod`' tag for users who are moderators of the group (`view-members-panel`, `group-info-panel`, `edit-group-panel`)

`Members Panel`
<img width="435" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/41a00a4c-9a95-4476-b33f-02f87f81e273">

`Group Info Panel`
<img width="297" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/1b7c7910-f2ef-45fb-8224-a856837dcbda">

`Edit Group Panel`
<img width="301" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/edcaa06a-5903-44c7-9bd7-aafffbae7ee7">