### PR TITLE
feat: download and decrypt images only when conversation is active

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -21,6 +21,7 @@ describe('ChannelViewContainer', () => {
       sendMessage: () => undefined,
       uploadFileMessage: () => undefined,
       openDeleteMessage: () => undefined,
+      loadAttachmentDetails: () => undefined,
 
       editMessage: () => undefined,
       context: {

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -110,7 +110,7 @@ describe('ChannelViewContainer', () => {
   it('fetches messages on mount', () => {
     const fetchMessages = jest.fn();
 
-    subject({ fetchMessages, channelId: 'the-channel-id' });
+    subject({ fetchMessages, channelId: 'the-channel-id', channel: { hasLoadedMessages: false } });
 
     expect(fetchMessages).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
   });

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -38,7 +38,7 @@ export interface Properties extends PublicProperties {
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
 }
 
 interface PublicProperties {
@@ -86,8 +86,8 @@ export class Container extends React.Component<Properties> {
   }
 
   componentDidMount() {
-    const { channelId } = this.props;
-    if (channelId) {
+    const { channelId, channel } = this.props;
+    if (channelId && !channel.hasLoadedMessages) {
       this.props.fetchMessages({ channelId });
     }
   }

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -3,7 +3,14 @@ import classNames from 'classnames';
 import { RootState } from '../../store/reducer';
 
 import { connectContainer } from '../../store/redux-container';
-import { fetch as fetchMessages, editMessage, Message, EditMessageOptions } from '../../store/messages';
+import {
+  fetch as fetchMessages,
+  editMessage,
+  Message,
+  EditMessageOptions,
+  loadAttachmentDetails,
+  Media,
+} from '../../store/messages';
 import { Channel, ConversationStatus, denormalize, onReply } from '../../store/channels';
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
@@ -31,6 +38,7 @@ export interface Properties extends PublicProperties {
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 interface PublicProperties {
@@ -73,6 +81,7 @@ export class Container extends React.Component<Properties> {
       openDeleteMessage,
       openMessageInfo,
       toggleSecondarySidekick,
+      loadAttachmentDetails,
     };
   }
 
@@ -212,6 +221,7 @@ export class Container extends React.Component<Properties> {
           isSecondarySidekickOpen={this.props.isSecondarySidekickOpen}
           toggleSecondarySidekick={this.props.toggleSecondarySidekick}
           openMessageInfo={this.props.openMessageInfo}
+          loadAttachmentDetails={this.props.loadAttachmentDetails}
         />
       </>
     );

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -48,6 +48,7 @@ describe('ChatView', () => {
       isSecondarySidekickOpen: false,
       toggleSecondarySidekick: () => null,
       openMessageInfo: () => null,
+      loadAttachmentDetails: () => null,
 
       ...props,
     };

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -52,7 +52,7 @@ export interface Properties {
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
 }
 
 export interface State {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Waypoint } from 'react-waypoint';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Message as MessageModel, MediaType, EditMessageOptions } from '../../store/messages';
+import { Message as MessageModel, MediaType, EditMessageOptions, Media } from '../../store/messages';
 import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
@@ -52,6 +52,7 @@ export interface Properties {
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 export interface State {
@@ -180,6 +181,7 @@ export class ChatView extends React.Component<Properties, State> {
                 showTimestamp={messageRenderProps.showTimestamp}
                 showAuthorName={messageRenderProps.showAuthorName}
                 onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
+                loadAttachmentDetails={this.props.loadAttachmentDetails}
                 {...message}
               />
             </div>

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -65,6 +65,22 @@ describe('message', () => {
     expect(wrapper.find('.message__block-image').exists()).toBe(true);
   });
 
+  it('renders image placeholder if no media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    const wrapper = subject({ loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
+
+    expect(wrapper.find('.message__image-placeholder').exists()).toBe(true);
+  });
+
+  it('calls loadAttachmentDetails if no media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({ messageId: 'test-id', loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
+
+    expect(loadAttachmentDetails).toHaveBeenCalled();
+  });
+
   it('does not renders message text', () => {
     const wrapper = subject({ message: 'the message' });
 

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -127,7 +127,7 @@ export class Message extends React.Component<Properties, State> {
 
     if (!url) {
       this.props.loadAttachmentDetails({ media, messageId });
-      return <div className='image-placeholder'>Loading...</div>;
+      return <div {...cn('image-placeholder')}>Loading...</div>;
     }
 
     if (MediaType.Image === type) {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -8,7 +8,7 @@ import { getProvider } from '../../lib/cloudinary/provider';
 import { MessageInput } from '../message-input/container';
 import { User } from '../../store/channels';
 import { ParentMessage as ParentMessageType } from '../../lib/chat/types';
-import { UserForMention } from '../message-input/utils';
+import { Media, UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
@@ -50,6 +50,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 export interface State {
@@ -122,6 +123,16 @@ export class Message extends React.Component<Properties, State> {
 
   renderMedia(media) {
     const { type, url, name } = media;
+    const messageId = this.props.messageId.toString();
+
+    console.log('XXXURL', url);
+    console.log('XXXMEDIA', media);
+
+    if (!url) {
+      this.props.loadAttachmentDetails({ media, messageId });
+      return <div className='image-placeholder'>Loading...</div>;
+    }
+
     if (MediaType.Image === type) {
       return (
         <div {...cn('block-image')} onClick={this.onImageClick(media)}>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -50,7 +50,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
 }
 
 export interface State {
@@ -123,10 +123,7 @@ export class Message extends React.Component<Properties, State> {
 
   renderMedia(media) {
     const { type, url, name } = media;
-    const messageId = this.props.messageId.toString();
-
-    console.log('XXXURL', url);
-    console.log('XXXMEDIA', media);
+    const messageId = this.props.messageId;
 
     if (!url) {
       this.props.loadAttachmentDetails({ media, messageId });

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -242,4 +242,8 @@
       left: 7px;
     }
   }
+
+  &__image-placeholder {
+    @include glass-text-secondary-color;
+  }
 }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -26,11 +26,14 @@ async function parseMediaData(matrixMessage) {
 
 async function buildMediaObject(content) {
   if (content.file && content.info) {
-    const blob = await decryptFile(content.file, content.info);
+    console.log('XXXCONTENT', content);
+    // const blob = await decryptFile(content.file, content.info);
+    // console.log('XXXXBLOBBY', blob);
     return {
-      url: URL.createObjectURL(blob),
+      url: null,
       type: 'image',
-      ...content.info,
+      info: { ...content.info },
+      file: { ...content.file },
     };
   } else if (content.url) {
     return {
@@ -71,7 +74,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
       admin: {},
       mentionedUsers: [],
       hidePreview: false,
-      media: null,
+      // media: null,
       image: null,
     },
     parentMessageText: '',

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,6 +1,5 @@
 import { CustomEventType, MatrixConstants, MembershipStateType, NotifiableEventType } from './types';
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
-import { decryptFile } from './media';
 import { AdminMessageType, Message, MessageSendStatus } from '../../../store/messages';
 import { getObjectDiff, parsePlainBody } from './utils';
 import { PowerLevels } from '../types';
@@ -26,9 +25,6 @@ async function parseMediaData(matrixMessage) {
 
 async function buildMediaObject(content) {
   if (content.file && content.info) {
-    console.log('XXXCONTENT', content);
-    // const blob = await decryptFile(content.file, content.info);
-    // console.log('XXXXBLOBBY', blob);
     return {
       url: null,
       type: 'image',
@@ -74,7 +70,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
       admin: {},
       mentionedUsers: [],
       hidePreview: false,
-      // media: null,
+      media: null,
       image: null,
     },
     parentMessageText: '',

--- a/src/lib/chat/matrix/media.ts
+++ b/src/lib/chat/matrix/media.ts
@@ -46,8 +46,8 @@ export async function encryptFile(file: File): Promise<{ info: encrypt.IEncrypte
 }
 
 // https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/utils/DecryptFile.ts#L50
-export async function decryptFile(encrypedFile, info): Promise<Blob> {
-  const signedUrl = await getAttachmentUrl({ key: encrypedFile.url });
+export async function decryptFile(encryptedFile, info): Promise<Blob> {
+  const signedUrl = await getAttachmentUrl({ key: encryptedFile.url });
 
   // Download the encrypted file as an array buffer.
   const response = await fetch(signedUrl);
@@ -58,7 +58,7 @@ export async function decryptFile(encrypedFile, info): Promise<Blob> {
 
   try {
     // Decrypt the array buffer using the information taken from the event content.
-    const dataArray = await encrypt.decryptAttachment(responseData, encrypedFile);
+    const dataArray = await encrypt.decryptAttachment(responseData, encryptedFile);
 
     // Turn the array into a Blob and give it the correct MIME-type.
     return new Blob([dataArray], { type: info?.mimetype });

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -106,7 +106,7 @@ const fetch = createAction<Payload>(SagaActionTypes.Fetch);
 const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
-const loadAttachmentDetails = createAction<{ media: Media; messageId: string }>(SagaActionTypes.LoadAttachmentDetails);
+const loadAttachmentDetails = createAction<{ media: Media; messageId: number }>(SagaActionTypes.LoadAttachmentDetails);
 
 const slice = createNormalizedSlice({
   name: 'messages',

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -99,12 +99,14 @@ export enum SagaActionTypes {
   Send = 'messages/saga/send',
   DeleteMessage = 'messages/saga/deleteMessage',
   EditMessage = 'messages/saga/editMessage',
+  LoadAttachmentDetails = 'messages/saga/loadAttachmentDetails',
 }
 
 const fetch = createAction<Payload>(SagaActionTypes.Fetch);
 const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
+const loadAttachmentDetails = createAction<{ media: Media; messageId: string }>(SagaActionTypes.LoadAttachmentDetails);
 
 const slice = createNormalizedSlice({
   name: 'messages',
@@ -112,4 +114,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { fetch, send, deleteMessage, editMessage, removeAll };
+export { fetch, send, deleteMessage, editMessage, removeAll, loadAttachmentDetails };

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -134,7 +134,6 @@ export function* fetch(action) {
 
   let messagesResponse: any;
   let messages: any[];
-  console.log('XXXFetch Messages Hit');
   try {
     const chatClient = yield call(chat.get);
 
@@ -603,14 +602,11 @@ function* readReceiptReceived({ payload }) {
 }
 
 export function* loadAttachmentDetails(action) {
-  console.log('XXXaction', action);
   const { media, messageId } = action.payload;
-  // if in progress then don't fetch
+
   try {
     const blob = yield call(decryptFile, media.file, media.info);
-    console.log('XXXblob', blob);
     const url = URL.createObjectURL(blob);
-    console.log('XXXurl', url);
     yield put(receiveMessage({ id: messageId, media: { ...media, url } }));
   } catch (error) {
     console.error('Failed to download and decrypt image:', error);

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -134,7 +134,7 @@ export function* fetch(action) {
 
   let messagesResponse: any;
   let messages: any[];
-  console.log('XXXYOLOLOO HWRER MY GGGG');
+  console.log('XXXFetch Messages Hit');
   try {
     const chatClient = yield call(chat.get);
 
@@ -151,35 +151,8 @@ export function* fetch(action) {
 
     // we prefer this order (new messages first), so that if any new message has an updated property
     // (eg. parentMessage), then it gets written to state
-    // Create a map of existing messages by ID for quick lookup
-    const existingMessagesMap = existingMessages.reduce((acc, msg) => {
-      acc[msg.id] = msg;
-      return acc;
-    }, {});
-
-    // Merge messages and ensure media URLs are not reset if they already exist
-    messages = messagesResponse.messages.map((msg) => {
-      const existingMessage = existingMessagesMap[msg.id];
-      if (existingMessage) {
-        // Preserve the existing media URL if it exists
-        if (existingMessage.media && existingMessage.media.url) {
-          msg.media = { ...msg.media, url: existingMessage.media.url };
-        }
-        // Preserve the existing image URL if it exists
-        if (existingMessage.image && existingMessage.image.url) {
-          msg.image = { ...msg.image, url: existingMessage.image.url };
-        }
-      }
-      return msg;
-    });
-
-    // Add any existing messages that were not in the response
-    const newMessageIds = new Set(messages.map((m) => m.id));
-    existingMessages.forEach((msg) => {
-      if (!newMessageIds.has(msg.id)) {
-        messages.push(msg);
-      }
-    });
+    messages = [...messagesResponse.messages, ...existingMessages];
+    messages = uniqBy(messages, (m) => m.id ?? m);
 
     yield call(receiveChannel, {
       id: channelId,


### PR DESCRIPTION
Note :: the UI for the placeholder is a basic implementation for now. This will be improved in follow ups.

### What does this do?
- The implementation and refactoring for downloading and decrypting images when conversation is active.

### Why are we making this change?
-  Prevent download/decrypt happening on initial load for every conversation. 

### How do I test this?
- Run test as usual.
- Run UI and check images media rendering for active conversations. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
