### PR TITLE
chore: upgrade to React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "@todesktop/client-core": "^1.3.0",
         "@types/jest": "^24.9.1",
         "@types/node": "^20.11.0",
-        "@types/react": "^16.14.21",
-        "@types/react-dom": "^16.9.14",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
         "@types/react-redux": "^7.1.20",
         "@vitejs/plugin-react-swc": "^3.7.0",
         "@web3-react/core": "^6.1.9",
@@ -48,8 +48,8 @@
         "moment": "^2.29.4",
         "normalizr": "^3.6.2",
         "rc-tooltip": "^5.3.1",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "react-dropzone": "^14.2.3",
         "react-mentions": "^4.4.7",
         "react-portal": "^4.2.1",
@@ -10009,6 +10009,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/@testing-library/react/node_modules/@types/react-dom": {
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "^17"
+      }
+    },
     "node_modules/@testing-library/react/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10709,20 +10718,20 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.35.tgz",
-      "integrity": "sha512-NUEiwmSS1XXtmBcsm1NyRRPYjoZF2YTE89/5QiLt5mlGffYK9FQqOKuOLuXNrjPQV04oQgaZG+Yq02ZfHoFyyg==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "16.9.14",
-      "license": "MIT",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "dependencies": {
-        "@types/react": "^16"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-portal": {
@@ -10756,10 +10765,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "license": "MIT"
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
@@ -32701,11 +32706,11 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "license": "MIT",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -32975,15 +32980,23 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "license": "MIT",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-dropzone": {
@@ -35020,6 +35033,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -46919,6 +46933,15 @@
             "pretty-format": "^27.0.2"
           }
         },
+        "@types/react-dom": {
+          "version": "17.0.25",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+          "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+          "dev": true,
+          "requires": {
+            "@types/react": "^18.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -47212,7 +47235,7 @@
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
-        "@types/react": "^16.14.21"
+        "@types/react": "^18.0.0"
       }
     },
     "@types/eslint": {
@@ -47303,7 +47326,7 @@
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "requires": {
-        "@types/react": "^16.14.21",
+        "@types/react": "^18.0.0",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -47514,33 +47537,34 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.35.tgz",
-      "integrity": "sha512-NUEiwmSS1XXtmBcsm1NyRRPYjoZF2YTE89/5QiLt5mlGffYK9FQqOKuOLuXNrjPQV04oQgaZG+Yq02ZfHoFyyg==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "@types/react-dom": {
-      "version": "16.9.14",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "requires": {
-        "@types/react": "^16.14.21"
+        "@types/react": "^18.0.0"
       }
     },
     "@types/react-portal": {
       "version": "4.0.4",
       "dev": true,
       "requires": {
-        "@types/react": "^16.14.21"
+        "@types/react": "^18.0.0"
       }
     },
     "@types/react-redux": {
       "version": "7.1.20",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "^16.14.21",
+        "@types/react": "^18.0.0",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
       }
@@ -47558,9 +47582,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-    },
-    "@types/scheduler": {
-      "version": "0.16.2"
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -63097,10 +63118,11 @@
       }
     },
     "react": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-app-polyfill": {
@@ -63291,11 +63313,22 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.23.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+          "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        }
       }
     },
     "react-dropzone": {
@@ -64718,6 +64751,7 @@
     },
     "scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "react-dropzone": "^14.2.3",
         "react-mentions": "^4.4.7",
         "react-portal": "^4.2.1",
-        "react-redux": "^7.2.6",
+        "react-redux": "^7.2.8",
         "react-router-dom": "^5.3.4",
         "react-waypoint": "^10.3.0",
         "redux": "^4.1.2",
@@ -32942,8 +32942,9 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "7.2.6",
-      "license": "MIT",
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -32953,7 +32954,7 @@
         "react-is": "^17.0.2"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17"
