### PR TITLE
refactor(messages/saga): change batch interval back to 0.5s due to making loading specific conversations slower

### DIFF
--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -417,7 +417,7 @@ export function* receiveDelete(action) {
 
 let savedMessages = [];
 export function* receiveNewMessage(action) {
-  const BATCH_INTERVAL = 2000;
+  const BATCH_INTERVAL = 500;
 
   savedMessages.push(action.payload);
   if (savedMessages.length > 1) {


### PR DESCRIPTION
### What does this do?
- reduces the batch interval for new messages received back down to 0.5s

### Why are we making this change?
- the existing interval was set to 2s making loading specific conversations slower

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
