### PR TITLE
refactor(favorites): use channel label management to handle favorite room tagging

### DIFF
--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -17,8 +17,8 @@ describe(ConversationItem, () => {
       myUserId: '',
       activeConversationId: '',
       onClick: () => null,
-      onFavoriteRoom: () => null,
-      onUnfavoriteRoom: () => null,
+      onAddLabel: () => null,
+      onRemoveLabel: () => null,
       ...props,
     };
 

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { otherMembersToString } from '../../../../platform-apps/channels/util';
 import { getOtherMembersTypingDisplayText, highlightFilter } from '../../lib/utils';
-import { Channel } from '../../../../store/channels';
+import { Channel, RoomLabels } from '../../../../store/channels';
 
 import { MoreMenu } from './more-menu';
 import { Avatar } from '@zero-tech/zui/components';
@@ -23,8 +23,8 @@ export interface Properties {
   activeConversationId: string;
 
   onClick: (conversationId: string) => void;
-  onFavoriteRoom: (roomId: string) => void;
-  onUnfavoriteRoom: (roomId: string) => void;
+  onAddLabel: (roomId: string, label: RoomLabels) => void;
+  onRemoveLabel: (roomId: string, label: RoomLabels) => void;
 }
 
 export interface State {
@@ -46,12 +46,12 @@ export class ConversationItem extends React.Component<Properties, State> {
     }
   };
 
-  onFavorite = () => {
-    this.props.onFavoriteRoom(this.props.conversation.id);
+  onAddLabel = (label: RoomLabels) => {
+    this.props.onAddLabel(this.props.conversation.id, label);
   };
 
-  onUnfavorite = () => {
-    this.props.onUnfavoriteRoom(this.props.conversation.id);
+  onRemoveLabel = (label: RoomLabels) => {
+    this.props.onRemoveLabel(this.props.conversation.id, label);
   };
 
   openContextMenu = (e) => {
@@ -97,11 +97,11 @@ export class ConversationItem extends React.Component<Properties, State> {
     return (
       <div onClick={stopPropagation}>
         <MoreMenu
-          isFavorite={this.props.conversation.isFavorite}
-          onFavorite={this.onFavorite}
-          onUnfavorite={this.onUnfavorite}
+          labels={this.props.conversation.labels}
           isOpen={this.state.isContextMenuOpen}
           onClose={this.closeContextMenu}
+          onAddLabel={this.onAddLabel}
+          onRemoveLabel={this.onRemoveLabel}
         />
       </div>
     );

--- a/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Properties, MoreMenu } from '.';
 import { DropdownMenu } from '@zero-tech/zui/components';
+import { RoomLabels } from '../../../../../store/channels';
 
 describe(MoreMenu, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
-      isFavorite: false,
+      labels: [],
       isOpen: false,
-      onFavorite: () => {},
-      onUnfavorite: () => {},
+      onAddLabel: () => {},
+      onRemoveLabel: () => {},
       onClose: () => {},
       ...props,
     };
@@ -17,32 +18,32 @@ describe(MoreMenu, () => {
     return shallow(<MoreMenu {...allProps} />);
   };
 
-  it('fires onFavorite event', function () {
-    const onFavorite = jest.fn();
+  it('fires onAddLabel event', function () {
+    const onAddLabel = jest.fn();
 
-    selectItem(subject({ onFavorite, isFavorite: false }), 'favorite');
+    selectItem(subject({ onAddLabel, labels: [] }), 'favorite');
 
-    expect(onFavorite).toHaveBeenCalled();
+    expect(onAddLabel).toHaveBeenCalledWith(RoomLabels.FAVORITE);
   });
 
-  it('fires onUnfavorite event', function () {
-    const onUnfavorite = jest.fn();
+  it('fires onRemoveLabel event', function () {
+    const onRemoveLabel = jest.fn();
 
-    selectItem(subject({ onUnfavorite, isFavorite: true }), 'unfavorite');
+    selectItem(subject({ onRemoveLabel, labels: [RoomLabels.FAVORITE] }), 'unfavorite');
 
-    expect(onUnfavorite).toHaveBeenCalled();
+    expect(onRemoveLabel).toHaveBeenCalledWith(RoomLabels.FAVORITE);
   });
 
-  it('should display "Unfavorite" label when isFavorite is true', () => {
-    const wrapper = subject({ isFavorite: true });
+  it('should display "Unfavorite" label when room has favorite label', () => {
+    const wrapper = subject({ labels: [RoomLabels.FAVORITE] });
 
     const favoriteItem = menuItem(wrapper, 'unfavorite');
 
     expectLabelToContainText(favoriteItem, 'Unfavorite');
   });
 
-  it('should display "Favorite" label when isFavorite is false', () => {
-    const wrapper = subject({ isFavorite: false });
+  it('should display "Favorite" label when room does NOT have favorite label', () => {
+    const wrapper = subject({ labels: [] });
 
     const favoriteItem = menuItem(wrapper, 'favorite');
 

--- a/src/components/messenger/list/conversation-item/more-menu/index.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.tsx
@@ -2,25 +2,26 @@ import React from 'react';
 
 import { DropdownMenu } from '@zero-tech/zui/components';
 import { IconBookmark, IconBookmarkX } from '@zero-tech/zui/icons';
+import { RoomLabels } from '../../../../../store/channels';
 
 import './styles.scss';
 
 export interface Properties {
-  isFavorite: boolean;
+  labels: RoomLabels[];
   isOpen: boolean;
 
-  onFavorite: () => void;
-  onUnfavorite: () => void;
   onClose: (isOpen: boolean) => void;
+  onAddLabel: (label: RoomLabels) => void;
+  onRemoveLabel: (label: RoomLabels) => void;
 }
 
 export class MoreMenu extends React.Component<Properties> {
-  favorite = () => {
-    this.props.onFavorite();
+  addLabel = (label: RoomLabels) => () => {
+    this.props.onAddLabel(label);
   };
 
-  unfavorite = () => {
-    this.props.onUnfavorite();
+  removeLabel = (label: RoomLabels) => () => {
+    this.props.onRemoveLabel(label);
   };
 
   renderMenuOption(icon, label) {
@@ -40,18 +41,17 @@ export class MoreMenu extends React.Component<Properties> {
   get menuItems() {
     const menuItems = [];
 
-    if (!this.props.isFavorite) {
+    if (!this.props.labels?.includes(RoomLabels.FAVORITE)) {
       menuItems.push({
         id: 'favorite',
         label: this.renderMenuOption(<IconBookmark size={20} />, 'Favorite'),
-
-        onSelect: this.favorite,
+        onSelect: this.addLabel(RoomLabels.FAVORITE),
       });
     } else {
       menuItems.push({
         id: 'unfavorite',
         label: this.renderMenuOption(<IconBookmarkX size={20} />, 'Unfavorite'),
-        onSelect: this.unfavorite,
+        onSelect: this.removeLabel(RoomLabels.FAVORITE),
       });
     }
 

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { ConversationListPanel, Properties } from '.';
-import { Channel } from '../../../../store/channels';
+import { Channel, RoomLabels } from '../../../../store/channels';
 import { stubConversation } from '../../../../store/test/store';
 
 describe('ConversationListPanel', () => {
@@ -14,8 +14,8 @@ describe('ConversationListPanel', () => {
       search: () => undefined,
       onConversationClick: () => null,
       onCreateConversation: () => null,
-      onFavoriteRoom: () => null,
-      onUnfavoriteRoom: () => null,
+      onAddLabel: () => null,
+      onRemoveLabel: () => null,
       ...props,
     };
 
@@ -67,8 +67,8 @@ describe('ConversationListPanel', () => {
   it('renders conversations based on selected tab', function () {
     const conversations = [
       stubConversation({ name: 'convo-1' }),
-      stubConversation({ name: 'convo-2', isFavorite: true }),
-      stubConversation({ name: 'convo-3', isFavorite: true }),
+      stubConversation({ name: 'convo-2', labels: [RoomLabels.FAVORITE] }),
+      stubConversation({ name: 'convo-3', labels: [RoomLabels.FAVORITE] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -91,8 +91,8 @@ describe('ConversationListPanel', () => {
   it('renders tab unread counts', function () {
     const conversations = [
       stubConversation({ name: 'convo-1', unreadCount: 3 }),
-      stubConversation({ name: 'convo-2', unreadCount: 11, isFavorite: true }),
-      stubConversation({ name: 'convo-3', unreadCount: 17, isFavorite: true }),
+      stubConversation({ name: 'convo-2', unreadCount: 11, labels: [RoomLabels.FAVORITE] }),
+      stubConversation({ name: 'convo-3', unreadCount: 17, labels: [RoomLabels.FAVORITE] }),
       stubConversation({ name: 'convo-4', unreadCount: 7 }),
     ];
     const wrapper = subject({ conversations: conversations as any });
@@ -107,7 +107,7 @@ describe('ConversationListPanel', () => {
   it('does not render unread count if count is zero', function () {
     const conversations = [
       stubConversation({ name: 'convo-1', unreadCount: 0 }),
-      stubConversation({ name: 'convo-2', unreadCount: 0, isFavorite: true }),
+      stubConversation({ name: 'convo-2', unreadCount: 0, labels: [RoomLabels.FAVORITE] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Channel } from '../../../../store/channels';
+import { Channel, RoomLabels } from '../../../../store/channels';
 import { ConversationItem } from '../conversation-item';
 import { Input } from '@zero-tech/zui/components';
 import { Item, Option } from '../../lib/types';
@@ -23,8 +23,8 @@ export interface Properties {
   search: (input: string) => any;
   onCreateConversation: (userId: string) => void;
   onConversationClick: (payload: { conversationId: string }) => void;
-  onFavoriteRoom: (payload: { roomId: string }) => void;
-  onUnfavoriteRoom: (payload: { roomId: string }) => void;
+  onAddLabel: (payload: { roomId: string; label: RoomLabels }) => void;
+  onRemoveLabel: (payload: { roomId: string; label: RoomLabels }) => void;
 }
 
 enum Tab {
@@ -107,16 +107,16 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     this.setState({ selectedTab: Tab.Favorites });
   };
 
-  onFavoriteRoom = (roomId: string) => {
-    this.props.onFavoriteRoom({ roomId });
+  onAddLabel = (roomId: string, label: RoomLabels) => {
+    this.props.onAddLabel({ roomId, label });
   };
 
-  onUnfavoriteRoom = (roomId: string) => {
-    this.props.onUnfavoriteRoom({ roomId });
+  onRemoveLabel = (roomId: string, label: RoomLabels) => {
+    this.props.onRemoveLabel({ roomId, label });
   };
 
   get favoriteConversations() {
-    return this.props.conversations.filter((c) => c.isFavorite);
+    return this.props.conversations.filter((c) => c.labels?.includes(RoomLabels.FAVORITE));
   }
 
   get allUnreadCount() {
@@ -185,8 +185,8 @@ export class ConversationListPanel extends React.Component<Properties, State> {
                     onClick={this.openExistingConversation}
                     myUserId={this.props.myUserId}
                     activeConversationId={this.props.activeConversationId}
-                    onFavoriteRoom={this.onFavoriteRoom}
-                    onUnfavoriteRoom={this.onUnfavoriteRoom}
+                    onAddLabel={this.onAddLabel}
+                    onRemoveLabel={this.onRemoveLabel}
                   />
                 ))}
               {this.filteredConversations.length === 0 && !this.state.filter && this.renderEmptyConversationList()}

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -48,10 +48,10 @@ describe('messenger-list', () => {
       receiveSearchResults: () => null,
       logout: () => null,
       closeRewardsDialog: () => null,
-      onFavoriteRoom: () => null,
-      onUnfavoriteRoom: () => null,
       openUserProfile: () => null,
       totalRewardsViewed: () => null,
+      onAddLabel: () => null,
+      onRemoveLabel: () => null,
 
       ...props,
     };

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store/reducer';
-import { Channel } from '../../../store/channels';
-import { openConversation, onFavoriteRoom, onUnfavoriteRoom } from '../../../store/channels';
+import { Channel, onAddLabel, onRemoveLabel, openConversation } from '../../../store/channels';
 import { denormalizeConversations } from '../../../store/channels-list';
 import { compareDatesDesc } from '../../../lib/date';
 import { MemberNetworks } from '../../../store/users/types';
@@ -71,10 +70,10 @@ export interface Properties extends PublicProperties {
   receiveSearchResults: (data) => void;
   closeConversationErrorDialog: () => void;
   closeRewardsDialog: () => void;
-  onFavoriteRoom: (payload: { roomId: string }) => void;
-  onUnfavoriteRoom: (payload: { roomId: string }) => void;
   openUserProfile: () => void;
   totalRewardsViewed: () => void;
+  onAddLabel: () => void;
+  onRemoveLabel: () => void;
 }
 
 interface State {
@@ -124,10 +123,10 @@ export class Container extends React.Component<Properties, State> {
       receiveSearchResults,
       closeConversationErrorDialog,
       closeRewardsDialog,
-      onFavoriteRoom,
-      onUnfavoriteRoom,
       openUserProfile,
       totalRewardsViewed,
+      onAddLabel,
+      onRemoveLabel,
     };
   }
 
@@ -258,8 +257,8 @@ export class Container extends React.Component<Properties, State> {
             onConversationClick={this.props.onConversationClick}
             myUserId={this.props.myUserId}
             activeConversationId={this.props.activeConversationId}
-            onFavoriteRoom={this.props.onFavoriteRoom}
-            onUnfavoriteRoom={this.props.onUnfavoriteRoom}
+            onAddLabel={this.props.onAddLabel}
+            onRemoveLabel={this.props.onRemoveLabel}
           />
         )}
         {this.props.stage === SagaStage.InitiateConversation && (

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -17,8 +17,6 @@ export interface RealtimeChatEvents {
   onOtherUserJoinedChannel: (channelId: string, user: UserModel) => void;
   onOtherUserLeftChannel: (channelId: string, user: UserModel) => void;
   receiveLiveRoomEvent: (eventData) => void;
-  roomFavorited: (roomId: string) => void;
-  roomUnfavorited: (roomId: string) => void;
   roomMuted: (roomId: string) => void;
   roomUnmuted: (roomId: string) => void;
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
@@ -281,14 +279,6 @@ export async function isRoomMember(userId: string, roomId: string) {
 
 export async function getSecureBackup() {
   return await chat.get().matrix.getSecureBackup();
-}
-
-export async function addRoomToFavorites(roomId: string) {
-  return await chat.get().matrix.addRoomToFavorites(roomId);
-}
-
-export async function removeRoomFromFavorites(roomId: string) {
-  return await chat.get().matrix.removeRoomFromFavorites(roomId);
 }
 
 export async function addRoomToMuted(roomId: string) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -1,5 +1,5 @@
 import { EditMessageOptions, Message, MessagesResponse } from '../../store/messages';
-import { Channel, User as UserModel } from '../../store/channels/index';
+import { Channel, RoomLabels, User as UserModel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
 import { ParentMessage, User } from './types';
@@ -24,6 +24,7 @@ export interface RealtimeChatEvents {
   roomMemberTyping: (roomId: string, userIds: string[]) => void;
   roomMemberPowerLevelChanged: (roomId: string, matrixId: string, powerLevel: number) => void;
   readReceiptReceived: (messageId: string, userId: string, roomId: string) => void;
+  roomLabelChange: (roomId: string, labels: string) => void;
 }
 
 export interface MatrixKeyBackupInfo {
@@ -334,10 +335,18 @@ export async function getMessageReadReceipts(roomId: string, messageId: string) 
   return await chat.get().matrix.getMessageReadReceipts(roomId, messageId);
 }
 
-export async function getRoomTags(conversations: Partial<Channel>[]) {
-  return await chat.get().matrix.getRoomTags(conversations);
-}
-
 export async function uploadFileMessage(channelId: string, media: File, rootMessageId: string = '', optimisticId = '') {
   return chat.get().matrix.uploadFileMessage(channelId, media, rootMessageId, optimisticId);
+}
+
+export async function addRoomToLabel(roomId: string, label: RoomLabels) {
+  return await chat.get().matrix.addRoomToLabel(roomId, label);
+}
+
+export async function removeRoomFromLabel(roomId: string, label: RoomLabels) {
+  return await chat.get().matrix.removeRoomFromLabel(roomId, label);
+}
+
+export async function getRoomTags(conversations: Partial<Channel>[]) {
+  return await chat.get().matrix.getRoomTags(conversations);
 }

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1084,38 +1084,6 @@ describe('matrix client', () => {
     });
   });
 
-  describe('addRoomToFavorites', () => {
-    it('sets room tag with "m.favorite"', async () => {
-      const roomId = '!testRoomId';
-      const setRoomTag = jest.fn().mockResolvedValue({});
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ setRoomTag })),
-      });
-
-      await client.connect(null, 'token');
-      await client.addRoomToFavorites(roomId);
-
-      expect(setRoomTag).toHaveBeenCalledWith(roomId, 'm.favorite');
-    });
-  });
-
-  describe('removeRoomFromFavorites', () => {
-    it('deletes "m.favorite" tag from room', async () => {
-      const roomId = '!testRoomId';
-      const deleteRoomTag = jest.fn().mockResolvedValue({});
-
-      const client = subject({
-        createClient: jest.fn(() => getSdkClient({ deleteRoomTag })),
-      });
-
-      await client.connect(null, 'token');
-      await client.removeRoomFromFavorites(roomId);
-
-      expect(deleteRoomTag).toHaveBeenCalledWith(roomId, 'm.favorite');
-    });
-  });
-
   describe('addRoomToMuted', () => {
     it('sets room tag with "m.mute"', async () => {
       const roomId = '!testRoomId';
@@ -1181,13 +1149,13 @@ describe('matrix client', () => {
   describe('getRoomTags', () => {
     it('returns correct tags for all rooms', async () => {
       const conversations = [
-        { id: 'room1', isFavorite: false, isMuted: false, labels: [] },
-        { id: 'room2', isFavorite: false, isMuted: false, labels: [] },
+        { id: 'room1', isMuted: false, labels: [] },
+        { id: 'room2', isMuted: false, labels: [] },
       ];
 
       const getRoomTags = jest
         .fn()
-        .mockResolvedValueOnce({ tags: { 'm.favorite': {}, 'm.mute': {}, 'm.label1': {}, 'm.label2': {} } })
+        .mockResolvedValueOnce({ tags: { 'm.favorite': {}, 'm.mute': {}, 'm.work': {}, 'm.family': {} } })
         .mockResolvedValueOnce({ tags: {} });
 
       const client = subject({ createClient: jest.fn(() => getSdkClient({ getRoomTags })) });
@@ -1200,20 +1168,20 @@ describe('matrix client', () => {
       expect(conversations).toEqual([
         {
           id: 'room1',
-          isFavorite: true,
           isMuted: true,
           labels: [
-            'm.label1',
-            'm.label2',
+            'm.favorite',
+            'm.work',
+            'm.family',
           ],
         },
-        { id: 'room2', isFavorite: false, isMuted: false, labels: [] },
+        { id: 'room2', isMuted: false, labels: [] },
       ]);
     });
 
     it('returns false for tags that are not present', async () => {
       const conversations = [
-        { id: 'room1', isFavorite: false, isMuted: false, labels: [] },
+        { id: 'room1', isMuted: false, labels: [] },
       ];
 
       const getRoomTags = jest.fn().mockResolvedValue({ tags: {} });
@@ -1224,7 +1192,7 @@ describe('matrix client', () => {
 
       expect(getRoomTags).toHaveBeenCalledWith('room1');
       expect(conversations).toEqual([
-        { id: 'room1', isFavorite: false, isMuted: false, labels: [] },
+        { id: 'room1', isMuted: false, labels: [] },
       ]);
     });
   });

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -20,7 +20,6 @@ export enum MatrixConstants {
   NEW_CONTENT = 'm.new_content',
   REPLACE = 'm.replace',
   BAD_ENCRYPTED_MSGTYPE = 'm.bad.encrypted',
-  FAVORITE = 'm.favorite',
   MUTE = 'm.mute',
   READ_RECEIPT_PREFERENCE = 'm.read_receipt_preference',
 }

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -35,6 +35,13 @@ export enum ConversationStatus {
   ERROR,
 }
 
+export enum RoomLabels {
+  WORK = 'm.work',
+  FAMILY = 'm.family',
+  SOCIAL = 'm.social',
+  ARCHIVED = 'm.archived',
+}
+
 export interface Channel {
   id: string;
   optimisticId?: string;
@@ -57,6 +64,7 @@ export interface Channel {
   isFavorite: boolean;
   otherMembersTyping: string[];
   isMuted?: boolean;
+  labels?: RoomLabels[];
 }
 
 export const CHANNEL_DEFAULTS = {
@@ -79,6 +87,7 @@ export const CHANNEL_DEFAULTS = {
   isFavorite: false,
   otherMembersTyping: [],
   isMuted: false,
+  labels: [],
 };
 
 export enum SagaActionTypes {
@@ -91,6 +100,8 @@ export enum SagaActionTypes {
   UserTypingInRoom = 'channels/saga/userTypingInRoom',
   OnMuteRoom = 'channels/saga/onMuteRoom',
   OnUnmuteRoom = 'channels/saga/onUnmuteRoom',
+  OnAddLabel = 'channels/saga/onAddLabel',
+  OnRemoveLabel = 'channels/saga/onRemoveLabel',
 }
 
 const openConversation = createAction<{ conversationId: string }>(SagaActionTypes.OpenConversation);
@@ -102,6 +113,8 @@ const onUnfavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnfa
 const userTypingInRoom = createAction<{ roomId: string }>(SagaActionTypes.UserTypingInRoom);
 const onMuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnMuteRoom);
 const onUnmuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnmuteRoom);
+const onAddLabel = createAction<{ roomId: string; label: string }>(SagaActionTypes.OnAddLabel);
+const onRemoveLabel = createAction<{ roomId: string; label: string }>(SagaActionTypes.OnRemoveLabel);
 
 const slice = createNormalizedSlice({
   name: 'channels',
@@ -125,4 +138,6 @@ export {
   userTypingInRoom,
   onMuteRoom,
   onUnmuteRoom,
+  onAddLabel,
+  onRemoveLabel,
 };

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -40,6 +40,7 @@ export enum RoomLabels {
   FAMILY = 'm.family',
   SOCIAL = 'm.social',
   ARCHIVED = 'm.archived',
+  FAVORITE = 'm.favorite',
 }
 
 export interface Channel {
@@ -61,7 +62,6 @@ export interface Channel {
   adminMatrixIds: string[];
   moderatorIds?: string[];
   reply?: ParentMessage;
-  isFavorite: boolean;
   otherMembersTyping: string[];
   isMuted?: boolean;
   labels?: RoomLabels[];
@@ -84,7 +84,6 @@ export const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   moderatorIds: [],
-  isFavorite: false,
   otherMembersTyping: [],
   isMuted: false,
   labels: [],

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -94,8 +94,6 @@ export enum SagaActionTypes {
   OpenConversation = 'channels/saga/openConversation',
   OnReply = 'channels/saga/onReply',
   OnRemoveReply = 'channels/saga/onRemoveReply',
-  OnFavoriteRoom = 'channels/saga/onFavoriteRoom',
-  OnUnfavoriteRoom = 'channels/saga/onUnfavoriteRoom',
   UserTypingInRoom = 'channels/saga/userTypingInRoom',
   OnMuteRoom = 'channels/saga/onMuteRoom',
   OnUnmuteRoom = 'channels/saga/onUnmuteRoom',
@@ -107,8 +105,6 @@ const openConversation = createAction<{ conversationId: string }>(SagaActionType
 const unreadCountUpdated = createAction<UnreadCountUpdatedPayload>(SagaActionTypes.UnreadCountUpdated);
 const onReply = createAction<{ reply: ParentMessage }>(SagaActionTypes.OnReply);
 const onRemoveReply = createAction(SagaActionTypes.OnRemoveReply);
-const onFavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnFavoriteRoom);
-const onUnfavoriteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnfavoriteRoom);
 const userTypingInRoom = createAction<{ roomId: string }>(SagaActionTypes.UserTypingInRoom);
 const onMuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnMuteRoom);
 const onUnmuteRoom = createAction<{ roomId: string }>(SagaActionTypes.OnUnmuteRoom);
@@ -132,8 +128,6 @@ export {
   openConversation,
   onReply,
   onRemoveReply,
-  onFavoriteRoom,
-  onUnfavoriteRoom,
   userTypingInRoom,
   onMuteRoom,
   onUnmuteRoom,

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -2,14 +2,10 @@ import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import {
-  roomFavorited,
   markAllMessagesAsRead,
   markConversationAsRead,
   receiveChannel,
-  onFavoriteRoom,
   unreadCountUpdated,
-  onUnfavoriteRoom,
-  roomUnfavorited,
   publishUserTypingEvent,
   receivedRoomMembersTyping,
   receivedRoomMemberPowerLevelChanged,
@@ -26,11 +22,9 @@ import { rootReducer } from '../reducer';
 import { ConversationStatus, RoomLabels, denormalize as denormalizeChannel } from '../channels';
 import { StoreBuilder } from '../test/store';
 import {
-  addRoomToFavorites,
   addRoomToLabel,
   addRoomToMuted,
   chat,
-  removeRoomFromFavorites,
   removeRoomFromLabel,
   removeRoomFromMuted,
   sendTypingEvent,
@@ -134,62 +128,6 @@ describe(receiveChannel, () => {
     // Clean up because full comparison is important here
     delete channel.__denormalized;
     expect(channel).toEqual({ ...CHANNEL_DEFAULTS, id: 'channel-id', unreadCount: 3 });
-  });
-});
-
-describe(roomFavorited, () => {
-  it('updates favorites for room', async () => {
-    const initialState = new StoreBuilder().withConversationList({ id: 'room-id', isFavorite: false }).build();
-    const { storeState } = await expectSaga(roomFavorited, {
-      payload: { roomId: 'room-id' },
-    })
-      .withReducer(rootReducer, initialState)
-      .run();
-
-    const channel = denormalizeChannel('room-id', storeState);
-    expect(channel.isFavorite).toEqual(true);
-  });
-});
-
-describe(onFavoriteRoom, () => {
-  it('calls addRoomToFavorites when channel is not already favorite', async () => {
-    const initialState = new StoreBuilder().withConversationList({ id: 'channel-id', isFavorite: false }).build();
-
-    await expectSaga(onFavoriteRoom, { payload: { roomId: 'channel-id' } })
-      .withReducer(rootReducer, initialState)
-      .provide([
-        [matchers.call.fn(addRoomToFavorites), undefined],
-      ])
-      .call(addRoomToFavorites, 'channel-id')
-      .run();
-  });
-});
-
-describe(roomUnfavorited, () => {
-  it('updates unfavorite for room', async () => {
-    const initialState = new StoreBuilder().withConversationList({ id: 'room-id', isFavorite: true }).build();
-    const { storeState } = await expectSaga(roomUnfavorited, {
-      payload: { roomId: 'room-id' },
-    })
-      .withReducer(rootReducer, initialState)
-      .run();
-
-    const channel = denormalizeChannel('room-id', storeState);
-    expect(channel.isFavorite).toEqual(false);
-  });
-});
-
-describe(onUnfavoriteRoom, () => {
-  it('calls removeRoomFromFavorites when channel is already favorite', async () => {
-    const initialState = new StoreBuilder().withConversationList({ id: 'channel-id', isFavorite: true }).build();
-
-    await expectSaga(onUnfavoriteRoom, { payload: { roomId: 'channel-id' } })
-      .withReducer(rootReducer, initialState)
-      .provide([
-        [matchers.call.fn(removeRoomFromFavorites), undefined],
-      ])
-      .call(removeRoomFromFavorites, 'channel-id')
-      .run();
   });
 });
 
@@ -446,7 +384,6 @@ const CHANNEL_DEFAULTS = {
   messagesFetchStatus: null,
   adminMatrixIds: [],
   moderatorIds: [],
-  isFavorite: false,
   otherMembersTyping: [],
   isMuted: false,
   labels: [],

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -5,8 +5,6 @@ import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
 import {
-  addRoomToFavorites,
-  removeRoomFromFavorites,
   chat,
   sendTypingEvent as matrixSendUserTypingEvent,
   addRoomToMuted,
@@ -113,42 +111,6 @@ export function* receiveChannel(channel: Partial<Channel>) {
   }
 
   yield put(rawReceive(data));
-}
-
-export function* onFavoriteRoom(action) {
-  const { roomId } = action.payload;
-  try {
-    yield call(addRoomToFavorites, roomId);
-  } catch (error) {
-    console.error(`Failed to add room ${roomId} to favorites:`, error);
-  }
-}
-
-export function* onUnfavoriteRoom(action) {
-  const { roomId } = action.payload;
-  try {
-    yield call(removeRoomFromFavorites, roomId);
-  } catch (error) {
-    console.error(`Failed to remove room ${roomId} from favorites:`, error);
-  }
-}
-
-export function* roomFavorited(action) {
-  const { roomId } = action.payload;
-  try {
-    yield call(receiveChannel, { id: roomId, isFavorite: true });
-  } catch (error) {
-    console.error(`Failed to update favorite status for room ${roomId}:`, error);
-  }
-}
-
-export function* roomUnfavorited(action) {
-  const { roomId } = action.payload;
-  try {
-    yield call(receiveChannel, { id: roomId, isFavorite: false });
-  } catch (error) {
-    console.error(`Failed to update unfavorite status for room ${roomId}:`, error);
-  }
 }
 
 export function* onMuteRoom(action) {
@@ -302,16 +264,12 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.OpenConversation, ({ payload }: any) => openConversation(payload.conversationId));
   yield takeLatest(SagaActionTypes.OnReply, ({ payload }: any) => onReply(payload.reply));
   yield takeLatest(SagaActionTypes.OnRemoveReply, onRemoveReply);
-  yield takeLatest(SagaActionTypes.OnFavoriteRoom, onFavoriteRoom);
-  yield takeLatest(SagaActionTypes.OnUnfavoriteRoom, onUnfavoriteRoom);
   yield takeLatest(SagaActionTypes.OnMuteRoom, onMuteRoom);
   yield takeLatest(SagaActionTypes.OnUnmuteRoom, onUnmuteRoom);
   yield takeLatest(SagaActionTypes.OnAddLabel, onAddLabel);
   yield takeLatest(SagaActionTypes.OnRemoveLabel, onRemoveLabel);
 
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.UnreadCountChanged, unreadCountUpdated);
-  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomFavorited, roomFavorited);
-  yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomUnfavorited, roomUnfavorited);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomMuted, roomMuted);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomUnmuted, roomUnmuted);
   yield takeEveryFromBus(yield call(getChatBus), ChatEvents.RoomMemberTyping, receivedRoomMembersTyping);

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -17,8 +17,6 @@ export enum Events {
   OtherUserLeftChannel = 'chat/channel/otherUserLeft',
   LiveRoomEventReceived = 'chat/message/liveRoomEventReceived',
   ChatConnectionComplete = 'chat/connection/complete',
-  RoomFavorited = 'chat/channel/roomFavorited',
-  RoomUnfavorited = 'chat/channel/roomUnfavorited',
   RoomMuted = 'chat/channel/roomMuted',
   RoomUnmuted = 'chat/channel/roomUnmuted',
   RoomMemberTyping = 'chat/channel/roomMemberTyping',
@@ -88,8 +86,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const onOtherUserLeftChannel = (channelId, user) =>
       emit({ type: Events.OtherUserLeftChannel, payload: { channelId, user } });
     const receiveLiveRoomEvent = (eventData) => emit({ type: Events.LiveRoomEventReceived, payload: { eventData } });
-    const roomFavorited = (roomId) => emit({ type: Events.RoomFavorited, payload: { roomId } });
-    const roomUnfavorited = (roomId) => emit({ type: Events.RoomUnfavorited, payload: { roomId } });
     const roomMuted = (roomId) => emit({ type: Events.RoomMuted, payload: { roomId } });
     const roomUnmuted = (roomId) => emit({ type: Events.RoomUnmuted, payload: { roomId } });
     const roomMemberTyping = (roomId, userIds) => emit({ type: Events.RoomMemberTyping, payload: { roomId, userIds } });
@@ -111,8 +107,6 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       onOtherUserJoinedChannel,
       onOtherUserLeftChannel,
       receiveLiveRoomEvent,
-      roomFavorited,
-      roomUnfavorited,
       roomMuted,
       roomUnmuted,
       roomMemberTyping,

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -24,6 +24,7 @@ export enum Events {
   RoomMemberTyping = 'chat/channel/roomMemberTyping',
   RoomMemberPowerLevelChanged = 'chat/channel/roomMemberPowerLevelChanged',
   ReadReceiptReceived = 'chat/message/readReceiptReceived',
+  RoomLabelChange = 'chat/channel/roomLabelChange',
 }
 
 let theBus;
@@ -96,6 +97,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       emit({ type: Events.RoomMemberPowerLevelChanged, payload: { roomId, matrixId, powerLevel } });
     const readReceiptReceived = (messageId, userId, roomId) =>
       emit({ type: Events.ReadReceiptReceived, payload: { messageId, userId, roomId } });
+    const roomLabelChange = (roomId, labels) => emit({ type: Events.RoomLabelChange, payload: { roomId, labels } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -116,6 +118,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       roomMemberTyping,
       roomMemberPowerLevelChanged,
       readReceiptReceived,
+      roomLabelChange,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);


### PR DESCRIPTION
### What does this do?
- replaces specific favorites functions/calls with label management functions/calls to handle favorite room tagging

### Why are we making this change?
- now that we have label management in place we can consolidate the handling of room tagging.

### How do I test this?
- run tests as usual.
- run the ui and test favorite room tagging is working as expected.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

https://github.com/user-attachments/assets/5f3321b0-fbc4-40c6-9508-0488d49415b9

