### PR TITLE
feat(message-info): add container and component

### DIFF
--- a/src/components/messenger/message-info/container.tsx
+++ b/src/components/messenger/message-info/container.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { connectContainer } from '../../../store/redux-container';
+import { MessageInfo } from '.';
+import { RootState } from '../../../store/reducer';
+import { closeMessageInfo } from '../../../store/message-info';
+import { denormalize as denormalizeChannel } from '../../../store/channels';
+import { User } from '../../../store/channels';
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  readBy: User[];
+  sentTo: User[];
+
+  closeMessageInfo: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    const {
+      chat: { activeConversationId },
+      messageInfo: { selectedMessageId },
+    } = state;
+
+    const channel = denormalizeChannel(activeConversationId, state) || {};
+    const messages = channel.messages || [];
+    const selectedMessage = messages.find((msg) => msg.id === selectedMessageId) || {};
+
+    const readBy = selectedMessage.readBy || [];
+    const sentTo = (channel.otherMembers || []).filter(
+      (user) => !readBy.some((readUser) => readUser.userId === user.userId)
+    );
+
+    return {
+      readBy,
+      sentTo,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { closeMessageInfo };
+  }
+
+  render() {
+    return (
+      <MessageInfo
+        readBy={this.props.readBy}
+        sentTo={this.props.sentTo}
+        closeMessageInfo={this.props.closeMessageInfo}
+      />
+    );
+  }
+}
+
+export const MessageInfoContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/message-info/index.tsx
+++ b/src/components/messenger/message-info/index.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { OverviewPanel } from './overview-panel';
+import { User } from '../../../store/channels';
+
+export interface Properties {
+  readBy: User[];
+  sentTo: User[];
+
+  closeMessageInfo: () => void;
+}
+
+export class MessageInfo extends React.Component<Properties> {
+  render() {
+    return (
+      <OverviewPanel
+        readBy={this.props.readBy}
+        sentTo={this.props.sentTo}
+        closeMessageInfo={this.props.closeMessageInfo}
+      />
+    );
+  }
+}

--- a/src/components/messenger/message-info/overview-panel/index.test.tsx
+++ b/src/components/messenger/message-info/overview-panel/index.test.tsx
@@ -1,0 +1,66 @@
+import { shallow } from 'enzyme';
+import { OverviewPanel, Properties } from '.';
+import { PanelHeader } from '../../list/panel-header';
+import { CitizenListItem } from '../../../citizen-list-item';
+import { User } from '../../../../store/channels';
+import { bem } from '../../../../lib/bem';
+
+import { stubUser } from '../../../../store/test/store';
+
+const cn = bem('.message-info-overview-panel');
+
+describe(OverviewPanel, () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      readBy: [],
+      sentTo: [],
+
+      closeMessageInfo: () => {},
+      ...props,
+    };
+
+    return shallow(<OverviewPanel {...allProps} />);
+  };
+
+  it('calls closeMessageInfo on PanelHeader back event', () => {
+    const closeMessageInfo = jest.fn();
+    const wrapper = subject({ closeMessageInfo });
+
+    wrapper.find(PanelHeader).simulate('back');
+
+    expect(closeMessageInfo).toHaveBeenCalled();
+  });
+
+  it('renders readBy section', () => {
+    const readBy: User[] = [stubUser({ userId: '1' })];
+    const wrapper = subject({ readBy });
+
+    expect(wrapper.find(cn('section'))).toHaveLength(1);
+    expect(wrapper.find(cn('section-title')).at(0)).toHaveText('Read By');
+    expect(wrapper.find(CitizenListItem)).toHaveLength(1);
+  });
+
+  it('does not render readBy section if readBy is empty', () => {
+    const sentTo: User[] = [stubUser({ userId: '1' })];
+    const wrapper = subject({ readBy: [], sentTo });
+
+    expect(wrapper.find(cn('section'))).toHaveLength(1);
+    expect(wrapper.find(cn('section-title')).at(0)).toHaveText('Sent To');
+  });
+
+  it('renders sentTo section', () => {
+    const sentTo: User[] = [stubUser({ userId: '1' })];
+    const wrapper = subject({ sentTo });
+
+    expect(wrapper.find(cn('section'))).toHaveLength(1);
+    expect(wrapper.find(cn('section-title')).at(0)).toHaveText('Sent To');
+  });
+
+  it('does not render sentTo section if sentTo is empty', () => {
+    const readBy: User[] = [stubUser({ userId: '1' })];
+    const wrapper = subject({ readBy, sentTo: [] });
+
+    expect(wrapper.find(cn('section'))).toHaveLength(1);
+    expect(wrapper.find(cn('section-title')).at(0)).toHaveText('Read By');
+  });
+});

