### PR TITLE
feat(reply-card): render media if media is present in parent message

### DIFF
--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -275,6 +275,8 @@ export class MessageInput extends React.Component<Properties, State> {
               senderIsCurrentUser={this.props.replyIsCurrentUser}
               senderFirstName={reply?.sender?.firstName}
               senderLastName={reply?.sender?.lastName}
+              mediaUrl={reply?.media?.url}
+              mediaName={reply?.media?.name}
               onRemove={this.props.onRemoveReply}
             />
           )}

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -271,7 +271,7 @@ export class MessageInput extends React.Component<Properties, State> {
         <div {...cn('addon-row')}>
           {reply && (
             <ReplyCard
-              message={reply.message}
+              message={reply?.message}
               senderIsCurrentUser={this.props.replyIsCurrentUser}
               senderFirstName={reply?.sender?.firstName}
               senderLastName={reply?.sender?.lastName}

--- a/src/components/reply-card/reply-card.test.tsx
+++ b/src/components/reply-card/reply-card.test.tsx
@@ -57,7 +57,7 @@ describe('ReplyCard', () => {
     expect(wrapper.find('.reply-card__header').text()).toEqual('You');
   });
 
-  it('renders media when media url is present', function () {
+  it('renders media when media url is present and NO message', function () {
     const wrapper = subject({
       senderIsCurrentUser: true,
       senderFirstName: 'Jackie',
@@ -67,6 +67,21 @@ describe('ReplyCard', () => {
     });
 
     expect(wrapper).toHaveElement('.reply-card__media-container');
+    expect(wrapper).not.toHaveElement(ContentHighlighter);
+  });
+
+  it('renders media and message when media url and message are present', function () {
+    const wrapper = subject({
+      senderIsCurrentUser: true,
+      senderFirstName: 'Jackie',
+      senderLastName: 'Chan',
+      mediaName: 'test-media-name',
+      mediaUrl: 'test-media-url',
+      message: 'hello',
+    });
+
+    expect(wrapper).toHaveElement('.reply-card__media-container');
+    expect(wrapper).toHaveElement(ContentHighlighter);
   });
 
   it('does not render media when media url is NOT present', function () {
@@ -76,6 +91,7 @@ describe('ReplyCard', () => {
       senderLastName: 'Chan',
       mediaName: '',
       mediaUrl: '',
+      message: 'hello',
     });
 
     expect(wrapper).not.toHaveElement('.reply-card__media-container');

--- a/src/components/reply-card/reply-card.test.tsx
+++ b/src/components/reply-card/reply-card.test.tsx
@@ -12,6 +12,8 @@ describe('ReplyCard', () => {
       senderIsCurrentUser: false,
       senderFirstName: '',
       senderLastName: '',
+      mediaName: '',
+      mediaUrl: '',
       onRemove: jest.fn(),
       ...props,
     };
@@ -26,7 +28,7 @@ describe('ReplyCard', () => {
     expect(wrapper.find(ContentHighlighter).prop('message').trim()).toStrictEqual(message);
   });
 
-  it('call onRemove when close icon iss clicked', function () {
+  it('call onRemove when close icon is clicked', function () {
     const onRemove = jest.fn();
 
     const wrapper = subject({ onRemove });
@@ -53,5 +55,29 @@ describe('ReplyCard', () => {
     });
 
     expect(wrapper.find('.reply-card__header').text()).toEqual('You');
+  });
+
+  it('renders media when media url is present', function () {
+    const wrapper = subject({
+      senderIsCurrentUser: true,
+      senderFirstName: 'Jackie',
+      senderLastName: 'Chan',
+      mediaName: 'test-media-name',
+      mediaUrl: 'test-media-url',
+    });
+
+    expect(wrapper).toHaveElement('.reply-card__media-container');
+  });
+
+  it('does not render media when media url is NOT present', function () {
+    const wrapper = subject({
+      senderIsCurrentUser: true,
+      senderFirstName: 'Jackie',
+      senderLastName: 'Chan',
+      mediaName: '',
+      mediaUrl: '',
+    });
+
+    expect(wrapper).not.toHaveElement('.reply-card__media-container');
   });
 });

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -13,6 +13,8 @@ export interface Properties {
   senderIsCurrentUser: boolean;
   senderFirstName: string;
   senderLastName: string;
+  mediaUrl: string;
+  mediaName: string;
 
   onRemove?: () => void;
 }
@@ -38,6 +40,13 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
     return (
       <div {...cn()}>
         <IconCornerDownRight size={16} />
+
+        {this.props.mediaUrl && (
+          <div {...cn('media-container')}>
+            <img {...cn('media')} src={this.props.mediaUrl} alt={this.props.mediaName} />
+          </div>
+        )}
+
         <div {...cn('content')}>
           <div {...cn('header')}>{this.name}</div>
           <div {...cn('message')}>

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -49,9 +49,12 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
 
         <div {...cn('content')}>
           <div {...cn('header')}>{this.name}</div>
-          <div {...cn('message')}>
-            <ContentHighlighter variant='tertiary' message={message} />
-          </div>
+
+          {message && (
+            <div {...cn('message')}>
+              <ContentHighlighter variant='tertiary' message={message} />
+            </div>
+          )}
         </div>
         <IconButton Icon={IconXClose} size={24} onClick={this.itemRemoved} />
       </div>

--- a/src/components/reply-card/styles.scss
+++ b/src/components/reply-card/styles.scss
@@ -31,4 +31,16 @@
   &__header {
     margin-bottom: 4px;
   }
+
+  &__media {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &__media {
+    width: 48px;
+    height: 48px;
+    border-radius: 4px;
+  }
 }

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -1,3 +1,5 @@
+import { Media } from '../../store/messages';
+
 export interface ChatMessage {
   [key: string]: any;
 }
@@ -20,6 +22,7 @@ export interface ParentMessage {
   admin?: any;
   optimisticId?: string;
   rootMessageId?: string;
+  media?: Media;
 }
 
 export interface User {


### PR DESCRIPTION
### What does this do?
- updates reply card to display media (image) if media url is present.
- message is optional to ensure a reply can contain media only.

### Why are we making this change?
- to reply to media messages.

### How do I test this?
- run tests as usual.
- this is not yet wired up to allow replying to media messages so you will not be able to test this yet by running the UI. However, you may enable 'Reply' menu item on the message menu if you'd like to test this (as per below).

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Demo

Uploading imagereply.mov…

