### PR TITLE
ci: check for unmet peer deps

### DIFF
--- a/.github/workflows/check-peer-deps.yml
+++ b/.github/workflows/check-peer-deps.yml
@@ -1,0 +1,21 @@
+name: check-peer-deps
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Common Setup
+        uses: ./.github/actions/common
+
+      - name: Run peer-deps
+        run: npm run peer-deps

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:vitest": "vitest",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
+    "peer-deps": "npx check-peer-dependencies --findSolutions --npm",
     "start:legacy": "NODE_OPTIONS='--openssl-legacy-provider' DISABLE_ESLINT_PLUGIN=true craco start",
     "build:legacy": "NODE_OPTIONS='--openssl-legacy-provider --max-old-space-size=4096' craco build",
     "eject": "react-scripts eject",


### PR DESCRIPTION
### What does this do?

Logs unmet peer dependencies in CI.

### Why are we making this change?

Now that we have some unmet peer dependencies in the codebase, it would be nice to keep track of them so we know we're not introducing any new ones.

There may be better ways to solve this, but I think for now we can just check the output of `peer-deps` manually. I thought it would be nice to log it in CI rather than having to run it locally.