### PR TITLE
refactor(matrix-client): update set read receipt function argument type and remove flag

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -4,7 +4,6 @@ import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage, User } from './types';
 import { MemberNetworks } from '../../store/users/types';
-import { ReadReceiptPreferenceType } from './matrix/types';
 
 export interface RealtimeChatEvents {
   receiveNewMessage: (channelId: string, message: Message) => void;
@@ -329,7 +328,7 @@ export async function removeUserAsModerator(roomId: string, userId: string) {
   return await chat.get().matrix.removeUserAsModerator(roomId, userId);
 }
 
-export async function setReadReceiptPreference(preference: ReadReceiptPreferenceType) {
+export async function setReadReceiptPreference(preference: string) {
   return await chat.get().matrix.setReadReceiptPreference(preference);
 }
 

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -106,12 +106,6 @@ function resolveWith<T>(valueToResolve: T) {
   return { resolve: theResolve, mock: () => promise };
 }
 
-const featureFlags = { enableReadReceiptPreferences: false };
-
-jest.mock('../../lib/feature-flags', () => ({
-  featureFlags,
-}));
-
 describe('matrix client', () => {
   describe('disconnect', () => {
     it('stops client completely on disconnect', async () => {
@@ -961,8 +955,6 @@ describe('matrix client', () => {
 
   describe('markRoomAsRead', () => {
     it('marks room as read successfully', async () => {
-      featureFlags.enableReadReceiptPreferences = true;
-
       const roomId = '!testRoomId';
       const latestEventId = 'latest-event-id';
       const latestEvent = {
@@ -987,35 +979,6 @@ describe('matrix client', () => {
 
       expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent, ReceiptType.Read);
       expect(setRoomReadMarkers).toHaveBeenCalledWith(roomId, latestEventId);
-    });
-
-    // temporary test
-    it('read receipt is private if feature flag is not enabled', async () => {
-      featureFlags.enableReadReceiptPreferences = false;
-
-      const roomId = '!testRoomId';
-      const latestEventId = 'latest-event-id';
-      const latestEvent = {
-        event: { event_id: latestEventId },
-      };
-
-      const sendReadReceipt = jest.fn().mockResolvedValue(undefined);
-      const setRoomReadMarkers = jest.fn().mockResolvedValue(undefined);
-      const getLiveTimelineEvents = jest.fn().mockReturnValue([latestEvent]);
-      const getRoom = jest.fn().mockReturnValue(
-        stubRoom({
-          getLiveTimeline: jest.fn().mockReturnValue(stubTimeline({ getEvents: getLiveTimelineEvents })),
-        })
-      );
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ sendReadReceipt, setRoomReadMarkers, getRoom })),
-      });
-
-      await client.connect(null, 'token');
-      await client.markRoomAsRead(roomId);
-
-      expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent, ReceiptType.ReadPrivate);
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -679,7 +679,7 @@ export class MatrixClient implements IChatClient {
     }
   }
 
-  async setReadReceiptPreference(preference: ReadReceiptPreferenceType) {
+  async setReadReceiptPreference(preference: string) {
     await this.matrix.setAccountData(MatrixConstants.READ_RECEIPT_PREFERENCE, { readReceipts: preference });
   }
 
@@ -729,9 +729,7 @@ export class MatrixClient implements IChatClient {
     const userReceiptPreference = await this.getReadReceiptPreference();
 
     const receiptType =
-      featureFlags.enableReadReceiptPreferences && userReceiptPreference === ReadReceiptPreferenceType.Public
-        ? ReceiptType.Read
-        : ReceiptType.ReadPrivate;
+      userReceiptPreference === ReadReceiptPreferenceType.Public ? ReceiptType.Read : ReceiptType.ReadPrivate;
 
     await this.matrix.sendReadReceipt(latestEvent, receiptType);
     await this.matrix.setRoomReadMarkers(roomId, latestEvent.event.event_id);


### PR DESCRIPTION
### What does this do?
- updates argument type for the setReadReceiptFunction
- Removes flag. We would normally just flip this, it is safe to remove here.

### Why are we making this change?
- leads the way to handle setting of receipts in an improved way (follow up PRs).

### How do I test this?
- run tests as usual. this wasn't wired up yet.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
