### PR TITLE
refactor(messages-saga): increase batch interval when receiving new messages

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -417,12 +417,14 @@ export function* receiveDelete(action) {
 
 let savedMessages = [];
 export function* receiveNewMessage(action) {
+  const BATCH_INTERVAL = 2000;
+
   savedMessages.push(action.payload);
   if (savedMessages.length > 1) {
     // we already have a leading event that's awaiting the debounce delay
     return;
   }
-  yield delay(500);
+  yield delay(BATCH_INTERVAL);
   // Clone and empty so follow up events can debounce again
   const batchedPayloads = [...savedMessages];
   savedMessages = [];


### PR DESCRIPTION
### What does this do?
-  increases batch interval when receiving new messages

### Why are we making this change?
- increase the "batch processing" from 0.5s to 2s for improved performance (as requested).

### How do I test this?
- run tests as usual.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
