### PR TITLE
feat(matrix-client): matrix set receipt preferences and get receipt preferences when reading a room

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -4,6 +4,7 @@ import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage, User } from './types';
 import { MemberNetworks } from '../../store/users/types';
+import { ReadReceiptPreferenceType } from './matrix/types';
 
 export interface RealtimeChatEvents {
   receiveNewMessage: (channelId: string, message: Message) => void;
@@ -325,4 +326,8 @@ export async function setUserAsModerator(roomId: string, userId: string) {
 
 export async function removeUserAsModerator(roomId: string, userId: string) {
   return await chat.get().matrix.removeUserAsModerator(roomId, userId);
+}
+
+export async function setReadReceiptPreference(preference: ReadReceiptPreferenceType) {
+  return await chat.get().matrix.setReadReceiptPreference(preference);
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -685,8 +685,8 @@ export class MatrixClient implements IChatClient {
 
   async getReadReceiptPreference() {
     try {
-      const accountData = this.matrix.getAccountData(MatrixConstants.READ_RECEIPT_PREFERENCE);
-      return accountData?.getContent().readReceipts || ReadReceiptPreferenceType.Public;
+      const accountData = await this.matrix.getAccountData(MatrixConstants.READ_RECEIPT_PREFERENCE);
+      return accountData?.event?.content?.readReceipts || ReadReceiptPreferenceType.Public;
     } catch (err) {
       console.error('Error getting read receipt preference', err);
       return ReadReceiptPreferenceType.Public;

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -21,6 +21,7 @@ export enum MatrixConstants {
   REPLACE = 'm.replace',
   BAD_ENCRYPTED_MSGTYPE = 'm.bad.encrypted',
   FAVORITE = 'm.favorite',
+  READ_RECEIPT_PREFERENCE = 'm.read_receipt_preference',
 }
 
 export enum CustomEventType {
@@ -33,4 +34,9 @@ export enum DecryptErrorConstants {
 
 export enum NotifiableEventType {
   RoomMessage = 'RoomMessage',
+}
+
+export enum ReadReceiptPreferenceType {
+  Public = 'public',
+  Private = 'private',
 }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -89,6 +89,14 @@ export class FeatureFlags {
   set allowModeratorActions(value: boolean) {
     this._setBoolean('allowModeratorActions', value);
   }
+
+  get enableReadReceiptPreferences() {
+    return this._getBoolean('enableReadReceiptPreferences', false);
+  }
+
+  set enableReadReceiptPreferences(value: boolean) {
+    this._setBoolean('enableReadReceiptPreferences', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -6,6 +6,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { UnreadCountUpdatedPayload } from './types';
 import { ParentMessage } from '../../lib/chat/types';
 import { Wallet } from '../authentication/types';
+import { ReadReceiptPreferenceType } from '../../lib/chat/matrix/types';
 
 export interface User {
   userId: string;
@@ -87,6 +88,7 @@ export enum SagaActionTypes {
   OnFavoriteRoom = 'channels/saga/onFavoriteRoom',
   OnUnfavoriteRoom = 'channels/saga/onUnfavoriteRoom',
   UserTypingInRoom = 'channels/saga/userTypingInRoom',
+  OnSetReadReceiptPreference = 'channels/saga/onSetReadReceiptPreference',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
@@ -96,6 +98,9 @@ const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
 const onFavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnFavoriteRoom);
 const onUnfavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnfavoriteRoom);
 const userTypingInRoom = createAction<{ roomId: string }>(SagaActionTypes.UserTypingInRoom);
+const onSetReadReceiptPreference = createAction<{ preference: ReadReceiptPreferenceType }>(
+  SagaActionTypes.OnSetReadReceiptPreference
+);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -117,4 +122,5 @@ export {
   onFavoriteRoom,
   onUnfavoriteRoom,
   userTypingInRoom,
+  onSetReadReceiptPreference,
 };

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -9,6 +9,7 @@ import {
   removeRoomFromFavorites,
   chat,
   sendTypingEvent as matrixSendUserTypingEvent,
+  setReadReceiptPreference,
 } from '../../lib/chat';
 import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
@@ -220,6 +221,15 @@ export function* receivedRoomMemberPowerLevelChanged(action) {
   yield call(receiveChannel, { id: roomId, moderatorIds });
 }
 
+export function* onSetReadReceiptPreference(action) {
+  const { preference } = action.payload;
+  try {
+    yield call(setReadReceiptPreference, preference);
+  } catch (error) {
+    console.error('Failed to set read receipt preference:', error);
+  }
+}
+
 export function* saga() {
   yield spawn(listenForMessageSent);
   yield leadingDebounce(4000, SagaActionTypes.UserTypingInRoom, publishUserTypingEvent);
@@ -229,6 +239,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.OnRemoveReply, onRemoveReply);
   yield takeLatest(SagaActionTypes.OnFavoriteRoom, onFavoriteRoom);
   yield takeLatest(SagaActionTypes.OnUnfavoriteRoom, onUnfavoriteRoom);
+  yield takeLatest(SagaActionTypes.OnSetReadReceiptPreference, onSetReadReceiptPreference);
 
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.UnreadCountChanged, unreadCountUpdated);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomFavorited, roomFavorited);


### PR DESCRIPTION
Note: UI updates in follow up.

### What does this do?
- Implements user-configurable read receipt preferences with a default to private if feature flagged, default to public if not, and includes a feature flag for enabling this functionality 
- test coverage

### Why are we making this change?
- To give users control over their read receipt visibility, enhancing privacy and user experience.

### How do I test this?
- run tests as usual.
- this is not yet wired up so you can not test manually in the UI without code changes to do so.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
