### PR TITLE
feat(matrix-client): implement and handle adding / removing custom mute conversation tags

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -20,6 +20,8 @@ export interface RealtimeChatEvents {
   receiveLiveRoomEvent: (eventData) => void;
   roomFavorited: (roomId: string) => void;
   roomUnfavorited: (roomId: string) => void;
+  roomMuted: (roomId: string) => void;
+  roomUnmuted: (roomId: string) => void;
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
   roomMemberPowerLevelChanged: (roomId: string, matrixId: string, powerLevel: number) => void;
   readReceiptReceived: (messageId: string, userId: string) => void;
@@ -302,6 +304,14 @@ export async function addRoomToFavorites(roomId: string) {
 
 export async function removeRoomFromFavorites(roomId: string) {
   return await chat.get().matrix.removeRoomFromFavorites(roomId);
+}
+
+export async function addRoomToMuted(roomId: string) {
+  return await chat.get().matrix.addRoomToMuted(roomId);
+}
+
+export async function removeRoomFromMuted(roomId: string) {
+  return await chat.get().matrix.removeRoomFromMuted(roomId);
 }
 
 export async function uploadImageUrl(

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1144,4 +1144,74 @@ describe('matrix client', () => {
       expect(isFavorite).toBe(false);
     });
   });
+
+  describe('addRoomToMuted', () => {
+    it('sets room tag with "m.mute"', async () => {
+      const roomId = '!testRoomId';
+      const setRoomTag = jest.fn().mockResolvedValue({});
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ setRoomTag })),
+      });
+
+      await client.connect(null, 'token');
+      await client.addRoomToMuted(roomId);
+
+      expect(setRoomTag).toHaveBeenCalledWith(roomId, 'm.mute');
+    });
+  });
+
+  describe('removeRoomFromMuted', () => {
+    it('deletes "m.mute" tag from room', async () => {
+      const roomId = '!testRoomId';
+      const deleteRoomTag = jest.fn().mockResolvedValue({});
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ deleteRoomTag })),
+      });
+
+      await client.connect(null, 'token');
+      await client.removeRoomFromMuted(roomId);
+
+      expect(deleteRoomTag).toHaveBeenCalledWith(roomId, 'm.mute');
+    });
+  });
+
+  describe('isRoomMuted', () => {
+    it('returns true if "m.mute" tag is present for room', async () => {
+      const roomId = '!testRoomId';
+      const getRoomTags = jest.fn().mockResolvedValue({
+        tags: {
+          'm.mute': {},
+        },
+      });
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getRoomTags })),
+      });
+
+      await client.connect(null, 'token');
+      const isMuted = await client.isRoomMuted(roomId);
+
+      expect(getRoomTags).toHaveBeenCalledWith(roomId);
+      expect(isMuted).toBe(true);
+    });
+
+    it('returns false if "m.mute" tag is not present for room', async () => {
+      const roomId = '!testRoomId';
+      const getRoomTags = jest.fn().mockResolvedValue({
+        tags: {},
+      });
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getRoomTags })),
+      });
+
+      await client.connect(null, 'token');
+      const isMuted = await client.isRoomMuted(roomId);
+
+      expect(getRoomTags).toHaveBeenCalledWith(roomId);
+      expect(isMuted).toBe(false);
+    });
+  });
 });

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -198,6 +198,7 @@ export function mapToLiveRoomEvent(liveEvent) {
     id: event.event_id,
     type: eventType,
     createdAt: event.origin_server_ts,
+    roomId: event.room_id,
     sender: {
       userId: event.sender,
     },

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -21,6 +21,7 @@ export enum MatrixConstants {
   REPLACE = 'm.replace',
   BAD_ENCRYPTED_MSGTYPE = 'm.bad.encrypted',
   FAVORITE = 'm.favorite',
+  MUTE = 'm.mute',
   READ_RECEIPT_PREFERENCE = 'm.read_receipt_preference',
 }
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -56,6 +56,7 @@ export interface Channel {
   reply?: ParentMessage;
   isFavorite: boolean;
   otherMembersTyping: string[];
+  isMuted?: boolean;
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -77,6 +78,7 @@ export const CHANNEL_DEFAULTS = {
   moderatorIds: [],
   isFavorite: false,
   otherMembersTyping: [],
+  isMuted: false,
 };
 
 export enum SagaActionTypes {
@@ -87,6 +89,8 @@ export enum SagaActionTypes {
   OnFavoriteRoom = 'channels/saga/onFavoriteRoom',
   OnUnfavoriteRoom = 'channels/saga/onUnfavoriteRoom',
   UserTypingInRoom = 'channels/saga/userTypingInRoom',
+  OnMuteRoom = 'channels/saga/onMuteRoom',
+  OnUnmuteRoom = 'channels/saga/onUnmuteRoom',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
@@ -96,6 +100,8 @@ const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
 const onFavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnFavoriteRoom);
 const onUnfavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnfavoriteRoom);
 const userTypingInRoom = createAction<{ roomId: string }>(SagaActionTypes.UserTypingInRoom);
+const onMuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnMuteRoom);
+const onUnmuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnmuteRoom);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -117,4 +123,6 @@ export {
   onFavoriteRoom,
   onUnfavoriteRoom,
   userTypingInRoom,
+  onMuteRoom,
+  onUnmuteRoom,
 };

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -13,12 +13,23 @@ import {
   publishUserTypingEvent,
   receivedRoomMembersTyping,
   receivedRoomMemberPowerLevelChanged,
+  roomMuted,
+  onMuteRoom,
+  roomUnmuted,
+  onUnmuteRoom,
 } from './saga';
 
 import { rootReducer } from '../reducer';
 import { ConversationStatus, denormalize as denormalizeChannel } from '../channels';
 import { StoreBuilder } from '../test/store';
