### PR TITLE
feat(settings-panel): add ability to select and set background option on settings panel in user profile flow

### DIFF
--- a/src/components/messenger/user-profile/index.tsx
+++ b/src/components/messenger/user-profile/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { OverviewPanel } from './overview-panel';
 import { Stage } from '../../../store/user-profile';
 import { EditProfileContainer } from '../../edit-profile/container';
-import { SettingsPanel } from './settings-panel';
+import { SettingsPanelContainer } from './settings-panel/container';
 
 export interface Properties {
   stage: Stage;
@@ -39,7 +39,7 @@ export class UserProfile extends React.Component<Properties> {
         )}
 
         {this.props.stage === Stage.EditProfile && <EditProfileContainer onClose={this.props.onBackToOverview} />}
-        {this.props.stage === Stage.Settings && <SettingsPanel onBack={this.props.onBackToOverview} />}
+        {this.props.stage === Stage.Settings && <SettingsPanelContainer onClose={this.props.onBackToOverview} />}
       </>
     );
   }

--- a/src/components/messenger/user-profile/settings-panel/container.tsx
+++ b/src/components/messenger/user-profile/settings-panel/container.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import { RootState } from '../../../../store/reducer';
+import { connectContainer } from '../../../../store/redux-container';
+
+import { SettingsPanel } from '.';
+import { MainBackground, setMainBackground } from '../../../../store/background';
+
+export interface PublicProperties {
+  onClose?: () => void;
+}
+
+export interface Properties extends PublicProperties {
+  selectedMainBackground: MainBackground;
+
+  setMainBackground: (payload: { selectedBackground: MainBackground }) => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState) {
+    const { background } = state;
+    return {
+      selectedMainBackground: background.selectedMainBackground,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { setMainBackground };
+  }
+
+  render() {
+    return (
+      <SettingsPanel
+        selectedMainBackground={this.props.selectedMainBackground}
+        onBack={this.props.onClose}
+        onSetMainBackground={this.props.setMainBackground}
+      />
+    );
+  }
+}
+
+export const SettingsPanelContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/user-profile/settings-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/settings-panel/index.test.tsx
@@ -2,11 +2,16 @@ import { shallow } from 'enzyme';
 
 import { SettingsPanel, Properties } from '.';
 import { PanelHeader } from '../../list/panel-header';
+import { MainBackground } from '../../../../store/background';
+import { SelectInput } from '@zero-tech/zui/components';
 
 describe(SettingsPanel, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
+      selectedMainBackground: MainBackground.StaticGreenParticles,
+
       onBack: () => {},
+      onSetMainBackground: () => {},
 
       ...props,
     };
@@ -22,4 +27,20 @@ describe(SettingsPanel, () => {
 
     expect(onBack).toHaveBeenCalled();
   });
+
+  it('publishes onSetMainBackground event', () => {
+    const onSetMainBackground = jest.fn();
+    const wrapper = subject({ onSetMainBackground });
+
+    selectInputItem(wrapper, SelectInput, MainBackground.AnimatedBlackParticles);
+
+    expect(onSetMainBackground).toHaveBeenCalledWith(MainBackground.AnimatedBlackParticles);
+    expect(onSetMainBackground).toHaveBeenCalledOnce();
+  });
 });
+
+export function selectInputItem(wrapper, selector, itemId: string) {
+  const selectInput = wrapper.find(selector);
+  const item = selectInput.prop('items').find((item) => item.id === itemId);
+  item.onSelect();
+}

--- a/src/components/messenger/user-profile/settings-panel/index.tsx
+++ b/src/components/messenger/user-profile/settings-panel/index.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react';
 
 import { bemClassName } from '../../../../lib/bem';
+import { MainBackground } from '../../../../store/background';
+import { translateBackgroundValue } from './utils';
 
 import { PanelHeader } from '../../list/panel-header';
