### PR TITLE
refactor(matrix-client, channels-list-saga): optimize room tags fetching by parallelizing network requests

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -343,3 +343,7 @@ export async function getReadReceiptPreference() {
 export async function getMessageReadReceipts(roomId: string, messageId: string) {
   return await chat.get().matrix.getMessageReadReceipts(roomId, messageId);
 }
+
+export async function getRoomTags(conversations: Partial<Channel>[]) {
+  return await chat.get().matrix.getRoomTags(conversations);
+}

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1140,29 +1140,45 @@ describe('matrix client', () => {
   });
 
   describe('getRoomTags', () => {
-    it('returns correct tags for room', async () => {
-      const roomId = '!testRoomId';
-      const getRoomTags = jest.fn().mockResolvedValue({ tags: { 'm.favorite': {}, 'm.mute': {} } });
+    it('returns correct tags for all rooms', async () => {
+      const conversations = [
+        { id: 'room1', isFavorite: false, isMuted: false },
+        { id: 'room2', isFavorite: false, isMuted: false },
+      ];
+
+      const getRoomTags = jest
+        .fn()
+        .mockResolvedValueOnce({ tags: { 'm.favorite': {}, 'm.mute': {} } })
+        .mockResolvedValueOnce({ tags: {} });
 
       const client = subject({ createClient: jest.fn(() => getSdkClient({ getRoomTags })) });
 
       await client.connect(null, 'token');
-      const tags = await client.getRoomTags(roomId);
+      await client.getRoomTags(conversations);
 
-      expect(getRoomTags).toHaveBeenCalledWith(roomId);
-      expect(tags).toEqual({ isFavorite: true, isMuted: true });
+      expect(getRoomTags).toHaveBeenCalledWith('room1');
+      expect(getRoomTags).toHaveBeenCalledWith('room2');
+      expect(conversations).toEqual([
+        { id: 'room1', isFavorite: true, isMuted: true },
+        { id: 'room2', isFavorite: false, isMuted: false },
+      ]);
     });
 
     it('returns false for tags that are not present', async () => {
-      const roomId = '!testRoomId';
+      const conversations = [
+        { id: 'room1', isFavorite: false, isMuted: false },
+      ];
+
       const getRoomTags = jest.fn().mockResolvedValue({ tags: {} });
       const client = subject({ createClient: jest.fn(() => getSdkClient({ getRoomTags })) });
 
       await client.connect(null, 'token');
-      const tags = await client.getRoomTags(roomId);
+      await client.getRoomTags(conversations);
 
-      expect(getRoomTags).toHaveBeenCalledWith(roomId);
-      expect(tags).toEqual({ isFavorite: false, isMuted: false });
+      expect(getRoomTags).toHaveBeenCalledWith('room1');
+      expect(conversations).toEqual([
+        { id: 'room1', isFavorite: false, isMuted: false },
+      ]);
     });
   });
 });

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -1,7 +1,7 @@
 import { testSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { chat } from '../../lib/chat';
+import { chat, getRoomTags } from '../../lib/chat';
 
 import {
   fetchConversations,
@@ -15,6 +15,7 @@ import {
   roomNameChanged,
   fetchRoomAvatar,
   roomAvatarChanged,
+  loadSecondaryConversationData,
 } from './saga';
 
 import { RootState, rootReducer } from '../reducer';
@@ -54,6 +55,7 @@ describe('channels list saga', () => {
         [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
         [matchers.call.fn(mapToZeroUsers), null],
         [matchers.call.fn(getUserReadReceiptPreference), null],
+        [matchers.call.fn(getRoomTags), null],
       ]);
     }
 
@@ -121,6 +123,20 @@ describe('channels list saga', () => {
         'optimistic-id-2',
         'conversation-id',
       ]);
+    });
+
+    it('calls loadSecondaryConversationData', async () => {
+      await subject(fetchConversations)
+        .provide([
+          [matchers.call.fn(chat.get), chatClient],
+          [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
+          [matchers.call.fn(mapToZeroUsers), null],
+          [matchers.call.fn(getUserReadReceiptPreference), null],
+          [matchers.call.fn(getRoomTags), null],
+        ])
+        .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
+        .fork(loadSecondaryConversationData, [...MOCK_CONVERSATIONS])
+        .run();
     });
   });
 


### PR DESCRIPTION
### What does this do?
- Optimizes room tags fetching by making concurrent network requests to improve performance.

### Why are we making this change?
- To reduce the overall loading time and enhance the user experience by fetching data more efficiently.

### How do I test this?
- run test as usual.
- run the UI and test initial loading time of app - check network dev tools tab, and you can enable timer logs feature flag to check timings.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
