### PR TITLE
fix(settings): checkbox icon position

### DIFF
--- a/src/components/messenger/user-profile/settings-panel/styles.scss
+++ b/src/components/messenger/user-profile/settings-panel/styles.scss
@@ -90,7 +90,7 @@
   &__checkbox-icon {
     position: absolute;
     top: 10px;
-    left: 18px;
+    left: 22px;
     color: theme.$color-secondary-11;
   }
 }


### PR DESCRIPTION
### What does this do?
- fixes icon position in settings > read receipts checkbox.

### Why are we making this change?
- positioning (before and after below)

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
  Before:
  
  
<img width="245" alt="Screenshot 2024-06-14 at 14 09 52" src="https://github.com/zer0-os/zOS/assets/39112648/615d2896-7431-4cd0-9c47-691b007e08c7">


  After:
  
  
<img width="245" alt="Screenshot 2024-06-14 at 14 09 38" src="https://github.com/zer0-os/zOS/assets/39112648/4755fa6e-cecb-4734-a093-1361456dbe09">

