### PR TITLE
fix(reply-card-and-parent-message): maintain aspect ratio for media images in reply card

### DIFF
--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -61,5 +61,6 @@
     width: 40px;
     height: 40px;
     border-radius: 4px;
+    object-fit: cover;
   }
 }

--- a/src/components/reply-card/styles.scss
+++ b/src/components/reply-card/styles.scss
@@ -56,5 +56,6 @@
     width: 48px;
     height: 48px;
     border-radius: 4px;
+    object-fit: cover;
   }
 }


### PR DESCRIPTION
### What does this do?
- Ensures that media images in the reply card maintain their aspect ratio and fit within the container without stretching.

### Why are we making this change?
- To improve the visual presentation of media images in reply cards and prevent them from appearing distorted.

### How do I test this?
- run tests as usual.
- run ui and reply to image messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before:

<img width="556" alt="Screenshot 2024-06-19 at 13 33 14" src="https://github.com/zer0-os/zOS/assets/39112648/93f756fc-a3bc-4e4e-84dc-6a3e5cbbc8cd">

After:

<img width="556" alt="Screenshot 2024-06-19 at 13 33 26" src="https://github.com/zer0-os/zOS/assets/39112648/5e659c0b-bdaa-4285-a572-defde6af890c">
