### PR TITLE
feat(read-receipts): track and publish live receipts

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,6 +23,7 @@ export interface RealtimeChatEvents {
   roomUnfavorited: (roomId: string) => void;
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
   roomMemberPowerLevelChanged: (roomId: string, matrixId: string, powerLevel: number) => void;
+  readReceiptReceived: (messageId: string, userId: string) => void;
 }
 
 export interface MatrixKeyBackupInfo {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -938,6 +938,10 @@ export class MatrixClient implements IChatClient {
       }
     });
 
+    this.matrix.on(RoomEvent.Receipt, async (event) => {
+      this.publishReceiptEvent(event);
+    });
+
     this.matrix.on(MatrixEventEvent.Decrypted, async (decryptedEvent: MatrixEvent) => {
       const event = decryptedEvent.getEffectiveEvent();
       if (event.type === EventType.RoomMessage) {
@@ -1130,6 +1134,16 @@ export class MatrixClient implements IChatClient {
       this.events.roomFavorited(roomId);
     } else {
       this.events.roomUnfavorited(roomId);
+    }
+  }
+
+  private publishReceiptEvent(event: MatrixEvent) {
+    const content = event.getContent();
+    for (const eventId in content) {
+      const receiptData = content[eventId]['m.read'] || {};
+      for (const userId in receiptData) {
+        this.events.readReceiptReceived(eventId, userId);
+      }
     }
   }
 

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -22,6 +22,7 @@ export enum Events {
   RoomUnfavorited = 'chat/channel/roomUnfavorited',
   RoomMemberTyping = 'chat/channel/roomMemberTyping',
   RoomMemberPowerLevelChanged = 'chat/channel/roomMemberPowerLevelChanged',
+  ReadReceiptReceived = 'chat/message/readReceiptReceived',
 }
 
 let theBus;
@@ -92,6 +93,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const roomMemberTyping = (roomId, userIds) => emit({ type: Events.RoomMemberTyping, payload: { roomId, userIds } });
     const roomMemberPowerLevelChanged = (roomId, matrixId, powerLevel) =>
       emit({ type: Events.RoomMemberPowerLevelChanged, payload: { roomId, matrixId, powerLevel } });
+    const readReceiptReceived = (messageId, userId) =>
+      emit({ type: Events.ReadReceiptReceived, payload: { messageId, userId } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -110,6 +113,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       roomUnfavorited,
       roomMemberTyping,
       roomMemberPowerLevelChanged,
+      readReceiptReceived,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);


### PR DESCRIPTION
### What does this do?
- tracks and publishes real time read receipts (currently feature flagged).

### Why are we making this change?
- to update the UI in real time for read receipts (as per demo below).

### How do I test this?
- run tests as usual.
- run ui and follow the demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


DEMO


https://github.com/zer0-os/zOS/assets/39112648/564d7d2f-d340-4195-90e4-15f7018b99a4

