### PR TITLE
feat(matrix-client): add functionally to process and handle read receipts for edited messages

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -78,7 +78,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     parentMessageId: parent ? parent['m.in_reply_to']?.event_id : null,
     isHidden: content?.msgtype === MatrixConstants.BAD_ENCRYPTED_MSGTYPE,
     ...(await parseMediaData(matrixMessage)),
-    readBy: [],
+    // readBy: [],
   };
 }
 


### PR DESCRIPTION
### What does this do?

Handles edited messages and read receipts : 
- sends read receipt for non-edited event
- sends read receipt for original event if latest event is an edit
- sends read receipt for latest event if original event is not found

### Why are we making this change?
- previously editing a message was causing issues with the read receipts. these changes fix that.

### How do I test this?
- run tests as usual.
- run the ui and test real time and non real time read receipt events for edited messages and non edited messages.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
