### PR TITLE
Increase `{ width, line-height }` of text in Member Management Dialog

### DIFF
--- a/src/components/group-management/member-management-dialog/container.tsx
+++ b/src/components/group-management/member-management-dialog/container.tsx
@@ -120,7 +120,7 @@ class MakeModerator implements ConfirmationDefinition {
   getMessage() {
     return (
       <>
-        Are you sure you want to make <b>{this.userName}</b> moderator of <i>{this.roomLabel}</i>?
+        Are you sure you want to make <b>{this.userName}</b> moderator of <i>{this.roomLabel}</i> ?
       </>
     );
   }
@@ -134,7 +134,7 @@ class RemoveModerator implements ConfirmationDefinition {
   getMessage() {
     return (
       <>
-        Are you sure you want to remove <b>{this.userName}</b> as moderator of <i>{this.roomLabel}</i>?
+        Are you sure you want to remove <b>{this.userName}</b> as moderator of <i>{this.roomLabel}</i> ?
       </>
     );
   }

--- a/src/components/group-management/member-management-dialog/styles.scss
+++ b/src/components/group-management/member-management-dialog/styles.scss
@@ -1,7 +1,8 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .remove-member-dialog {
-  width: 528px;
+  width: 586px;
+  line-height: 22px;
 
   & > *:last-child {
     margin-top: 24px;


### PR DESCRIPTION
### What does this do?

Before:
<img width="803" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/9cbd871b-f169-4aae-83b0-2718079c723e">

After:
<img width="780" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/ea738cbd-905f-47b1-ab2e-e72d338bb24c">
