### PR TITLE
feat(mobile-restriction): add and render restriction page on mobile devices

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
 import { Router, Redirect, Route, Switch } from 'react-router-dom';
 import { ContextProvider as Web3ReactContextProvider } from './lib/web3/web3-react';
-import { showReleaseVersionInConsole, initializeErrorBoundary, isElectron } from './utils';
+import { showReleaseVersionInConsole, initializeErrorBoundary, isElectron, isMobile } from './utils';
 import { ErrorBoundary } from './components/error-boundary/';
 
 import '@zer0-os/zos-component-library/dist/index.css';
@@ -21,6 +21,7 @@ import { Web3Connect } from './components/web3-connect';
 import { getHistory } from './lib/browser';
 import { ElectronTitlebar } from './components/electron-titlebar';
 import { desktopInit } from './lib/desktop';
+import { Restricted } from './restricted';
 
 desktopInit();
 runSagas();
@@ -43,12 +44,18 @@ ReactDOM.render(
               <Web3Connect>
                 {isElectron() && <ElectronTitlebar />}
                 <Switch>
-                  <Route path='/get-access' exact component={Invite} />
-                  <Route path='/login' exact component={LoginPage} />
-                  <Route path='/reset-password' exact component={ResetPassword} />
-                  <Route path='/conversation/:conversationId' exact component={MessengerMain} />
-                  <Route path='/' exact component={MessengerMain} />
-                  <Route component={redirectToRoot} />
+                  {isMobile() ? (
+                    <Route path='/' component={Restricted} />
+                  ) : (
+                    <>
+                      <Route path='/get-access' exact component={Invite} />
+                      <Route path='/login' exact component={LoginPage} />
+                      <Route path='/reset-password' exact component={ResetPassword} />
+                      <Route path='/conversation/:conversationId' exact component={MessengerMain} />
+                      <Route path='/' exact component={MessengerMain} />
+                      <Route component={redirectToRoot} />
+                    </>
+                  )}
                 </Switch>
               </Web3Connect>
             </Web3ReactContextProvider>

--- a/src/restricted.scss
+++ b/src/restricted.scss
@@ -1,0 +1,29 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import './background';
+@import './glass';
+
+.restricted {
+  @include root-background;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100vh;
+
+  &__logo-container {
+    mix-blend-mode: screen;
+  }
+
+  &__text-container {
+    @include glass-text-primary-color;
+
+    padding: 0 16px;
+    margin: 0;
+
+    font-size: 14px;
+    text-align: center;
+  }
+}

--- a/src/restricted.tsx
+++ b/src/restricted.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+import { connectContainer } from './store/redux-container';
+import { ThemeEngine } from './components/theme-engine';
+import ZeroLogo from './zero-logo.svg?react';
+
+import { bemClassName } from './lib/bem';
+
+import './restricted.scss';
+
+const cn = bemClassName('restricted');
+
+export class Container extends React.Component {
+  static mapState() {
+    return {};
+  }
+
+  static mapActions() {
+    return {};
+  }
+
+  render() {
+    return (
+      <>
+        <div {...cn('')}>
+          <div {...cn('logo-container')}>
+            <ZeroLogo />
+          </div>
+          <div {...cn('text-container')}>
+            <p>Please accept your ZERO invite on a desktop browser, such as Chrome or Brave.</p>
+            <p>
+              Once you have registered you can use ZERO on your phone, by downloading from the Apple App Store or Google
+              Play store.
+            </p>
+          </div>
+        </div>
+
+        <ThemeEngine />
+      </>
+    );
+  }
+}
+
+export const Restricted = withRouter(connectContainer<{}>(Container));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,3 +36,7 @@ export function getMainBackgroundVideoSrc(selectedMainBackground) {
       return '';
   }
 }
+
+export const isMobile = () => {
+  return /Mobi|Android/i.test(navigator.userAgent);
+};


### PR DESCRIPTION
Note :: this is a first attempt / approach at implementing a restricted page. I will be deploying this to development to test, but this does not necessarily mean we will keep these additions, i.e. if there is a better way to handle restricting mobile devices.

### What does this do?
- adds and renders restriction page on mobile devices

### Why are we making this change?
- as per request
- prevent users using the app via web browser on mobile

### How do I test this?
- run tests as usual.
- once deployed to development, using a mobile visit the dev url and check the restricted page is rendered.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1409" alt="Screenshot 2024-06-18 at 12 37 44" src="https://github.com/zer0-os/zOS/assets/39112648/c8e160ea-6f11-414b-bb40-8e862468434d">

