### PR TITLE
`trim` the invite code on the input during registration

### DIFF
--- a/src/authentication/validate-invite/index.test.tsx
+++ b/src/authentication/validate-invite/index.test.tsx
@@ -98,4 +98,15 @@ describe('Invite', () => {
 
     expect(wrapper.find('Button').prop('isDisabled')).toEqual(false);
   });
+
+  it('trims input', function () {
+    const validateInvite = jest.fn();
+    const code = '  123456  ';
+    const wrapper = subject({ validateInvite });
+
+    wrapper.find('Input').simulate('change', code);
+    wrapper.find('form').simulate('submit', inputEvent());
+
+    expect(validateInvite).toHaveBeenCalledWith({ code: '123456' });
+  });
 });

--- a/src/authentication/validate-invite/index.tsx
+++ b/src/authentication/validate-invite/index.tsx
@@ -31,7 +31,7 @@ export class Invite extends React.Component<Properties, State> {
   };
 
   onInviteCodeChanged = (code: string) => {
-    this.setState({ inviteCode: code });
+    this.setState({ inviteCode: code.trim() });
   };
 
   submitForm = async (e) => {


### PR DESCRIPTION
### What does this do?

If you had copied the invite code with a "space" at end, the GET ACCESS call would fail even if the code is correct (sc below).

<img width="399" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/e10f1a7f-f693-4e56-b49f-f8879160b61a">

Fixed now, as we're trimming the input.