+import { SelectInput } from '@zero-tech/zui/components';
 
 import './styles.scss';
 
 const cn = bemClassName('settings-panel');
 
 export interface Properties {
+  selectedMainBackground: MainBackground;
+
   onBack: () => void;
+  onSetMainBackground: (payload: { selectedBackground: MainBackground }) => void;
 }
 
 export class SettingsPanel extends React.Component<Properties> {
@@ -17,14 +23,59 @@ export class SettingsPanel extends React.Component<Properties> {
     this.props.onBack();
   };
 
+  setMainBackground = (background) => {
+    this.props.onSetMainBackground(background);
+  };
+
+  renderSelectInputLabel(label) {
+    return <div>{label}</div>;
+  }
+
+  get getMainBackgroundItems() {
+    const mainBackgroundItems = [];
+
+    mainBackgroundItems.push({
+      id: MainBackground.StaticGreenParticles,
+      label: this.renderSelectInputLabel('Green Particle (Static)'),
+      onSelect: () => this.setMainBackground(MainBackground.StaticGreenParticles),
+    });
+
+    mainBackgroundItems.push({
+      id: MainBackground.AnimatedGreenParticles,
+      label: this.renderSelectInputLabel('Greeen Particle (Animated)'),
+      onSelect: () => this.setMainBackground(MainBackground.AnimatedGreenParticles),
+    });
+
+    mainBackgroundItems.push({
+      id: MainBackground.AnimatedBlackParticles,
+      label: this.renderSelectInputLabel('Black Particle (Animated)'),
+      onSelect: () => this.setMainBackground(MainBackground.AnimatedBlackParticles),
+    });
+
+    return mainBackgroundItems;
+  }
+
   render() {
+    const mainBackgroundItems = this.getMainBackgroundItems;
+    const selectedBackgroundLabel = translateBackgroundValue(this.props.selectedMainBackground);
+
     return (
       <div {...cn()}>
         <div {...cn('header-container')}>
           <PanelHeader title={'Settings'} onBack={this.back} />
         </div>
 
-        <div {...cn('body')}></div>
+        <div {...cn('body')}>
+          <div {...cn('select-input-container')}>
+            <SelectInput
+              items={mainBackgroundItems}
+              label='Select Background'
+              placeholder='Select Background'
+              value={selectedBackgroundLabel}
+              itemSize='compact'
+            />
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/messenger/user-profile/settings-panel/styles.scss
+++ b/src/components/messenger/user-profile/settings-panel/styles.scss
@@ -1,4 +1,4 @@
-@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../glass';
 
 .settings-panel {
   flex-grow: 1;
@@ -18,5 +18,13 @@
 
     justify-content: space-between;
     margin: 16px 16px 0 16px;
+  }
+
+  &__select-input-container {
+    > *:last-child {
+      > div {
+        min-width: 236px;
+      }
+    }
   }
 }

--- a/src/components/messenger/user-profile/settings-panel/utils.test.ts
+++ b/src/components/messenger/user-profile/settings-panel/utils.test.ts
@@ -1,0 +1,20 @@
+import { MainBackground } from '../../../../store/background';
+import { translateBackgroundValue } from './utils';
+
+describe('translateBackgroundValue', () => {
+  it('should return "Green Particle (Static)" for MainBackground.StaticGreenParticles', () => {
+    expect(translateBackgroundValue(MainBackground.StaticGreenParticles)).toBe('Green Particle (Static)');
+  });
+
+  it('should return "Green Particle (Animated)" for MainBackground.AnimatedGreenParticles', () => {
+    expect(translateBackgroundValue(MainBackground.AnimatedGreenParticles)).toBe('Green Particle (Animated)');
+  });
+
+  it('should return "Black Particle (Animated)" for MainBackground.AnimatedBlackParticles', () => {
+    expect(translateBackgroundValue(MainBackground.AnimatedBlackParticles)).toBe('Black Particle (Animated)');
+  });
+
+  it('should return an empty string for an unknown value', () => {
+    expect(translateBackgroundValue('unknown-value')).toBe('');
+  });
+});

--- a/src/components/messenger/user-profile/settings-panel/utils.ts
+++ b/src/components/messenger/user-profile/settings-panel/utils.ts
@@ -1,0 +1,14 @@
+import { MainBackground } from '../../../../store/background';
+
+export function translateBackgroundValue(value) {
+  switch (value) {
+    case MainBackground.StaticGreenParticles:
+      return 'Green Particle (Static)';
+    case MainBackground.AnimatedGreenParticles:
+      return 'Green Particle (Animated)';
+    case MainBackground.AnimatedBlackParticles:
+      return 'Black Particle (Animated)';
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
### What does this do?
- adds ability to select and set background option on settings panel in user profile flow

### Why are we making this change?
- to enable background preferences.

### How do I test this?
- run tests as usual.
- run UI > enableSetBackground > open user profile > open settings > choose background > check UI.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO


https://github.com/zer0-os/zOS/assets/39112648/9a1dc64f-914a-4e4d-9069-2e44d7430fa1

