### PR TITLE
refactor(matrix-client): room tag fetching to optimize initial load time by consolidating network requests

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1107,44 +1107,6 @@ describe('matrix client', () => {
     });
   });
 
-  describe('isRoomFavorited', () => {
-    it('returns true if "m.favorite" tag is present for room', async () => {
-      const roomId = '!testRoomId';
-      const getRoomTags = jest.fn().mockResolvedValue({
-        tags: {
-          'm.favorite': {},
-        },
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRoomTags })),
-      });
-
-      await client.connect(null, 'token');
-      const isFavorite = await client.isRoomFavorited(roomId);
-
-      expect(getRoomTags).toHaveBeenCalledWith(roomId);
-      expect(isFavorite).toBe(true);
-    });
-
-    it('returns false if "m.favorite" tag is not present for room', async () => {
-      const roomId = '!testRoomId';
-      const getRoomTags = jest.fn().mockResolvedValue({
-        tags: {},
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRoomTags })),
-      });
-
-      await client.connect(null, 'token');
-      const isFavorite = await client.isRoomFavorited(roomId);
-
-      expect(getRoomTags).toHaveBeenCalledWith(roomId);
-      expect(isFavorite).toBe(false);
-    });
-  });
-
   describe('addRoomToMuted', () => {
     it('sets room tag with "m.mute"', async () => {
       const roomId = '!testRoomId';
@@ -1177,41 +1139,30 @@ describe('matrix client', () => {
     });
   });
 
-  describe('isRoomMuted', () => {
-    it('returns true if "m.mute" tag is present for room', async () => {
+  describe('getRoomTags', () => {
+    it('returns correct tags for room', async () => {
       const roomId = '!testRoomId';
-      const getRoomTags = jest.fn().mockResolvedValue({
-        tags: {
-          'm.mute': {},
-        },
-      });
+      const getRoomTags = jest.fn().mockResolvedValue({ tags: { 'm.favorite': {}, 'm.mute': {} } });
 
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRoomTags })),
-      });
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ getRoomTags })) });
 
       await client.connect(null, 'token');
-      const isMuted = await client.isRoomMuted(roomId);
+      const tags = await client.getRoomTags(roomId);
 
       expect(getRoomTags).toHaveBeenCalledWith(roomId);
-      expect(isMuted).toBe(true);
+      expect(tags).toEqual({ isFavorite: true, isMuted: true });
     });
 
-    it('returns false if "m.mute" tag is not present for room', async () => {
+    it('returns false for tags that are not present', async () => {
       const roomId = '!testRoomId';
-      const getRoomTags = jest.fn().mockResolvedValue({
-        tags: {},
-      });
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ getRoomTags })),
-      });
+      const getRoomTags = jest.fn().mockResolvedValue({ tags: {} });
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ getRoomTags })) });
 
       await client.connect(null, 'token');
-      const isMuted = await client.isRoomMuted(roomId);
+      const tags = await client.getRoomTags(roomId);
 
       expect(getRoomTags).toHaveBeenCalledWith(roomId);
-      expect(isMuted).toBe(false);
+      expect(tags).toEqual({ isFavorite: false, isMuted: false });
     });
   });
 });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -837,13 +837,6 @@ export class MatrixClient implements IChatClient {
     await this.matrix.deleteRoomTag(roomId, MatrixConstants.FAVORITE);
   }
 
-  async isRoomFavorited(roomId: string): Promise<boolean> {
-    await this.waitForConnection();
-
-    const result = await this.matrix.getRoomTags(roomId);
-    return !!result.tags?.[MatrixConstants.FAVORITE];
-  }
-
   async addRoomToMuted(roomId) {
     await this.waitForConnection();
 
@@ -856,11 +849,14 @@ export class MatrixClient implements IChatClient {
     await this.matrix.deleteRoomTag(roomId, MatrixConstants.MUTE);
   }
 
-  async isRoomMuted(roomId) {
+  async getRoomTags(roomId: string): Promise<{ isFavorite: boolean; isMuted: boolean }> {
     await this.waitForConnection();
 
     const result = await this.matrix.getRoomTags(roomId);
-    return !!result.tags?.[MatrixConstants.MUTE];
+    return {
+      isFavorite: !!result.tags?.[MatrixConstants.FAVORITE],
+      isMuted: !!result.tags?.[MatrixConstants.MUTE],
+    };
   }
 
   async sendTypingEvent(roomId: string, isTyping: boolean): Promise<void> {
@@ -1184,13 +1180,9 @@ export class MatrixClient implements IChatClient {
 
     const unreadCount = room.getUnreadNotificationCount(NotificationCountType.Total);
 
-    featureFlags.enableTimerLogs && console.time(`xxxisRoomFavorited${room.roomId}`);
-    const isFavorite = await this.isRoomFavorited(room.roomId);
-    featureFlags.enableTimerLogs && console.timeEnd(`xxxisRoomFavorited${room.roomId}`);
-
-    featureFlags.enableTimerLogs && console.time(`xxxisRoomMuted${room.roomId}`);
-    const isMuted = await this.isRoomMuted(room.roomId);
-    featureFlags.enableTimerLogs && console.timeEnd(`xxxisRoomMuted${room.roomId}`);
+    featureFlags.enableTimerLogs && console.time(`xxxgetRoomTags${room.roomId}`);
+    const { isFavorite, isMuted } = await this.getRoomTags(room.roomId);
+    featureFlags.enableTimerLogs && console.timeEnd(`xxxgetRoomTags${room.roomId}`);
 
     const [admins, mods] = this.getRoomAdminsAndMods(room);
 


### PR DESCRIPTION
### What does this do?
- This refactor consolidates the fetching of room tags for favorites and muted status into a single function to optimize initial load times.

### Why are we making this change?
- This change reduces the number of network requests during the initial loading of conversations, significantly improving performance for users with many conversations.

### How do I test this?
- run tests as usual.
- run UI and check initial load time.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
