### PR TITLE
refactor(messages-saga): process real time read receipts only for active conversations

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,7 +23,7 @@ export interface RealtimeChatEvents {
   roomUnmuted: (roomId: string) => void;
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
   roomMemberPowerLevelChanged: (roomId: string, matrixId: string, powerLevel: number) => void;
-  readReceiptReceived: (messageId: string, userId: string) => void;
+  readReceiptReceived: (messageId: string, userId: string, roomId: string) => void;
 }
 
 export interface MatrixKeyBackupInfo {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -953,8 +953,8 @@ export class MatrixClient implements IChatClient {
       }
     });
 
-    this.matrix.on(RoomEvent.Receipt, async (event) => {
-      this.publishReceiptEvent(event);
+    this.matrix.on(RoomEvent.Receipt, async (event, room) => {
+      this.publishReceiptEvent(event, room);
     });
 
     this.matrix.on(MatrixEventEvent.Decrypted, async (decryptedEvent: MatrixEvent) => {
@@ -1147,12 +1147,12 @@ export class MatrixClient implements IChatClient {
     }
   }
 
-  private publishReceiptEvent(event: MatrixEvent) {
+  private publishReceiptEvent(event: MatrixEvent, room: Room) {
     const content = event.getContent();
     for (const eventId in content) {
       const receiptData = content[eventId]['m.read'] || {};
       for (const userId in receiptData) {
-        this.events.readReceiptReceived(eventId, userId);
+        this.events.readReceiptReceived(eventId, userId, room.roomId);
       }
     }
   }

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -94,8 +94,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const roomMemberTyping = (roomId, userIds) => emit({ type: Events.RoomMemberTyping, payload: { roomId, userIds } });
     const roomMemberPowerLevelChanged = (roomId, matrixId, powerLevel) =>
       emit({ type: Events.RoomMemberPowerLevelChanged, payload: { roomId, matrixId, powerLevel } });
-    const readReceiptReceived = (messageId, userId) =>
-      emit({ type: Events.ReadReceiptReceived, payload: { messageId, userId } });
+    const readReceiptReceived = (messageId, userId, roomId) =>
+      emit({ type: Events.ReadReceiptReceived, payload: { messageId, userId, roomId } });
 
     chatClient.initChat({
       receiveNewMessage,

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -578,20 +578,22 @@ function* receiveLiveRoomEventAction({ payload }) {
 }
 
 function* readReceiptReceived({ payload }) {
-  const { messageId, userId } = payload;
+  const { messageId, userId, roomId } = payload;
 
-  const zeroUsersMap: { [id: string]: User } = yield select((state) => state.normalized.users || {});
-  const currentUser = yield select(currentUserSelector());
+  if (yield select(_isActive(roomId))) {
+    const zeroUsersMap: { [id: string]: User } = yield select((state) => state.normalized.users || {});
+    const currentUser = yield select(currentUserSelector());
 
-  const readByUser = Object.values(zeroUsersMap).find((user) => user.matrixId === userId);
+    const readByUser = Object.values(zeroUsersMap).find((user) => user.matrixId === userId);
 
-  if (readByUser && readByUser.userId !== currentUser.id) {
-    const selectedMessage = yield select(messageSelector(messageId));
+    if (readByUser && readByUser.userId !== currentUser.id) {
+      const selectedMessage = yield select(messageSelector(messageId));
 
-    if (selectedMessage) {
-      const updatedReadBy = [...(selectedMessage.readBy || []), readByUser];
+      if (selectedMessage) {
+        const updatedReadBy = [...(selectedMessage.readBy || []), readByUser];
 
-      yield put(receiveMessage({ id: messageId, readBy: updatedReadBy }));
+        yield put(receiveMessage({ id: messageId, readBy: updatedReadBy }));
+      }
     }
   }
 }


### PR DESCRIPTION
### What does this do?
- process real time read receipts only for active conversations

### Why are we making this change?
- to reduce the need to process of read receipts in conversations that are not open to optimise performance

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

