### PR TITLE
feat(delivered-receipts): add functionality for real-time/non-real time delivered receipts and ui

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -139,14 +139,15 @@ export class ChatView extends React.Component<Properties, State> {
 
   isRead() {
     const lastMessage = this.getUsersLastNonAdminMessage();
-    if (!lastMessage) return;
+    if (!lastMessage) return false;
     return lastMessage?.readBy && lastMessage.readBy.length > 0;
   }
 
   getUsersLastNonAdminMessage() {
     const { messages } = this.props;
+    const currentUser = this.props.user;
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (!messages[i].isAdmin && this.isUserOwnerOfMessage(messages[i])) {
+      if (!messages[i].isAdmin && messages[i].sender.userId === currentUser.id) {
         return messages[i];
       }
     }

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -147,7 +147,7 @@ export class ChatView extends React.Component<Properties, State> {
     const { messages } = this.props;
     const currentUser = this.props.user;
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (!messages[i].isAdmin && messages[i].sender.userId === currentUser.id) {
+      if (!messages[i].isAdmin && messages[i].sender?.userId === currentUser?.id) {
         return messages[i];
       }
     }

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -456,4 +456,64 @@ describe('message', () => {
       expect(onImageClick).not.toHaveBeenCalled();
     });
   });
+
+  describe('getReceiptIcon', () => {
+    it('renders IconCheck for in-progress messages', () => {
+      const wrapper = subject({
+        message: 'text',
+        sendStatus: MessageSendStatus.IN_PROGRESS,
+        isOwner: true,
+        isLastMessage: true,
+      });
+
+      expect(wrapper.find('.message__sent-icon')).toExist();
+    });
+
+    it('renders IconCheckDouble with "read" class for read messages', () => {
+      const wrapper = subject({
+        message: 'text',
+        sendStatus: MessageSendStatus.SUCCESS,
+        isOwner: true,
+        isLastMessage: true,
+        isMessageRead: true,
+      });
+
+      expect(wrapper.find('.message__read-icon--read')).toExist();
+    });
+
+    it('renders IconCheckDouble with "delivered" class for delivered messages', () => {
+      const wrapper = subject({
+        message: 'text',
+        sendStatus: MessageSendStatus.SUCCESS,
+        isOwner: true,
+        isLastMessage: true,
+        isMessageRead: false,
+      });
+
+      expect(wrapper.find('.message__read-icon--delivered')).toExist();
+    });
+
+    it('renders IconCheckDouble with "delivered" class when sendStatus is undefined', () => {
+      const wrapper = subject({
+        message: 'text',
+        sendStatus: undefined,
+        isOwner: true,
+        isLastMessage: true,
+      });
+
+      expect(wrapper.find('.message__read-icon--delivered')).toExist();
+    });
+
+    it('renders nothing for failed messages', () => {
+      const wrapper = subject({
+        message: 'text',
+        sendStatus: MessageSendStatus.FAILED,
+        isOwner: true,
+        isLastMessage: true,
+      });
+
+      expect(wrapper.find('.message__read-icon')).not.toExist();
+      expect(wrapper.find('.message__sent-icon')).not.toExist();
+    });
+  });
 });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -150,6 +150,21 @@ export class Message extends React.Component<Properties, State> {
     return '';
   }
 
+  getReceiptIcon() {
+    const { sendStatus, isMessageRead } = this.props;
+
+    if (sendStatus === MessageSendStatus.IN_PROGRESS) {
+      return <IconCheck {...cn('sent-icon')} size={14} />;
+    }
+
+    if (sendStatus === MessageSendStatus.SUCCESS || sendStatus === undefined) {
+      const iconClass = isMessageRead ? 'read' : 'delivered';
+      return <IconCheckDouble {...cn('read-icon', `${iconClass}`)} size={14} />;
+    }
+
+    return null;
+  }
+
   renderFooter() {
     if (this.state.isEditing) {
       return;
@@ -173,13 +188,8 @@ export class Message extends React.Component<Properties, State> {
       );
     }
     if (this.props.isOwner && this.props.isLastMessage) {
-      footerElements.push(
-        this.props.isMessageRead ? (
-          <IconCheckDouble {...cn('read-icon')} size={14} />
-        ) : (
-          <IconCheck {...cn('unread-icon')} size={14} />
-        )
-      );
+      const icon = this.getReceiptIcon();
+      icon && footerElements.push(icon);
     }
 
     if (footerElements.length === 0) {

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -202,11 +202,19 @@
     display: inline-block;
   }
 
-  &__unread-icon {
+  &__sent-icon {
     @include glass-text-secondary-color;
   }
 
   &__read-icon {
     color: theme.$color-secondary-11;
+
+    &--read {
+      color: theme.$color-secondary-11;
+    }
+
+    &--delivered {
+      @include glass-text-secondary-color;
+    }
   }
 }

--- a/src/components/messenger/message-info/container.tsx
+++ b/src/components/messenger/message-info/container.tsx
@@ -29,8 +29,8 @@ export class Container extends React.Component<Properties> {
     const channel = denormalizeChannel(activeConversationId, state) || {};
     const messages = channel.messages || [];
     const selectedMessage = messages.find((msg) => msg.id === selectedMessageId) || {};
-    const readBy = selectedMessage.readBy || [];
     const sentBy = selectedMessage?.sender?.userId !== user.data?.id ? selectedMessage?.sender : null;
+    const readBy = (selectedMessage.readBy || []).filter((user) => user.userId !== selectedMessage?.sender?.userId);
     const sentTo = (channel.otherMembers || []).filter(
       (user) =>
         !readBy.some((readUser) => readUser.userId === user.userId) && user.userId !== selectedMessage.sender?.userId


### PR DESCRIPTION
### What does this do?
- adds functionality for real-time/non-real time delivered receipts and updates ui to have three icons for sent, delivered and read states.

### Why are we making this change?
- as per request.

### How do I test this?
- run test as usual.
- run the UI > send a message > check receipt state.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/0a9493c7-ca5a-4912-941c-6c1b7ce260bb

