### PR TITLE
feat(messenger-list): add custom opaque footer button color

### DIFF
--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -31,6 +31,15 @@ $side-padding: 16px;
 
   &__footer-button {
     margin-bottom: 16px;
+    background: #181818;
+
+    &:hover {
+      background: #181818;
+    }
+
+    &:active {
+      background: #141414;
+    }
   }
 }
 


### PR DESCRIPTION
### What does this do?
- adds a custom opaque footer button colour (invite button on conversation list panel).

### Why are we making this change?
- as requested for improved ux.

### How do I test this?
- run ui and check button as per demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO


https://github.com/zer0-os/zOS/assets/39112648/f5016885-61c6-4151-b4ec-f1b84c4170d0

