### PR TITLE
feat(user-profile/overview-panel): add scrollbar container to panel

### DIFF
--- a/src/components/messenger/user-profile/overview-panel/index.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.tsx
@@ -186,19 +186,17 @@ export class OverviewPanel extends React.Component<Properties, State> {
 
   renderFooter() {
     return (
-      <>
-        <div {...cn('footer')}>
-          <Button
-            {...cn('footer-button')}
-            variant={ButtonVariant.Secondary}
-            color={ButtonColor.Greyscale}
-            onPress={this.openLogoutDialog}
-            startEnhancer={<IconLogOut3 size={20} />}
-          >
-            Log Out
-          </Button>
-        </div>
-      </>
+      <div {...cn('footer')}>
+        <Button
+          {...cn('footer-button')}
+          variant={ButtonVariant.Secondary}
+          color={ButtonColor.Greyscale}
+          onPress={this.openLogoutDialog}
+          startEnhancer={<IconLogOut3 size={20} />}
+        >
+          Log Out
+        </Button>
+      </div>
     );
   }
 

--- a/src/components/messenger/user-profile/overview-panel/index.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.tsx
@@ -18,6 +18,7 @@ import {
 import { InviteDialogContainer } from '../../../invite-dialog/container';
 import { RewardsItemContainer } from './rewards-item/container';
 import { featureFlags } from '../../../../lib/feature-flags';
+import { ScrollbarContainer } from '../../../scrollbar-container';
 
 import './styles.scss';
 
@@ -185,17 +186,19 @@ export class OverviewPanel extends React.Component<Properties, State> {
 
   renderFooter() {
     return (
-      <div {...cn('footer')}>
-        <Button
-          {...cn('footer-button')}
-          variant={ButtonVariant.Secondary}
-          color={ButtonColor.Greyscale}
-          onPress={this.openLogoutDialog}
-          startEnhancer={<IconLogOut3 size={20} />}
-        >
-          Log Out
-        </Button>
-      </div>
+      <>
+        <div {...cn('footer')}>
+          <Button
+            {...cn('footer-button')}
+            variant={ButtonVariant.Secondary}
+            color={ButtonColor.Greyscale}
+            onPress={this.openLogoutDialog}
+            startEnhancer={<IconLogOut3 size={20} />}
+          >
+            Log Out
+          </Button>
+        </div>
+      </>
     );
   }
 
@@ -214,16 +217,21 @@ export class OverviewPanel extends React.Component<Properties, State> {
           <PanelHeader title={'Profile'} onBack={this.navigateBack} />
         </div>
 
-        <div {...cn('body')}>
-          <div {...cn('section')}>
-            {this.renderDetails()}
-            {featureFlags.enableRewards && this.renderRewards()}
+        <ScrollbarContainer variant='on-hover'>
+          <div {...cn('panel-content-wrapper')}>
+            <div {...cn('body')}>
+              <div {...cn('section')}>
+                {this.renderDetails()}
+                {featureFlags.enableRewards && this.renderRewards()}
+              </div>
+
+              {this.renderActions()}
+            </div>
+
+            {this.renderFooter()}
           </div>
+        </ScrollbarContainer>
 
-          {this.renderActions()}
-        </div>
-
-        {this.renderFooter()}
         {this.renderInviteDialog()}
       </div>
     );

--- a/src/components/messenger/user-profile/overview-panel/styles.scss
+++ b/src/components/messenger/user-profile/overview-panel/styles.scss
@@ -22,6 +22,15 @@
     width: 235px;
   }
 
+  &__panel-content-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
+  }
+
   &__body {
     margin: 16px 16px 0 16px;
     flex-grow: 1;


### PR DESCRIPTION
### What does this do?
- adds scrollbar container to overview panel (user-profile)

### Why are we making this change?
- to ensure panel content can be reached on page if screen is smaller in height

### How do I test this?
- run test as usual.
- run the UI > decrease screensize when on user profile overview panel > hover over panel and check scrol.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/user-attachments/assets/fba6838c-0797-4b4d-8723-8eb08f34ffac

