### PR TITLE
fix(read-receipts): ensure read receipts persist on refresh or logout/login

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -332,6 +332,10 @@ export async function setReadReceiptPreference(preference: string) {
   return await chat.get().matrix.setReadReceiptPreference(preference);
 }
 
+export async function getReadReceiptPreference() {
+  return await chat.get().matrix.getReadReceiptPreference();
+}
+
 export async function getMessageReadReceipts(roomId: string, messageId: string) {
   return await chat.get().matrix.getMessageReadReceipts(roomId, messageId);
 }

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -28,6 +28,7 @@ import { expectSaga } from '../../test/saga';
 import { getZEROUsers } from './api';
 import { mapAdminUserIdToZeroUserId, mapChannelMembers } from './utils';
 import { openFirstConversation } from '../channels/saga';
+import { getUserReadReceiptPreference } from '../user-profile/saga';
 
 const mockConversation = (id: string) => ({
   id: `conversation_${id}`,
@@ -56,6 +57,7 @@ describe('channels list saga', () => {
         [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
         [matchers.call.fn(mapToZeroUsers), null],
         [matchers.fork.fn(fetchUserPresence), null],
+        [matchers.call.fn(getUserReadReceiptPreference), null],
       ]);
     }
 
@@ -64,6 +66,7 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
+          [matchers.call.fn(getUserReadReceiptPreference), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
@@ -76,6 +79,7 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
+          [matchers.call.fn(getUserReadReceiptPreference), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .call(chat.get)
@@ -95,6 +99,7 @@ describe('channels list saga', () => {
           [matchers.call.fn(fetchUserPresence), null],
           [matchers.call.fn(mapAdminUserIdToZeroUserId), null],
           [matchers.call.fn(getConversationsBus), conversationsChannelStub],
+          [matchers.call.fn(getUserReadReceiptPreference), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .put(conversationsChannelStub, { type: ConversationEvents.ConversationsLoaded })

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -24,6 +24,7 @@ import { union } from 'lodash';
 import { uniqNormalizedList } from '../utils';
 import { channelListStatus, rawConversationsList } from './selectors';
 import { setIsConversationsLoaded } from '../chat';
+import { getUserReadReceiptPreference } from '../user-profile/saga';
 
 export function* mapToZeroUsers(channels: any[]) {
   let allMatrixIds = [];
@@ -80,6 +81,7 @@ export function* fetchConversations() {
 
   const otherMembersOfConversations = conversations.flatMap((c) => c.otherMembers);
   yield fork(fetchUserPresence, otherMembersOfConversations);
+  yield call(getUserReadReceiptPreference);
 
   const existingConversationList = yield select(denormalizeConversations);
   const optimisticConversationIds = existingConversationList

--- a/src/store/user-profile/index.ts
+++ b/src/store/user-profile/index.ts
@@ -23,7 +23,7 @@ export type UserProfileState = {
 
 export const initialState: UserProfileState = {
   stage: Stage.None,
-  isPublicReadReceipts: true,
+  isPublicReadReceipts: null,
 };
 
 export const openUserProfile = createAction(SagaActionTypes.OpenUserProfile);

--- a/src/store/user-profile/saga.test.ts
+++ b/src/store/user-profile/saga.test.ts
@@ -7,11 +7,12 @@ import {
   openSettings,
   onPrivateReadReceipts,
   onPublicReadReceipts,
+  getUserReadReceiptPreference,
 } from './saga';
 import { UserProfileState, initialState as initialUserProfileState, Stage, setStage, setPublicReadReceipts } from '.';
 import { rootReducer } from '../reducer';
 import { User } from '../authentication/types';
-import { setReadReceiptPreference } from '../../lib/chat';
+import { getReadReceiptPreference, setReadReceiptPreference } from '../../lib/chat';
 
 describe('openUserProfile', () => {
   it('should set stage to Overview', async () => {
@@ -86,7 +87,7 @@ describe('onPublicReadReceipts', () => {
       ...initialState(),
       userProfile: {
         ...initialState().userProfile,
-        isPublicReadReceipt: false,
+        isPublicReadReceipts: false,
       },
     };
 
@@ -100,6 +101,54 @@ describe('onPublicReadReceipts', () => {
       ])
       .put(setPublicReadReceipts(true))
       .run();
+  });
+});
+
+describe('getUserReadReceiptPreference', () => {
+  it('should set isPublicReadReceipts to true when preference is public', async () => {
+    const initialStateWithPrivateReadReceipts = {
+      ...initialState(),
+      userProfile: {
+        ...initialState().userProfile,
+        isPublicReadReceipts: false,
+      },
+    };
+
+    const { storeState } = await expectSaga(getUserReadReceiptPreference)
+      .withReducer(rootReducer, initialStateWithPrivateReadReceipts)
+      .provide([
+        [
+          matchers.call.fn(getReadReceiptPreference),
+          'public',
+        ],
+      ])
+      .put(setPublicReadReceipts(true))
+      .run();
+
+    expect(storeState.userProfile.isPublicReadReceipts).toEqual(true);
+  });
+
+  it('should set isPublicReadReceipts to false when preference is private', async () => {
+    const initialStateWithPublicReadReceipts = {
+      ...initialState(),
+      userProfile: {
+        ...initialState().userProfile,
+        isPublicReadReceipts: true,
+      },
+    };
+
+    const { storeState } = await expectSaga(getUserReadReceiptPreference)
+      .withReducer(rootReducer, initialStateWithPublicReadReceipts)
+      .provide([
+        [
+          matchers.call.fn(getReadReceiptPreference),
+          'private',
+        ],
+      ])
+      .put(setPublicReadReceipts(false))
+      .run();
+
+    expect(storeState.userProfile.isPublicReadReceipts).toEqual(false);
   });
 });
 

--- a/src/store/user-profile/saga.ts
+++ b/src/store/user-profile/saga.ts
@@ -1,6 +1,6 @@
 import { call, put, takeLatest } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setStage, setPublicReadReceipts } from '.';
-import { setReadReceiptPreference } from '../../lib/chat';
+import { getReadReceiptPreference, setReadReceiptPreference } from '../../lib/chat';
 
 export function* openUserProfile() {
   yield put(setStage(Stage.Overview));
@@ -33,6 +33,16 @@ export function* onPublicReadReceipts() {
     yield put(setPublicReadReceipts(true));
   } catch (error) {
     console.error('Failed to set read receipt preference:', error);
+  }
+}
+
+export function* getUserReadReceiptPreference() {
+  const preference = yield call(getReadReceiptPreference);
+
+  if (preference === 'public') {
+    yield put(setPublicReadReceipts(true));
+  } else {
+    yield put(setPublicReadReceipts(false));
   }
 }
 


### PR DESCRIPTION
### What does this do?
- ensures read receipts preferences are fetched to persist choice after refresh or logout.

### Why are we making this change?
- to ensure read receipts preferences are working as expected.

### How do I test this?
- run tests as usual.
- run the ui and choose a read receipt preference > refresh page and check setting is the same.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

