### PR TITLE
feat: edit message design changes

### DIFF
--- a/src/components/message/edit-message-actions/edit-message-actions.test.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.test.tsx
@@ -18,20 +18,20 @@ describe('EditMessageActions', () => {
     return shallow(<EditMessageActions {...allProps} />);
   };
 
-  it('should call onCancel when Discard Changes icon is clicked', () => {
+  it('should call onCancel when Discard Changes icon is pressed', () => {
     const onCancel = jest.fn();
     const wrapper = subject({ onCancel });
 
-    wrapper.find('.edit-message-actions__icon').first().simulate('click');
+    wrapper.find('Button').first().simulate('press');
 
     expect(onCancel).toHaveBeenCalled();
   });
 
-  it('should call onEdit when Save Changes icon is clicked', () => {
+  it('should call onEdit when Save Changes icon is pressed', () => {
     const onEdit = jest.fn();
     const wrapper = subject({ onEdit });
 
-    wrapper.find('.edit-message-actions__icon').at(1).simulate('click');
+    wrapper.find('Button').at(1).simulate('press');
 
     expect(onEdit).toHaveBeenCalled();
   });
@@ -39,14 +39,14 @@ describe('EditMessageActions', () => {
   it('should disable Save Changes icon when value is empty', () => {
     const wrapper = subject({ value: '' });
 
-    const isDisabled = wrapper.find('.edit-message-actions__icon').at(1).prop('isDisabled');
+    const isDisabled = wrapper.find('Button').at(1).prop('isDisabled');
     expect(isDisabled).toBe(true);
   });
 
   it('should enable Save Changes icon when value is not empty', () => {
     const wrapper = subject({ value: 'not empty' });
 
-    const isDisabled = wrapper.find('.edit-message-actions__icon').at(1).prop('isDisabled');
+    const isDisabled = wrapper.find('Button').at(1).prop('isDisabled');
     expect(isDisabled).toBe(false);
   });
 

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
 import { bemClassName } from '../../../lib/bem';
-
-import { IconCheck, IconXClose } from '@zero-tech/zui/icons';
-import { IconButton, Tooltip } from '@zero-tech/zui/components';
+import { Button, Color, Size, Variant } from '@zero-tech/zui/components/Button';
+import { Tooltip } from '@zero-tech/zui/components';
 
 import './styles.scss';
 
@@ -56,21 +55,31 @@ export default class EditMessageActions extends React.Component<Properties> {
     return (
       <div {...cn()} ref={this.editMessageActionRef}>
         <Tooltip content={this.props.secondaryTooltipText}>
-          <IconButton {...cn('icon')} onClick={this.props.onCancel} Icon={IconXClose} isFilled size='small' />
+          <Button
+            {...cn('icon')}
+            color={Color.Greyscale}
+            onPress={this.props.onCancel}
+            size={Size.Small}
+            variant={Variant.Secondary}
+          >
+            Cancel
+          </Button>
         </Tooltip>
         <Tooltip
           content={this.props.primaryTooltipText}
           open={this.state.tooltipOpen}
           onOpenChange={this.handleTooltipChange}
         >
-          <IconButton
+          <Button
             {...cn('icon', isDisabled && 'disabled')}
-            onClick={this.props.onEdit}
-            Icon={IconCheck}
+            color={Color.Highlight}
             isDisabled={isDisabled}
-            isFilled
-            size='small'
-          />
+            onPress={this.props.onEdit}
+            size={Size.Small}
+            variant={Variant.Secondary}
+          >
+            Send
+          </Button>
         </Tooltip>
       </div>
     );

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -55,13 +55,7 @@ export default class EditMessageActions extends React.Component<Properties> {
     return (
       <div {...cn()} ref={this.editMessageActionRef}>
         <Tooltip content={this.props.secondaryTooltipText}>
-          <Button
-            {...cn('icon')}
-            color={Color.Greyscale}
-            onPress={this.props.onCancel}
-            size={Size.Small}
-            variant={Variant.Secondary}
-          >
+          <Button color={Color.Greyscale} onPress={this.props.onCancel} size={Size.Small} variant={Variant.Secondary}>
             Cancel
           </Button>
         </Tooltip>
@@ -71,7 +65,6 @@ export default class EditMessageActions extends React.Component<Properties> {
           onOpenChange={this.handleTooltipChange}
         >
           <Button
-            {...cn('icon', isDisabled && 'disabled')}
             color={Color.Highlight}
             isDisabled={isDisabled}
             onPress={this.props.onEdit}

--- a/src/components/message/edit-message-actions/styles.scss
+++ b/src/components/message/edit-message-actions/styles.scss
@@ -5,17 +5,4 @@
   justify-content: flex-end;
   gap: 8px;
   padding: 8px 0px 0px;
-
-  &__icon {
-    color: theme.$color-greyscale-12;
-
-    &--disabled {
-      color: theme.$color-greyscale-9;
-      cursor: not-allowed;
-
-      &:hover {
-        background-color: unset;
-      }
-    }
-  }
 }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -38,6 +38,9 @@
 
       &--edit {
         border-radius: 8px 2px 0px 8px;
+        // stretch the edit block to 100% width
+        width: 100vw;
+        max-width: 100%;
       }
     }
 


### PR DESCRIPTION
### What does this do?

https://linear.app/zero-tech/issue/ZOS-26/edit-message-design

- Replaces `❌` and `✔️` icons in `EditMessageActions` with `Cancel` and `Send`
- When editing, editing bubble width now matches max message width

### Why are we making this change?

N/a

### How do I test this?

1. Send a message, preferably a long one so you can test max input width
2. Open Edit Message dialog (right click on message, or hit triple dot menu beside message, and click "Edit)

- Edit message buttons should be `Cancel` and `Send`, rather than `❌` and `✔️`
- Input should match max message width