### PR TITLE
Trigger `lowerMinimumInviteAndKickLevels` before setting a user as `Moderator`

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -191,7 +191,7 @@ export class MatrixClient implements IChatClient {
         }
 
         // just to be safe, above we check if the user is the creator of the room
-        // but also check if this users has a power level of 100,
+        // but we also check if *this* user has a power level of 100,
         // otherwise sendStateEvent will fail
         const users = powerLevelsContent.users || {};
         if (users[this.userId] !== PowerLevels.Owner) {
@@ -736,6 +736,8 @@ export class MatrixClient implements IChatClient {
 
   async setUserAsModerator(roomId: string, user): Promise<void> {
     await this.waitForConnection();
+
+    this.lowerMinimumInviteAndKickLevels([this.matrix.getRoom(roomId)]);
     await this.matrix.setPowerLevel(roomId, user.matrixId, PowerLevels.Moderator);
   }
 


### PR DESCRIPTION
### What does this do?

Executes `lowerMinimumInviteAndKickLevels` before setting a user as `Mod` in a room. This is just to "make sure" that all groups have the correct permissions set, for a `Mod` to perform `{ invite, kick }` actions. 

For example, if a room is created via android/iOS, and we don't have the right `power_levels` set for a room in that case, then this should handle it (since we're explicitly correcting the room's power_levels as soon as we set a moderator). 
