### PR TITLE
feat(page-load-saga): apply mobile restriction logic to page load saga

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
 import { Router, Redirect, Route, Switch } from 'react-router-dom';
 import { ContextProvider as Web3ReactContextProvider } from './lib/web3/web3-react';
-import { showReleaseVersionInConsole, initializeErrorBoundary, isElectron, isMobile } from './utils';
+import { showReleaseVersionInConsole, initializeErrorBoundary, isElectron } from './utils';
 import { ErrorBoundary } from './components/error-boundary/';
 
 import '@zer0-os/zos-component-library/dist/index.css';
@@ -44,11 +44,12 @@ ReactDOM.render(
               <Web3Connect>
                 {isElectron() && <ElectronTitlebar />}
                 <Switch>
+                  <Route path='/restricted' exact component={Restricted} />
                   <Route path='/get-access' exact component={Invite} />
                   <Route path='/login' exact component={LoginPage} />
                   <Route path='/reset-password' exact component={ResetPassword} />
                   <Route path='/conversation/:conversationId' exact component={MessengerMain} />
-                  <Route path='/' exact component={isMobile() ? Restricted : MessengerMain} />
+                  <Route path='/' exact component={MessengerMain} />
                   <Route component={redirectToRoot} />
                 </Switch>
               </Web3Connect>

--- a/src/store/page-load/saga.test.ts
+++ b/src/store/page-load/saga.test.ts
@@ -117,6 +117,21 @@ describe('page-load saga', () => {
     expect(history.replace).not.toHaveBeenCalled();
   });
 
+  it('redirects to /restricted if on mobile', async () => {
+    const initialState = { pageload: { isComplete: false } };
+
+    history = new StubHistory('/');
+    const { storeState } = await subject(saga)
+      .provide([
+        [call(getNavigator), stubNavigator('Mobi')],
+      ])
+      .withReducer(rootReducer, initialState as any)
+      .run();
+
+    expect(history.replace).toHaveBeenCalledWith({ pathname: '/restricted' });
+    expect(storeState.pageload.isComplete).toBe(true);
+  });
+
   describe('showAndroidDownload', () => {
     function subject(path: string, userAgent: string) {
       const initialState = { pageload: { showAndroidDownload: false } };

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -12,6 +12,12 @@ const anonymousPaths = [
 
 export function* saga() {
   const history = yield call(getHistory);
+  const navigator = yield call(getNavigator);
+  const isMobileDevice = /Mobi|Android/i.test(navigator.userAgent);
+
+  if (isMobileDevice) {
+    history.replace({ pathname: '/restricted' });
+  }
 
   const success = yield call(getCurrentUser);
   if (success) {


### PR DESCRIPTION
### What does this do?
- applies mobile restriction logic to page load saga
- adds restricted route

### Why are we making this change?
- handling this logic in the page load saga prevents unexpected issues when rendering routes i.e. flickering when page load completes

### How do I test this?
- run tests as usual.
- once merged this can be tested on development via mobile device.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
