### PR TITLE
feat(message-info): add and update readBy on messages - add message-info saga

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -78,6 +78,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     parentMessageId: parent ? parent['m.in_reply_to']?.event_id : null,
     isHidden: content?.msgtype === MatrixConstants.BAD_ENCRYPTED_MSGTYPE,
     ...(await parseMediaData(matrixMessage)),
+    readBy: [],
   };
 }
 

--- a/src/store/message-info/index.ts
+++ b/src/store/message-info/index.ts
@@ -1,0 +1,30 @@
+import { PayloadAction, createAction, createSlice } from '@reduxjs/toolkit';
+
+export enum SagaActionTypes {
+  OpenMessageInfo = 'message-info/open-message-info',
+  CloseMessageInfo = 'message-info/close-message-info',
+}
+
+export const openMessageInfo = createAction<{ roomId: string; messageId: number }>(SagaActionTypes.OpenMessageInfo);
+export const closeMessageInfo = createAction(SagaActionTypes.CloseMessageInfo);
+
+export type MessageInfoState = {
+  selectedMessageId: string;
+};
+
+export const initialState: MessageInfoState = {
+  selectedMessageId: '',
+};
+
+const slice = createSlice({
+  name: 'message-info',
+  initialState,
+  reducers: {
+    setSelectedMessageId: (state, action: PayloadAction<string>) => {
+      state.selectedMessageId = action.payload;
+    },
+  },
+});
+
+export const { setSelectedMessageId } = slice.actions;
+export const { reducer } = slice;

--- a/src/store/message-info/saga.test.ts
+++ b/src/store/message-info/saga.test.ts
@@ -1,0 +1,38 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import { call } from 'redux-saga/effects';
+
+import { openOverview, closeOverview } from './saga';
+import { setSelectedMessageId } from './index';
+import { getMessageReadReceipts } from '../../lib/chat';
+import { updateReadByUsers } from '../messages/saga';
+
+describe('message-info saga', () => {
+  const roomId = 'room-id';
+  const messageId = 'message-id';
+
+  describe('openOverview', () => {
+    const receipts = [
+      { userId: '@user-1:matrix.org', eventId: 'event-1', ts: 1620000000000 },
+      { userId: '@user-2:matrix.org', eventId: 'event-2', ts: 1620000001000 },
+      { userId: '@current-user-id:matrix.org', eventId: 'event-3', ts: 1620000002000 },
+    ];
+
+    it('sets the selected message ID and updates the message readBy', async () => {
+      await expectSaga(openOverview, { payload: { roomId, messageId } })
+        .provide([
+          [call(getMessageReadReceipts, roomId, messageId), receipts],
+          [call(updateReadByUsers, messageId, receipts), undefined],
+        ])
+        .put(setSelectedMessageId(messageId))
+        .call(getMessageReadReceipts, roomId, messageId)
+        .call(updateReadByUsers, messageId, receipts)
+        .run();
+    });
+  });
+
+  describe('closeOverview', () => {
+    it('clears the selected message ID', async () => {
+      await expectSaga(closeOverview).put(setSelectedMessageId('')).run();
+    });
+  });
+});

--- a/src/store/message-info/saga.ts
+++ b/src/store/message-info/saga.ts
@@ -1,0 +1,35 @@
+import { call, fork, put, take, takeLatest } from 'redux-saga/effects';
+
+import { getMessageReadReceipts } from '../../lib/chat';
+import { SagaActionTypes, setSelectedMessageId } from './index';
+import { Events, getAuthChannel } from '../authentication/channels';
+import { updateReadByUsers } from '../messages/saga';
+
+function* authWatcher() {
+  const channel = yield call(getAuthChannel);
+  while (true) {
+    yield take(channel, Events.UserLogout);
+    yield call(closeOverview);
+  }
+}
+
+export function* openOverview(action) {
+  const { roomId, messageId } = action.payload;
+
+  yield put(setSelectedMessageId(messageId));
+
+  const receipts = yield call(getMessageReadReceipts, roomId, messageId);
+
+  yield call(updateReadByUsers, messageId, receipts);
+}
+
+export function* closeOverview() {
+  yield put(setSelectedMessageId(''));
+}
+
+export function* saga() {
+  yield fork(authWatcher);
+
+  yield takeLatest(SagaActionTypes.OpenMessageInfo, openOverview);
+  yield takeLatest(SagaActionTypes.CloseMessageInfo, closeOverview);
+}

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -5,6 +5,7 @@ import { createNormalizedSlice, removeAll } from '../normalized';
 
 import { LinkPreview } from '../../lib/link-preview';
 import { ParentMessage } from '../../lib/chat/types';
+import { User } from '../authentication/types';
 
 export interface AttachmentUploadResult {
   name: string;
@@ -84,6 +85,7 @@ export interface Message {
   optimisticId?: string;
   rootMessageId?: string;
   sendStatus: MessageSendStatus;
+  readBy?: User[];
 }
 
 export interface EditMessageOptions {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -500,6 +500,23 @@ export function* sendBrowserNotification(eventData) {
   }
 }
 
+export function* updateReadByUsers(messageId, receipts) {
+  const zeroUsersMap: { [id: string]: User } = yield select((state) => state.normalized.users || {});
+
+  const selectedMessage = yield select(messageSelector(messageId));
+  const filteredReceipts = receipts.filter((receipt) => receipt.ts >= selectedMessage?.createdAt);
+
+  const currentUser = yield select(currentUserSelector());
+
+  const readByUsers = filteredReceipts
+    .map((receipt) => {
+      return Object.values(zeroUsersMap).find((user) => user.matrixId === receipt.userId);
+    })
+    .filter((user) => user && user.userId !== currentUser.id);
+
+  yield put(receiveMessage({ id: messageId, readBy: readByUsers }));
+}
+
 export function* saga() {
   yield takeLatest(SagaActionTypes.Fetch, fetch);
   yield takeLatest(SagaActionTypes.Send, send);

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -18,6 +18,7 @@ import { reducer as confirmPasswordReset } from './confirm-password-reset';
 import { reducer as matrix } from './matrix';
 import { reducer as groupManagement } from './group-management';
 import { reducer as dialogs } from './dialogs';
+import { reducer as messageInfo } from './message-info';
 
 export const rootReducer = combineReducers({
   pageload,
@@ -38,6 +39,7 @@ export const rootReducer = combineReducers({
   matrix,
   groupManagement,
   dialogs,
+  messageInfo,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -19,6 +19,7 @@ import { saga as requestPasswordReset } from './request-password-reset/saga';
 import { saga as confirmPasswordReset } from './confirm-password-reset/saga';
 import { saga as matrix } from './matrix/saga';
 import { saga as groupManagement } from './group-management/saga';
+import { saga as messageInfo } from './message-info/saga';
 
 export function* rootSaga() {
   const allSagas = {
@@ -41,6 +42,7 @@ export function* rootSaga() {
     confirmPasswordReset,
     matrix,
     groupManagement,
+    messageInfo,
   };
 
   yield all(


### PR DESCRIPTION
### What does this do?
- adds message-info saga with open/close actions/
- adds updateReadByUsers function to message saga to handle the updating of readBy field on message object.
- adds test coverage.

### Why are we making this change?
- to handle read receipts.

### How do I test this?
- run tests as usual.
- UI not yet wired up, but hacked some together to be able to record a quick demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO


https://github.com/zer0-os/zOS/assets/39112648/891e6992-140f-4eec-9fb7-a907147a849b

