### PR TITLE
feat(conversation-list-item): fixed muted icon position

### DIFF
--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -41,10 +41,6 @@
   &__name {
     @include glass-text-primary-color;
 
-    display: flex;
-    align-items: center;
-    gap: 6px;
-
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -59,6 +55,10 @@
 
   &__timestamp {
     @include glass-text-tertiary-color;
+    display: flex;
+    justify-content: flex-end;
+    min-width: 42px;
+
     font-weight: 400;
     font-size: 10px;
     line-height: 15px;
@@ -66,7 +66,10 @@
   }
 
   &__muted-icon {
-    @include glass-text-secondary-color;
+    @include glass-text-tertiary-color;
+
+    margin-right: 6px;
+    align-self: center;
   }
 
   &__message {

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -150,8 +150,9 @@ export class ConversationItem extends React.Component<Properties, State> {
           <div {...cn('header')}>
             <div {...cn('name')} is-unread={isUnread}>
               {this.highlightedName()}
-              {conversation.isMuted && <IconBellOff1 {...cn('muted-icon')} size={16} />}
             </div>
+            {conversation.isMuted && <IconBellOff1 {...cn('muted-icon')} size={16} />}
+
             <div {...cn('timestamp')}>{previewDisplayDate}</div>
           </div>
           <div {...cn('content')}>


### PR DESCRIPTION
### What does this do?
- fixes the muted icon position

### Why are we making this change?
- ensure muted icons align in the conversation list

### How do I test this?
- run tests as usual
- run UI and check muted icons in conversation list items as per below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


<img width="393" alt="Screenshot 2024-07-03 at 17 10 49" src="https://github.com/zer0-os/zOS/assets/39112648/12305f4f-07db-4320-bb00-b7508b246bc3">

Truncated
<img width="393" alt="Screenshot 2024-07-03 at 17 11 27" src="https://github.com/zer0-os/zOS/assets/39112648/404a9cac-e448-4008-8bb3-917c66a571df">
