### PR TITLE
Allow Group Moderator access to `Edit Group` Panel & can `Remove Members` (**only**)

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -238,6 +238,14 @@ describe(DirectMessageChat, () => {
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
       });
+
+      it('is true when current user is room moderator', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ isOneOnOne: false, moderatorIds: ['current-user-id'] }))
+          .withCurrentUser(stubAuthenticatedUser({ id: 'current-user-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
     });
 
     describe('canAddMembers', () => {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -66,8 +66,9 @@ export class Container extends React.Component<Properties> {
     const directMessage = denormalize(activeConversationId, state);
     const currentUser = currentUserSelector(state);
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
+    const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.id) ?? false;
     const canLeaveRoom = !isCurrentUserRoomAdmin && (directMessage?.otherMembers || []).length > 1;
-    const canEdit = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
+    const canEdit = (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !directMessage?.isOneOnOne;
     const canAddMembers = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
     const canViewDetails = !directMessage?.isOneOnOne;
     const channel = rawChannelSelector(activeConversationId)(state);

--- a/src/components/messenger/group-management/container.test.tsx
+++ b/src/components/messenger/group-management/container.test.tsx
@@ -63,5 +63,63 @@ describe(Container, () => {
         expect.objectContaining({ conversationModeratorIds: ['user-id'] })
       );
     });
+
+    describe('canAddMembers', () => {
+      test('gets true when user is admin', () => {
+        const state = new StoreBuilder()
+          .managingGroup({})
+          .withCurrentUser({ matrixId: 'user-id' })
+          .withActiveConversation({ id: 'user-id', adminMatrixIds: ['user-id'] });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+
+      test('gets true when user is moderator', () => {
+        const state = new StoreBuilder()
+          .managingGroup({})
+          .withCurrentUser({ id: 'user-id' })
+          .withActiveConversation({ id: 'user-id', moderatorIds: ['user-id'] });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+
+      test('gets false when user is not admin or moderator', () => {
+        const state = new StoreBuilder().managingGroup({}).withActiveConversation({ id: 'user-id' });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+
+      test('gets false when conversation is one on one', () => {
+        const state = new StoreBuilder().managingGroup({}).withActiveConversation({ id: 'user-id', isOneOnOne: true });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+    });
+
+    describe('canEditGroup', () => {
+      test('gets true when user is admin', () => {
+        const state = new StoreBuilder()
+          .managingGroup({})
+          .withCurrentUser({ matrixId: 'user-id' })
+          .withActiveConversation({ id: 'user-id', adminMatrixIds: ['user-id'] });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canEditGroup: true }));
+      });
+
+      test('gets true when user is moderator', () => {
+        const state = new StoreBuilder()
+          .managingGroup({})
+          .withCurrentUser({ id: 'user-id' })
+          .withActiveConversation({ id: 'user-id', moderatorIds: ['user-id'] });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canEditGroup: true }));
+      });
+
+      test('gets false when user is not admin or moderator', () => {
+        const state = new StoreBuilder().managingGroup({}).withActiveConversation({ id: 'user-id' });
+
+        expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canEditGroup: false }));
+      });
+    });
   });
 });

--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -76,6 +76,7 @@ export class Container extends React.Component<Properties> {
     const conversationAdminIds = conversation?.adminMatrixIds;
     const conversationModeratorIds = conversation?.moderatorIds;
     const isCurrentUserRoomAdmin = conversationAdminIds?.includes(currentUser?.matrixId) ?? false;
+    const isCurrentUserRoomModerator = conversationModeratorIds?.includes(currentUser?.id) ?? false;
     const existingConversations = denormalizeConversations(state);
 
     return {
@@ -98,8 +99,8 @@ export class Container extends React.Component<Properties> {
       } as User,
       otherMembers: conversation ? conversation.otherMembers : [],
       editConversationState: groupManagement.editConversationState,
-      canAddMembers: isCurrentUserRoomAdmin && !conversation?.isOneOnOne,
-      canEditGroup: isCurrentUserRoomAdmin,
+      canAddMembers: (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !conversation?.isOneOnOne,
+      canEditGroup: isCurrentUserRoomAdmin || isCurrentUserRoomModerator,
       canLeaveGroup: !isCurrentUserRoomAdmin && conversation?.otherMembers?.length > 1,
       conversationAdminIds,
       conversationModeratorIds,

--- a/src/components/messenger/group-management/member-management-menu/container.test.tsx
+++ b/src/components/messenger/group-management/member-management-menu/container.test.tsx
@@ -19,5 +19,14 @@ describe(Container, () => {
         expect.objectContaining({ conversationModeratorIds: ['moderator-id-1', 'moderator-id-2'] })
       );
     });
+
+    test('gets allowModeratorManagement', () => {
+      const state = new StoreBuilder().withCurrentUser({ matrixId: 'admin-id' }).withActiveConversation({
+        id: 'id',
+        adminMatrixIds: ['admin-id'],
+      });
+
+      expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ allowModeratorManagement: true }));
+    });
   });
 });

