### PR TITLE
feat(user-profile/settings-panel): add scrollbar container to panel

### DIFF
--- a/src/components/messenger/user-profile/settings-panel/index.tsx
+++ b/src/components/messenger/user-profile/settings-panel/index.tsx
@@ -7,6 +7,7 @@ import { translateBackgroundValue } from './utils';
 import { PanelHeader } from '../../list/panel-header';
 import { SelectInput } from '@zero-tech/zui/components';
 import { IconCheck, IconLock1, IconPalette } from '@zero-tech/zui/icons';
+import { ScrollbarContainer } from '../../../scrollbar-container';
 
 import './styles.scss';
 
@@ -85,43 +86,45 @@ export class SettingsPanel extends React.Component<Properties> {
           <PanelHeader title={'Settings'} onBack={this.back} />
         </div>
 
-        <div {...cn('body')}>
-          <div>
-            <div {...cn('section-header')}>
-              <IconLock1 {...cn('section-icon')} size={24} />
-              <h4 {...cn('section-title')}>Privacy</h4>
+        <ScrollbarContainer variant='on-hover'>
+          <div {...cn('body')}>
+            <div>
+              <div {...cn('section-header')}>
+                <IconLock1 {...cn('section-icon')} size={24} />
+                <h4 {...cn('section-title')}>Privacy</h4>
+              </div>
+              <div {...cn('checkbox-container')}>
+                Messaging
+                <label {...cn('checkbox-label-wrapper')}>
+                  <input
+                    {...cn('checkbox')}
+                    type='checkbox'
+                    checked={this.props.isPublicReadReceipts}
+                    onChange={this.toggleReadReceipts}
+                  />
+                  {this.props.isPublicReadReceipts && <IconCheck {...cn('checkbox-icon')} size={14} isFilled />}
+                  Read Receipts
+                </label>
+              </div>
             </div>
-            <div {...cn('checkbox-container')}>
-              Messaging
-              <label {...cn('checkbox-label-wrapper')}>
-                <input
-                  {...cn('checkbox')}
-                  type='checkbox'
-                  checked={this.props.isPublicReadReceipts}
-                  onChange={this.toggleReadReceipts}
-                />
-                {this.props.isPublicReadReceipts && <IconCheck {...cn('checkbox-icon')} size={14} isFilled />}
-                Read Receipts
-              </label>
-            </div>
-          </div>
 
-          <div>
-            <div {...cn('section-header')}>
-              <IconPalette {...cn('section-icon')} size={24} />
-              <h4 {...cn('section-title')}>Appearance</h4>
-            </div>
-            <div {...cn('select-input-container')}>
-              <SelectInput
-                items={mainBackgroundItems}
-                label='Select Background'
-                placeholder='Select Background'
-                value={selectedBackgroundLabel}
-                itemSize='compact'
-              />
+            <div>
+              <div {...cn('section-header')}>
+                <IconPalette {...cn('section-icon')} size={24} />
+                <h4 {...cn('section-title')}>Appearance</h4>
+              </div>
+              <div {...cn('select-input-container')}>
+                <SelectInput
+                  items={mainBackgroundItems}
+                  label='Select Background'
+                  placeholder='Select Background'
+                  value={selectedBackgroundLabel}
+                  itemSize='compact'
+                />
+              </div>
             </div>
           </div>
-        </div>
+        </ScrollbarContainer>
       </div>
     );
   }

--- a/src/components/messenger/user-profile/settings-panel/styles.scss
+++ b/src/components/messenger/user-profile/settings-panel/styles.scss
@@ -17,8 +17,10 @@
     flex-direction: column;
     flex-grow: 1;
     gap: 24px;
-
     margin: 0 16px 16px 16px;
+
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
   }
 
   &__section-header {


### PR DESCRIPTION
### What does this do?
- adds scrollbar container to settings panel (user-profile)

### Why are we making this change?
- to ensure panel content can be reached on page if screen is smaller in height

### How do I test this?
- run test as usual.
- run the UI > decrease screensize when on user profile settings panel > hover over panel and check scroll.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/user-attachments/assets/a90c0f8c-ca17-4620-bfeb-f6b05d026b38

