### PR TITLE
[FIX] Sometimes the admin messages do not display when you set/remove a `Mod`

### DIFF
--- a/src/components/group-management/member-management-dialog/styles.scss
+++ b/src/components/group-management/member-management-dialog/styles.scss
@@ -1,7 +1,7 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 
 .remove-member-dialog {
-  width: 586px;
+  width: 600px;
   line-height: 22px;
 
   & > *:last-child {

--- a/src/lib/chat/matrix/chat-message.test.ts
+++ b/src/lib/chat/matrix/chat-message.test.ts
@@ -28,7 +28,7 @@ describe(getRoomPowerLevelsChangedAdminData, () => {
     expect(result).toBeNull();
   });
 
-  it('returns MEMBER_SET_AS_MODERATOR if user is promoted to moderator', () => {
+  it('returns MEMBER_SET_AS_MODERATOR if user is promoted to moderator (from 0 prev_content)', () => {
     const result = getRoomPowerLevelsChangedAdminData(
       {
         users: {
@@ -46,12 +46,46 @@ describe(getRoomPowerLevelsChangedAdminData, () => {
     expect(result).toEqual({ type: AdminMessageType.MEMBER_SET_AS_MODERATOR, userId: 'user-matrix-id' });
   });
 
-  it('returns MEMBER_REMOVED_AS_MODERATOR if user is demoted from moderator', () => {
+  it('returns MEMBER_SET_AS_MODERATOR if user is promoted to moderator (from empty prev_content)', () => {
+    const result = getRoomPowerLevelsChangedAdminData(
+      {
+        users: {
+          'admin-matrix-user-id': PowerLevels.Owner,
+          'user-matrix-id': PowerLevels.Moderator,
+        },
+      },
+      {
+        users: {
+          'admin-matrix-user-id': PowerLevels.Owner,
+        },
+      }
+    );
+    expect(result).toEqual({ type: AdminMessageType.MEMBER_SET_AS_MODERATOR, userId: 'user-matrix-id' });
+  });
+
+  it('returns MEMBER_REMOVED_AS_MODERATOR if user is demoted from moderator (to 0 power_level)', () => {
     const result = getRoomPowerLevelsChangedAdminData(
       {
         users: {
           'admin-matrix-user-id': PowerLevels.Owner,
           'user-matrix-id': PowerLevels.Viewer,
+        },
+      },
+      {
+        users: {
+          'admin-matrix-user-id': PowerLevels.Owner,
+          'user-matrix-id': PowerLevels.Moderator,
+        },
+      }
+    );
+    expect(result).toEqual({ type: AdminMessageType.MEMBER_REMOVED_AS_MODERATOR, userId: 'user-matrix-id' });
+  });
+
+  it('returns MEMBER_REMOVED_AS_MODERATOR if user is demoted from moderator (to empty power_level)', () => {
+    const result = getRoomPowerLevelsChangedAdminData(
+      {
+        users: {
+          'admin-matrix-user-id': PowerLevels.Owner,
         },
       },
       {

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -1,5 +1,6 @@
 import { EventType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
 import { User as ChannelMember } from '../../../store/channels';
+import isEqual from 'lodash.isequal';
 
 // Copied from the matrix-react-sdk
 export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: string): Promise<void> {
@@ -81,3 +82,20 @@ export function parsePlainBody(body) {
 
   return parsedBody;
 }
+
+export const getObjectDiff = (obj1, obj2, compareRef = false) => {
+  return Object.keys(obj1).reduce((result, key) => {
+    if (!obj2.hasOwnProperty(key)) {
+      result.push(key);
+    } else if (isEqual(obj1[key], obj2[key])) {
+      const resultKeyIndex = result.indexOf(key);
+
+      if (compareRef && obj1[key] !== obj2[key]) {
+        result[resultKeyIndex] = `${key} (ref)`;
+      } else {
+        result.splice(resultKeyIndex, 1);
+      }
+    }
+    return result;
+  }, Object.keys(obj2));
+};


### PR DESCRIPTION
### What does this do?

Sometimes the admin messages were not displaying in the UI, after you set/remove a user as a moderator. This was because, sometimes instead of "0" `power_level`, we would just get an "empty"/"undefined" field for the `power_level` in the event content. For eg.

Before
```js
{
  "admin": <100>
  "user-1": <50> // mod
}
```

Now, if we remove this user as mod, then we sometimes get ::

```js
{
  "admin": <100>
  // this is empty
}
```

In normal cases we should get something like:
```js
{
  "admin": <100>
  "user-1": <0> // normal user now
}
```

This PR handles the above case. 

Before (notice one admin message is missing):
<img width="775" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/b1070223-6e69-4239-ade2-928d25d11bcc">


After:
<img width="652" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/d5e6ad13-8b8f-4c16-bc4e-0f6e59c416a1">