+        "react": "^16.8.3 || ^17 || ^18"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -62999,7 +63000,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.6",
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "@testing-library/dom": "^10.1.0",
-        "@testing-library/react": "^12.1.5",
+        "@testing-library/dom": "^10.2.0",
+        "@testing-library/react": "^16.0.0",
         "@types/enzyme": "^3.10.10",
         "@types/jest-when": "^3.5.2",
         "@types/react-portal": "^4.0.4",
@@ -9852,9 +9852,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.2.0.tgz",
+      "integrity": "sha512-CytIvb6tVOADRngTHGWNxH8LPgO/3hi/BdCEHOf7Qd2GvZVClhVP0Wo/QHzWhpki49Bk0b4VT6xpt3fx8HTSIw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -9973,160 +9973,30 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
-      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.0.tgz",
+      "integrity": "sha512-guuxUKRWQ+FgNX0h0NS0FIq3Q3uLtWVpBzcLOggmfMoUpgBnzBzvLLd4fbm6yS8ydJd94cIfY4yP9qUQjM2KwQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@babel/runtime": "^7.12.5"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "<18.0.0",
-        "react-dom": "<18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@types/react-dom": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "^17"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@testing-library/react/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
-    },
-    "node_modules/@testing-library/react/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@todesktop/client-core": {
@@ -15884,38 +15754,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-equal-ident": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
@@ -15934,12 +15772,6 @@
         "lodash._baseisequal": "^3.0.0",
         "lodash._bindcallback": "^3.0.0"
       }
-    },
-    "node_modules/deep-equal/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -17406,32 +17238,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.0.16",
@@ -36104,18 +35910,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
-      "dependencies": {
-        "internal-slot": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -46815,9 +46609,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.2.0.tgz",
+      "integrity": "sha512-CytIvb6tVOADRngTHGWNxH8LPgO/3hi/BdCEHOf7Qd2GvZVClhVP0Wo/QHzWhpki49Bk0b4VT6xpt3fx8HTSIw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -46907,124 +46701,12 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
-      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.0.tgz",
+      "integrity": "sha512-guuxUKRWQ+FgNX0h0NS0FIq3Q3uLtWVpBzcLOggmfMoUpgBnzBzvLLd4fbm6yS8ydJd94cIfY4yP9qUQjM2KwQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "8.20.1",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-          "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^5.0.1",
-            "aria-query": "5.1.3",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.5.0",
-            "pretty-format": "^27.0.2"
-          }
-        },
-        "@types/react-dom": {
-          "version": "17.0.25",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-          "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
-          "dev": true,
-          "requires": {
-            "@types/react": "^18.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "aria-query": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-          "dev": true,
-          "requires": {
-            "deep-equal": "^2.0.5"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@todesktop/client-core": {
@@ -51274,40 +50956,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "requires": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
-    },
     "deep-equal-ident": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
@@ -52374,31 +52022,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
     },
     "es-iterator-helpers": {
       "version": "1.0.16",
@@ -65581,15 +65204,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "dev": true
-    },
-    "stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
-      "requires": {
-        "internal-slot": "^1.0.4"
-      }
     },
     "stream-browserify": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@testing-library/dom": "^10.2.0",
         "@testing-library/react": "^16.0.0",
         "@types/enzyme": "^3.10.10",
