### PR TITLE
Reset a user's `power_level` before `kicking` him out

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -729,6 +729,8 @@ export class MatrixClient implements IChatClient {
 
   async removeUser(roomId, user): Promise<void> {
     await this.waitForConnection();
+
+    await this.matrix.setPowerLevel(roomId, user.matrixId, PowerLevels.Viewer); // reset user power_level first
     await this.matrix.kick(roomId, user.matrixId);
   }
 


### PR DESCRIPTION
### What does this do?

Earlier, if a user is a `Moderator`, and he is removed from the group, then if he would rejoin he would still remain a moderator. This should not happen.

So before we kick a user out, now we first lower it's `power_level` down to `0` first, and then kick him out.

This is how the admin messages are now:
<img width="404" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/1721596d-19f1-4fc8-adff-625e9a0c470f">