--- a/src/components/messenger/group-management/member-management-menu/container.tsx
+++ b/src/components/messenger/group-management/member-management-menu/container.tsx
@@ -7,6 +7,7 @@ import { User, denormalize as denormalizeChannel } from '../../../../store/chann
 
 import { MemberManagementMenu } from '.';
 import { isUserModerator } from '../../list/utils/utils';
+import { currentUserSelector } from '../../../../store/authentication/selectors';
 
 export interface PublicProperties {
   user?: User;
@@ -18,6 +19,7 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   activeConversationId: string;
   conversationModeratorIds: string[];
+  allowModeratorManagement: boolean;
 
   openMemberManagement: (params: { type: MemberManagementAction; roomId: string; userId: string }) => void;
 }
@@ -31,9 +33,13 @@ export class Container extends React.Component<Properties> {
     const conversation = denormalizeChannel(activeConversationId, state);
     const conversationModeratorIds = conversation?.moderatorIds;
 
+    const currentUser = currentUserSelector(state);
+    const isCurrentUserRoomAdmin = conversation?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
+
     return {
       activeConversationId,
       conversationModeratorIds,
+      allowModeratorManagement: isCurrentUserRoomAdmin,
     };
   }
 
@@ -53,6 +59,7 @@ export class Container extends React.Component<Properties> {
         onOpenChange={this.props.onOpenChange}
         canRemove={this.props.canRemove}
         isUserModerator={isUserModerator(this.props.user, this.props.conversationModeratorIds)}
+        allowModeratorManagement={this.props.allowModeratorManagement}
       />
     );
   }

--- a/src/components/messenger/group-management/member-management-menu/index.test.tsx
+++ b/src/components/messenger/group-management/member-management-menu/index.test.tsx
@@ -53,6 +53,8 @@ describe(MemberManagementMenu, () => {
     });
 
     it('publishes onMakeMod event when Make Mod is clicked', () => {
+      featureFlags.allowModeratorActions = true;
+
       const onOpenMemberManagement = jest.fn();
       const wrapper = subject({ onOpenMemberManagement });
 

--- a/src/components/messenger/group-management/member-management-menu/index.test.tsx
+++ b/src/components/messenger/group-management/member-management-menu/index.test.tsx
@@ -16,6 +16,7 @@ describe(MemberManagementMenu, () => {
       canRemove: true,
       onOpenChange: () => {},
       onOpenMemberManagement: () => {},
+      allowModeratorManagement: true,
       ...props,
     };
 
@@ -32,6 +33,13 @@ describe(MemberManagementMenu, () => {
     const wrapper = subject({ isUserModerator: true });
     expect(menuItem(wrapper, 'remove-mod')).toBeDefined();
     expect(menuItem(wrapper, 'make-mod')).toBeUndefined();
+  });
+
+  it('does not render Make/Remove Mod menu item when moderator actions are not allowed', () => {
+    featureFlags.allowModeratorActions = false;
+    const wrapper = subject({ allowModeratorManagement: false });
+    expect(menuItem(wrapper, 'make-mod')).toBeUndefined();
+    expect(menuItem(wrapper, 'remove-mod')).toBeUndefined();
   });
 
   describe('Member Management Actions', () => {

--- a/src/components/messenger/group-management/member-management-menu/index.tsx
+++ b/src/components/messenger/group-management/member-management-menu/index.tsx
@@ -10,6 +10,7 @@ import { featureFlags } from '../../../../lib/feature-flags';
 export interface Properties {
   canRemove?: boolean;
   isUserModerator?: boolean;
+  allowModeratorManagement: boolean;
 
   onOpenChange: (isOpen: boolean) => void;
 
@@ -44,7 +45,7 @@ export class MemberManagementMenu extends React.Component<Properties> {
   get dropdownMenuItems() {
     const menuItems = [];
 
-    if (featureFlags.allowModeratorActions) {
+    if (featureFlags.allowModeratorActions && this.props.allowModeratorManagement) {
       if (this.props.isUserModerator) {
         menuItems.push({
           id: 'remove-mod',


### PR DESCRIPTION
### What does this do?

Allows group moderator access to `Edit Group` panel. In the `Edit group` Panel, 
- an `admin` has FULL access (edit group image, name, add/remove members, make/remove moderators)
- a `moderator` has LIMITED access :: it can only 
   -  a) add members to group
   - b) remove members from group (only those who aren't `admins` or `mods`)
   
This is the view from a moderator (as current user):

https://github.com/zer0-os/zOS/assets/33264364/7a2e1d68-0be4-4635-8619-55964154fcf0


This is the view from an admin (as current user):

https://github.com/zer0-os/zOS/assets/33264364/be48ee7e-998e-43f5-ad50-f8e057b125fb