### PR TITLE
feat(message): prevent custom context menu on textarea

### DIFF
--- a/src/components/message-input/mentions/index.test.tsx
+++ b/src/components/message-input/mentions/index.test.tsx
@@ -47,6 +47,15 @@ describe(Mentions, () => {
       { display: '3--dale', id: 'd-3', profileImage: 'http://example.com/3', primaryZID: '0://d-3:dale' },
     ]);
   });
+
+  it('should prevent stop propagation of contextmenu events', function () {
+    const wrapper = subject({});
+    const event = { stopPropagation: jest.fn() } as unknown as MouseEvent;
+
+    wrapper.simulate('contextmenu', event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
 });
 
 async function userSearch(wrapper, search) {

--- a/src/components/message-input/mentions/index.tsx
+++ b/src/components/message-input/mentions/index.tsx
@@ -45,6 +45,12 @@ export class Mentions extends React.Component<Properties> {
     return highlightFilter(text, currentMentionsText);
   }
 
+  handleOnContextMenu(event: MouseEvent) {
+    // Prevent the custom context menu from appearing, but still
+    // allow the default browser context menu to appear
+    event.stopPropagation();
+  }
+
   renderMentionTypes() {
     const mentions = [
       <Mention
@@ -81,6 +87,7 @@ export class Mentions extends React.Component<Properties> {
         value={this.props.value}
         allowSuggestionsAboveCursor
         suggestionsPortalHost={document.body}
+        onContextMenu={this.handleOnContextMenu}
       >
         {this.renderMentionTypes()}
       </MentionsInput>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -78,7 +78,10 @@ export class Message extends React.Component<Properties, State> {
       }
     }
 
-    if (event.button === 2) {
+    const hoveringNode = (event.target as HTMLElement).nodeName.toLowerCase();
+    const isHoveringTextArea = hoveringNode === 'textarea';
+
+    if (!isHoveringTextArea && event.button === 2) {
       event.preventDefault();
       event.stopPropagation();
       const { pageX, pageY } = event;

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -78,10 +78,7 @@ export class Message extends React.Component<Properties, State> {
       }
     }
 
-    const hoveringNode = (event.target as HTMLElement).nodeName.toLowerCase();
-    const isHoveringTextArea = hoveringNode === 'textarea';
-
-    if (!isHoveringTextArea && event.button === 2) {
+    if (event.button === 2) {
       event.preventDefault();
       event.stopPropagation();
       const { pageX, pageY } = event;


### PR DESCRIPTION
### What does this do?

https://linear.app/zero-tech/issue/ZOS-95/when-editing-a-message-if-your-browser-supports-spellcheck-you-should

- Prevents `contextmenu` from triggering when the user is hovering editable text (in this case, the `textarea` which appears after you hit `Edit`on a message)

### Why are we making this change?

N/a

### How do I test this?

https://github.com/zer0-os/zOS/assets/12437916/57d7a854-049f-4f76-83e1-95045d8d9fe5


