### PR TITLE
refactor(info-option): enable view message info for all members

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -268,9 +268,7 @@ export class Message extends React.Component<Properties, State> {
 
   canViewInfo = (): boolean => {
     return (
-      this.props.isOwner &&
-      this.props.sendStatus !== MessageSendStatus.IN_PROGRESS &&
-      this.props.sendStatus !== MessageSendStatus.FAILED
+      this.props.sendStatus !== MessageSendStatus.IN_PROGRESS && this.props.sendStatus !== MessageSendStatus.FAILED
     );
   };
 


### PR DESCRIPTION
### What does this do?
- enables view message info for all members

### Why are we making this change?
- as requested.

### How do I test this?
- run tests as usual.
- open any message menu and check message info is an option on the message menu and opens as expected

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
