### PR TITLE
Use `POST` instead of `GET` to fetch ZERO user's info using their matrixIds via `/matrix/users/zero`

### DIFF
--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -1,5 +1,5 @@
 import * as Request from 'superagent';
-import { get } from '../../lib/api/rest';
+import { get, post } from '../../lib/api/rest';
 import { User } from '../channels';
 import { rawUserToDomainUser } from './utils';
 
@@ -31,14 +31,17 @@ export async function uploadImage(file: File): Promise<FileResult> {
 }
 
 export async function getZEROUsers(matrixIds: string[]): Promise<[User]> {
-  return await get('/matrix/users/zero', { matrixIds })
-    .catch((_error) => null)
-    .then((response) => {
-      if (!response?.body) {
-        return [];
-      }
-
-      // The api endpoint does not return the standard user object, so we need to map it
-      return response.body.map(rawUserToDomainUser);
+  try {
+    const response = await post('/matrix/users/zero').send({
+      matrixIds,
     });
+
+    if (!response?.body) {
+      return [] as any;
+    }
+
+    return response.body.map(rawUserToDomainUser);
+  } catch (error) {
+    return;
+  }
 }

--- a/src/store/channels-list/api.ts
+++ b/src/store/channels-list/api.ts
@@ -30,18 +30,18 @@ export async function uploadImage(file: File): Promise<FileResult> {
   return { url };
 }
 
-export async function getZEROUsers(matrixIds: string[]): Promise<[User]> {
+export async function getZEROUsers(matrixIds: string[]): Promise<User[]> {
   try {
     const response = await post('/matrix/users/zero').send({
       matrixIds,
     });
 
     if (!response?.body) {
-      return [] as any;
+      return [];
     }
 
     return response.body.map(rawUserToDomainUser);
   } catch (error) {
-    return;
+    return [];
   }
 }


### PR DESCRIPTION
### What does this do?

API PR: [https://github.com/zer0-os/zos-api/pull/22](https://github.com/zer0-os/zos-api/pull/22)

#### Reason

Currently for a very group, which has a lot of matrixIds, the GET request from the browser was failing due to "URI too long" issue. Since this is converted to post now, we can send large data via `req.body` instead of `query.params`
