### PR TITLE
fix(icons): remove icon check double and replaces with two icon check icons

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -12,7 +12,7 @@ import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
-import { IconAlertCircle, IconCheck, IconCheckDouble } from '@zero-tech/zui/icons';
+import { IconAlertCircle, IconCheck } from '@zero-tech/zui/icons';
 import { Avatar } from '@zero-tech/zui/components';
 import { ContentHighlighter } from '../content-highlighter';
 import { bemClassName } from '../../lib/bem';
@@ -159,7 +159,12 @@ export class Message extends React.Component<Properties, State> {
 
     if (sendStatus === MessageSendStatus.SUCCESS || sendStatus === undefined) {
       const iconClass = isMessageRead ? 'read' : 'delivered';
-      return <IconCheckDouble {...cn('read-icon', `${iconClass}`)} size={14} />;
+      return (
+        <div {...cn('read-icon-container')}>
+          <IconCheck {...cn('read-icon', `${iconClass}`)} size={12} />
+          <IconCheck {...cn('read-icon', `${iconClass}`)} size={12} />
+        </div>
+      );
     }
 
     return null;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -206,8 +206,15 @@
     @include glass-text-secondary-color;
   }
 
+  &__read-icon-container {
+    position: relative;
+    display: inline-block;
+    width: 18px;
+    height: 14px;
+  }
+
   &__read-icon {
-    color: theme.$color-secondary-11;
+    position: absolute;
 
     &--read {
       color: theme.$color-secondary-11;
@@ -215,6 +222,14 @@
 
     &--delivered {
       @include glass-text-secondary-color;
+    }
+
+    &:first-child {
+      left: 0;
+    }
+
+    &:last-child {
+      left: 7px;
     }
   }
 }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -203,6 +203,8 @@
   }
 
   &__sent-icon {
+    padding: 0 2px;
+
     @include glass-text-secondary-color;
   }
 


### PR DESCRIPTION
### What does this do?
- replaces IconCheckDouble with two IconChecks.
- updates styles.

### Why are we making this change?
- IconCheckDouble appears to be causing issues (especially on the vite build) due to some exporting issues in ZUI. As a result, as a work around, we can just use two check icons to give the impression of a double tick icon for delivered and read receipts. This fixes the issues, and also fixes issues when running tests.

### How do I test this?
- run test as usual.
- run UI and check read receipt icons.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="122" alt="Screenshot 2024-06-14 at 13 23 56" src="https://github.com/zer0-os/zOS/assets/39112648/802f2d0a-f441-426e-8493-22f388e3ce6d">
