### PR TITLE
refactor(conversation-header): remove tooltip and re-align elements

### DIFF
--- a/src/components/messenger/chat/conversation-header/index.test.tsx
+++ b/src/components/messenger/chat/conversation-header/index.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme';
 
 import { ConversationHeader, Properties } from '.';
-import Tooltip from '../../../tooltip';
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import { GroupManagementMenu } from '../../../group-management-menu';
 import { bem } from '../../../../lib/bem';
@@ -40,22 +39,13 @@ describe(ConversationHeader, () => {
     it('renders channel name as title when name is provided', function () {
       const wrapper = subject({ name: 'this is my channel name' });
 
-      expect(wrapper.find(Tooltip).html()).toContain('this is my channel name');
+      expect(wrapper.find(c('title')).html()).toContain('this is my channel name');
     });
 
     it('renders otherMembers as title when name is NOT provided', function () {
       const wrapper = subject({ otherMembers: [stubUser({ firstName: 'first-name', lastName: 'last-name' })] });
 
-      expect(wrapper.find(Tooltip).html()).toContain(
-        otherMembersToString([stubUser({ firstName: 'first-name', lastName: 'last-name' })])
-      );
-    });
-
-    it('renders otherMembers in tooltip', function () {
-      const wrapper = subject({ otherMembers: [stubUser({ firstName: 'first-name', lastName: 'last-name' })] });
-
-      expect(wrapper.find(Tooltip)).toHaveProp(
-        'overlay',
+      expect(wrapper.find(c('title')).html()).toContain(
         otherMembersToString([stubUser({ firstName: 'first-name', lastName: 'last-name' })])
       );
     });
@@ -67,7 +57,7 @@ describe(ConversationHeader, () => {
         otherMembers: [stubUser({ firstName: 'Johnny', lastName: 'Sanderson' })],
       });
 
-      expect(wrapper.find(Tooltip).html()).toContain('Johnny Sanderson');
+      expect(wrapper.find(c('title')).html()).toContain('Johnny Sanderson');
     });
 
     it('renders a formatted subtitle', function () {
@@ -90,7 +80,7 @@ describe(ConversationHeader, () => {
         ],
       });
 
-      expect(wrapper.find(Tooltip).html()).toContain('Johnny Sanderson, Jack Black');
+      expect(wrapper.find(c('title')).html()).toContain('Johnny Sanderson, Jack Black');
     });
 
     it('fires toggleSecondarySidekick', function () {

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { User } from '../../../../store/channels';
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
-import Tooltip from '../../../tooltip';
 import { GroupManagementMenu } from '../../../group-management-menu';
 import { Avatar, IconButton } from '@zero-tech/zui/components';
 import { IconUsers1 } from '@zero-tech/zui/icons';
@@ -105,19 +104,9 @@ export class ConversationHeader extends React.Component<Properties> {
     const otherMembersString = otherMembersToString(otherMembers);
 
     return (
-      <Tooltip
-        placement='left'
-        overlay={otherMembersString}
-        align={{
-          offset: [
-            -10,
-            0,
-          ],
-        }}
-        {...cn('user-tooltip')}
-      >
+      <div {...cn('user-tooltip')}>
         <div>{name || otherMembersString}</div>
-      </Tooltip>
+      </div>
     );
   }
 

--- a/src/components/messenger/chat/conversation-header/styles.scss
+++ b/src/components/messenger/chat/conversation-header/styles.scss
@@ -32,6 +32,8 @@ $recent-indicator-size: 8px;
   }
 
   &__description {
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
   }
 


### PR DESCRIPTION
### What does this do?
-  remove tooltip and re-align elements from conversation header

### Why are we making this change?
- no longer required

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
