### PR TITLE
refactor(chat-view): temporarily disable message bubble read receipts processing

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -137,25 +137,25 @@ export class ChatView extends React.Component<Properties, State> {
     return this.props.user && message?.sender && this.props.user.id == message.sender.userId;
   }
 
-  isRead() {
-    const lastMessage = this.getUsersLastNonAdminMessage();
-    if (!lastMessage) return false;
-    return lastMessage?.readBy && lastMessage.readBy.length > 0;
-  }
+  // isRead() {
+  //   const lastMessage = this.getUsersLastNonAdminMessage();
+  //   if (!lastMessage) return false;
+  //   return lastMessage?.readBy && lastMessage.readBy.length > 0;
+  // }
 
-  getUsersLastNonAdminMessage() {
-    const { messages } = this.props;
-    const currentUser = this.props.user;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (!messages[i].isAdmin && messages[i].sender?.userId === currentUser?.id) {
-        return messages[i];
-      }
-    }
-    return null;
-  }
+  // getUsersLastNonAdminMessage() {
+  //   const { messages } = this.props;
+  //   const currentUser = this.props.user;
+  //   for (let i = messages.length - 1; i >= 0; i--) {
+  //     if (!messages[i].isAdmin && messages[i].sender?.userId === currentUser?.id) {
+  //       return messages[i];
+  //     }
+  //   }
+  //   return null;
+  // }
 
   renderMessageGroup(groupMessages) {
-    const lastMessage = this.getUsersLastNonAdminMessage();
+    // const lastMessage = this.getUsersLastNonAdminMessage();
 
     return groupMessages.map((message, index) => {
       if (message.isAdmin) {
@@ -199,8 +199,8 @@ export class ChatView extends React.Component<Properties, State> {
                 showTimestamp={messageRenderProps.showTimestamp}
                 showAuthorName={messageRenderProps.showAuthorName}
                 onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
-                isMessageRead={this.isRead()}
-                isLastMessage={message.id === lastMessage?.id}
+                // isMessageRead={this.isRead()}
+                // isLastMessage={message.id === lastMessage?.id}
                 {...message}
               />
             </div>

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -472,63 +472,63 @@ describe('message', () => {
     });
   });
 
-  describe('getReceiptIcon', () => {
-    it('renders IconCheck for in-progress messages', () => {
-      const wrapper = subject({
-        message: 'text',
-        sendStatus: MessageSendStatus.IN_PROGRESS,
-        isOwner: true,
-        isLastMessage: true,
-      });
+  // describe('getReceiptIcon', () => {
+  //   it('renders IconCheck for in-progress messages', () => {
+  //     const wrapper = subject({
+  //       message: 'text',
+  //       sendStatus: MessageSendStatus.IN_PROGRESS,
+  //       isOwner: true,
+  //       isLastMessage: true,
+  //     });
 
-      expect(wrapper.find('.message__sent-icon')).toExist();
-    });
+  //     expect(wrapper.find('.message__sent-icon')).toExist();
+  //   });
 
-    it('renders IconCheckDouble with "read" class for read messages', () => {
-      const wrapper = subject({
-        message: 'text',
-        sendStatus: MessageSendStatus.SUCCESS,
-        isOwner: true,
-        isLastMessage: true,
-        isMessageRead: true,
-      });
+  //   it('renders IconCheckDouble with "read" class for read messages', () => {
+  //     const wrapper = subject({
+  //       message: 'text',
+  //       sendStatus: MessageSendStatus.SUCCESS,
+  //       isOwner: true,
+  //       isLastMessage: true,
+  //       isMessageRead: true,
+  //     });
 
-      expect(wrapper.find('.message__read-icon--read')).toExist();
-    });
+  //     expect(wrapper.find('.message__read-icon--read')).toExist();
+  //   });
 
-    it('renders IconCheckDouble with "delivered" class for delivered messages', () => {
-      const wrapper = subject({
-        message: 'text',
-        sendStatus: MessageSendStatus.SUCCESS,
-        isOwner: true,
-        isLastMessage: true,
-        isMessageRead: false,
-      });
+  //   it('renders IconCheckDouble with "delivered" class for delivered messages', () => {
+  //     const wrapper = subject({
+  //       message: 'text',
+  //       sendStatus: MessageSendStatus.SUCCESS,
+  //       isOwner: true,
+  //       isLastMessage: true,
+  //       isMessageRead: false,
+  //     });
 
-      expect(wrapper.find('.message__read-icon--delivered')).toExist();
-    });
+  //     expect(wrapper.find('.message__read-icon--delivered')).toExist();
+  //   });
 
-    it('renders IconCheckDouble with "delivered" class when sendStatus is undefined', () => {
-      const wrapper = subject({
-        message: 'text',
-        sendStatus: undefined,
-        isOwner: true,
-        isLastMessage: true,
-      });
+  //   it('renders IconCheckDouble with "delivered" class when sendStatus is undefined', () => {
+  //     const wrapper = subject({
+  //       message: 'text',
+  //       sendStatus: undefined,
+  //       isOwner: true,
+  //       isLastMessage: true,
+  //     });
 
-      expect(wrapper.find('.message__read-icon--delivered')).toExist();
-    });
+  //     expect(wrapper.find('.message__read-icon--delivered')).toExist();
+  //   });
 
-    it('renders nothing for failed messages', () => {
-      const wrapper = subject({
-        message: 'text',
-        sendStatus: MessageSendStatus.FAILED,
-        isOwner: true,
-        isLastMessage: true,
-      });
+  //   it('renders nothing for failed messages', () => {
+  //     const wrapper = subject({
+  //       message: 'text',
+  //       sendStatus: MessageSendStatus.FAILED,
+  //       isOwner: true,
+  //       isLastMessage: true,
+  //     });
 
-      expect(wrapper.find('.message__read-icon')).not.toExist();
-      expect(wrapper.find('.message__sent-icon')).not.toExist();
-    });
-  });
+  //     expect(wrapper.find('.message__read-icon')).not.toExist();
+  //     expect(wrapper.find('.message__sent-icon')).not.toExist();
+  //   });
+  // });
 });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -12,7 +12,7 @@ import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
-import { IconAlertCircle, IconCheck } from '@zero-tech/zui/icons';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
 import { Avatar } from '@zero-tech/zui/components';
 import { ContentHighlighter } from '../content-highlighter';
 import { bemClassName } from '../../lib/bem';
@@ -50,8 +50,8 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
-  isMessageRead: boolean;
-  isLastMessage: boolean;
+  // isMessageRead: boolean;
+  // isLastMessage: boolean;
 }
 
 export interface State {
@@ -152,25 +152,25 @@ export class Message extends React.Component<Properties, State> {
     return '';
   }
 
-  getReceiptIcon() {
-    const { sendStatus, isMessageRead } = this.props;
+  // getReceiptIcon() {
+  //   const { sendStatus, isMessageRead } = this.props;
 
-    if (sendStatus === MessageSendStatus.IN_PROGRESS) {
-      return <IconCheck {...cn('sent-icon')} size={14} />;
-    }
+  //   if (sendStatus === MessageSendStatus.IN_PROGRESS) {
+  //     return <IconCheck {...cn('sent-icon')} size={14} />;
+  //   }
 
-    if (sendStatus === MessageSendStatus.SUCCESS || sendStatus === undefined) {
-      const iconClass = isMessageRead ? 'read' : 'delivered';
-      return (
-        <div {...cn('read-icon-container')}>
-          <IconCheck {...cn('read-icon', `${iconClass}`)} size={12} />
-          <IconCheck {...cn('read-icon', `${iconClass}`)} size={12} />
-        </div>
-      );
-    }
+  //   if (sendStatus === MessageSendStatus.SUCCESS || sendStatus === undefined) {
+  //     const iconClass = isMessageRead ? 'read' : 'delivered';
+  //     return (
+  //       <div {...cn('read-icon-container')}>
+  //         <IconCheck {...cn('read-icon', `${iconClass}`)} size={12} />
+  //         <IconCheck {...cn('read-icon', `${iconClass}`)} size={12} />
+  //       </div>
+  //     );
+  //   }
 
-    return null;
-  }
+  //   return null;
+  // }
 
   renderFooter() {
     if (this.state.isEditing) {
@@ -194,10 +194,10 @@ export class Message extends React.Component<Properties, State> {
         </div>
       );
     }
-    if (this.props.isOwner && this.props.isLastMessage) {
-      const icon = this.getReceiptIcon();
-      icon && footerElements.push(icon);
-    }
+    // if (this.props.isOwner && this.props.isLastMessage) {
+    //   const icon = this.getReceiptIcon();
+    //   icon && footerElements.push(icon);
+    // }
 
     if (footerElements.length === 0) {
       return;


### PR DESCRIPTION
Note :: the code has simply been commented out here for testing purposes on production. this will either be reverted or improved in a follow up.

### What does this do?
- temporarily disables message bubble read receipts processing

### Why are we making this change?
- check performance in production with this removed

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