-import { addRoomToFavorites, chat, removeRoomFromFavorites, sendTypingEvent } from '../../lib/chat';
+import {
+  addRoomToFavorites,
+  addRoomToMuted,
+  chat,
+  removeRoomFromFavorites,
+  removeRoomFromMuted,
+  sendTypingEvent,
+} from '../../lib/chat';
 
 const userId = 'user-id';
 
@@ -177,6 +188,62 @@ describe(onUnfavoriteRoom, () => {
   });
 });
 
+describe(roomMuted, () => {
+  it('updates muted for room', async () => {
+    const initialState = new StoreBuilder().withConversationList({ id: 'room-id', isMuted: false }).build();
+    const { storeState } = await expectSaga(roomMuted, {
+      payload: { roomId: 'room-id' },
+    })
+      .withReducer(rootReducer, initialState)
+      .run();
+
+    const channel = denormalizeChannel('room-id', storeState);
+    expect(channel.isMuted).toEqual(true);
+  });
+});
+
+describe(onMuteRoom, () => {
+  it('calls addRoomToMuted when channel is not already muted', async () => {
+    const initialState = new StoreBuilder().withConversationList({ id: 'room-id', isMuted: false }).build();
+
+    await expectSaga(onMuteRoom, { payload: { roomId: 'room-id' } })
+      .withReducer(rootReducer, initialState)
+      .provide([
+        [matchers.call.fn(addRoomToMuted), undefined],
+      ])
+      .call(addRoomToMuted, 'room-id')
+      .run();
+  });
+});
+
+describe(roomUnmuted, () => {
+  it('updates unmuted for room', async () => {
+    const initialState = new StoreBuilder().withConversationList({ id: 'room-id', isMuted: true }).build();
+    const { storeState } = await expectSaga(roomUnmuted, {
+      payload: { roomId: 'room-id' },
+    })
+      .withReducer(rootReducer, initialState)
+      .run();
+
+    const channel = denormalizeChannel('room-id', storeState);
+    expect(channel.isMuted).toEqual(false);
+  });
+});
+
+describe(onUnmuteRoom, () => {
+  it('calls removeRoomFromMuted when channel is already muted', async () => {
+    const initialState = new StoreBuilder().withConversationList({ id: 'channel-id', isMuted: true }).build();
+
+    await expectSaga(onUnmuteRoom, { payload: { roomId: 'channel-id' } })
+      .withReducer(rootReducer, initialState)
+      .provide([
+        [matchers.call.fn(removeRoomFromMuted), undefined],
+      ])
+      .call(removeRoomFromMuted, 'channel-id')
+      .run();
+  });
+});
+
 describe(publishUserTypingEvent, () => {
   it('sends typing event', async () => {
     const initialState = new StoreBuilder().withConversationList({ id: 'room-id' }).build();
@@ -314,4 +381,5 @@ const CHANNEL_DEFAULTS = {
   moderatorIds: [],
   isFavorite: false,
   otherMembersTyping: [],
+  isMuted: false,
 };

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -9,6 +9,8 @@ import {
   removeRoomFromFavorites,
   chat,
   sendTypingEvent as matrixSendUserTypingEvent,
+  addRoomToMuted,
+  removeRoomFromMuted,
 } from '../../lib/chat';
 import { mostRecentConversation } from '../channels-list/selectors';
 import { setActiveConversation } from '../chat/saga';
@@ -147,6 +149,42 @@ export function* roomUnfavorited(action) {
   }
 }
 
+export function* onMuteRoom(action) {
+  const { roomId } = action.payload;
+  try {
+    yield call(addRoomToMuted, roomId);
+  } catch (error) {
+    console.error(`Failed to mute room ${roomId}:`, error);
+  }
+}
+
+export function* onUnmuteRoom(action) {
+  const { roomId } = action.payload;
+  try {
+    yield call(removeRoomFromMuted, roomId);
+  } catch (error) {
+    console.error(`Failed to unmute room ${roomId}:`, error);
+  }
+}
+
+export function* roomMuted(action) {
+  const { roomId } = action.payload;
+  try {
+    yield call(receiveChannel, { id: roomId, isMuted: true });
+  } catch (error) {
+    console.error(`Failed to update mute status for room ${roomId}:`, error);
+  }
+}
+
+export function* roomUnmuted(action) {
+  const { roomId } = action.payload;
+  try {
+    yield call(receiveChannel, { id: roomId, isMuted: false });
+  } catch (error) {
+    console.error(`Failed to update unmute status for room ${roomId}:`, error);
+  }
+}
+
 export function* receivedRoomMembersTyping(action) {
   const { roomId, userIds: matrixIds } = action.payload;
 
@@ -229,10 +267,14 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.OnRemoveReply, onRemoveReply);
   yield takeLatest(SagaActionTypes.OnFavoriteRoom, onFavoriteRoom);
   yield takeLatest(SagaActionTypes.OnUnfavoriteRoom, onUnfavoriteRoom);
+  yield takeLatest(SagaActionTypes.OnMuteRoom, onMuteRoom);
+  yield takeLatest(SagaActionTypes.OnUnmuteRoom, onUnmuteRoom);
 
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.UnreadCountChanged, unreadCountUpdated);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomFavorited, roomFavorited);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomUnfavorited, roomUnfavorited);
+  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomMuted, roomMuted);
+  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomUnmuted, roomUnmuted);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomMemberTyping, receivedRoomMembersTyping);
   yield takeEveryFromBus(
     yield call(getChatBus),

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -20,6 +20,8 @@ export enum Events {
   ChatConnectionComplete = 'chat/connection/complete',
   RoomFavorited = 'chat/channel/roomFavorited',
   RoomUnfavorited = 'chat/channel/roomUnfavorited',
+  RoomMuted = 'chat/channel/roomMuted',
+  RoomUnmuted = 'chat/channel/roomUnmuted',
   RoomMemberTyping = 'chat/channel/roomMemberTyping',
   RoomMemberPowerLevelChanged = 'chat/channel/roomMemberPowerLevelChanged',
   ReadReceiptReceived = 'chat/message/readReceiptReceived',
@@ -90,6 +92,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
     const roomFavorited = (roomId) => emit({ type: Events.RoomFavorited, payload: { roomId } });
     const roomUnfavorited = (roomId) => emit({ type: Events.RoomUnfavorited, payload: { roomId } });
+    const roomMuted = (roomId) => emit({ type: Events.RoomMuted, payload: { roomId } });
+    const roomUnmuted = (roomId) => emit({ type: Events.RoomUnmuted, payload: { roomId } });
     const roomMemberTyping = (roomId, userIds) => emit({ type: Events.RoomMemberTyping, payload: { roomId, userIds } });
     const roomMemberPowerLevelChanged = (roomId, matrixId, powerLevel) =>
       emit({ type: Events.RoomMemberPowerLevelChanged, payload: { roomId, matrixId, powerLevel } });
@@ -111,6 +115,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       receiveLiveRoomEvent,
       roomFavorited,
       roomUnfavorited,
+      roomMuted,
+      roomUnmuted,
       roomMemberTyping,
       roomMemberPowerLevelChanged,
       readReceiptReceived,

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -90,6 +90,64 @@ describe('messages saga', () => {
       .run();
   });
 
+  it('sends a browser notification when the room is NOT muted', async () => {
+    const eventData = {
+      id: 8667728016,
+      sender: { userId: 'sender-id' },
+      createdAt: 1678861267433,
+      type: NotifiableEventType.RoomMessage,
+      roomId: 'room-id-1',
+    };
+
+    const initialState = {
+      normalized: {
+        channels: {
+          'room-id-1': { isMuted: false },
+        },
+      },
+    };
+
+    await expectSaga(sendBrowserNotification, eventData as any)
+      .provide([
+        [
+          matchers.call.fn(sendBrowserMessage),
+          undefined,
+        ],
+      ])
+      .call(sendBrowserMessage, mapMessage(eventData as any))
+      .withState(initialState)
+      .run();
+  });
+
+  it('does not send a browser notification when the room is muted', async () => {
+    const eventData = {
+      id: 8667728016,
+      sender: { userId: 'sender-id' },
+      createdAt: 1678861267433,
+      type: NotifiableEventType.RoomMessage,
+      roomId: 'room-id-1',
+    };
+
+    const initialState = {
+      normalized: {
+        channels: {
+          'room-id-1': { isMuted: true },
+        },
+      },
+    };
+
+    await expectSaga(sendBrowserNotification, eventData as any)
+      .provide([
+        [
+          matchers.call.fn(sendBrowserMessage),
+          undefined,
+        ],
+      ])
+      .not.call(sendBrowserMessage, mapMessage(eventData as any))
+      .withState(initialState)
+      .run();
+  });
+
   it('edit message', async () => {
     const channelId = '0x000000000000000000000000000000000000000A';
     const message = 'update message';

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -81,6 +81,10 @@ const _isActive = (roomId) => (state) => {
   return roomId === state.chat.activeConversationId;
 };
 
+export const isRoomMutedSelector = (channelId) => (state) => {
+  return getDeepProperty(state, `normalized.channels['${channelId}'].isMuted`, false);
+};
+
 export function* getLocalZeroUsersMap() {
   const users = yield select((state) => state.normalized.users || {});
   const zeroUsersMap: { [matrixId: string]: User } = {};
@@ -527,6 +531,9 @@ export function isOwner(currentUser, entityUserMatrixId) {
 
 export function* sendBrowserNotification(eventData) {
   if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return;
+
+  const isMuted = yield select(isRoomMutedSelector(eventData?.roomId));
+  if (isMuted) return;
 
   if (eventData.type === NotifiableEventType.RoomMessage) {
     yield call(sendBrowserMessage, mapMessage(eventData));


### PR DESCRIPTION
Note :: tests will be converted to vite tests in follow up.

### What does this do?
- implements adding and removing custom mute conversation tags 
- gets is room muted tags for rooms

### Why are we making this change?
- to be able to mute room notifications

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
