### PR TITLE
feat(restricted-route): add store link elements to restricted page

### DIFF
--- a/src/restricted.scss
+++ b/src/restricted.scss
@@ -26,4 +26,8 @@
     font-size: 14px;
     text-align: center;
   }
+
+  &__link {
+    color: theme.$color-secondary-11;
+  }
 }

--- a/src/restricted.tsx
+++ b/src/restricted.tsx
@@ -31,23 +31,11 @@ export class Container extends React.Component {
             <p>Please accept your ZERO invite on a desktop browser, such as Chrome or Brave.</p>
             <p>
               Once you have registered you can use ZERO on your phone, by downloading from the
-              <a
-                {...cn('link')}
-                href={config.appleAppStorePath}
-                // href='https://apps.apple.com/gb/app/zero-messenger/id6476882926'
-                target='_blank'
-                rel='noopener noreferrer'
-              >
+              <a {...cn('link')} href={config.appleAppStorePath} target='_blank' rel='noopener noreferrer'>
                 {' Apple App Store '}
               </a>
               or
-              <a
-                {...cn('link')}
-                href={config.googlePlayStorePath}
-                // href='https://play.google.com/store/apps/details?id=com.zero.android.messenger'
-                target='_blank'
-                rel='noopener noreferrer'
-              >
+              <a {...cn('link')} href={config.googlePlayStorePath} target='_blank' rel='noopener noreferrer'>
                 {' Google Play Store'}
               </a>
               .

--- a/src/restricted.tsx
+++ b/src/restricted.tsx
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router-dom';
 import { connectContainer } from './store/redux-container';
 import { ThemeEngine } from './components/theme-engine';
 import ZeroLogo from './zero-logo.svg?react';
+import { config } from './config';
 
 import { bemClassName } from './lib/bem';
 
@@ -29,8 +30,27 @@ export class Container extends React.Component {
           <div {...cn('text-container')}>
             <p>Please accept your ZERO invite on a desktop browser, such as Chrome or Brave.</p>
             <p>
-              Once you have registered you can use ZERO on your phone, by downloading from the Apple App Store or Google
-              Play store.
+              Once you have registered you can use ZERO on your phone, by downloading from the
+              <a
+                {...cn('link')}
+                href={config.appleAppStorePath}
+                // href='https://apps.apple.com/gb/app/zero-messenger/id6476882926'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {' Apple App Store '}
+              </a>
+              or
+              <a
+                {...cn('link')}
+                href={config.googlePlayStorePath}
+                // href='https://play.google.com/store/apps/details?id=com.zero.android.messenger'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {' Google Play Store'}
+              </a>
+              .
             </p>
           </div>
         </div>


### PR DESCRIPTION
### What does this do?
- add store link elements to restricted page

### Why are we making this change?
- so users can navigate to the correct store if they land on the restricted route page

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
<img width="1032" alt="Screenshot 2024-06-19 at 12 56 18" src="https://github.com/zer0-os/zOS/assets/39112648/3ad2168b-318b-4695-833e-db890f593bae">
