### PR TITLE
feat(feature-flags): add enableReadReceiptPreferences

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -89,6 +89,14 @@ export class FeatureFlags {
   set allowModeratorActions(value: boolean) {
     this._setBoolean('allowModeratorActions', value);
   }
+
+  get enableReadReceiptPreferences() {
+    return this._getBoolean('enableReadReceiptPreferences', false);
+  }
+
+  set enableReadReceiptPreferences(value: boolean) {
+    this._setBoolean('enableReadReceiptPreferences', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?
- adds enableReadReceiptPreferences to feature flags

### Why are we making this change?
- to feature flag user read receipt preferences

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
