### PR TITLE
feat(avatars): remove user status from avatars

### DIFF
--- a/src/components/citizen-list-item/index.test.tsx
+++ b/src/components/citizen-list-item/index.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 
 import { CitizenListItem, Properties } from '.';
 import { bem } from '../../lib/bem';
-import { Avatar, IconButton } from '@zero-tech/zui/components';
+import { IconButton } from '@zero-tech/zui/components';
 
 const c = bem('.citizen-list-item');
 
@@ -32,14 +32,6 @@ describe(CitizenListItem, () => {
     const handle = wrapper.find(c('handle'));
 
     expect(handle).toHaveText('0://zero:tech');
-  });
-
-  it('renders the user status', function () {
-    const wrapper = subject({ user: { isOnline: false } as any });
-
-    const avatar = wrapper.find(Avatar);
-
-    expect(avatar).toHaveProp('statusType', 'offline');
   });
 
   it('does not render remove icon if no handler provided', function () {

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -58,7 +58,7 @@ export class CitizenListItem extends React.Component<Properties, State> {
         tabIndex={0}
       >
         <div {...cn('details')}>
-          <Avatar size={'small'} imageURL={this.props.user.profileImage} tabIndex={-1} statusType={this.statusType} />
+          <Avatar size={'small'} imageURL={this.props.user.profileImage} tabIndex={-1} />
           <div {...cn('text-container')}>
             <span {...cn('name')}>{displayName(this.props.user)}</span>
             <span {...cn('handle')}>{this.props.user.displaySubHandle}</span>

--- a/src/components/messenger/chat/conversation-header/index.test.tsx
+++ b/src/components/messenger/chat/conversation-header/index.test.tsx
@@ -7,8 +7,6 @@ import { GroupManagementMenu } from '../../../group-management-menu';
 import { bem } from '../../../../lib/bem';
 import { stubUser } from '../../../../store/test/store';
 
-import { Avatar } from '@zero-tech/zui/components';
-
 const c = bem('.conversation-header');
 
 describe(ConversationHeader, () => {
@@ -71,39 +69,6 @@ describe(ConversationHeader, () => {
 
       expect(wrapper.find(Tooltip).html()).toContain('Johnny Sanderson');
     });
-
-    it('header renders online status in the subtitle', function () {
-      const wrapper = subject({ otherMembers: [stubUser({ isOnline: true })] });
-
-      expect(wrapper.find(c('subtitle'))).toHaveText('Online');
-    });
-
-    it('header renders avatar online status', function () {
-      const wrapper = subject({ otherMembers: [stubUser({ isOnline: true })] });
-
-      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'active');
-    });
-
-    it('header renders offline status', function () {
-      const wrapper = subject({ otherMembers: [stubUser({ isOnline: false })] });
-
-      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'offline');
-    });
-
-    it('renders a formatted subtitle', function () {
-      const wrapper = subject({
-        isOneOnOne: true,
-        otherMembers: [stubUser({ displaySubHandle: '0://arc:vet', isOnline: true, lastSeenAt: null })],
-      });
-
-      expect(wrapper.find(c('subtitle'))).toHaveText('0://arc:vet | Online');
-    });
-
-    it('renders empty subtitle if no primaryZID, no wallet and no lastSeenAt', function () {
-      const wrapper = subject({ isOneOnOne: true, otherMembers: [stubUser({ displaySubHandle: '' })] });
-
-      expect(wrapper.find(c('subtitle'))).toHaveText('');
-    });
   });
 
   describe('one to many chat', function () {
@@ -117,42 +82,6 @@ describe(ConversationHeader, () => {
       });
 
       expect(wrapper.find(Tooltip).html()).toContain('Johnny Sanderson, Jack Black');
-    });
-
-    it('header renders online status in the subtitle if any member is online', function () {
-      const wrapper = subject({
-        isOneOnOne: false,
-        otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: true })],
-      });
-
-      expect(wrapper.find(c('subtitle'))).toHaveText('Online');
-    });
-
-    it('header renders online status if any member is online', function () {
-      const wrapper = subject({
-        isOneOnOne: false,
-        otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: true })],
-      });
-
-      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'active');
-    });
-
-    it('header renders offline status', function () {
-      const wrapper = subject({
-        isOneOnOne: false,
-        otherMembers: [stubUser({ isOnline: false }), stubUser({ isOnline: false })],
-      });
-
-      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'offline');
-    });
-
-    it('renders online status as subtitle ', function () {
-      const wrapper = subject({
-        isOneOnOne: false,
-        otherMembers: [stubUser({ displaySubHandle: '0://arc:vet', isOnline: false })],
-      });
-
-      expect(wrapper.find(c('subtitle'))).toHaveText('Offline');
     });
 
     it('fires toggleSecondarySidekick', function () {

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -95,16 +95,7 @@ export class ConversationHeader extends React.Component<Properties> {
   }
 
   renderAvatar() {
-    return (
-      <Avatar
-        size={'medium'}
-        imageURL={this.avatarUrl()}
-        statusType={this.avatarStatus()}
-        tabIndex={-1}
-        isRaised
-        isGroup={!this.isOneOnOne()}
-      />
-    );
+    return <Avatar size={'medium'} imageURL={this.avatarUrl()} tabIndex={-1} isRaised isGroup={!this.isOneOnOne()} />;
   }
 
   renderSubTitle() {
@@ -155,7 +146,6 @@ export class ConversationHeader extends React.Component<Properties> {
 
           <span {...cn('description')}>
             <div {...cn('title')}>{this.renderTitle()}</div>
-            <div {...cn('subtitle')}>{this.renderSubTitle()}</div>
           </span>
         </div>
 

--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -133,24 +133,6 @@ describe(ConversationItem, () => {
 
     expect(wrapper.find(c('timestamp'))).toHaveText('Aug 1, 2021');
   });
-
-  describe('status', () => {
-    it('renders inactive if no other members are online', function () {
-      const wrapper = subject({
-        conversation: { icon: 'icon-url', ...convoWith({ isOnline: false }, { isOnline: false }) },
-      });
-
-      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'offline');
-    });
-
-    it('renders active if any other members are online', function () {
-      const wrapper = subject({
-        conversation: { icon: 'icon-url', ...convoWith({ isOnline: false }, { isOnline: true }) },
-      });
-
-      expect(wrapper.find(Avatar)).toHaveProp('statusType', 'active');
-    });
-  });
 });
 
 function title(wrapper) {

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -87,7 +87,6 @@ export class ConversationItem extends React.Component<Properties, State> {
       <Avatar
         size={'regular'}
         imageURL={imageUrl}
-        statusType={this.conversationStatus}
         tabIndex={-1}
         isRaised
         isGroup={!this.props.conversation.isOneOnOne}


### PR DESCRIPTION
### What does this do?
- remove user status from avatars

### Why are we making this change?
- presence has been disabled, therefore hiding user status`

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
