### PR TITLE
Add `Manage Accounts` section

### DIFF
--- a/src/components/messenger/user-profile/account-management-panel/container.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.test.tsx
@@ -41,5 +41,57 @@ describe('Container', () => {
         expect(props.isModalOpen).toEqual(true);
       });
     });
+
+    describe('currentUser', () => {
+      test('currentUser', () => {
+        const props = subject({
+          authentication: {
+            user: {
+              data: {
+                id: 'user-id',
+                profileSummary: {
+                  primaryEmail: 'email@zero.tech',
+                  firstName: 'John',
+                  lastName: 'Doe',
+                  profileImage: 'image',
+                },
+                wallets: [{ id: 'wallet-id-1', publicAddress: 'address456' }],
+              },
+            },
+          } as any,
+        });
+
+        expect(props.currentUser).toEqual({
+          userId: 'user-id',
+          firstName: 'John',
+          lastName: 'Doe',
+          profileImage: 'image',
+          primaryEmail: 'email@zero.tech',
+          wallets: [{ id: 'wallet-id-1', publicAddress: 'address456' }],
+        });
+      });
+    });
+
+    describe('canAddEmail', () => {
+      test('can add email', () => {
+        const props = subject({
+          authentication: {
+            user: { data: { profileSummary: { primaryEmail: null } } },
+          } as any,
+        });
+
+        expect(props.canAddEmail).toEqual(true);
+      });
+
+      test('cannot add email', () => {
+        const props = subject({
+          authentication: {
+            user: { data: { profileSummary: { primaryEmail: 'email@zero.tech' } } },
+          } as any,
+        });
+
+        expect(props.canAddEmail).toEqual(false);
+      });
+    });
   });
 });

--- a/src/components/messenger/user-profile/account-management-panel/container.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.tsx
@@ -11,6 +11,7 @@ import {
   closeWalletSelectModal,
   Errors,
 } from '../../../../store/account-management';
