### PR TITLE
refactor(timer-logs): move time end for fetching conversations

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -97,10 +97,12 @@ export function* fetchConversations() {
   const channel = yield call(getConversationsBus);
   yield put(channel, { type: ConversationEvents.ConversationsLoaded });
 
+  featureFlags.enableTimerLogs && console.timeEnd('xxxfetchConversations');
+
+  featureFlags.enableTimerLogs && console.time('xxxloadSecondaryConversationData');
   const combinedConversations = [...optimisticConversationIds, ...conversations];
   yield fork(loadSecondaryConversationData, combinedConversations);
-
-  featureFlags.enableTimerLogs && console.timeEnd('xxxfetchConversations');
+  featureFlags.enableTimerLogs && console.timeEnd('xxxloadSecondaryConversationData');
 }
 
 export function* loadSecondaryConversationData(conversations) {


### PR DESCRIPTION
### What does this do?
- moves time end for fetching conversations

### Why are we making this change?
- accurate timer logs

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