@@ -2261,6 +2262,30 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@cfaester/enzyme-adapter-react-18": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cfaester/enzyme-adapter-react-18/-/enzyme-adapter-react-18-0.8.0.tgz",
+      "integrity": "sha512-3Z3ThTUouHwz8oIyhTYQljEMNRFtlVyc3VOOHCbxs47U6cnXs8K9ygi/c1tv49s7MBlTXeIcuN+Ttd9aPtILFQ==",
+      "dev": true,
+      "dependencies": {
+        "enzyme-shallow-equal": "^1.0.0",
+        "function.prototype.name": "^1.1.6",
+        "has": "^1.0.4",
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0"
+      },
+      "peerDependencies": {
+        "enzyme": "^3.11.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@cfaester/enzyme-adapter-react-18/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -20162,12 +20187,10 @@
       "dev": true
     },
     "node_modules/has": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -33330,15 +33353,16 @@
       }
     },
     "node_modules/react-shallow-renderer": {
-      "version": "16.14.1",
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0"
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -41730,6 +41754,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@cfaester/enzyme-adapter-react-18": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cfaester/enzyme-adapter-react-18/-/enzyme-adapter-react-18-0.8.0.tgz",
+      "integrity": "sha512-3Z3ThTUouHwz8oIyhTYQljEMNRFtlVyc3VOOHCbxs47U6cnXs8K9ygi/c1tv49s7MBlTXeIcuN+Ttd9aPtILFQ==",
+      "dev": true,
+      "requires": {
+        "enzyme-shallow-equal": "^1.0.0",
+        "function.prototype.name": "^1.1.6",
+        "has": "^1.0.4",
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+          "dev": true
+        }
+      }
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -54142,11 +54187,10 @@
       "dev": true
     },
     "has": {
-      "version": "1.0.3",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+      "dev": true
     },
     "has-bigints": {
       "version": "1.0.2",
@@ -63298,11 +63342,13 @@
       }
     },
     "react-shallow-renderer": {
-      "version": "16.14.1",
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "react-style-singleton": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "react-mentions": "^4.4.7",
         "react-portal": "^4.2.1",
         "react-redux": "^7.2.6",
-        "react-router-dom": "^5.3.0",
+        "react-router-dom": "^5.3.4",
         "react-waypoint": "^10.3.0",
         "redux": "^4.1.2",
         "redux-saga": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
         "@types/enzyme": "^3.10.10",
         "@types/jest-when": "^3.5.2",
         "@types/react-portal": "^4.0.4",
-        "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
         "concurrently": "^7.1.0",
         "cross-env": "^7.0.3",
         "electron": "^18.1.0",
@@ -11454,46 +11453,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@wojtekmaj/enzyme-adapter-react-17": {
-      "version": "0.6.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/enzyme-adapter-utils": "^0.1.1",
-        "enzyme-shallow-equal": "^1.0.0",
-        "has": "^1.0.0",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.0",
-        "react-is": "^17.0.2",
-        "react-test-renderer": "^17.0.0"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.0.0",
-        "react": "^17.0.0-0",
-        "react-dom": "^17.0.0-0"
-      }
-    },
-    "node_modules/@wojtekmaj/enzyme-adapter-react-17/node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wojtekmaj/enzyme-adapter-utils": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function.prototype.name": "^1.1.0",
-        "has": "^1.0.0",
-        "object.assign": "^4.1.0",
-        "object.fromentries": "^2.0.0",
-        "prop-types": "^15.7.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0-0"
       }
     },
     "node_modules/@xobotyi/scrollbar-width": {
@@ -29079,18 +29038,6 @@
         "dom-walk": "^0.1.0"
       }
     },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.0.tgz",
@@ -33082,14 +33029,14 @@
       "license": "0BSD"
     },
     "node_modules/react-router": {
-      "version": "5.2.1",
-      "license": "MIT",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -33101,14 +33048,15 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.0",
-      "license": "MIT",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
+        "react-router": "5.3.4",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       },
@@ -33118,11 +33066,13 @@
     },
     "node_modules/react-router/node_modules/isarray": {
       "version": "0.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/react-router/node_modules/path-to-regexp": {
       "version": "1.8.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -33389,25 +33339,6 @@
     "node_modules/react-style-singleton/node_modules/tslib": {
       "version": "2.4.0",
       "license": "0BSD"
-    },
-    "node_modules/react-test-renderer": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
@@ -34859,15 +34790,6 @@
       },
       "engines": {
         "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.20.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/schema-utils": {
@@ -47926,37 +47848,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@wojtekmaj/enzyme-adapter-react-17": {
-      "version": "0.6.5",
-      "dev": true,
-      "requires": {
-        "@wojtekmaj/enzyme-adapter-utils": "^0.1.1",
-        "enzyme-shallow-equal": "^1.0.0",
-        "has": "^1.0.0",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.0",
-        "react-is": "^17.0.2",
-        "react-test-renderer": "^17.0.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.2",
-          "dev": true
-        }
-      }
-    },
-    "@wojtekmaj/enzyme-adapter-utils": {
-      "version": "0.1.1",
-      "dev": true,
-      "requires": {
-        "function.prototype.name": "^1.1.0",
-        "has": "^1.0.0",
-        "object.assign": "^4.1.0",
-        "object.fromentries": "^2.0.0",
-        "prop-types": "^15.7.0"
-      }
-    },
     "@xobotyi/scrollbar-width": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
@@ -60534,13 +60425,6 @@
         "dom-walk": "^0.1.0"
       }
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.0.tgz",
@@ -63164,13 +63048,14 @@
       }
     },
     "react-router": {
-      "version": "5.2.1",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -63179,10 +63064,14 @@
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
         },
         "path-to-regexp": {
           "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "requires": {
             "isarray": "0.0.1"
           }
