### PR TITLE
Update `workflows/development.yml` workflow to install with `--legacy-peer-deps`

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -52,7 +52,7 @@ jobs:
 
       - run: echo '//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}' >> .npmrc
 
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@main


### PR DESCRIPTION
### What does this do?

Currently `main` is broken due to this

<img width="766" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/7fc4a209-cda4-4bb6-9f09-9caed61102ef">
