### PR TITLE
feat(matrix-client/channels-saga): add room label management

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -1,5 +1,5 @@
 import { EditMessageOptions, Message, MessagesResponse } from '../../store/messages';
-import { Channel, User as UserModel } from '../../store/channels/index';
+import { Channel, RoomLabels, User as UserModel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage, User } from './types';
@@ -24,6 +24,7 @@ export interface RealtimeChatEvents {
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
   roomMemberPowerLevelChanged: (roomId: string, matrixId: string, powerLevel: number) => void;
   readReceiptReceived: (messageId: string, userId: string, roomId: string) => void;
+  roomLabelChange: (roomId: string, labels: string) => void;
 }
 
 export interface MatrixKeyBackupInfo {
@@ -334,10 +335,18 @@ export async function getMessageReadReceipts(roomId: string, messageId: string) 
   return await chat.get().matrix.getMessageReadReceipts(roomId, messageId);
 }
 
-export async function getRoomTags(conversations: Partial<Channel>[]) {
-  return await chat.get().matrix.getRoomTags(conversations);
-}
-
 export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = '', optimisticId = '') {
   return chat.get().matrix.uploadFileMessage(channelId, media, rootMessageId, optimisticId);
+}
+
+export async function addRoomToLabel(roomId: string, label: RoomLabels) {
+  return await chat.get().matrix.addRoomToLabel(roomId, label);
+}
+
+export async function removeRoomFromLabel(roomId: string, label: RoomLabels) {
+  return await chat.get().matrix.removeRoomFromLabel(roomId, label);
+}
+
+export async function getRoomTags(conversations: Partial<Channel>[]) {
+  return await chat.get().matrix.getRoomTags(conversations);
 }

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -35,6 +35,13 @@ export enum ConversationStatus {
   ERROR,
 }
 
+export enum RoomLabels {
+  WORK = 'm.work',
+  FAMILY = 'm.family',
+  SOCIAL = 'm.social',
+  ARCHIVED = 'm.archived',
+}
+
 export interface Channel {
   id: string;
   optimisticId?: string;
@@ -57,6 +64,7 @@ export interface Channel {
   isFavorite: boolean;
   otherMembersTyping: string[];
   isMuted?: boolean;
+  labels?: RoomLabels[];
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -79,6 +87,7 @@ export const CHANNEL_DEFAULTS = {
   isFavorite: false,
   otherMembersTyping: [],
   isMuted: false,
+  labels: [],
 };
 
 export enum SagaActionTypes {
@@ -91,6 +100,8 @@ export enum SagaActionTypes {
   UserTypingInRoom = 'channels/saga/userTypingInRoom',
   OnMuteRoom = 'channels/saga/onMuteRoom',
   OnUnmuteRoom = 'channels/saga/onUnmuteRoom',
+  OnAddLabel = 'channels/saga/onAddLabel',
+  OnRemoveLabel = 'channels/saga/onRemoveLabel',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
@@ -102,6 +113,8 @@ const onUnfavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnfa
 const userTypingInRoom = createAction<{ roomId: string }>(SagaActionTypes.UserTypingInRoom);
 const onMuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnMuteRoom);
 const onUnmuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnmuteRoom);
+const onAddLabel = createAction<{ roomId: string; label: string }>(SagaActionTypes.OnAddLabel);
+const onRemoveLabel = createAction<{ roomId: string; label: string }>(SagaActionTypes.OnRemoveLabel);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -125,4 +138,6 @@ export {
   userTypingInRoom,
   onMuteRoom,
   onUnmuteRoom,
+  onAddLabel,
+  onRemoveLabel,
 };

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -24,6 +24,7 @@ export enum Events {
   RoomMemberTyping = 'chat/channel/roomMemberTyping',
   RoomMemberPowerLevelChanged = 'chat/channel/roomMemberPowerLevelChanged',
   ReadReceiptReceived = 'chat/message/readReceiptReceived',
+  RoomLabelChange = 'chat/channel/roomLabelChange',
 }
 
 let theBus;
@@ -96,6 +97,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       emit({ type: Events.RoomMemberPowerLevelChanged, payload: { roomId, matrixId, powerLevel } });
     const readReceiptReceived = (messageId, userId, roomId) =>
       emit({ type: Events.ReadReceiptReceived, payload: { messageId, userId, roomId } });
+    const roomLabelChange = (roomId, labels) => emit({ type: Events.RoomLabelChange, payload: { roomId, labels } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -116,6 +118,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       roomMemberTyping,
       roomMemberPowerLevelChanged,
       readReceiptReceived,
+      roomLabelChange,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);


### PR DESCRIPTION
### What does this do?
- This change adds room label management using the RoomLabels enum and updates the getRoomTags function. 
- For now, we will filter out favorite and muted tags, ensuring the labels property only includes valid labels. I will refactor this in follow up.

### Why are we making this change?
- This change improves the organization and management of room labels by standardizing label handling, enhancing code clarity and maintainability.

### How do I test this?
- run tests as usual.
- no ui to run at this stage.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


Uploading labels.mov…


