### PR TITLE
refactor(conversation-header): re-add subtitle to display users primary zid or wallet address

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.test.tsx
+++ b/src/components/messenger/chat/conversation-header/index.test.tsx
@@ -69,6 +69,15 @@ describe(ConversationHeader, () => {
 
       expect(wrapper.find(Tooltip).html()).toContain('Johnny Sanderson');
     });
+
+    it('renders a formatted subtitle', function () {
+      const wrapper = subject({
+        isOneOnOne: true,
+        otherMembers: [stubUser({ displaySubHandle: '0://arc:vet', lastSeenAt: null })],
+      });
+
+      expect(wrapper.find(c('subtitle'))).toHaveText('0://arc:vet');
+    });
   });
 
   describe('one to many chat', function () {

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -4,7 +4,6 @@ import { User } from '../../../../store/channels';
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import Tooltip from '../../../tooltip';
 import { GroupManagementMenu } from '../../../group-management-menu';
-import { lastSeenText } from '../../list/utils/utils';
 import { Avatar, IconButton } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bemClassName } from '../../../../lib/bem';
@@ -82,18 +81,6 @@ export class ConversationHeader extends React.Component<Properties> {
     return '';
   }
 
-  avatarStatus() {
-    if (!this.props.otherMembers) {
-      return 'offline';
-    }
-
-    return this.anyOthersOnline() ? 'active' : 'offline';
-  }
-
-  anyOthersOnline() {
-    return this.props.otherMembers.some((m) => m.isOnline);
-  }
-
   renderAvatar() {
     return <Avatar size={'medium'} imageURL={this.avatarUrl()} tabIndex={-1} isRaised isGroup={!this.isOneOnOne()} />;
   }
@@ -106,11 +93,7 @@ export class ConversationHeader extends React.Component<Properties> {
     const member = this.props.otherMembers[0];
 
     if (this.isOneOnOne() && member) {
-      const lastSeen = lastSeenText(member);
-      const hasDivider = lastSeen && member.displaySubHandle ? ' | ' : '';
-      return `${member.displaySubHandle || ''}${hasDivider}${lastSeen}`.trim();
-    } else {
-      return this.anyOthersOnline() ? 'Online' : 'Offline';
+      return `${member.displaySubHandle || ''}`;
     }
   }
 
@@ -146,6 +129,7 @@ export class ConversationHeader extends React.Component<Properties> {
 
           <span {...cn('description')}>
             <div {...cn('title')}>{this.renderTitle()}</div>
+            <div {...cn('subtitle')}>{this.renderSubTitle()}</div>
           </span>
         </div>
 


### PR DESCRIPTION
### What does this do?
- re-adds subtitle to display users primary zid or wallet address

### Why are we making this change?
- to display users wallet/primaryzid

### How do I test this?
- run tests as usual
- run ui and check subtitle in conversation header

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="903" alt="Screenshot 2024-07-05 at 11 05 28" src="https://github.com/zer0-os/zOS/assets/39112648/00678157-6095-4f9c-ad40-abbf17b9f09d">
