### PR TITLE
feat(messages): allow editing text when sent with a media message

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -223,6 +223,21 @@ describe('message', () => {
     expect(wrapper.find('.message__footer').text()).toEqual('(Edited)');
   });
 
+  it('renders media when editing media message with text', () => {
+    const wrapper = subject({
+      message: 'the message',
+      media: { url: 'https://image.com/image.png', type: MediaType.Image },
+    });
+
+    const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+    wrapper.simulate('contextmenu', mockEvent);
+
+    wrapper.find(MessageMenu).props().onEdit();
+
+    expect(wrapper.find(MessageInput)).toExist();
+    expect(wrapper.find('.message__block-image img')).toExist();
+  });
+
   it('renders reply message', () => {
     const parentMessageText = 'the message';
     const wrapper = subject({

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -220,6 +220,7 @@ export class Message extends React.Component<Properties, State> {
   canEditMessage = (): boolean => {
     return (
       this.props.isOwner &&
+      this.props.message &&
       this.props.sendStatus !== MessageSendStatus.IN_PROGRESS &&
       this.props.sendStatus !== MessageSendStatus.FAILED
     );
@@ -448,6 +449,8 @@ export class Message extends React.Component<Properties, State> {
 
               {this.state.isEditing && this.props.message && (
                 <>
+                  {media && this.renderMedia(media)}
+
                   <div {...cn('block-edit')}>
                     <MessageInput
                       initialValue={this.props.message}

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -60,7 +60,7 @@ describe('Message Menu', () => {
   });
 
   describe('Edit Button', () => {
-    it('should render when canEdit is true and isMediaMessage is false', () => {
+    it('should render when canEdit is true', () => {
       const onEdit = jest.fn();
       const wrapper = subject({ canEdit: true, onEdit }) as ShallowWrapper;
 

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -50,7 +50,7 @@ export class MessageMenu extends React.Component<Properties> {
   renderItems = () => {
     const menuItems = [];
 
-    if (this.props.onEdit && this.props.canEdit && !this.props.isMediaMessage) {
+    if (this.props.onEdit && this.props.canEdit) {
       menuItems.push({
         id: 'edit',
         label: this.renderMenuOption(<IconEdit5 size={20} />, 'Edit'),


### PR DESCRIPTION
### What does this do?
- allows editing text when sent with a media message

### Why are we making this change?
- to be able to edit text messages that are sent with media (images).

### How do I test this?
- run tests as usual.
- run the UI > send a media message and text > open message menu > select `Edit` > edit message and click send.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
  

https://github.com/zer0-os/zOS/assets/39112648/ff4d9580-4655-471a-8461-149ef8261f11

