### PR TITLE
feat(android-smart-popup): replace store path

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!-- added unsafe-eval here, but we should restrict this to *just* the Olm module, rather than for all self  -->
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'unsafe-eval';" />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <meta name="apple-itunes-app" content="app-id=1261522628" />
+    <meta name="apple-itunes-app" content="app-id=6476882926" />
     <script src="/olm.js"></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/invite.tsx
+++ b/src/invite.tsx
@@ -35,7 +35,7 @@ export class Container extends React.Component<Properties> {
       stage: registration.stage,
       shouldRender: pageload.isComplete,
       showAndroidDownload: pageload.showAndroidDownload,
-      androidStorePath: config.androidStorePath,
+      androidStorePath: config.googlePlayStorePath,
     };
   }
 

--- a/src/pages/login/login-container.tsx
+++ b/src/pages/login/login-container.tsx
@@ -28,7 +28,7 @@ export class LoginContainer extends React.Component<LoginContainerProperties> {
       isLoggingIn: login.loading,
       shouldRender: pageload.isComplete,
       showAndroidDownload: pageload.showAndroidDownload,
-      androidStorePath: config.androidStorePath,
+      androidStorePath: config.googlePlayStorePath,
     };
   }
 


### PR DESCRIPTION
### What does this do?
- on android download uses, replace store path with latest app store path.

### Why are we making this change?
- direct users to latest app, not the outdated one.

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