@@ -63190,13 +63079,15 @@
       }
     },
     "react-router-dom": {
-      "version": "5.3.0",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
+        "react-router": "5.3.4",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
@@ -63361,22 +63252,6 @@
       "dependencies": {
         "tslib": {
           "version": "2.4.0"
-        }
-      }
-    },
-    "react-test-renderer": {
-      "version": "17.0.2",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.2",
-          "dev": true
         }
       }
     },
@@ -64416,14 +64291,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
-      }
-    },
-    "scheduler": {
-      "version": "0.20.2",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "@todesktop/client-core": "^1.3.0",
     "@types/jest": "^24.9.1",
     "@types/node": "^20.11.0",
-    "@types/react": "^16.14.21",
-    "@types/react-dom": "^16.9.14",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "@types/react-redux": "^7.1.20",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "@web3-react/core": "^6.1.9",
@@ -48,8 +48,8 @@
     "moment": "^2.29.4",
     "normalizr": "^3.6.2",
     "rc-tooltip": "^5.3.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-dropzone": "^14.2.3",
     "react-mentions": "^4.4.7",
     "react-portal": "^4.2.1",
@@ -135,8 +135,9 @@
     "wait-on": "^6.0.1"
   },
   "overrides": {
-    "@types/react": "^16.14.21",
-    "react@16.x": "^17.0.2",
+    "@types/react": "^18.0.0",
+    "react@16.x": "^18.0.0",
+    "react@17.x": "^18.0.0",
     "@zer0-os/zos-component-library": "$@zer0-os/zos-component-library",
     "@zero-tech/zui": "$@zero-tech/zui",
     "@radix-ui/react-popper": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@testing-library/dom": "^10.1.0",
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/dom": "^10.2.0",
+    "@testing-library/react": "^16.0.0",
     "@types/enzyme": "^3.10.10",
     "@types/jest-when": "^3.5.2",
     "@types/react-portal": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-dropzone": "^14.2.3",
     "react-mentions": "^4.4.7",
     "react-portal": "^4.2.1",
-    "react-redux": "^7.2.6",
+    "react-redux": "^7.2.8",
     "react-router-dom": "^5.3.4",
     "react-waypoint": "^10.3.0",
     "redux": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-mentions": "^4.4.7",
     "react-portal": "^4.2.1",
     "react-redux": "^7.2.6",
-    "react-router-dom": "^5.3.0",
+    "react-router-dom": "^5.3.4",
     "react-waypoint": "^10.3.0",
     "redux": "^4.1.2",
     "redux-saga": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@cfaester/enzyme-adapter-react-18": "^0.8.0",
     "@testing-library/dom": "^10.2.0",
     "@testing-library/react": "^16.0.0",
     "@types/enzyme": "^3.10.10",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@types/enzyme": "^3.10.10",
     "@types/jest-when": "^3.5.2",
     "@types/react-portal": "^4.0.4",
-    "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
     "concurrently": "^7.1.0",
     "cross-env": "^7.0.3",
     "electron": "^18.1.0",

--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -96,6 +96,8 @@ export class EditProfile extends React.Component<Properties, State> {
   renderZeroIDLabel = (): JSX.Element => (
     <div className={c('primary-zid-lable')}>
       Primary ZERO ID
+      {/* See: ZOS-115
+       * @ts-ignore */}
       <Tooltip content='Your primary ZERO ID is displayed with your username and other members can find you by searching for it.'>
         <div className={c('info-tooltip')}>
           <IconHelpCircle size={16} />

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import './styles.scss';
 import { bemClassName } from '../../lib/bem';
@@ -7,6 +7,7 @@ import { Waypoint } from 'react-waypoint';
 const cn = bemClassName('inverted-scroll');
 
 export interface Properties {
+  children?: ReactNode;
   className?: string;
   isScrollbarHidden?: boolean;
 }

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -363,6 +363,8 @@ export class MessageInput extends React.Component<Properties, State> {
           {!this.props.isEditing && (
             <div {...cn('icon-outer')}>
               <div {...cn('icon-wrapper')}>
+                {/* See: ZOS-115
+                 * @ts-ignore */}
                 <Tooltip content={this.sendDisabledTooltipContent} open={this.state.isSendTooltipOpen}>
                   <IconButton
                     {...cn('icon', 'end-action')}

--- a/src/components/message/edit-message-actions/edit-message-actions.tsx
+++ b/src/components/message/edit-message-actions/edit-message-actions.tsx
@@ -54,11 +54,15 @@ export default class EditMessageActions extends React.Component<Properties> {
 
     return (
       <div {...cn()} ref={this.editMessageActionRef}>
+        {/* See: ZOS-115
+         * @ts-ignore */}
         <Tooltip content={this.props.secondaryTooltipText}>
           <Button color={Color.Greyscale} onPress={this.props.onCancel} size={Size.Small} variant={Variant.Secondary}>
             Cancel
           </Button>
         </Tooltip>
+        {/* See: ZOS-115
+         * @ts-ignore */}
         <Tooltip
           content={this.props.primaryTooltipText}
           open={this.state.tooltipOpen}

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Item, Option } from '../lib/types';
 import { Avatar, Input } from '@zero-tech/zui/components';
@@ -9,6 +9,7 @@ import '../list/styles.scss';
 import { highlightFilter, itemToOption } from '../lib/utils';
 import classNames from 'classnames';
 export interface Properties {
+  children?: ReactNode;
   inputRef?: React.RefObject<HTMLInputElement>;
   search: (query: string) => Promise<Item[]>;
   selectedOptions?: Option[];

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -21,6 +21,7 @@ export enum Color {
 }
 
 export interface Properties {
+  children?: React.ReactNode;
   title: string;
   primaryText?: string;
   primaryVariant?: Variant;

--- a/src/components/tooltip-popup/tooltip-popup.tsx
+++ b/src/components/tooltip-popup/tooltip-popup.tsx
@@ -10,6 +10,7 @@ import TooltipHead from '../../tooltip-head.svg?react';
 const c = bem('tooltip-popup');
 
 export interface Properties {
+  children?: ReactNode;
   open?: TooltipPrimitive.TooltipProps['open'];
   onOpenChange?: TooltipPrimitive.TooltipProps['onOpenChange'];
   side?: TooltipPrimitive.TooltipContentProps['side'];

--- a/src/components/web3-connect/index.tsx
+++ b/src/components/web3-connect/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { providers } from 'ethers';
@@ -9,6 +9,7 @@ import { Chains, ConnectionStatus, Connectors } from '../../lib/web3';
 import { setChain, setAddress, setConnectionStatus, updateConnector, setConnectionError } from '../../store/web3';
 
 export interface Properties {
+  children?: ReactNode;
   connectionStatus: ConnectionStatus;
   setConnectionStatus: (status: ConnectionStatus) => void;
   setAddress: (address: string) => void;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,30 +39,30 @@ const container = document.getElementById('platform');
 const root = createRoot(container!); // createRoot(container!) if you use TypeScript
 
 root.render(
-  // <React.StrictMode>
-  <ErrorBoundary boundary={'core'}>
-    <Provider store={store}>
-      <EscapeManagerProvider>
-        <Router history={history}>
-          <Web3ReactContextProvider>
-            <Web3Connect>
-              {isElectron() && <ElectronTitlebar />}
-              <Switch>
-                <Route path='/restricted' exact component={Restricted} />
-                <Route path='/get-access' exact component={Invite} />
-                <Route path='/login' exact component={LoginPage} />
-                <Route path='/reset-password' exact component={ResetPassword} />
-                <Route path='/conversation/:conversationId' exact component={MessengerMain} />
-                <Route path='/' exact component={MessengerMain} />
-                <Route component={redirectToRoot} />
-              </Switch>
-            </Web3Connect>
-          </Web3ReactContextProvider>
-        </Router>
-      </EscapeManagerProvider>
-    </Provider>
-  </ErrorBoundary>
-  // </React.StrictMode>
+  <React.StrictMode>
+    <ErrorBoundary boundary={'core'}>
+      <Provider store={store}>
+        <EscapeManagerProvider>
+          <Router history={history}>
+            <Web3ReactContextProvider>
+              <Web3Connect>
+                {isElectron() && <ElectronTitlebar />}
+                <Switch>
+                  <Route path='/restricted' exact component={Restricted} />
+                  <Route path='/get-access' exact component={Invite} />
+                  <Route path='/login' exact component={LoginPage} />
+                  <Route path='/reset-password' exact component={ResetPassword} />
+                  <Route path='/conversation/:conversationId' exact component={MessengerMain} />
+                  <Route path='/' exact component={MessengerMain} />
+                  <Route component={redirectToRoot} />
+                </Switch>
+              </Web3Connect>
+            </Web3ReactContextProvider>
+          </Router>
+        </EscapeManagerProvider>
+      </Provider>
+    </ErrorBoundary>
+  </React.StrictMode>
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,30 +39,30 @@ const container = document.getElementById('platform');
 const root = createRoot(container!); // createRoot(container!) if you use TypeScript
 
 root.render(
-  <React.StrictMode>
-    <ErrorBoundary boundary={'core'}>
-      <Provider store={store}>
-        <EscapeManagerProvider>
-          <Router history={history}>
-            <Web3ReactContextProvider>
-              <Web3Connect>
-                {isElectron() && <ElectronTitlebar />}
-                <Switch>
-                  <Route path='/restricted' exact component={Restricted} />
-                  <Route path='/get-access' exact component={Invite} />
-                  <Route path='/login' exact component={LoginPage} />
-                  <Route path='/reset-password' exact component={ResetPassword} />
-                  <Route path='/conversation/:conversationId' exact component={MessengerMain} />
-                  <Route path='/' exact component={MessengerMain} />
-                  <Route component={redirectToRoot} />
-                </Switch>
-              </Web3Connect>
-            </Web3ReactContextProvider>
-          </Router>
-        </EscapeManagerProvider>
-      </Provider>
-    </ErrorBoundary>
-  </React.StrictMode>
+  // <React.StrictMode>
+  <ErrorBoundary boundary={'core'}>
+    <Provider store={store}>
+      <EscapeManagerProvider>
+        <Router history={history}>
+          <Web3ReactContextProvider>
+            <Web3Connect>
+              {isElectron() && <ElectronTitlebar />}
+              <Switch>
+                <Route path='/restricted' exact component={Restricted} />
+                <Route path='/get-access' exact component={Invite} />
+                <Route path='/login' exact component={LoginPage} />
+                <Route path='/reset-password' exact component={ResetPassword} />
+                <Route path='/conversation/:conversationId' exact component={MessengerMain} />
+                <Route path='/' exact component={MessengerMain} />
+                <Route component={redirectToRoot} />
+              </Switch>
+            </Web3Connect>
+          </Web3ReactContextProvider>
+        </Router>
+      </EscapeManagerProvider>
+    </Provider>
+  </ErrorBoundary>
+  // </React.StrictMode>
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import './init';
 import React from 'react';
 
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { MessengerMain } from './messenger-main';
 import { store, runSagas } from './store';
 import { Provider } from 'react-redux';
@@ -34,7 +34,11 @@ export const history = getHistory();
 
 const redirectToRoot = () => <Redirect to={'/'} />;
 
-ReactDOM.render(
+const container = document.getElementById('platform');
+
+const root = createRoot(container!); // createRoot(container!) if you use TypeScript
+
+root.render(
   <React.StrictMode>
     <ErrorBoundary boundary={'core'}>
       <Provider store={store}>
@@ -58,8 +62,7 @@ ReactDOM.render(
         </EscapeManagerProvider>
       </Provider>
     </ErrorBoundary>
-  </React.StrictMode>,
-  document.getElementById('platform')
+  </React.StrictMode>
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/lib/web3/web3-react.tsx
+++ b/src/lib/web3/web3-react.tsx
@@ -8,14 +8,18 @@
  * here until we have the time to replace it.
  **/
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Web3ReactProvider, getWeb3ReactContext } from '@web3-react/core';
 import { providers } from 'ethers';
 
 import { get as getConnector } from './connectors';
 
-export class ContextProvider extends React.Component {
+interface Properties {
+  children?: ReactNode;
+}
+
+export class ContextProvider extends React.Component<Properties> {
   getLibrary = (provider) => new providers.Web3Provider(provider);
 
   render() {

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -60,6 +60,8 @@ export class Container extends React.Component<Properties> {
     return (
       <>
         <AuthenticationContextProvider value={this.authenticationContext}>
+          {/* See: ZOS-115
+           * @ts-ignore */}
           <ZUIProvider>
             <Main />
           </ZUIProvider>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,6 @@
 import 'jest-extended/all';
 import { configure } from 'enzyme';
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import Adapter from '@cfaester/enzyme-adapter-react-18';
 
 import 'jest-enzyme';
 


### PR DESCRIPTION
### What does this do?

- React 17 -> React 18. `react`, `react-dom`, and typings, all upgraded.
- Used [the new `root.render` function](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#:~:text=//%20Before,(%3CApp%20tab%3D%22home%22%20/%3E)%3B) at app root.
- Upgraded `testing-library/react` to work with React 18. All of our RTL tests are working as expected.
- Installed and configured an [Enzyme React 18 adapter](https://www.npmjs.com/package/@cfaester/enzyme-adapter-react-18) (`@cfaester/enzyme-adapter-react-18`). All of our Enzyme tests are working as expected.
- Removed `@wojtekmaj/enzyme-adapter-react-17`.
- Upgraded `react-router-dom` to `5.3.2`, [which supports React 18 `StrictMode`](https://github.com/remix-run/react-router/releases/tag/v5.3.2).
- Upgraded `react-redux` to `7.2.8`, [which supports React 18 StrictMode](https://github.com/reduxjs/react-redux/releases/tag/v7.2.8).
- Handles some type issues caused by React 18 not including `children` in intrinsic props (#2040).

### Why are we making this change?

We are taking baby steps getting to the latest versions of all of our tooling. We don't want to be barred out of using a tool because we're on an old version of React.

### How do I test this?

- Run `test` and `test:vitest`.
- Test flows manually.

### Key decisions and Risk Assessment

This one seems high risk, as there are some pretty major dependency changes.

I used [the React 18 migration blog](https://react.dev/blog/2022/03/08/react-18-upgrade-guide) to guide me through the upgrade, so the process was as accurate as possible. Even so, I may have missed something, as I do not yet have complete knowledge of the codebase.

As such, we should make sure to manually test all key features, as we may not be able to completely trust our unit tests.

In the future, we should write e2e tests to help with large migrations such as this.