--- a/src/components/messenger/message-info/overview-panel/index.test.tsx
+++ b/src/components/messenger/message-info/overview-panel/index.test.tsx
@@ -54,6 +54,7 @@ describe(OverviewPanel, () => {
 
     expect(wrapper.find(cn('section'))).toHaveLength(1);
     expect(wrapper.find(cn('section-title')).at(0)).toHaveText('Sent To');
+    expect(wrapper.find(CitizenListItem)).toHaveLength(1);
   });
 
   it('does not render sentTo section if sentTo is empty', () => {

--- a/src/components/messenger/message-info/overview-panel/index.tsx
+++ b/src/components/messenger/message-info/overview-panel/index.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import { bemClassName } from '../../../../lib/bem';
+import { PanelHeader } from '../../list/panel-header';
+import { CitizenListItem } from '../../../citizen-list-item';
+import { ScrollbarContainer } from '../../../scrollbar-container';
+import { User } from '../../../../store/channels';
+
+import './styles.scss';
+
+const cn = bemClassName('message-info-overview-panel');
+
+export interface Properties {
+  readBy: User[];
+  sentTo: User[];
+
+  closeMessageInfo: () => void;
+}
+
+export class OverviewPanel extends React.Component<Properties> {
+  close = () => {
+    this.props.closeMessageInfo();
+  };
+
+  renderMembers = () => {
+    const { readBy, sentTo } = this.props;
+
+    return (
+      <ScrollbarContainer>
+        {readBy.length > 0 && (
+          <div {...cn('section')}>
+            <div {...cn('section-title')}>Read By</div>
+
+            {readBy.map((u) => (
+              <CitizenListItem key={u.userId} user={u}></CitizenListItem>
+            ))}
+          </div>
+        )}
+
+        {sentTo.length > 0 && (
+          <div {...cn('section')}>
+            <div {...cn('section-title')}>Sent To</div>
+
+            {sentTo.map((u) => (
+              <CitizenListItem key={u.userId} user={u}></CitizenListItem>
+            ))}
+          </div>
+        )}
+      </ScrollbarContainer>
+    );
+  };
+
+  render() {
+    return (
+      <div {...cn()}>
+        <div {...cn('header-container')}>
+          <PanelHeader title={'Message Info'} onBack={this.close} />
+        </div>
+
+        <div {...cn('body')}>{this.renderMembers()}</div>
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/message-info/overview-panel/styles.scss
+++ b/src/components/messenger/message-info/overview-panel/styles.scss
@@ -1,0 +1,32 @@
+@import '../../../../glass';
+
+.message-info-overview-panel {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+
+  &__body {
+    margin: 0 16px 16px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  &__section-title {
+    @include glass-text-secondary-color;
+
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 14px;
+    text-transform: uppercase;
+    margin-bottom: 2px;
+  }
+}


### PR DESCRIPTION
### What does this do?
- adds message info container, index and overview panel.

### Why are we making this change?
- in order to display read receipts in message info panel.

### How do I test this?
- run tests as usual.
- this will not be wired up to the UI yet.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="325" alt="Screenshot 2024-05-30 at 19 01 32" src="https://github.com/zer0-os/zOS/assets/39112648/28371f9f-572c-4441-bc52-e33706a68991">