+import { currentUserSelector } from '../../../../store/authentication/selectors';
 
 export interface PublicProperties {
   onClose?: () => void;
@@ -19,6 +20,8 @@ export interface PublicProperties {
 export interface Properties extends PublicProperties {
   isModalOpen: boolean;
   error: string;
+  currentUser: any;
+  canAddEmail: boolean;
 
   addNewWallet: (payload: { connector: Connectors }) => void;
   openWalletSelectModal: () => void;
@@ -29,9 +32,21 @@ export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const { accountManagement } = state;
 
+    const currentUser = currentUserSelector(state);
+    const primaryEmail = currentUser?.profileSummary.primaryEmail;
+
     return {
       error: Container.mapErrors(accountManagement.errors),
       isModalOpen: accountManagement.isWalletSelectModalOpen,
+      currentUser: {
+        userId: currentUser?.id,
+        firstName: currentUser?.profileSummary.firstName,
+        lastName: currentUser?.profileSummary.lastName,
+        profileImage: currentUser?.profileSummary.profileImage,
+        primaryEmail: currentUser?.profileSummary.primaryEmail,
+        wallets: currentUser?.wallets || [],
+      },
+      canAddEmail: !primaryEmail,
     };
   }
 
@@ -59,6 +74,8 @@ export class Container extends React.Component<Properties> {
       <AccountManagementPanel
         error={this.props.error}
         isModalOpen={this.props.isModalOpen}
+        currentUser={this.props.currentUser}
+        canAddEmail={this.props.canAddEmail}
         onSelect={this.connectorSelected}
         onOpenModal={() => this.props.openWalletSelectModal()}
         onCloseModal={() => this.props.closeWalletSelectModal()}

--- a/src/components/messenger/user-profile/account-management-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.test.tsx
@@ -2,12 +2,18 @@ import { shallow } from 'enzyme';
 
 import { Properties, AccountManagementPanel } from '.';
 import { PanelHeader } from '../../list/panel-header';
+import { bem } from '../../../../lib/bem';
+import { Button } from '@zero-tech/zui/components/Button';
+
+const c = bem('.account-management-panel');
 
 describe(AccountManagementPanel, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
       error: '',
       isModalOpen: false,
+      currentUser: {},
+      canAddEmail: false,
 
       onBack: () => {},
       onSelect: () => {},
@@ -69,10 +75,97 @@ describe(AccountManagementPanel, () => {
   it('renders error alert if error is present', () => {
     const wrapper = subject({ error: 'An error occurred' });
 
-    expect(wrapper.find('Alert').prop('variant')).toEqual('error');
-    expect(wrapper.find('Alert').prop('isFilled')).toEqual(true);
+    expect(wrapper.find('Alert[variant="error"]').exists()).toEqual(true);
+    expect(wrapper.find('Alert[variant="error"]').prop('isFilled')).toEqual(true);
 
-    const props = wrapper.find('Alert').prop('children');
+    const props = wrapper.find('Alert[variant="error"]').prop('children');
     expect(props).toEqual(<div className='account-management-panel__alert-text'>An error occurred</div>);
+  });
+
+  describe('wallets section', () => {
+    it('renders wallets header (no wallet)', () => {
+      const wrapper = subject({ currentUser: { wallets: [], primaryEmail: 'test@zero.tech' } });
+
+      expect(wrapper.find(c('wallets-header')).text()).toEqual('no wallets');
+    });
+
+    it('renders wallets header (1 wallet)', () => {
+      const wrapper = subject({ currentUser: { wallets: [{ id: 'wallet-id-1' }] } });
+
+      expect(wrapper.find(c('wallets-header')).text()).toEqual('1 wallet');
+    });
+
+    it('renders wallets header (multiple wallets)', () => {
+      const wrapper = subject({ currentUser: { wallets: [{ id: 'wallet-id-1' }, { id: 'wallet-id-2' }] } });
+
+      expect(wrapper.find(c('wallets-header')).text()).toEqual('2 wallets');
+    });
+
+    it('renders wallet list items', () => {
+      const wrapper = subject({
+        currentUser: {
+          wallets: [
+            { id: 'wallet-id-1', publicAddress: 'address-1' },
+            { id: 'wallet-id-2', publicAddress: 'address-2' },
+          ],
+        },
+      });
+
+      expect(wrapper.find('WalletListItem')).toHaveLength(2);
+      expect(wrapper.find('WalletListItem').at(0).prop('wallet')).toEqual({
+        id: 'wallet-id-1',
+        publicAddress: 'address-1',
+      });
+      expect(wrapper.find('WalletListItem').at(1).prop('wallet')).toEqual({
+        id: 'wallet-id-2',
+        publicAddress: 'address-2',
+      });
+    });
+
+    it('renders no wallets found alert', () => {
+      const wrapper = subject({ currentUser: { wallets: [], primaryEmail: 'test@zero.tech' } });
+
+      expect(wrapper.find('Alert[variant="info"]').exists()).toEqual(true);
+      expect(wrapper.find(c('alert-info-text')).text()).toEqual('No wallets found');
+    });
+  });
+
+  describe('email section', () => {
+    it('renders email header', () => {
+      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech' } });
+
+      expect(wrapper.find(c('email-header')).text()).toEqual('Email');
+    });
+
+    it('renders email item', () => {
+      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech' } });
+
+      expect(wrapper.find('CitizenListItem').prop('user')).toEqual({
+        firstName: 'test@zero.tech',
+        primaryEmail: 'test@zero.tech',
+      });
+    });
+
+    it('renders no email found alert', () => {
+      const wrapper = subject({
+        currentUser: { primaryEmail: null, wallets: [{ id: 'wallet-id-1', publicAddress: 'address456' }] },
+      });
+
+      expect(wrapper.find('Alert[variant="info"]').exists()).toEqual(true);
+      expect(wrapper.find(c('alert-info-text')).text()).toEqual('No email account found');
+    });
+
+    it('renders add email button if canAddEmail is true', () => {
+      const wrapper = subject({ currentUser: { primaryEmail: null }, canAddEmail: true });
+
+      expect(wrapper.find(Button).exists()).toEqual(true);
+      expect(wrapper.find(Button).prop('children')).toEqual('Add email');
+    });
+
+    it('does not render add email button if canAddEmail is false', () => {
+      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech' }, canAddEmail: false });
+
+      expect(wrapper.find(Button).exists()).toEqual(false);
+    });
   });
 });

--- a/src/components/messenger/user-profile/account-management-panel/index.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.tsx
@@ -8,12 +8,16 @@ import { Alert, Modal } from '@zero-tech/zui/components';
 import { IconPlus } from '@zero-tech/zui/icons';
 import './styles.scss';
 import { WalletSelect } from '../../../wallet-select';
+import { WalletListItem } from '../../../wallet-list-item';
+import { CitizenListItem } from '../../../citizen-list-item';
 
 const cn = bemClassName('account-management-panel');
 
 export interface Properties {
   isModalOpen: boolean;
   error: string;
+  currentUser: any;
+  canAddEmail: boolean;
 
   onBack: () => void;
   onOpenModal: () => void;
@@ -41,6 +45,81 @@ export class AccountManagementPanel extends React.Component<Properties> {
     );
   };
 
+  // note: hiding this for now
+  renderAddNewWalletButton = () => {
+    return (
+      <div {...cn('add-wallet')}>
+        <Button
+          variant={ButtonVariant.Secondary}
+          onPress={this.props.onOpenModal}
+          startEnhancer={<IconPlus size={20} isFilled />}
+        >
+          Add new wallet
+        </Button>
+      </div>
+    );
+  };
+
+  renderWalletsSection = () => {
+    const { currentUser } = this.props;
+    const wallets = currentUser?.wallets || [];
+
+    return (
+      <div>
+        <div {...cn('wallets-header')}>
+          <span>{wallets.length || 'no'}</span> wallet{wallets.length === 1 ? '' : 's'}
+        </div>
+        {wallets.length > 0 ? (
+          wallets.map((w) => <WalletListItem key={w.id} wallet={w}></WalletListItem>)
+        ) : (
+          <div {...cn('alert-small')}>
+            <Alert variant='info'>
+              <div {...cn('alert-info-text')}>No wallets found</div>
+            </Alert>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  renderEmailSection = () => {
+    const { currentUser } = this.props;
+
+    return (
+      <div {...cn('email-container')}>
+        <div {...cn('email-header')}>
+          <span>Email</span>
+        </div>
+
+        {currentUser?.primaryEmail ? (
+          <CitizenListItem
+            user={{ ...currentUser, firstName: currentUser.primaryEmail }}
+            tag={''}
+            onSelected={() => {}}
+          />
+        ) : (
+          <div {...cn('alert-small')}>
+            <Alert variant='info'>
+              <div {...cn('alert-info-text')}>No email account found</div>
+            </Alert>
+          </div>
+        )}
+
+        {this.props.canAddEmail && (
+          <div>
+            <Button
+              variant={ButtonVariant.Secondary}
+              onPress={() => {}}
+              startEnhancer={<IconPlus size={20} isFilled />}
+            >
+              Add email
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   render() {
     return (
       <div {...cn()}>
@@ -49,15 +128,8 @@ export class AccountManagementPanel extends React.Component<Properties> {
         </div>
 
         <div {...cn('content')}>
-          <div {...cn('footer')}>
-            <Button
-              variant={ButtonVariant.Secondary}
-              onPress={this.props.onOpenModal}
-              startEnhancer={<IconPlus size={20} isFilled />}
-            >
-              Add new wallet
-            </Button>
-          </div>
+          {this.renderWalletsSection()}
+          {this.renderEmailSection()}
 
           {this.props.error && (
             <Alert variant='error' isFilled>

--- a/src/components/messenger/user-profile/account-management-panel/styles.scss
+++ b/src/components/messenger/user-profile/account-management-panel/styles.scss
@@ -16,10 +16,42 @@
     margin: 16px 16px 0 16px;
   }
 
+  &__wallets-header {
+    @include glass-text-secondary-color;
+    height: 24px;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 14px;
+    text-transform: uppercase;
+  }
+
+  &__email-container {
+    margin-top: 50px;
+  }
+
+  &__email-header {
+    @include glass-text-secondary-color;
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    height: 24px;
+  }
+
   &__wallet-select-modal {
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
+  }
+
+  &__alert-small {
+    display: flex;
+    justify-content: center;
+    padding: 4px 8px 4px 0px;
+  }
+
+  &__alert-info-text {
+    font-size: 14px;
+    line-height: 20px;
   }
 
   &__alert-text {
@@ -27,7 +59,7 @@
     line-height: 17px;
   }
 
-  &__footer {
+  &__add-wallet {
     margin: 8px 0;
   }
 }

--- a/src/components/wallet-list-item/index.test.tsx
+++ b/src/components/wallet-list-item/index.test.tsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+
+import { WalletListItem, Properties } from '.';
+import { bem } from '../../lib/bem';
+
+const c = bem('.wallet-list-item');
+
+describe(WalletListItem, () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      wallet: [] as any,
+      tag: '',
+
+      ...props,
+    };
+
+    return shallow(<WalletListItem {...allProps} />);
+  };
+
+  it('renders the wallet item', function () {
+    const wrapper = subject({ wallet: { publicAddress: '0xA100C16E67884Da7d515211Bb065592079bEcde6' } as any });
+
+    expect(wrapper.find(c('wallet'))).toHaveText('0xA100...cde6');
+  });
+
+  it('renders a tag if provided', function () {
+    const wrapper = subject({ tag: 'default' });
+
+    expect(wrapper.find(c('tag')).text()).toEqual('default');
+  });
+
+  it('does NOT render tag if NOT provided', function () {
+    const wrapper = subject({});
+
+    expect(wrapper).not.toHaveElement(c('tag'));
+  });
+});

--- a/src/components/wallet-list-item/index.tsx
+++ b/src/components/wallet-list-item/index.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { bemClassName } from '../../lib/bem';
+import { getUserSubHandle } from '../../lib/user';
+
+import './styles.scss';
+
+import { Wallet } from '../../store/authentication/types';
+import { Avatar } from '@zero-tech/zui/components';
+
+const cn = bemClassName('wallet-list-item');
+
+export interface Properties {
+  wallet: Wallet;
+  tag?: string;
+}
+
+export class WalletListItem extends React.Component<Properties> {
+  render() {
+    return (
+      <div {...cn('')} tabIndex={0}>
+        <div {...cn('details')}>
+          <Avatar size={'medium'} imageURL={''} tabIndex={-1} />
+          <div {...cn('text-container')}>
+            <span {...cn('wallet')}>{getUserSubHandle('', this.props.wallet.publicAddress)}</span>
+          </div>
+        </div>
+
+        {this.props.tag && <div {...cn('tag')}>{this.props.tag}</div>}
+      </div>
+    );
+  }
+}

--- a/src/components/wallet-list-item/styles.scss
+++ b/src/components/wallet-list-item/styles.scss
@@ -1,0 +1,50 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../glass';
+
+.wallet-list-item {
+  box-sizing: border-box;
+  height: 48px;
+  padding: 8px;
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 8px;
+  overflow: hidden;
+  outline: none;
+
+  &:hover {
+    @include glass-state-hover-color;
+  }
+
+  &__details {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  &__text-container {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  &__wallet {
+    font-size: 14px;
+    line-height: 20px;
+    flex-grow: 1;
+
+    @include glass-text-primary-color;
+  }
+
+  &__tag {
+    @include glass-text-secondary-color;
+
+    font-size: 12px;
+    line-height: 15px;
+    padding-left: 4px;
+  }
+}


### PR DESCRIPTION
### What does this do?

(wallet and no email)
<img width="317" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/2bf0e326-ee05-4cd2-a503-5dc2d69dccf0">

(email but no wallet): in this case we have disabled "add new wallet" button for now, since it will be added in future.
<img width="350" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/013011c6-e000-4b51-b3b9-efb62e1df451">
