### PR TITLE
feat(user-profile/account-management-panel): add scrollbar container to panel

### DIFF
--- a/src/components/messenger/user-profile/account-management-panel/index.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.tsx
@@ -11,6 +11,7 @@ import { WalletListItem } from '../../../wallet-list-item';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { IconXClose } from '@zero-tech/zui/icons';
 import { CreateEmailAccountContainer } from '../../../../authentication/create-email-account/container';
+import { ScrollbarContainer } from '../../../scrollbar-container';
 
 const cn = bemClassName('account-management-panel');
 
@@ -131,24 +132,28 @@ export class AccountManagementPanel extends React.Component<Properties> {
           <PanelHeader title={'Accounts'} onBack={this.back} />
         </div>
 
-        <div {...cn('content')}>
-          {this.renderWalletsSection()}
-          {this.renderEmailSection()}
+        <ScrollbarContainer variant='on-hover'>
+          <div {...cn('panel-content-wrapper')}>
+            <div {...cn('content')}>
+              {this.renderWalletsSection()}
+              {this.renderEmailSection()}
 
-          {this.props.error && (
-            <Alert variant='error' isFilled>
-              <div {...cn('alert-text')}>{this.props.error}</div>
-            </Alert>
-          )}
+              {this.props.error && (
+                <Alert variant='error' isFilled>
+                  <div {...cn('alert-text')}>{this.props.error}</div>
+                </Alert>
+              )}
 
-          {this.props.successMessage && (
-            <Alert variant='success' isFilled>
-              <div {...cn('alert-text')}>{this.props.successMessage}</div>
-            </Alert>
-          )}
-        </div>
+              {this.props.successMessage && (
+                <Alert variant='success' isFilled>
+                  <div {...cn('alert-text')}>{this.props.successMessage}</div>
+                </Alert>
+              )}
+            </div>
 
-        {this.renderAddEmailAccountModal()}
+            {this.renderAddEmailAccountModal()}
+          </div>
+        </ScrollbarContainer>
       </div>
     );
   }

--- a/src/components/messenger/user-profile/account-management-panel/styles.scss
+++ b/src/components/messenger/user-profile/account-management-panel/styles.scss
@@ -12,6 +12,15 @@
     width: 235px;
   }
 
+  &__panel-content-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
+  }
+
   &__content {
     margin: 16px 16px 0 16px;
   }


### PR DESCRIPTION
### What does this do?
- adds scrollbar container to account management panel (user-profile)

### Why are we making this change?
- to ensure panel content can be reached on page if screen is smaller in height

### How do I test this?
- run test as usual.
- run the UI > decrease screensize when on user profile account management panel > hover over panel and check scroll.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?




https://github.com/user-attachments/assets/2a3fd47b-3578-4a6c-9b43-398e699440d7


