### PR TITLE
fix(ELT-16): notification onclick show window

### DIFF
--- a/src/lib/browser/index.ts
+++ b/src/lib/browser/index.ts
@@ -2,19 +2,29 @@ import { createBrowserHistory, createHashHistory } from 'history';
 import { getProvider } from '../../lib/cloudinary/provider';
 import { Message } from '../../store/messages';
 import { isElectron } from '../../utils';
+import { nativeWindow } from '@todesktop/client-core';
 
 const DEFAULT_HEADING = 'Chat message received';
 
 export const send = (options: { body; heading; tag }) => {
   const { body, heading, tag } = options;
 
-  new Notification(heading, {
+  const notification = new Notification(heading, {
     // it appears on desktop (Windows) a long tag prevents the notification
     // from triggering so we disable it on Electron
     tag: !isElectron() ? tag : undefined,
     body,
     icon: getProvider().getSource({ src: '', local: false, options: {} }),
   });
+
+  // add click event to show window on desktop
+  if (isElectron()) {
+    notification.onclick = (e) => {
+      e.preventDefault();
+      nativeWindow.show();
+      notification.close();
+    };
+  }
 };
 
 export function mapMessage(message: Message) {


### PR DESCRIPTION
### What does this do?
Clicking notification popup on desktop app will now open / maximize the desktop window.
See [ELT-16]

### Why are we making this change?

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
