### PR TITLE
fix(page-load-saga): ensure restricted route persists and does not switch to login route on load complete

### DIFF
--- a/src/store/page-load/saga.test.ts
+++ b/src/store/page-load/saga.test.ts
@@ -131,44 +131,6 @@ describe('page-load saga', () => {
     expect(history.replace).toHaveBeenCalledWith({ pathname: '/restricted' });
     expect(storeState.pageload.isComplete).toBe(true);
   });
-
-  describe('showAndroidDownload', () => {
-    function subject(path: string, userAgent: string) {
-      const initialState = { pageload: { showAndroidDownload: false } };
-      return expectSaga(saga)
-        .provide([
-          [call(getHistory), new StubHistory(path)],
-          [call(getCurrentUser), false],
-          [call(getNavigator), stubNavigator(userAgent)],
-          [spawn(redirectOnUserLogin), null],
-        ])
-        .withReducer(rootReducer, initialState as any);
-    }
-
-    it('is false if not on a configured page', async () => {
-      const { storeState } = await subject('/', 'Android').run();
-
-      expect(storeState.pageload.showAndroidDownload).toBe(false);
-    });
-
-    it('is false if not an android user agent', async () => {
-      const { storeState } = await subject('/login', 'Chrome').run();
-
-      expect(storeState.pageload.showAndroidDownload).toBe(false);
-    });
-
-    it('is true if the user agent matches and is login page', async () => {
-      const { storeState } = await subject('/login', 'Android').run();
-
-      expect(storeState.pageload.showAndroidDownload).toBe(true);
-    });
-
-    it('is true if the user agent matches and is get-access page', async () => {
-      const { storeState } = await subject('/get-access', 'Android').run();
-
-      expect(storeState.pageload.showAndroidDownload).toBe(true);
-    });
-  });
 });
 
 describe(redirectToEntryPath, () => {

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -17,6 +17,8 @@ export function* saga() {
 
   if (isMobileDevice) {
     history.replace({ pathname: '/restricted' });
+    yield put(setIsComplete(true));
+    return;
   }
 
   const success = yield call(getCurrentUser);


### PR DESCRIPTION
Note :: Further refactoring required. We should move the android download functionality to the restricted component for the restricted route now that we would prevent the user from reaching the login route.

### What does this do?
- set load to complete if restricted route is reached due to device being mobile.
- this removes test with regards to showing android download links. 

### Why are we making this change?
- prevents the route changing to login when page load is complete on a mobile device.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
