### PR TITLE
feat: download and decrypt images only when conversation is active

### DIFF
--- a/src/_animation.scss
+++ b/src/_animation.scss
@@ -15,3 +15,12 @@
     opacity: 0;
   }
 }
+
+@keyframes loadingShimmer {
+  0% {
+    background-position: -320px 0;
+  }
+  100% {
+    background-position: calc(320px + 100%) 0;
+  }
+}

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -21,6 +21,7 @@ describe('ChannelViewContainer', () => {
       sendMessage: () => undefined,
       uploadFileMessage: () => undefined,
       openDeleteMessage: () => undefined,
+      loadAttachmentDetails: () => undefined,
 
       editMessage: () => undefined,
       context: {

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -60,13 +60,13 @@ describe('ChannelViewContainer', () => {
     const messages = [
       { id: 'message-root', rootMessageId: '' },
       { id: 'message-two', rootMessageId: '' },
-      { id: 'message-child', rootMessageId: 'message-root', media: { some: 'media' } },
+      { id: 'message-child', rootMessageId: 'message-root', media: { id: '1', media: 'media' } },
     ];
 
     const wrapper = subject({ channel: { messages } });
 
     expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([
-      { ...messages[0], media: { some: 'media' } },
+      { ...messages[0], media: { id: '1', media: 'media' } },
       messages[1],
     ]);
   });
@@ -75,13 +75,13 @@ describe('ChannelViewContainer', () => {
     const messages = [
       { id: 'message-root', optimisticId: 'optimistic-message-root', rootMessageId: '' },
       { id: 'message-two', rootMessageId: '' },
-      { id: 'message-child', rootMessageId: 'optimistic-message-root', media: { some: 'media' } },
+      { id: 'message-child', rootMessageId: 'optimistic-message-root', media: { id: '1', media: 'media' } },
     ];
 
     const wrapper = subject({ channel: { messages } });
 
     expect(wrapper.find(ChatView).prop('messages')).toStrictEqual([
-      { ...messages[0], media: { some: 'media' } },
+      { ...messages[0], media: { id: '1', media: 'media' } },
       messages[1],
     ]);
   });

--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -110,7 +110,7 @@ describe('ChannelViewContainer', () => {
   it('fetches messages on mount', () => {
     const fetchMessages = jest.fn();
 
-    subject({ fetchMessages, channelId: 'the-channel-id' });
+    subject({ fetchMessages, channelId: 'the-channel-id', channel: { hasLoadedMessages: false } });
 
     expect(fetchMessages).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
   });

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -38,7 +38,7 @@ export interface Properties extends PublicProperties {
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
 }
 
 interface PublicProperties {
@@ -86,8 +86,8 @@ export class Container extends React.Component<Properties> {
   }
 
   componentDidMount() {
-    const { channelId } = this.props;
-    if (channelId) {
+    const { channelId, channel } = this.props;
+    if (channelId && !channel.hasLoadedMessages) {
       this.props.fetchMessages({ channelId });
     }
   }

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -38,7 +38,7 @@ export interface Properties extends PublicProperties {
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media }) => void;
 }
 
 interface PublicProperties {

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -3,7 +3,14 @@ import classNames from 'classnames';
 import { RootState } from '../../store/reducer';
 
 import { connectContainer } from '../../store/redux-container';
-import { fetch as fetchMessages, editMessage, Message, EditMessageOptions } from '../../store/messages';
+import {
+  fetch as fetchMessages,
+  editMessage,
+  Message,
+  EditMessageOptions,
+  loadAttachmentDetails,
+  Media,
+} from '../../store/messages';
 import { Channel, ConversationStatus, denormalize, onReply } from '../../store/channels';
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
@@ -31,6 +38,7 @@ export interface Properties extends PublicProperties {
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 interface PublicProperties {
@@ -73,6 +81,7 @@ export class Container extends React.Component<Properties> {
       openDeleteMessage,
       openMessageInfo,
       toggleSecondarySidekick,
+      loadAttachmentDetails,
     };
   }
 
@@ -212,6 +221,7 @@ export class Container extends React.Component<Properties> {
           isSecondarySidekickOpen={this.props.isSecondarySidekickOpen}
           toggleSecondarySidekick={this.props.toggleSecondarySidekick}
           openMessageInfo={this.props.openMessageInfo}
+          loadAttachmentDetails={this.props.loadAttachmentDetails}
         />
       </>
     );

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -38,7 +38,7 @@ export interface Properties extends PublicProperties {
   openDeleteMessage: (messageId: number) => void;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 interface PublicProperties {

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -48,6 +48,7 @@ describe('ChatView', () => {
       isSecondarySidekickOpen: false,
       toggleSecondarySidekick: () => null,
       openMessageInfo: () => null,
+      loadAttachmentDetails: () => null,
 
       ...props,
     };

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -52,7 +52,7 @@ export interface Properties {
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 export interface State {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -52,7 +52,7 @@ export interface Properties {
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
 }
 
 export interface State {

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Waypoint } from 'react-waypoint';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Message as MessageModel, MediaType, EditMessageOptions } from '../../store/messages';
+import { Message as MessageModel, MediaType, EditMessageOptions, Media } from '../../store/messages';
 import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
@@ -52,6 +52,7 @@ export interface Properties {
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 export interface State {
@@ -180,6 +181,7 @@ export class ChatView extends React.Component<Properties, State> {
                 showTimestamp={messageRenderProps.showTimestamp}
                 showAuthorName={messageRenderProps.showAuthorName}
                 onHiddenMessageInfoClick={this.props.onHiddenMessageInfoClick}
+                loadAttachmentDetails={this.props.loadAttachmentDetails}
                 {...message}
               />
             </div>

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -52,7 +52,7 @@ export interface Properties {
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media }) => void;
 }
 
 export interface State {

--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -296,7 +296,7 @@ describe(linkParentMessage, () => {
 describe(linkMediaMessage, () => {
   it('links a media message to its root message', () => {
     const messages = [
-      { id: '1', rootMessageId: 'root-1', message: 'media message', media: 'media' },
+      { id: '1', rootMessageId: 'root-1', message: 'media message', media: { media: 'media' } },
       { id: 'root-1', message: 'root message' },
     ];
     const messagesById = mapMessagesById(messages);
@@ -305,7 +305,7 @@ describe(linkMediaMessage, () => {
 
     linkMediaMessage(messages[0], messagesById, mediaMessages, result);
 
-    expect(messagesById['root-1'].media).toEqual('media');
+    expect(messagesById['root-1'].media).toEqual({ id: '1', media: 'media' });
     expect(mediaMessages).toEqual([messages[0]]);
     expect(result).toEqual([]);
   });

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -131,7 +131,7 @@ export function linkParentMessage(message, messagesById, messagesByRootId) {
 export function linkMediaMessage(message, messagesById, mediaMessages, messages) {
   const rootMessage = messagesById[message.rootMessageId];
   if (rootMessage) {
-    rootMessage.media = message.media;
+    rootMessage.media = { id: message.id, ...message.media };
     mediaMessages.push(message);
   } else {
     messages.push(message);

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -65,6 +65,22 @@ describe('message', () => {
     expect(wrapper.find('.message__block-image').exists()).toBe(true);
   });
 
+  it('renders image placeholder if no media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    const wrapper = subject({ loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
+
+    expect(wrapper.find('.message__image-placeholder').exists()).toBe(true);
+  });
+
+  it('calls loadAttachmentDetails if no media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({ messageId: 'test-id', loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
+
+    expect(loadAttachmentDetails).toHaveBeenCalled();
+  });
+
   it('does not renders message text', () => {
     const wrapper = subject({ message: 'the message' });
 

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -68,7 +68,7 @@ describe('message', () => {
   it('renders image placeholder if no media url', () => {
     const loadAttachmentDetails = jest.fn();
 
-    const wrapper = subject({ loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
+    const wrapper = subject({ loadAttachmentDetails, media: { id: '1', url: null, type: MediaType.Image } });
 
     expect(wrapper.find('.message__image-placeholder').exists()).toBe(true);
   });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -50,7 +50,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
+  loadAttachmentDetails: (payload: { media: Media }) => void;
 }
 
 export interface State {
@@ -121,11 +121,11 @@ export class Message extends React.Component<Properties, State> {
     this.handleMediaAspectRatio(width, height);
   };
 
-  renderMedia(media, messageId) {
+  renderMedia(media) {
     const { type, url, name } = media;
 
     if (!url) {
-      this.props.loadAttachmentDetails({ media, messageId });
+      this.props.loadAttachmentDetails({ media });
       return (
         <div {...cn('block-image')}>
           <div {...cn('image-placeholder-container')}>
@@ -415,7 +415,7 @@ export class Message extends React.Component<Properties, State> {
   }
 
   render() {
-    const { message, media, preview, sender, isOwner, messageId } = this.props;
+    const { message, media, preview, sender, isOwner } = this.props;
     return (
       <div
         className={classNames('message', this.props.className, {
@@ -446,7 +446,7 @@ export class Message extends React.Component<Properties, State> {
               {!this.state.isEditing && (
                 <>
                   {this.props.showAuthorName && this.renderAuthorName()}
-                  {media && this.renderMedia(media, messageId)}
+                  {media && this.renderMedia(media)}
                   {this.renderLinkPreview()}
                   {this.renderParentMessage()}
                   {this.renderBody()}
@@ -455,7 +455,7 @@ export class Message extends React.Component<Properties, State> {
 
               {this.state.isEditing && this.props.message && (
                 <>
-                  {media && this.renderMedia(media, messageId)}
+                  {media && this.renderMedia(media)}
 
                   <div {...cn('block-edit')}>
                     <MessageInput

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -50,7 +50,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
-  loadAttachmentDetails: (payload: { media: Media }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 export interface State {
@@ -125,7 +125,7 @@ export class Message extends React.Component<Properties, State> {
     const { type, url, name } = media;
 
     if (!url) {
-      this.props.loadAttachmentDetails({ media });
+      this.props.loadAttachmentDetails({ media, messageId: media.id ?? this.props.messageId.toString() });
       return (
         <div {...cn('image-placeholder-container')}>
           <div {...cn('image-placeholder')} />

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -127,10 +127,8 @@ export class Message extends React.Component<Properties, State> {
     if (!url) {
       this.props.loadAttachmentDetails({ media });
       return (
-        <div {...cn('block-image')}>
-          <div {...cn('image-placeholder-container')}>
-            <div {...cn('image-placeholder')} />
-          </div>
+        <div {...cn('image-placeholder-container')}>
+          <div {...cn('image-placeholder')} />
         </div>
       );
     }

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Message as MessageModel, MediaType, EditMessageOptions, MessageSendStatus } from '../../store/messages';
+import { Message as MessageModel, MediaType, EditMessageOptions, MessageSendStatus, Media } from '../../store/messages';
 import { download } from '../../lib/api/attachment';
 import { LinkPreview } from '../link-preview';
 import { getProvider } from '../../lib/cloudinary/provider';
 import { MessageInput } from '../message-input/container';
 import { User } from '../../store/channels';
 import { ParentMessage as ParentMessageType } from '../../lib/chat/types';
-import { Media, UserForMention } from '../message-input/utils';
+import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
@@ -121,9 +121,8 @@ export class Message extends React.Component<Properties, State> {
     this.handleMediaAspectRatio(width, height);
   };
 
-  renderMedia(media) {
+  renderMedia(media, messageId) {
     const { type, url, name } = media;
-    const messageId = this.props.messageId;
 
     if (!url) {
       this.props.loadAttachmentDetails({ media, messageId });
@@ -410,7 +409,7 @@ export class Message extends React.Component<Properties, State> {
   }
 
   render() {
-    const { message, media, preview, sender, isOwner } = this.props;
+    const { message, media, preview, sender, isOwner, messageId } = this.props;
     return (
       <div
         className={classNames('message', this.props.className, {
@@ -441,7 +440,7 @@ export class Message extends React.Component<Properties, State> {
               {!this.state.isEditing && (
                 <>
                   {this.props.showAuthorName && this.renderAuthorName()}
-                  {media && this.renderMedia(media)}
+                  {media && this.renderMedia(media, messageId)}
                   {this.renderLinkPreview()}
                   {this.renderParentMessage()}
                   {this.renderBody()}
@@ -450,7 +449,7 @@ export class Message extends React.Component<Properties, State> {
 
               {this.state.isEditing && this.props.message && (
                 <>
-                  {media && this.renderMedia(media)}
+                  {media && this.renderMedia(media, messageId)}
 
                   <div {...cn('block-edit')}>
                     <MessageInput

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -129,7 +129,7 @@ export class Message extends React.Component<Properties, State> {
       return (
         <div {...cn('block-image')}>
           <div {...cn('image-placeholder-container')}>
-            <div {...cn('image-placeholder')}>loading</div>
+            <div {...cn('image-placeholder')} />
           </div>
         </div>
       );

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -127,7 +127,7 @@ export class Message extends React.Component<Properties, State> {
 
     if (!url) {
       this.props.loadAttachmentDetails({ media, messageId });
-      return <div className='image-placeholder'>Loading...</div>;
+      return <div {...cn('image-placeholder')}>Loading...</div>;
     }
 
     if (MediaType.Image === type) {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -8,7 +8,7 @@ import { getProvider } from '../../lib/cloudinary/provider';
 import { MessageInput } from '../message-input/container';
 import { User } from '../../store/channels';
 import { ParentMessage as ParentMessageType } from '../../lib/chat/types';
-import { UserForMention } from '../message-input/utils';
+import { Media, UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
@@ -50,6 +50,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
 }
 
 export interface State {
@@ -122,6 +123,16 @@ export class Message extends React.Component<Properties, State> {
 
   renderMedia(media) {
     const { type, url, name } = media;
+    const messageId = this.props.messageId.toString();
+
+    console.log('XXXURL', url);
+    console.log('XXXMEDIA', media);
+
+    if (!url) {
+      this.props.loadAttachmentDetails({ media, messageId });
+      return <div className='image-placeholder'>Loading...</div>;
+    }
+
     if (MediaType.Image === type) {
       return (
         <div {...cn('block-image')} onClick={this.onImageClick(media)}>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -50,7 +50,7 @@ interface Properties extends MessageModel {
   showAuthorName: boolean;
   isHidden: boolean;
   onHiddenMessageInfoClick: () => void;
-  loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
+  loadAttachmentDetails: (payload: { media: Media; messageId: number }) => void;
 }
 
 export interface State {
@@ -123,10 +123,7 @@ export class Message extends React.Component<Properties, State> {
 
   renderMedia(media) {
     const { type, url, name } = media;
-    const messageId = this.props.messageId.toString();
-
-    console.log('XXXURL', url);
-    console.log('XXXMEDIA', media);
+    const messageId = this.props.messageId;
 
     if (!url) {
       this.props.loadAttachmentDetails({ media, messageId });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -126,7 +126,13 @@ export class Message extends React.Component<Properties, State> {
 
     if (!url) {
       this.props.loadAttachmentDetails({ media, messageId });
-      return <div {...cn('image-placeholder')}>Loading...</div>;
+      return (
+        <div {...cn('block-image')}>
+          <div {...cn('image-placeholder-container')}>
+            <div {...cn('image-placeholder')}>loading</div>
+          </div>
+        </div>
+      );
     }
 
     if (MediaType.Image === type) {

--- a/src/components/message/parent-message/index.tsx
+++ b/src/components/message/parent-message/index.tsx
@@ -36,9 +36,10 @@ export class ParentMessage extends React.PureComponent<Properties> {
         <div {...cn('parent-message')}>
           <IconCornerDownRight size={16} />
 
-          {this.props.mediaUrl && (
+          {this.props?.mediaName && (
             <div {...cn('media-container')}>
-              <img {...cn('media')} src={this.props.mediaUrl} alt={this.props.mediaName} />
+              {this.props?.mediaUrl && <img {...cn('media')} src={this.props?.mediaUrl} alt={this.props?.mediaName} />}
+              {!this.props.mediaUrl && <div {...cn('image-placeholder')} />}
             </div>
           )}
 

--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -1,5 +1,6 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @import '../../../glass';
+@import '../../../animation';
 
 .parent-message-container {
   display: flex;
@@ -65,14 +66,21 @@
     height: 100%;
     border-radius: 4px;
     object-fit: cover;
+
+    animation: fadein 1s ease-in forwards;
   }
 
   &__image-placeholder {
-    background-color: theme.$color-greyscale-12;
-    border-radius: 4px;
     width: 100%;
     height: 100%;
+    border-radius: 4px;
     filter: blur(2px);
-    opacity: 0.2;
+
+    background-color: rgb(54, 93, 87, 0.2);
+    background: linear-gradient(90deg, rgba(54, 93, 87, 0.2) 25%, rgba(54, 93, 87, 0.4) 50%, rgba(54, 93, 87, 0.2) 75%);
+    background-size: 500px 100%;
+
+    animation: fadein 1s ease-in forwards;
+    animation: loadingShimmer 2s infinite linear;
   }
 }

--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -66,4 +66,13 @@
     border-radius: 4px;
     object-fit: cover;
   }
+
+  &__image-placeholder {
+    background-color: theme.$color-greyscale-12;
+    border-radius: 4px;
+    width: 100%;
+    height: 100%;
+    filter: blur(2px);
+    opacity: 0.2;
+  }
 }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -2,6 +2,15 @@
 @use '../../shared-components/theme-engine/theme' as themeDeprecated;
 @import '../../glass';
 
+@keyframes loadingShimmer {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+}
+
 .message {
   display: flex;
   justify-content: flex-start;
@@ -9,6 +18,16 @@
   gap: 8px;
   overflow: hidden;
   width: 100%;
+
+  &__image-placeholder {
+    background-color: theme.$color-greyscale-12;
+
+    width: 300px;
+    height: 200px;
+
+    filter: blur(2px);
+    opacity: 0.2;
+  }
 
   &--owner {
     flex-direction: row-reverse;
@@ -243,7 +262,21 @@
     }
   }
 
+  &__image-placeholder-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 300px;
+    height: 200px;
+    padding: 8px;
+  }
+
   &__image-placeholder {
-    @include glass-text-secondary-color;
+    background-color: theme.$color-greyscale-12;
+    width: 100%;
+    height: 100%;
+    filter: blur(2px);
+    opacity: 0.2;
+    border-radius: 8px;
   }
 }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -242,4 +242,8 @@
       left: 7px;
     }
   }
+
+  &__image-placeholder {
+    @include glass-text-secondary-color;
+  }
 }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -1,15 +1,7 @@
 @use '~@zero-tech/zui/styles/theme' as theme;
 @use '../../shared-components/theme-engine/theme' as themeDeprecated;
 @import '../../glass';
-
-@keyframes loadingShimmer {
-  0% {
-    background-position: -200px 0;
-  }
-  100% {
-    background-position: calc(200px + 100%) 0;
-  }
-}
+@import '../../animation';
 
 .message {
   display: flex;
@@ -18,16 +10,6 @@
   gap: 8px;
   overflow: hidden;
   width: 100%;
-
-  &__image-placeholder {
-    background-color: theme.$color-greyscale-12;
-
-    width: 300px;
-    height: 200px;
-
-    filter: blur(2px);
-    opacity: 0.2;
-  }
 
   &--owner {
     flex-direction: row-reverse;
@@ -269,14 +251,23 @@
     width: 300px;
     height: 200px;
     padding: 8px;
+
+    margin: auto;
+    max-width: 100%;
+    max-height: 640px;
   }
 
   &__image-placeholder {
-    background-color: theme.$color-greyscale-12;
     width: 100%;
     height: 100%;
-    filter: blur(2px);
-    opacity: 0.2;
     border-radius: 8px;
+    filter: blur(2px);
+
+    background-color: rgb(54, 93, 87, 0.2);
+    background: linear-gradient(90deg, rgba(54, 93, 87, 0.2) 25%, rgba(54, 93, 87, 0.4) 50%, rgba(54, 93, 87, 0.2) 75%);
+    background-size: 600px 100%;
+
+    animation: fadein 1s ease-in forwards;
+    animation: loadingShimmer 2s infinite linear;
   }
 }

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -105,6 +105,8 @@
       max-width: 100%;
       max-height: 640px;
     }
+
+    animation: fadein 1s ease-in forwards;
   }
 
   &__block-audio {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -5,12 +5,12 @@ import { getObjectDiff, parsePlainBody } from './utils';
 import { PowerLevels } from '../types';
 
 async function parseMediaData(matrixMessage) {
-  const { content } = matrixMessage;
+  const { event_id, content } = matrixMessage;
 
   let media = null;
   try {
     if (content?.msgtype === MsgType.Image) {
-      media = await buildMediaObject(content);
+      media = await buildMediaObject(content, event_id);
     }
   } catch (e) {
     console.error('error ocurred while parsing media data: ', e);
@@ -23,13 +23,14 @@ async function parseMediaData(matrixMessage) {
   };
 }
 
-async function buildMediaObject(content) {
+async function buildMediaObject(content, eventId) {
   if (content.file && content.info) {
     return {
+      id: eventId,
       url: null,
       type: 'image',
-      ...content.info,
       file: { ...content.file },
+      ...content.info,
     };
   } else if (content.url) {
     return {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -28,7 +28,7 @@ async function buildMediaObject(content) {
     return {
       url: null,
       type: 'image',
-      info: { ...content.info },
+      ...content.info,
       file: { ...content.file },
     };
   } else if (content.url) {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -5,12 +5,12 @@ import { getObjectDiff, parsePlainBody } from './utils';
 import { PowerLevels } from '../types';
 
 async function parseMediaData(matrixMessage) {
-  const { event_id, content } = matrixMessage;
+  const { content } = matrixMessage;
 
   let media = null;
   try {
     if (content?.msgtype === MsgType.Image) {
-      media = await buildMediaObject(content, event_id);
+      media = await buildMediaObject(content);
     }
   } catch (e) {
     console.error('error ocurred while parsing media data: ', e);
@@ -23,10 +23,9 @@ async function parseMediaData(matrixMessage) {
   };
 }
 
-async function buildMediaObject(content, eventId) {
+async function buildMediaObject(content) {
   if (content.file && content.info) {
     return {
-      id: eventId,
       url: null,
       type: 'image',
       file: { ...content.file },

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -26,11 +26,14 @@ async function parseMediaData(matrixMessage) {
 
 async function buildMediaObject(content) {
   if (content.file && content.info) {
-    const blob = await decryptFile(content.file, content.info);
+    console.log('XXXCONTENT', content);
+    // const blob = await decryptFile(content.file, content.info);
+    // console.log('XXXXBLOBBY', blob);
     return {
-      url: URL.createObjectURL(blob),
+      url: null,
       type: 'image',
-      ...content.info,
+      info: { ...content.info },
+      file: { ...content.file },
     };
   } else if (content.url) {
     return {
@@ -71,7 +74,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
       admin: {},
       mentionedUsers: [],
       hidePreview: false,
-      media: null,
+      // media: null,
       image: null,
     },
     parentMessageText: '',

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,6 +1,5 @@
 import { CustomEventType, MatrixConstants, MembershipStateType, NotifiableEventType } from './types';
 import { EventType, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk';
-import { decryptFile } from './media';
 import { AdminMessageType, Message, MessageSendStatus } from '../../../store/messages';
 import { getObjectDiff, parsePlainBody } from './utils';
 import { PowerLevels } from '../types';
@@ -26,9 +25,6 @@ async function parseMediaData(matrixMessage) {
 
 async function buildMediaObject(content) {
   if (content.file && content.info) {
-    console.log('XXXCONTENT', content);
-    // const blob = await decryptFile(content.file, content.info);
-    // console.log('XXXXBLOBBY', blob);
     return {
       url: null,
       type: 'image',
@@ -74,7 +70,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
       admin: {},
       mentionedUsers: [],
       hidePreview: false,
-      // media: null,
+      media: null,
       image: null,
     },
     parentMessageText: '',

--- a/src/lib/chat/matrix/media.ts
+++ b/src/lib/chat/matrix/media.ts
@@ -46,23 +46,22 @@ export async function encryptFile(file: File): Promise<{ info: encrypt.IEncrypte
 }
 
 // https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/utils/DecryptFile.ts#L50
-export async function decryptFile(encryptedFile, info): Promise<Blob> {
+export async function decryptFile(encryptedFile, mimetype): Promise<Blob> {
   const signedUrl = await getAttachmentUrl({ key: encryptedFile.url });
 
   // Download the encrypted file as an array buffer.
   const response = await fetch(signedUrl);
   if (!response.ok) {
-    throw new Error(`Error occurred while downloading file ${info.name}: ${await response.text()}`);
+    throw new Error(`Error occurred while downloading file ${encryptedFile.url}: ${await response.text()}`);
   }
   const responseData: ArrayBuffer = await response.arrayBuffer();
 
   try {
     // Decrypt the array buffer using the information taken from the event content.
     const dataArray = await encrypt.decryptAttachment(responseData, encryptedFile);
-
     // Turn the array into a Blob and give it the correct MIME-type.
-    return new Blob([dataArray], { type: info?.mimetype });
+    return new Blob([dataArray], { type: mimetype });
   } catch (e) {
-    throw new Error(`Error occurred while decrypting file ${info.name}: ${e}`);
+    throw new Error(`Error occurred while decrypting file ${encryptedFile.url}: ${e}`);
   }
 }

--- a/src/lib/chat/matrix/media.ts
+++ b/src/lib/chat/matrix/media.ts
@@ -46,8 +46,8 @@ export async function encryptFile(file: File): Promise<{ info: encrypt.IEncrypte
 }
 
 // https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/utils/DecryptFile.ts#L50
-export async function decryptFile(encrypedFile, info): Promise<Blob> {
-  const signedUrl = await getAttachmentUrl({ key: encrypedFile.url });
+export async function decryptFile(encryptedFile, info): Promise<Blob> {
+  const signedUrl = await getAttachmentUrl({ key: encryptedFile.url });
 
   // Download the encrypted file as an array buffer.
   const response = await fetch(signedUrl);
@@ -58,7 +58,7 @@ export async function decryptFile(encrypedFile, info): Promise<Blob> {
 
   try {
     // Decrypt the array buffer using the information taken from the event content.
-    const dataArray = await encrypt.decryptAttachment(responseData, encrypedFile);
+    const dataArray = await encrypt.decryptAttachment(responseData, encryptedFile);
 
     // Turn the array into a Blob and give it the correct MIME-type.
     return new Blob([dataArray], { type: info?.mimetype });

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -106,7 +106,7 @@ const fetch = createAction<Payload>(SagaActionTypes.Fetch);
 const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
-const loadAttachmentDetails = createAction<{ media: Media; messageId: string }>(SagaActionTypes.LoadAttachmentDetails);
+const loadAttachmentDetails = createAction<{ media: Media; messageId: number }>(SagaActionTypes.LoadAttachmentDetails);
 
 const slice = createNormalizedSlice({
   name: 'messages',

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -99,12 +99,14 @@ export enum SagaActionTypes {
   Send = 'messages/saga/send',
   DeleteMessage = 'messages/saga/deleteMessage',
   EditMessage = 'messages/saga/editMessage',
+  LoadAttachmentDetails = 'messages/saga/loadAttachmentDetails',
 }
 
 const fetch = createAction<Payload>(SagaActionTypes.Fetch);
 const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
+const loadAttachmentDetails = createAction<{ media: Media; messageId: string }>(SagaActionTypes.LoadAttachmentDetails);
 
 const slice = createNormalizedSlice({
   name: 'messages',
@@ -112,4 +114,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { fetch, send, deleteMessage, editMessage, removeAll };
+export { fetch, send, deleteMessage, editMessage, removeAll, loadAttachmentDetails };

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -106,7 +106,7 @@ const fetch = createAction<Payload>(SagaActionTypes.Fetch);
 const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
-const loadAttachmentDetails = createAction<{ media: Media; messageId: number }>(SagaActionTypes.LoadAttachmentDetails);
+const loadAttachmentDetails = createAction<{ media: Media }>(SagaActionTypes.LoadAttachmentDetails);
 
 const slice = createNormalizedSlice({
   name: 'messages',

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -602,60 +602,48 @@ function* readReceiptReceived({ payload }) {
 }
 
 const inProgress = {};
-let count = 0;
 export function* loadAttachmentDetails(action) {
-  const { media, messageId } = action.payload;
+  const { media } = action.payload;
 
   console.log('XXX 1: Get Payload', action.payload);
 
-  count++;
-
-  if (count > 10) {
-    console.log('XXX: Stopping - Counter Limit Reached');
-
-    return;
-  }
-
-  console.log('XXX 2: Bypass Counter Stop');
-
-  if (inProgress[messageId] || media.url) {
+  if (inProgress[media.id] || media.url) {
     console.log('XXX: Stopping - In Progress || Media Url');
     return;
   }
 
-  console.log('XXX 3: Bypass In Progress Stop');
+  console.log('XXX 2: Bypass In Progress Stop');
 
-  inProgress[messageId] = true;
+  inProgress[media.id] = true;
 
   try {
     const blob = yield call(decryptFile, media.file, media.mimetype);
-    console.log('XXX 4: Blob Success', blob);
+    console.log('XXX 3: Blob Success', blob);
 
-    const mediaUrl = URL.createObjectURL(blob);
-    console.log('XXX 5: URL Creation Success', mediaUrl);
+    const url = URL.createObjectURL(blob);
+    console.log('XXX 4: URL Creation Success', url);
 
-    if (!mediaUrl) {
+    if (!url) {
       console.log('XXX: Stopping - URL Creation Failed');
       return;
     }
 
-    console.log('XXX 6: Bypass URL Creation Stop');
+    console.log('XXX 5: Bypass URL Creation Stop');
 
     yield put(
       receiveMessage({
-        id: messageId,
-        media: { ...media, url: mediaUrl },
-        image: { ...media, url: mediaUrl },
-        // rootMessageId: media?.rootMessageId || '',
+        id: media.id,
+        media: { ...media, url: url },
+        image: { ...media, url: url },
       })
     );
 
-    console.log('XXX 7: Success - Receive Message Success');
+    console.log('XXX 6: Success - Receive Message Success');
   } catch (error) {
     console.error('Failed to download and decrypt image:', error);
   }
 
-  console.log('XXX 8: End');
+  console.log('XXX 7: End');
 
-  inProgress[messageId] = false;
+  inProgress[media.id] = false;
 }

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -134,7 +134,6 @@ export function* fetch(action) {
 
   let messagesResponse: any;
   let messages: any[];
-  console.log('XXXFetch Messages Hit');
   try {
     const chatClient = yield call(chat.get);
 
@@ -603,14 +602,11 @@ function* readReceiptReceived({ payload }) {
 }
 
 export function* loadAttachmentDetails(action) {
-  console.log('XXXaction', action);
   const { media, messageId } = action.payload;
-  // if in progress then don't fetch
+
   try {
     const blob = yield call(decryptFile, media.file, media.info);
-    console.log('XXXblob', blob);
     const url = URL.createObjectURL(blob);
-    console.log('XXXurl', url);
     yield put(receiveMessage({ id: messageId, media: { ...media, url } }));
   } catch (error) {
     console.error('Failed to download and decrypt image:', error);

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -134,7 +134,7 @@ export function* fetch(action) {
 
   let messagesResponse: any;
   let messages: any[];
-  console.log('XXXYOLOLOO HWRER MY GGGG');
+  console.log('XXXFetch Messages Hit');
   try {
     const chatClient = yield call(chat.get);
 
@@ -151,35 +151,8 @@ export function* fetch(action) {
 
     // we prefer this order (new messages first), so that if any new message has an updated property
     // (eg. parentMessage), then it gets written to state
-    // Create a map of existing messages by ID for quick lookup
-    const existingMessagesMap = existingMessages.reduce((acc, msg) => {
-      acc[msg.id] = msg;
-      return acc;
-    }, {});
-
-    // Merge messages and ensure media URLs are not reset if they already exist
-    messages = messagesResponse.messages.map((msg) => {
-      const existingMessage = existingMessagesMap[msg.id];
-      if (existingMessage) {
-        // Preserve the existing media URL if it exists
-        if (existingMessage.media && existingMessage.media.url) {
-          msg.media = { ...msg.media, url: existingMessage.media.url };
-        }
-        // Preserve the existing image URL if it exists
-        if (existingMessage.image && existingMessage.image.url) {
-          msg.image = { ...msg.image, url: existingMessage.image.url };
-        }
-      }
-      return msg;
-    });
-
-    // Add any existing messages that were not in the response
-    const newMessageIds = new Set(messages.map((m) => m.id));
-    existingMessages.forEach((msg) => {
-      if (!newMessageIds.has(msg.id)) {
-        messages.push(msg);
-      }
-    });
+    messages = [...messagesResponse.messages, ...existingMessages];
+    messages = uniqBy(messages, (m) => m.id ?? m);
 
     yield call(receiveChannel, {
       id: channelId,


### PR DESCRIPTION
Note :: waypoint could be improved as to when onEnter is triggered if it is a conversation with very few messages, but not a blocker here.

### What does this do?
- The implementation and refactoring for downloading and decrypting images when conversation is active.

### Why are we making this change?
-  Prevent download/decrypt happening on initial load for every conversation. 

### How do I test this?
- Run test as usual.
- Run UI and check images media rendering for active conversations. 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/user-attachments/assets/10d95bd9-69c6-41b9-adfd-3e86e4deb39f

