### PR TITLE
feat(chat-view): implement message bubble read receipts

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -29,7 +29,7 @@ export interface Properties extends PublicProperties {
   isSecondarySidekickOpen: boolean;
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
-  openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  openMessageInfo: (payload: { messageId: number }) => void;
 }
 
 interface PublicProperties {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -51,7 +51,7 @@ export interface Properties {
   conversationErrorMessage: string;
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
-  openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  openMessageInfo: (payload: { messageId: number }) => void;
 }
 
 export interface State {
@@ -109,7 +109,7 @@ export class ChatView extends React.Component<Properties, State> {
   };
 
   openMessageInfo = (messageId: number) => {
-    this.props.openMessageInfo({ roomId: this.props.id, messageId });
+    this.props.openMessageInfo({ messageId });
 
     if (!this.props.isSecondarySidekickOpen) {
       this.props.toggleSecondarySidekick();
@@ -135,6 +135,10 @@ export class ChatView extends React.Component<Properties, State> {
   isUserOwnerOfMessage(message: MessageModel) {
     // eslint-disable-next-line eqeqeq
     return this.props.user && message?.sender && this.props.user.id == message.sender.userId;
+  }
+
+  isRead(message: MessageModel) {
+    return message?.readBy && message?.readBy?.length === this.props?.otherMembers?.length;
   }
 
   renderMessageGroup(groupMessages) {
@@ -178,6 +182,7 @@ export class ChatView extends React.Component<Properties, State> {
                 showTimestamp={messageRenderProps.showTimestamp}
                 showAuthorName={messageRenderProps.showAuthorName}
                 onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
+                isMessageReadByAllMembers={this.isRead(message)}
                 {...message}
               />
             </div>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -12,7 +12,7 @@ import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
-import { IconAlertCircle } from '@zero-tech/zui/icons';
+import { IconAlertCircle, IconCheck, IconCheckDouble } from '@zero-tech/zui/icons';
 import { Avatar } from '@zero-tech/zui/components';
 import { ContentHighlighter } from '../content-highlighter';
 import { bemClassName } from '../../lib/bem';
@@ -48,6 +48,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
+  isMessageReadByAllMembers: boolean;
 }
 
 export interface State {
@@ -168,6 +169,15 @@ export class Message extends React.Component<Properties, State> {
           Failed to send&nbsp;
           <IconAlertCircle size={16} />
         </div>
+      );
+    }
+    if (this.props.isOwner) {
+      footerElements.push(
+        this.props.isMessageReadByAllMembers ? (
+          <IconCheckDouble {...cn('read-icon')} size={14} />
+        ) : (
+          <IconCheck {...cn('unread-icon')} size={14} />
+        )
       );
     }
 

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -201,4 +201,12 @@
     margin-top: 0.8px;
     display: inline-block;
   }
+
+  &__unread-icon {
+    @include glass-text-secondary-color;
+  }
+
+  &__read-icon {
+    color: theme.$color-secondary-11;
+  }
 }

--- a/src/components/messenger/message-info/container.tsx
+++ b/src/components/messenger/message-info/container.tsx
@@ -29,9 +29,10 @@ export class Container extends React.Component<Properties> {
     const selectedMessage = messages.find((msg) => msg.id === selectedMessageId) || {};
 
     const readBy = selectedMessage.readBy || [];
-    const sentTo = (channel.otherMembers || []).filter(
-      (user) => !readBy.some((readUser) => readUser.userId === user.userId)
-    );
+
+    const sentTo = (channel.otherMembers || [])
+      .filter((user) => !readBy.some((readUser) => readUser.userId === user.userId))
+      .filter((user) => user.userId !== selectedMessage.sender?.userId);
 
     return {
       readBy,

--- a/src/store/message-info/index.ts
+++ b/src/store/message-info/index.ts
@@ -10,7 +10,7 @@ export enum SagaActionTypes {
   CloseMessageInfo = 'message-info/close-message-info',
 }
 
-export const openMessageInfo = createAction<{ roomId: string; messageId: number }>(SagaActionTypes.OpenMessageInfo);
+export const openMessageInfo = createAction<{ messageId: number }>(SagaActionTypes.OpenMessageInfo);
 export const closeMessageInfo = createAction(SagaActionTypes.CloseMessageInfo);
 
 export type MessageInfoState = {

--- a/src/store/message-info/saga.test.ts
+++ b/src/store/message-info/saga.test.ts
@@ -4,7 +4,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { openOverview, closeOverview } from './saga';
 import { Stage, setSelectedMessageId, setStage } from './index';
 import { getMessageReadReceipts } from '../../lib/chat';
-import { updateReadByUsers } from '../messages/saga';
 import { resetConversationManagement } from '../group-management/saga';
 
 describe('message-info saga', () => {
@@ -18,17 +17,14 @@ describe('message-info saga', () => {
       { userId: '@current-user-id:matrix.org', eventId: 'event-3', ts: 1620000002000 },
     ];
 
-    it('sets the selected message ID and updates the message readBy', async () => {
+    it('sets the selected message ID', async () => {
       await expectSaga(openOverview, { payload: { roomId, messageId } })
         .provide([
           [matchers.call.fn(resetConversationManagement), undefined],
           [matchers.call.fn(getMessageReadReceipts), receipts],
-          [matchers.call.fn(updateReadByUsers), undefined],
         ])
         .put(setStage(Stage.Overview))
         .put(setSelectedMessageId(messageId))
-        .call(getMessageReadReceipts, roomId, messageId)
-        .call(updateReadByUsers, messageId, receipts)
         .run();
     });
   });

--- a/src/store/message-info/saga.ts
+++ b/src/store/message-info/saga.ts
@@ -1,9 +1,7 @@
 import { call, fork, put, take, takeLatest } from 'redux-saga/effects';
 
-import { getMessageReadReceipts } from '../../lib/chat';
 import { SagaActionTypes, Stage, setSelectedMessageId, setStage } from './index';
 import { Events, getAuthChannel } from '../authentication/channels';
-import { updateReadByUsers } from '../messages/saga';
 import { resetConversationManagement } from '../group-management/saga';
 
 function* authWatcher() {
@@ -15,15 +13,11 @@ function* authWatcher() {
 }
 
 export function* openOverview(action) {
-  const { roomId, messageId } = action.payload;
+  const { messageId } = action.payload;
 
   yield call(resetConversationManagement);
   yield put(setStage(Stage.Overview));
   yield put(setSelectedMessageId(messageId));
-
-  const receipts = yield call(getMessageReadReceipts, roomId, messageId);
-
-  yield call(updateReadByUsers, messageId, receipts);
 }
 
 export function* closeOverview() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -14,7 +14,7 @@ import { send as sendBrowserMessage, mapMessage } from '../../lib/browser';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { Uploadable, createUploadableFile } from './uploadable';
-import { chat } from '../../lib/chat';
+import { chat, getMessageReadReceipts } from '../../lib/chat';
 import { User } from '../channels';
 import { mapMessageSenders } from './utils.matrix';
 import { uniqNormalizedList } from '../utils';
@@ -155,6 +155,10 @@ export function* fetch(action) {
       hasLoadedMessages: true,
       messagesFetchStatus: MessagesFetchState.SUCCESS,
     });
+
+    for (const message of messages) {
+      yield call(mapMessageReadByUsers, message.id, channelId);
+    }
   } catch (error) {
     yield call(receiveChannel, { id: channelId, messagesFetchStatus: MessagesFetchState.FAILED });
   }
@@ -500,21 +504,22 @@ export function* sendBrowserNotification(eventData) {
   }
 }
 
-export function* updateReadByUsers(messageId, receipts) {
-  const zeroUsersMap: { [id: string]: User } = yield select((state) => state.normalized.users || {});
+export function* mapMessageReadByUsers(messageId, channelId) {
+  const receipts = yield call(getMessageReadReceipts, channelId, messageId);
+  if (receipts) {
+    const zeroUsersMap: { [id: string]: User } = yield select((state) => state.normalized.users || {});
 
-  const selectedMessage = yield select(messageSelector(messageId));
-  const filteredReceipts = receipts.filter((receipt) => receipt.ts >= selectedMessage?.createdAt);
+    const selectedMessage = yield select(messageSelector(messageId));
+    const filteredReceipts = receipts.filter((receipt) => receipt.ts >= selectedMessage?.createdAt);
 
-  const currentUser = yield select(currentUserSelector());
+    const readByUsers = filteredReceipts
+      .map((receipt) => {
+        return Object.values(zeroUsersMap).find((user) => user.matrixId === receipt.userId);
+      })
+      .filter((user) => user && user.userId !== selectedMessage?.sender?.userId);
 
-  const readByUsers = filteredReceipts
-    .map((receipt) => {
-      return Object.values(zeroUsersMap).find((user) => user.matrixId === receipt.userId);
-    })
-    .filter((user) => user && user.userId !== currentUser.id);
-
-  yield put(receiveMessage({ id: messageId, readBy: readByUsers }));
+    yield put(receiveMessage({ id: messageId, readBy: readByUsers }));
+  }
 }
 
 export function* saga() {


### PR DESCRIPTION
### What does this do?
- feat(chat-view): implements message bubble read receipts

### Why are we making this change?
- read receipts on message bubbles to show if a conversation is fully read.

### How do I test this?
- run the UI and check for the read receipts on message bubbles.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="178" alt="Screenshot 2024-06-04 at 16 40 27" src="https://github.com/zer0-os/zOS/assets/39112648/e0fe00bc-5807-457e-ae55-35e504b6d4d3">
