### PR TITLE
feat(user-profile/downloads-panel): add scrollbar container to panel

### DIFF
--- a/src/components/messenger/user-profile/downloads-panel/index.tsx
+++ b/src/components/messenger/user-profile/downloads-panel/index.tsx
@@ -5,6 +5,7 @@ import { bemClassName } from '../../../../lib/bem';
 
 import { PanelHeader } from '../../list/panel-header';
 import { IconLaptop1, IconPhone } from '@zero-tech/zui/icons';
+import { ScrollbarContainer } from '../../../scrollbar-container';
 
 import './styles.scss';
 
@@ -54,23 +55,25 @@ export class DownloadsPanel extends React.Component<Properties> {
           <PanelHeader title={'Download'} onBack={this.back} />
         </div>
 
-        <div {...cn('body')}>
-          <div>
-            <div {...cn('section-header')}>
-              <IconLaptop1 {...cn('section-icon')} size={24} />
-              <h4 {...cn('section-title')}>Desktop</h4>
+        <ScrollbarContainer variant='on-hover'>
+          <div {...cn('body')}>
+            <div>
+              <div {...cn('section-header')}>
+                <IconLaptop1 {...cn('section-icon')} size={24} />
+                <h4 {...cn('section-title')}>Desktop</h4>
+              </div>
+              {this.renderDownloadLinks(desktopLinks, true)}
             </div>
-            {this.renderDownloadLinks(desktopLinks, true)}
-          </div>
 
-          <div>
-            <div {...cn('section-header')}>
-              <IconPhone {...cn('section-icon')} size={24} />
-              <h4 {...cn('section-title')}>Mobile</h4>
+            <div>
+              <div {...cn('section-header')}>
+                <IconPhone {...cn('section-icon')} size={24} />
+                <h4 {...cn('section-title')}>Mobile</h4>
+              </div>
+              {this.renderDownloadLinks(mobileLinks)}
             </div>
-            {this.renderDownloadLinks(mobileLinks)}
           </div>
-        </div>
+        </ScrollbarContainer>
       </div>
     );
   }

--- a/src/components/messenger/user-profile/downloads-panel/styles.scss
+++ b/src/components/messenger/user-profile/downloads-panel/styles.scss
@@ -17,8 +17,10 @@
     flex-direction: column;
     flex-grow: 1;
     gap: 24px;
-
     margin: 0 16px 16px 16px;
+
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
   }
 
   &__section-header {


### PR DESCRIPTION
### What does this do?
- adds scrollbar container to downloads panel (user-profile)

### Why are we making this change?
- to ensure panel content can be reached on page if screen is smaller in height

### How do I test this?
- run test as usual.
- run the UI > decrease screensize when on user profile downloads panel > hover over panel and check scroll.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/user-attachments/assets/f61104b6-36c8-4d8f-a418-b9e3ad40c6c5


