### PR TITLE
Enable rewards 

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -43,7 +43,7 @@ export class FeatureFlags {
   }
 
   get enableRewards() {
-    return this._getBoolean('enableRewards', false);
+    return this._getBoolean('enableRewards', true);
   }
 
   set enableRewards(value: boolean) {


### PR DESCRIPTION
### What does this do?

Flips the feature flag to enable rewards on production. 
<img width="327" alt="image" src="https://github.com/zer0-os/zOS/assets/33264364/6ee726b3-edb5-4d3d-bcb7-fe15ddd620c0">
