### PR TITLE
feat(user-profile/edit-profile): add scrollbar container to panel

### DIFF
--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -7,6 +7,7 @@ import { State as EditProfileState } from '../../store/edit-profile';
 import { featureFlags } from '../../lib/feature-flags';
 import { PanelHeader } from '../messenger/list/panel-header';
 import { Button, Variant as ButtonVariant } from '@zero-tech/zui/components/Button';
+import { ScrollbarContainer } from '../scrollbar-container';
 
 import { bem } from '../../lib/bem';
 import './styles.scss';
@@ -175,67 +176,71 @@ export class EditProfile extends React.Component<Properties, State> {
           <PanelHeader title='Edit Profile' onBack={this.props.onClose} />
         </div>
 
-        <div className={c('body')}>
-          <ImageUpload
-            className={c('image-upload')}
-            onChange={this.trackImage}
-            icon={this.renderImageUploadIcon()}
-            uploadText='Select or drag and drop'
-            isError={Boolean(this.props.errors.image)}
-            errorMessage={this.props.errors.image}
-            imageSrc={this.props.currentProfileImage} // to show the existing image
-          />
-          <Input
-            label='Display Name'
-            name='name'
-            value={this.state.name}
-            onChange={this.trackName}
-            error={!!this.nameError}
-            alert={this.nameError}
-            className={c('body-input')}
-          />
-          {featureFlags.allowEditPrimaryZID && (
-            <div className={c('select-input')}>
-              {this.renderZeroIDLabel()}
-              <SelectInput
-                items={this.menuItems}
-                label=''
-                placeholder={this.props.currentPrimaryZID || 'None (wallet address)'}
-                value={this.state.primaryZID}
-                itemSize='spacious'
-                menuClassName={c('zid-select-menu')}
+        <ScrollbarContainer variant='on-hover'>
+          <div className={c('content-wrapper')}>
+            <div className={c('body')}>
+              <ImageUpload
+                className={c('image-upload')}
+                onChange={this.trackImage}
+                icon={this.renderImageUploadIcon()}
+                uploadText='Select or drag and drop'
+                isError={Boolean(this.props.errors.image)}
+                errorMessage={this.props.errors.image}
+                imageSrc={this.props.currentProfileImage} // to show the existing image
               />
+              <Input
+                label='Display Name'
+                name='name'
+                value={this.state.name}
+                onChange={this.trackName}
+                error={!!this.nameError}
+                alert={this.nameError}
+                className={c('body-input')}
+              />
+              {featureFlags.allowEditPrimaryZID && (
+                <div className={c('select-input')}>
+                  {this.renderZeroIDLabel()}
+                  <SelectInput
+                    items={this.menuItems}
+                    label=''
+                    placeholder={this.props.currentPrimaryZID || 'None (wallet address)'}
+                    value={this.state.primaryZID}
+                    itemSize='spacious'
+                    menuClassName={c('zid-select-menu')}
+                  />
+                </div>
+              )}
             </div>
-          )}
-        </div>
-        {this.imageError && (
-          <Alert className={c('alert-small')} variant='error'>
-            <div className={c('alert-text')}>{this.imageError}</div>
-          </Alert>
-        )}
-        {this.generalError && (
-          <Alert className={c('alert-small')} variant='error'>
-            <div className={c('alert-text')}>{this.generalError}</div>
-          </Alert>
-        )}
+            {this.imageError && (
+              <Alert className={c('alert-small')} variant='error'>
+                <div className={c('alert-text')}>{this.imageError}</div>
+              </Alert>
+            )}
+            {this.generalError && (
+              <Alert className={c('alert-small')} variant='error'>
+                <div className={c('alert-text')}>{this.generalError}</div>
+              </Alert>
+            )}
 
-        {this.changesSaved && (
-          <Alert className={c('alert-small')} variant='success'>
-            <div className={c('alert-text')}>Changes saved successfully</div>
-          </Alert>
-        )}
+            {this.changesSaved && (
+              <Alert className={c('alert-small')} variant='success'>
+                <div className={c('alert-text')}>Changes saved successfully</div>
+              </Alert>
+            )}
 
-        <div className={c('footer')}>
-          <Button
-            isLoading={this.isLoading}
-            isSubmit
-            isDisabled={this.isDisabled}
-            onPress={this.handleEdit}
-            variant={ButtonVariant.Secondary}
-          >
-            Save Changes
-          </Button>
-        </div>
+            <div className={c('footer')}>
+              <Button
+                isLoading={this.isLoading}
+                isSubmit
+                isDisabled={this.isDisabled}
+                onPress={this.handleEdit}
+                variant={ButtonVariant.Secondary}
+              >
+                Save Changes
+              </Button>
+            </div>
+          </div>
+        </ScrollbarContainer>
       </div>
     );
   }

--- a/src/components/edit-profile/styles.scss
+++ b/src/components/edit-profile/styles.scss
@@ -11,8 +11,22 @@
 }
 
 .edit-profile {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+  flex-grow: 1;
+
   &__header-container {
     display: flex;
+  }
+
+  &__content-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
   }
 
   &__body {


### PR DESCRIPTION
### What does this do?
- adds scrollbar container to edit profile panel (user-profile)

### Why are we making this change?
- to ensure panel content can be reached on page if screen is smaller in height

### How do I test this?
- run test as usual.
- run the UI > decrease screensize when on user profile edit profile panel > hover over panel and check scroll.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/user-attachments/assets/8202a329-6eda-4b03-be47-2850c3ec62d4



