### PR TITLE
feat(chat-view-container): move message linking and mapping logic to container level

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -14,6 +14,7 @@ import { compareDatesAsc } from '../../lib/date';
 import { openDeleteMessage } from '../../store/dialogs';
 import { openMessageInfo } from '../../store/message-info';
 import { toggleSecondarySidekick } from '../../store/group-management';
+import { linkMessages, mapMessagesById, mapMessagesByRootId } from './utils';
 
 export interface Properties extends PublicProperties {
   channel: Channel;
@@ -141,22 +142,9 @@ export class Container extends React.Component<Properties> {
   };
 
   get messages() {
-    const messagesById = {};
-    const messages = [];
-    // Assumption is that messages are already ordered by date and that
-    // the "child" message will always come after the "parent" message.
-    (this.channel?.messages || []).forEach((m) => {
-      if (m.rootMessageId && messagesById[m.rootMessageId]) {
-        messagesById[m.rootMessageId].media = m.media;
-      } else {
-        // Hmm... not sure how we ended up with integers as our message ids. For now, just cast to a string.
-        messagesById[m.id.toString()] = m;
-        if (m.id.toString() !== m.optimisticId) {
-          messagesById[m.optimisticId] = m;
-        }
-        messages.push(m);
-      }
-    });
+    const messagesById = mapMessagesById(this.channel?.messages || []);
+    const messagesByRootId = mapMessagesByRootId(this.channel?.messages || []);
+    const messages = linkMessages(this.channel?.messages || [], messagesById, messagesByRootId);
 
     return messages.sort((a, b) => compareDatesAsc(a.createdAt, b.createdAt));
   }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -69,6 +69,7 @@ export interface Message {
   parentMessageText?: string;
   parentMessageMedia?: Media;
   parentMessage?: ParentMessage;
+  parentMessageId?: string;
   isAdmin: boolean;
   createdAt: number;
   updatedAt: number;

--- a/src/store/messages/utils.matrix.test.ts
+++ b/src/store/messages/utils.matrix.test.ts
@@ -1,14 +1,10 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import * as matchers from 'redux-saga-test-plan/matchers';
 
 import { mapMessageSenders } from './utils.matrix';
 import { getZEROUsers } from '../channels-list/api';
-import { chat } from '../../lib/chat';
 import { StoreBuilder } from '../test/store';
 import { rootReducer } from '../reducer';
 import { call } from 'redux-saga/effects';
-
-const chatClient = { getMessageByRoomId: () => {} };
 
 describe(mapMessageSenders, () => {
   let messages: any;
@@ -98,78 +94,6 @@ describe(mapMessageSenders, () => {
       firstName: 'Test',
       lastName: 'User 2',
       profileImage: 'image-url-2',
-    });
-  });
-
-  it('sets the parentMessage to message if present in the message list', async () => {
-    const initialState = {
-      normalized: {
-        users: {
-          'user-1': users[0],
-          'user-2': users[1],
-        },
-      },
-    };
-
-    const parentMessage = messages[0];
-    messages[1].parentMessageId = parentMessage.id; // make 2nd message in the list a reply to the first
-
-    await expectSaga(mapMessageSenders, messages, 'channel-id').withState(initialState).run();
-
-    expect(messages[1].parentMessage).toEqual(messages[0]); // check if the parent message is assigned properly
-  });
-
-  it('sets the parentMessage to message if not present in the message list but IS present in state', async () => {
-    const messages = [
-      { id: '1', parentMessageId: 'existing-message-1', message: 'message-1', sender: { userId: 'matrix-1' } } as any,
-    ];
-    const initialState = new StoreBuilder()
-      .withUsers({ userId: 'user-1', matrixId: 'matrix-1' })
-      .withConversationList({ id: '1', messages: [{ id: 'existing-message-1', message: 'the parent!' } as any] });
-
-    await expectSaga(mapMessageSenders, messages, 'channel-id').withState(initialState.build()).run();
-
-    expect(messages[0].parentMessageText).toEqual('the parent!');
-  });
-
-  it('calls matrix API to fetch parent message if not present in the message list OR state', async () => {
-    const initialState = {
-      normalized: {
-        users: {
-          'user-1': users[0],
-          'user-2': users[1],
-        },
-      },
-    };
-
-    const oldMessage = {
-      id: 'some-very-old-message-id',
-      sender: { userId: 'matrix-user-1', firstName: '' },
-      message: 'parent message',
-    };
-    messages[1].parentMessageId = oldMessage.id; // 2nd message's parent is a very old message (so not present in current list)
-
-    await expectSaga(mapMessageSenders, messages, 'channel-id')
-      .provide([
-        [matchers.call.fn(chat.get), chatClient],
-        [matchers.call.fn(chatClient.getMessageByRoomId), oldMessage],
-      ])
-      .withState(initialState)
-      .call(chat.get)
-      .call([chatClient, chatClient.getMessageByRoomId], 'channel-id', 'some-very-old-message-id')
-      .run();
-
-    expect(messages[1].parentMessage).toEqual({
-      id: 'some-very-old-message-id',
-      // parent message's sender is also mapped to a ZERO user
-      sender: {
-        userId: 'user-1',
-        matrixId: 'matrix-user-1',
-        firstName: 'Test',
-        lastName: 'User 1',
-        profileImage: 'image-url-1',
-      },
-      message: 'parent message',
     });
   });
 });

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -1,44 +1,6 @@
-import { call, select } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
-import { getLocalZeroUsersMap, messageSelector } from './saga';
-import { chat } from '../../lib/chat';
-
-function* mapParentForMessages(messages, channelId: string, zeroUsersMap) {
-  const chatClient = yield call(chat.get);
-
-  const messagesById = {};
-  messages.forEach((m) => {
-    messagesById[m.id] = m;
-  });
-
-  const messagesByRootId = {};
-
-  for (const message of messages) {
-    if (message.rootMessageId && !messagesByRootId[message.rootMessageId]) {
-      messagesByRootId[message.rootMessageId] = message;
-    }
-
-    if (message.parentMessageId) {
-      let parentMessage = messagesById[message.parentMessageId];
-
-      if (!parentMessage) {
-        // Check the state for the message
-        parentMessage = yield select(messageSelector(message.parentMessageId));
-      }
-
-      if (!parentMessage) {
-        // if we don't have the parent message in our list or in state we need to fetch it
-        // this can happen when a message is a reply to a message which is not in the current page/list
-        parentMessage = yield call([chatClient, chatClient.getMessageByRoomId], channelId, message.parentMessageId);
-        parentMessage.sender = zeroUsersMap[parentMessage.sender?.userId] || parentMessage.sender;
-      }
-
-      message.parentMessage = parentMessage;
-      message.parentMessageText = parentMessage.isHidden ? 'Message hidden' : parentMessage.message;
-      message.parentMessageMedia = messagesByRootId[parentMessage?.id]?.media ?? parentMessage?.media;
-    }
-  }
-}
+import { getLocalZeroUsersMap } from './saga';
 
 // takes in a list of messages, and maps the sender to a ZERO user for each message
 // this is used to display the sender's name and profile image
@@ -62,8 +24,6 @@ export function* mapMessageSenders(messages, channelId) {
   messages.forEach((message) => {
     message.sender = localUsersMap[message.sender?.userId] || message.sender; // note: message.sender.userId is the matrixId
   });
-
-  yield call(mapParentForMessages, messages, channelId, localUsersMap);
 
   return localUsersMap;
 }

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -4,7 +4,7 @@ import { getLocalZeroUsersMap } from './saga';
 
 // takes in a list of messages, and maps the sender to a ZERO user for each message
 // this is used to display the sender's name and profile image
-export function* mapMessageSenders(messages, channelId) {
+export function* mapMessageSenders(messages, _channelId) {
   const localUsersMap = yield call(getLocalZeroUsersMap);
 
   const matrixIds = [];


### PR DESCRIPTION
### What does this do?
- moves message linking and mapping logic to container level from message saga and utils

### Why are we making this change?
- fix issue with fetching message data

### How do I test this?
- run tests as usual.
- run the UI and ensure message edit, replies, images etc render as expected.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/zer0-os/zOS/assets/39112648/0434241e-a117-414b-beeb-2436805899dd

