### PR TITLE
feat(message-info-overview-panel): add highlighter for mentions in message content

### DIFF
--- a/src/components/messenger/message-info/overview-panel/index.tsx
+++ b/src/components/messenger/message-info/overview-panel/index.tsx
@@ -5,6 +5,7 @@ import { PanelHeader } from '../../list/panel-header';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { User } from '../../../../store/channels';
+import { ContentHighlighter } from '../../../content-highlighter';
 
 import './styles.scss';
 import moment from 'moment';
@@ -35,7 +36,9 @@ export class OverviewPanel extends React.Component<Properties> {
       <div {...cn('message-container')}>
         {this.props.message && (
           <div {...cn('message-content-container')}>
-            <div {...cn('message-content')}>{this.props.message}</div>
+            <div {...cn('message-content')}>
+              <ContentHighlighter message={this.props.message} />
+            </div>
           </div>
         )}
         {this.renderTime()}


### PR DESCRIPTION
### What does this do?
- adds content highlighter to message content to message info overview panel

### Why are we making this change?
- render mentions correctly

### How do I test this?
- run ui and send a message with a mention. open message info and check message content.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
