### PR TITLE
feat: app switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,17 +33,14 @@ export const App = () => {
 };
 
 const useAppMain = () => {
-  const { isAuthenticated, background } = useSelector((state: RootState) => ({
-    isAuthenticated: !!state.authentication.user?.data,
-    background: state.background.selectedMainBackground,
-  }));
+  const isAuthenticated = useSelector((state: RootState) => !!state.authentication.user?.data);
+  const background = useSelector((state: RootState) => state.background.selectedMainBackground);
+  const videoBackgroundSrc = getMainBackgroundVideoSrc(background);
 
   const mainClassName = classNames('main', 'messenger-full-screen', getMainBackgroundClass(background), {
     'sidekick-panel-open': isAuthenticated,
     background: isAuthenticated,
   });
-
-  const videoBackgroundSrc = getMainBackgroundVideoSrc(background);
 
   return {
     isAuthenticated,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { RootState } from './store';
 import classNames from 'classnames';
 import { getMainBackgroundClass } from './utils';
 import { AppBar } from './components/app-bar';
+import { DialogManager } from './components/dialog-manager/container';
 
 export const App = () => {
   const { mainClassName } = useAppMain();
@@ -16,6 +17,7 @@ export const App = () => {
     // @ts-ignore
     <ZUIProvider>
       <div className={mainClassName}>
+        <DialogManager />
         <AppBar />
         <AppRouter />
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
 import { AppRouter } from './apps/app-router';
+import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 
 export const App = () => {
-  return <AppRouter />;
+  return (
+    // See: ZOS-115
+    // @ts-ignore
+    <ZUIProvider>
+      <AppRouter />
+    </ZUIProvider>
+  );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,5 @@
+import { AppRouter } from './apps/app-router';
+
+export const App = () => {
+  return <AppRouter />;
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,38 @@
+import './main.scss';
+
+import { useSelector } from 'react-redux';
 import { AppRouter } from './apps/app-router';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
+import { RootState } from './store';
+import classNames from 'classnames';
+import { getMainBackgroundClass } from './utils';
 
 export const App = () => {
+  const { mainClassName } = useAppMain();
+
   return (
     // See: ZOS-115
     // @ts-ignore
     <ZUIProvider>
-      <AppRouter />
+      <div className={mainClassName}>
+        <AppRouter />
+      </div>
     </ZUIProvider>
   );
+};
+
+const useAppMain = () => {
+  const { isAuthenticated, background } = useSelector((state: RootState) => ({
+    isAuthenticated: !!state.authentication.user?.data,
+    background: state.background.selectedMainBackground,
+  }));
+
+  const mainClassName = classNames('main', 'messenger-full-screen', getMainBackgroundClass(background), {
+    'sidekick-panel-open': isAuthenticated,
+    background: isAuthenticated,
+  });
+
+  return {
+    mainClassName,
+  };
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,16 +10,20 @@ import { AppBar } from './components/app-bar';
 import { DialogManager } from './components/dialog-manager/container';
 
 export const App = () => {
-  const { mainClassName } = useAppMain();
+  const { isAuthenticated, mainClassName } = useAppMain();
 
   return (
     // See: ZOS-115
     // @ts-ignore
     <ZUIProvider>
       <div className={mainClassName}>
-        <DialogManager />
-        <AppBar />
-        <AppRouter />
+        {isAuthenticated && (
+          <>
+            <DialogManager />
+            <AppBar />
+            <AppRouter />
+          </>
+        )}
       </div>
     </ZUIProvider>
   );
@@ -37,6 +41,7 @@ const useAppMain = () => {
   });
 
   return {
+    isAuthenticated,
     mainClassName,
   };
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import { getMainBackgroundClass } from './utils';
 import { AppBar } from './components/app-bar';
 import { DialogManager } from './components/dialog-manager/container';
+import { ThemeEngine } from './components/theme-engine';
 
 export const App = () => {
   const { isAuthenticated, mainClassName } = useAppMain();
@@ -24,6 +25,7 @@ export const App = () => {
             <AppRouter />
           </>
         )}
+        <ThemeEngine />
       </div>
     </ZUIProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { RootState } from './store';
 import classNames from 'classnames';
 import { getMainBackgroundClass } from './utils';
+import { AppBar } from './components/app-bar';
 
 export const App = () => {
   const { mainClassName } = useAppMain();
@@ -15,6 +16,7 @@ export const App = () => {
     // @ts-ignore
     <ZUIProvider>
       <div className={mainClassName}>
+        <AppBar />
         <AppRouter />
       </div>
     </ZUIProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,13 @@ import { AppRouter } from './apps/app-router';
 import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { RootState } from './store';
 import classNames from 'classnames';
-import { getMainBackgroundClass } from './utils';
+import { getMainBackgroundClass, getMainBackgroundVideoSrc } from './utils';
 import { AppBar } from './components/app-bar';
 import { DialogManager } from './components/dialog-manager/container';
 import { ThemeEngine } from './components/theme-engine';
 
 export const App = () => {
-  const { isAuthenticated, mainClassName } = useAppMain();
+  const { isAuthenticated, mainClassName, videoBackgroundSrc } = useAppMain();
 
   return (
     // See: ZOS-115
@@ -20,6 +20,7 @@ export const App = () => {
       <div className={mainClassName}>
         {isAuthenticated && (
           <>
+            {videoBackgroundSrc && <VideoBackground src={videoBackgroundSrc} />}
             <DialogManager />
             <AppBar />
             <AppRouter />
@@ -42,8 +43,20 @@ const useAppMain = () => {
     background: isAuthenticated,
   });
 
+  const videoBackgroundSrc = getMainBackgroundVideoSrc(background);
+
   return {
     isAuthenticated,
     mainClassName,
+    videoBackgroundSrc,
   };
+};
+
+const VideoBackground = ({ src }: { src: string }) => {
+  return (
+    <video data-testid='app-video-background' key={src} className='main-background-video' autoPlay loop muted>
+      <source src={src} type='video/mp4' />
+      Your browser does not support the video tag.
+    </video>
+  );
 };

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -7,7 +7,7 @@ import { getMainBackgroundClass, getMainBackgroundVideoSrc } from './utils';
 
 vi.mock('./utils', () => {
   return {
-    getMainBackgroundVideoSrc: vi.fn().mockReturnValue('mock-background-video-src'),
+    getMainBackgroundVideoSrc: vi.fn().mockReturnValue('https://foo.bar/src'),
     getMainBackgroundClass: vi.fn().mockReturnValue('mock-main-background-class'),
   };
 });
@@ -160,7 +160,9 @@ describe(App, () => {
 
     it('should render correct background video', () => {
       expect(getMainBackgroundVideoSrc).toHaveBeenCalledWith('foo');
-      expect(screen.getByTestId('app-video-background')).toBeTruthy();
+
+      const video = screen.getByTestId('app-video-background');
+      expect(video.querySelector('source').src).toBe('https://foo.bar/src');
     });
   });
 });

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -16,6 +16,12 @@ vi.mock('@zero-tech/zui/ZUIProvider', () => ({
   },
 }));
 
+vi.mock('./components/app-bar', () => ({
+  AppBar: () => {
+    return <div data-testid='app-bar' />;
+  },
+}));
+
 describe(App, () => {
   it('should wrap app with ZUIProvider', () => {
     const { container } = renderWithProviders(<App />);
@@ -40,6 +46,13 @@ describe(App, () => {
 
     expect(main).toBeTruthy();
     expect(main.classList).toContain('messenger-full-screen');
+  });
+
+  it('should render AppBar', () => {
+    renderWithProviders(<App />);
+
+    const appBar = screen.getByTestId('app-bar');
+    expect(appBar).toBeTruthy();
   });
 
   describe('when user is not authenticated', () => {

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { App } from './App';
 import { renderWithProviders } from './test-utils';
 import { screen } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
 
 vi.mock('./apps/app-router', () => ({
   AppRouter: () => {
@@ -9,11 +10,27 @@ vi.mock('./apps/app-router', () => ({
   },
 }));
 
+vi.mock('@zero-tech/zui/ZUIProvider', () => ({
+  ZUIProvider: (props: PropsWithChildren) => {
+    return <div data-testid='zui-provider' {...props} />;
+  },
+}));
+
 const renderComponent = () => {
-  renderWithProviders(<App />);
+  return renderWithProviders(<App />);
 };
 
 describe(App, () => {
+  it('should wrap app with ZUIProvider', () => {
+    const { container } = renderComponent();
+
+    const zuiProvider = screen.getByTestId('zui-provider');
+
+    expect(zuiProvider).toBeTruthy();
+    expect(zuiProvider).toBe(container.firstChild);
+    expect(container.childNodes).toHaveLength(1);
+  });
+
   it('should render AppRouter', () => {
     renderComponent();
 

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -39,12 +39,6 @@ describe(App, () => {
     expect(container.childNodes).toHaveLength(1);
   });
 
-  it('should render AppRouter', () => {
-    renderWithProviders(<App />);
-
-    expect(screen.getByTestId('app-router')).toBeTruthy();
-  });
-
   it('should render main element with default class names', () => {
     const { container } = renderWithProviders(<App />);
 
@@ -52,20 +46,6 @@ describe(App, () => {
 
     expect(main).toBeTruthy();
     expect(main.classList).toContain('messenger-full-screen');
-  });
-
-  it('should render AppBar', () => {
-    renderWithProviders(<App />);
-
-    const appBar = screen.getByTestId('app-bar');
-    expect(appBar).toBeTruthy();
-  });
-
-  it('should render DialogManager', () => {
-    renderWithProviders(<App />);
-
-    const dialogManager = screen.getByTestId('dialog-manager');
-    expect(dialogManager).toBeTruthy();
   });
 
   describe('when user is not authenticated', () => {
@@ -88,6 +68,26 @@ describe(App, () => {
 
     it('should not add background class to main div', () => {
       expect(container.querySelector('div.main')?.classList).not.toContain('background');
+    });
+
+    it('should render AppBar', () => {
+      renderWithProviders(<App />);
+
+      const appBar = screen.queryByTestId('app-bar');
+      expect(appBar).not.toBeTruthy();
+    });
+
+    it('should not render DialogManager', () => {
+      renderWithProviders(<App />);
+
+      const dialogManager = screen.queryByTestId('dialog-manager');
+      expect(dialogManager).not.toBeTruthy();
+    });
+
+    it('should not render AppRouter', () => {
+      renderWithProviders(<App />);
+
+      expect(screen.queryByTestId('app-router')).not.toBeTruthy();
     });
   });
 
@@ -114,6 +114,26 @@ describe(App, () => {
 
     it('should add background class to main div', () => {
       expect(container.querySelector('div.main')?.classList).toContain('background');
+    });
+
+    it('should render AppBar', () => {
+      renderWithProviders(<App />);
+
+      const appBar = screen.getByTestId('app-bar');
+      expect(appBar).toBeTruthy();
+    });
+
+    it('should render DialogManager', () => {
+      renderWithProviders(<App />);
+
+      const dialogManager = screen.getByTestId('dialog-manager');
+      expect(dialogManager).toBeTruthy();
+    });
+
+    it('should render AppRouter', () => {
+      renderWithProviders(<App />);
+
+      expect(screen.getByTestId('app-router')).toBeTruthy();
     });
   });
 });

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -29,23 +29,21 @@ vi.mock('./components/dialog-manager/container', () => ({
 }));
 
 describe(App, () => {
-  it('should wrap app with ZUIProvider', () => {
-    const { container } = renderWithProviders(<App />);
+  describe('by default', () => {
+    var container: HTMLElement;
 
-    const zuiProvider = screen.getByTestId('zui-provider');
+    beforeEach(() => {
+      container = renderWithProviders(<App />).container;
+    });
 
-    expect(zuiProvider).toBeTruthy();
-    expect(zuiProvider).toBe(container.firstChild);
-    expect(container.childNodes).toHaveLength(1);
-  });
+    it('should wrap app with ZUIProvider', () => {
+      expect(screen.getByTestId('zui-provider')).toBe(container.firstChild);
+      expect(container.childNodes).toHaveLength(1);
+    });
 
-  it('should render main element with default class names', () => {
-    const { container } = renderWithProviders(<App />);
-
-    const main = container.querySelector('div.main');
-
-    expect(main).toBeTruthy();
-    expect(main.classList).toContain('messenger-full-screen');
+    it('should render main element with default class names', () => {
+      expect(container.querySelector('div.main').classList).toContain('messenger-full-screen');
+    });
   });
 
   describe('when user is not authenticated', () => {
@@ -71,22 +69,14 @@ describe(App, () => {
     });
 
     it('should render AppBar', () => {
-      renderWithProviders(<App />);
-
-      const appBar = screen.queryByTestId('app-bar');
-      expect(appBar).not.toBeTruthy();
+      expect(screen.queryByTestId('app-bar')).not.toBeTruthy();
     });
 
     it('should not render DialogManager', () => {
-      renderWithProviders(<App />);
-
-      const dialogManager = screen.queryByTestId('dialog-manager');
-      expect(dialogManager).not.toBeTruthy();
+      expect(screen.queryByTestId('dialog-manager')).not.toBeTruthy();
     });
 
     it('should not render AppRouter', () => {
-      renderWithProviders(<App />);
-
       expect(screen.queryByTestId('app-router')).not.toBeTruthy();
     });
   });
@@ -117,22 +107,14 @@ describe(App, () => {
     });
 
     it('should render AppBar', () => {
-      renderWithProviders(<App />);
-
-      const appBar = screen.getByTestId('app-bar');
-      expect(appBar).toBeTruthy();
+      expect(screen.getByTestId('app-bar')).toBeTruthy();
     });
 
     it('should render DialogManager', () => {
-      renderWithProviders(<App />);
-
-      const dialogManager = screen.getByTestId('dialog-manager');
-      expect(dialogManager).toBeTruthy();
+      expect(screen.getByTestId('dialog-manager')).toBeTruthy();
     });
 
     it('should render AppRouter', () => {
-      renderWithProviders(<App />);
-
       expect(screen.getByTestId('app-router')).toBeTruthy();
     });
   });

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -16,13 +16,9 @@ vi.mock('@zero-tech/zui/ZUIProvider', () => ({
   },
 }));
 
-const renderComponent = () => {
-  return renderWithProviders(<App />);
-};
-
 describe(App, () => {
   it('should wrap app with ZUIProvider', () => {
-    const { container } = renderComponent();
+    const { container } = renderWithProviders(<App />);
 
     const zuiProvider = screen.getByTestId('zui-provider');
 
@@ -32,8 +28,66 @@ describe(App, () => {
   });
 
   it('should render AppRouter', () => {
-    renderComponent();
+    renderWithProviders(<App />);
 
     expect(screen.getByTestId('app-router')).toBeTruthy();
+  });
+
+  it('should render main element with default class names', () => {
+    const { container } = renderWithProviders(<App />);
+
+    const main = container.querySelector('div.main');
+
+    expect(main).toBeTruthy();
+    expect(main.classList).toContain('messenger-full-screen');
+  });
+
+  describe('when user is not authenticated', () => {
+    var container: HTMLElement;
+
+    beforeEach(() => {
+      container = renderWithProviders(<App />, {
+        preloadedState: {
+          // @ts-ignore
+          authentication: {
+            user: null,
+          },
+        },
+      }).container;
+    });
+
+    it('should not add sidekick-panel-open class to main div', () => {
+      expect(container.querySelector('div.main')?.classList).not.toContain('sidekick-panel-open');
+    });
+
+    it('should not add background class to main div', () => {
+      expect(container.querySelector('div.main')?.classList).not.toContain('background');
+    });
+  });
+
+  describe('when user is authenticated', () => {
+    var container: HTMLElement;
+
+    beforeEach(() => {
+      container = renderWithProviders(<App />, {
+        preloadedState: {
+          // @ts-ignore
+          authentication: {
+            user: {
+              // @ts-ignore
+              data: {},
+            },
+          },
+        },
+      }).container;
+    });
+
+    it('should add sidekick-panel-open class to main div', () => {
+      expect(container.querySelector('div.main')?.classList).toContain('sidekick-panel-open');
+    });
+
+    it('should add background class to main div', () => {
+      expect(container.querySelector('div.main')?.classList).toContain('background');
+    });
   });
 });

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -28,6 +28,12 @@ vi.mock('./components/dialog-manager/container', () => ({
   },
 }));
 
+vi.mock('./components/theme-engine', () => ({
+  ThemeEngine: () => {
+    return <div data-testid='theme-engine' />;
+  },
+}));
+
 describe(App, () => {
   describe('by default', () => {
     var container: HTMLElement;
@@ -43,6 +49,10 @@ describe(App, () => {
 
     it('should render main element with default class names', () => {
       expect(container.querySelector('div.main').classList).toContain('messenger-full-screen');
+    });
+
+    it('should render ThemeEngine', () => {
+      expect(screen.getByTestId('theme-engine')).toBeTruthy();
     });
   });
 

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -1,0 +1,22 @@
+import { vi } from 'vitest';
+import { App } from './App';
+import { renderWithProviders } from './test-utils';
+import { screen } from '@testing-library/react';
+
+vi.mock('./apps/app-router', () => ({
+  AppRouter: () => {
+    return <div data-testid='app-router' />;
+  },
+}));
+
+const renderComponent = () => {
+  renderWithProviders(<App />);
+};
+
+describe(App, () => {
+  it('should render AppRouter', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('app-router')).toBeTruthy();
+  });
+});

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -22,6 +22,12 @@ vi.mock('./components/app-bar', () => ({
   },
 }));
 
+vi.mock('./components/dialog-manager/container', () => ({
+  DialogManager: () => {
+    return <div data-testid='dialog-manager' />;
+  },
+}));
+
 describe(App, () => {
   it('should wrap app with ZUIProvider', () => {
     const { container } = renderWithProviders(<App />);
@@ -53,6 +59,13 @@ describe(App, () => {
 
     const appBar = screen.getByTestId('app-bar');
     expect(appBar).toBeTruthy();
+  });
+
+  it('should render DialogManager', () => {
+    renderWithProviders(<App />);
+
+    const dialogManager = screen.getByTestId('dialog-manager');
+    expect(dialogManager).toBeTruthy();
   });
 
   describe('when user is not authenticated', () => {

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -3,6 +3,14 @@ import { App } from './App';
 import { renderWithProviders } from './test-utils';
 import { screen } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
+import { getMainBackgroundClass, getMainBackgroundVideoSrc } from './utils';
+
+vi.mock('./utils', () => {
+  return {
+    getMainBackgroundVideoSrc: vi.fn().mockReturnValue('mock-background-video-src'),
+    getMainBackgroundClass: vi.fn().mockReturnValue('mock-main-background-class'),
+  };
+});
 
 vi.mock('./apps/app-router', () => ({
   AppRouter: () => {
@@ -39,7 +47,14 @@ describe(App, () => {
     var container: HTMLElement;
 
     beforeEach(() => {
-      container = renderWithProviders(<App />).container;
+      container = renderWithProviders(<App />, {
+        preloadedState: {
+          background: {
+            // @ts-ignore
+            selectedMainBackground: 'foo',
+          },
+        },
+      }).container;
     });
 
     it('should wrap app with ZUIProvider', () => {
@@ -53,6 +68,17 @@ describe(App, () => {
 
     it('should render ThemeEngine', () => {
       expect(screen.getByTestId('theme-engine')).toBeTruthy();
+    });
+
+    it('should not render with video background', () => {
+      expect(screen.queryByTestId('app-video-background')).not.toBeTruthy();
+    });
+
+    it('should apply correct background class for selected background', () => {
+      const { container } = renderWithProviders(<App />);
+
+      expect(getMainBackgroundClass).toHaveBeenCalledWith('foo');
+      expect(container.querySelector('div.main')?.classList).toContain('mock-main-background-class');
     });
   });
 
@@ -104,6 +130,10 @@ describe(App, () => {
               data: {},
             },
           },
+          background: {
+            // @ts-ignore
+            selectedMainBackground: 'foo',
+          },
         },
       }).container;
     });
@@ -126,6 +156,11 @@ describe(App, () => {
 
     it('should render AppRouter', () => {
       expect(screen.getByTestId('app-router')).toBeTruthy();
+    });
+
+    it('should render correct background video', () => {
+      expect(getMainBackgroundVideoSrc).toHaveBeenCalledWith('foo');
+      expect(screen.getByTestId('app-video-background')).toBeTruthy();
     });
   });
 });

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 
 import { Container as Main, Properties } from './Main';
 import { MessengerChat } from './components/messenger/chat';
-import { MainBackground } from './store/background';
 
 describe(Main, () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -11,7 +10,6 @@ describe(Main, () => {
       context: {
         isAuthenticated: false,
       },
-      selectedMainBackground: MainBackground.StaticGreenParticles,
       ...props,
     };
 
@@ -22,23 +20,5 @@ describe(Main, () => {
     const wrapper = subject({ context: { isAuthenticated: true } });
 
     expect(wrapper).toHaveElement(MessengerChat);
-  });
-
-  it('renders animated background when not static', () => {
-    const wrapper = subject({
-      context: { isAuthenticated: true },
-      selectedMainBackground: MainBackground.AnimatedBlackParticles,
-    });
-
-    expect(wrapper.find('video.main-background-video')).toHaveLength(1);
-  });
-
-  it('does not render animated background when static', () => {
-    const wrapper = subject({
-      context: { isAuthenticated: true },
-      selectedMainBackground: MainBackground.StaticGreenParticles,
-    });
-
-    expect(wrapper.find('video.main-background-video')).toHaveLength(0);
   });
 });

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { Container as Main, Properties } from './Main';
-import { ThemeEngine } from './components/theme-engine';
 import { MessengerChat } from './components/messenger/chat';
 import { MainBackground } from './store/background';
 
@@ -18,12 +17,6 @@ describe(Main, () => {
 
     return shallow(<Main {...allProps} />);
   };
-
-  it('renders theme engine', () => {
-    const wrapper = subject();
-
-    expect(wrapper).toHaveElement(ThemeEngine);
-  });
 
   it('renders direct message chat component', () => {
     const wrapper = subject({ context: { isAuthenticated: true } });

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
-import { ThemeEngine } from './components/theme-engine';
 
 import { Sidekick } from './components/sidekick/index';
 import { withContext as withAuthenticationContext } from './components/authentication/context';
@@ -56,7 +55,6 @@ export class Container extends React.Component<Properties> {
             </FeatureFlag>
           </>
         )}
-        <ThemeEngine />
       </>
     );
   }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -8,7 +8,6 @@ import { withContext as withAuthenticationContext } from './components/authentic
 import { MessengerChat } from './components/messenger/chat';
 import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
-import { AppBar } from './components/app-bar';
 import { DialogManager } from './components/dialog-manager/container';
 import { getMainBackgroundVideoSrc } from './utils';
 
@@ -51,7 +50,6 @@ export class Container extends React.Component<Properties> {
             {videoSrc && this.renderAnimatedBackground(videoSrc)}
 
             <DialogManager />
-            <AppBar />
             <Sidekick />
             <MessengerChat />
             <Sidekick variant='secondary' />

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -3,7 +3,6 @@ import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
 import { ThemeEngine } from './components/theme-engine';
 
-import classNames from 'classnames';
 import { Sidekick } from './components/sidekick/index';
 import { withContext as withAuthenticationContext } from './components/authentication/context';
 import { MessengerChat } from './components/messenger/chat';
@@ -11,7 +10,7 @@ import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
 import { AppBar } from './components/app-bar';
 import { DialogManager } from './components/dialog-manager/container';
-import { getMainBackgroundClass, getMainBackgroundVideoSrc } from './utils';
+import { getMainBackgroundVideoSrc } from './utils';
 
 export interface Properties {
   context: {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -7,46 +7,27 @@ import { withContext as withAuthenticationContext } from './components/authentic
 import { MessengerChat } from './components/messenger/chat';
 import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
-import { getMainBackgroundVideoSrc } from './utils';
 
 export interface Properties {
   context: {
     isAuthenticated: boolean;
   };
-  selectedMainBackground: string;
 }
 
 export class Container extends React.Component<Properties> {
-  static mapState(state: RootState): Partial<Properties> {
-    const {
-      background: { selectedMainBackground },
-    } = state;
-
-    return { selectedMainBackground };
+  static mapState(_state: RootState): Partial<Properties> {
+    return {};
   }
 
   static mapActions(_state: RootState): Partial<Properties> {
     return {};
   }
 
-  renderAnimatedBackground(src) {
-    return (
-      <video key={src} className='main-background-video' autoPlay loop muted>
-        <source src={src} type='video/mp4' />
-        Your browser does not support the video tag.
-      </video>
-    );
-  }
-
   render() {
-    const videoSrc = getMainBackgroundVideoSrc(this.props.selectedMainBackground);
-
     return (
       <>
         {this.props.context.isAuthenticated && (
           <>
-            {videoSrc && this.renderAnimatedBackground(videoSrc)}
-
             <Sidekick />
             <MessengerChat />
             <Sidekick variant='secondary' />

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -3,7 +3,6 @@ import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
 import { ThemeEngine } from './components/theme-engine';
 
-import './main.scss';
 import classNames from 'classnames';
 import { Sidekick } from './components/sidekick/index';
 import { withContext as withAuthenticationContext } from './components/authentication/context';
@@ -45,15 +44,9 @@ export class Container extends React.Component<Properties> {
 
   render() {
     const videoSrc = getMainBackgroundVideoSrc(this.props.selectedMainBackground);
-    const backgroundClass = getMainBackgroundClass(this.props.selectedMainBackground);
-
-    const mainClassName = classNames('main', 'messenger-full-screen', backgroundClass, {
-      'sidekick-panel-open': this.props.context.isAuthenticated,
-      background: this.props.context.isAuthenticated,
-    });
 
     return (
-      <div className={mainClassName}>
+      <>
         {this.props.context.isAuthenticated && (
           <>
             {videoSrc && this.renderAnimatedBackground(videoSrc)}
@@ -69,7 +62,7 @@ export class Container extends React.Component<Properties> {
           </>
         )}
         <ThemeEngine />
-      </div>
+      </>
     );
   }
 }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -8,7 +8,6 @@ import { withContext as withAuthenticationContext } from './components/authentic
 import { MessengerChat } from './components/messenger/chat';
 import { DevPanelContainer } from './components/dev-panel/container';
 import { FeatureFlag } from './components/feature-flag';
-import { DialogManager } from './components/dialog-manager/container';
 import { getMainBackgroundVideoSrc } from './utils';
 
 export interface Properties {
@@ -49,7 +48,6 @@ export class Container extends React.Component<Properties> {
           <>
             {videoSrc && this.renderAnimatedBackground(videoSrc)}
 
-            <DialogManager />
             <Sidekick />
             <MessengerChat />
             <Sidekick variant='secondary' />

--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -6,6 +6,7 @@
 
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { MessengerMain } from '../messenger-main';
+import { FeatureFlag } from '../components/feature-flag';
 
 const redirectToRoot = () => <Redirect to={'/'} />;
 
@@ -14,7 +15,20 @@ export const AppRouter = () => {
     <Switch>
       <Route path='/conversation/:conversationId' exact component={MessengerMain} />
       <Route path='/' exact component={MessengerMain} />
+      <FeatureFlag featureFlag='enableExplorer'>
+        <Route path='/explorer' exact component={MockExplorer} />
+      </FeatureFlag>
       <Route component={redirectToRoot} />
     </Switch>
+  );
+};
+
+const MockExplorer = () => {
+  return (
+    <iframe
+      style={{ width: '100%', height: '100%', border: 'none', pointerEvents: 'auto' }}
+      src={'https://explorer.zero.tech/'}
+      title='Explorer'
+    />
   );
 };

--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -15,9 +15,11 @@ export const AppRouter = () => {
     <Switch>
       <Route path='/conversation/:conversationId' exact component={MessengerMain} />
       <Route path='/' exact component={MessengerMain} />
-      <FeatureFlag featureFlag='enableExplorer'>
-        <Route path='/explorer' exact component={MockExplorer} />
-      </FeatureFlag>
+      {process.env.NODE_ENV !== 'test' && (
+        <FeatureFlag featureFlag='enableExplorer'>
+          <Route path='/explorer' exact component={MockExplorer} />
+        </FeatureFlag>
+      )}
       <Route component={redirectToRoot} />
     </Switch>
   );

--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -1,0 +1,20 @@
+/*
+ * AppRouter controls which app is rendered based on the route.
+ * e.g.
+ * - /conversation/:conversationId renders Messenger
+ */
+
+import { Redirect, Route, Switch } from 'react-router-dom';
+import { MessengerMain } from '../messenger-main';
+
+const redirectToRoot = () => <Redirect to={'/'} />;
+
+export const AppRouter = () => {
+  return (
+    <Switch>
+      <Route path='/conversation/:conversationId' exact component={MessengerMain} />
+      <Route path='/' exact component={MessengerMain} />
+      <Route component={redirectToRoot} />
+    </Switch>
+  );
+};

--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -25,6 +25,10 @@ export const AppRouter = () => {
   );
 };
 
+/**
+ * Just a mock Explorer for now so something renders when
+ * the Explorer feature flag is enabled.
+ */
 const MockExplorer = () => {
   return (
     <iframe

--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -7,6 +7,7 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { MessengerMain } from '../messenger-main';
 import { FeatureFlag } from '../components/feature-flag';
+import { featureFlags } from '../lib/feature-flags';
 
 const redirectToRoot = () => <Redirect to={'/'} />;
 
@@ -15,7 +16,7 @@ export const AppRouter = () => {
     <Switch>
       <Route path='/conversation/:conversationId' exact component={MessengerMain} />
       <Route path='/' exact component={MessengerMain} />
-      {process.env.NODE_ENV !== 'test' && (
+      {featureFlags.enableExplorer && (
         <FeatureFlag featureFlag='enableExplorer'>
           <Route path='/explorer' exact component={MockExplorer} />
         </FeatureFlag>

--- a/src/apps/app-router.vitest.tsx
+++ b/src/apps/app-router.vitest.tsx
@@ -3,10 +3,13 @@ import { MemoryRouter } from 'react-router-dom';
 import { AppRouter } from './app-router';
 import { vi } from 'vitest';
 import { renderWithProviders } from '../test-utils';
+import { featureFlags } from '../lib/feature-flags';
+
+featureFlags.enableExplorer = false;
 
 vi.mock('../messenger-main', () => ({
   MessengerMain: () => {
-    return 'MessengerMain';
+    return <div data-testid='messenger-main' />;
   },
 }));
 
@@ -21,16 +24,16 @@ const renderComponent = (route: string | undefined = '/') => {
 describe(AppRouter, () => {
   it('should render MessengerMain component when route is /', () => {
     renderComponent('/');
-    expect(screen.getByText('MessengerMain')).toBeTruthy();
+    expect(screen.getByTestId('messenger-main')).toBeTruthy();
   });
 
   it('should render MessengerMain component when route is /conversation/:conversationId', () => {
     renderComponent('/conversation/123');
-    expect(screen.getByText('MessengerMain')).toBeTruthy();
+    expect(screen.getByTestId('messenger-main')).toBeTruthy();
   });
 
   it('should redirect to / when route is invalid', () => {
     renderComponent('/foo-bar');
-    expect(screen.getByText('MessengerMain')).toBeTruthy();
+    expect(screen.getByTestId('messenger-main')).toBeTruthy();
   });
 });

--- a/src/apps/app-router.vitest.tsx
+++ b/src/apps/app-router.vitest.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRouter } from './app-router';
+import { vi } from 'vitest';
+import { renderWithProviders } from '../test-utils';
+
+vi.mock('../messenger-main', () => ({
+  MessengerMain: () => {
+    return 'MessengerMain';
+  },
+}));
+
+const renderComponent = (route: string | undefined = '/') => {
+  renderWithProviders(
+    <MemoryRouter initialEntries={[route]}>
+      <AppRouter />
+    </MemoryRouter>
+  );
+};
+
+describe(AppRouter, () => {
+  it('should render MessengerMain component when route is /', () => {
+    renderComponent('/');
+    expect(screen.getByText('MessengerMain')).toBeTruthy();
+  });
+
+  it('should render MessengerMain component when route is /conversation/:conversationId', () => {
+    renderComponent('/conversation/123');
+    expect(screen.getByText('MessengerMain')).toBeTruthy();
+  });
+
+  it('should redirect to / when route is invalid', () => {
+    renderComponent('/foo-bar');
+    expect(screen.getByText('MessengerMain')).toBeTruthy();
+  });
+});

--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
 import { WorldPanelItem } from './world-panel-item';
-import { IconDotsGrid, IconMessageSquare2 } from '@zero-tech/zui/icons';
+import { IconDotsGrid, IconGlobe3, IconMessageSquare2 } from '@zero-tech/zui/icons';
 import { MoreAppsModal } from './more-apps-modal';
+import { Link } from 'react-router-dom';
 
 import { bemClassName } from '../../lib/bem';
 
 import './styles.scss';
+import { FeatureFlag } from '../feature-flag';
 
 const cn = bemClassName('app-bar');
 
@@ -27,6 +29,11 @@ export class AppBar extends React.Component<Properties, State> {
       <>
         <div {...cn('')}>
           <WorldPanelItem Icon={IconMessageSquare2} label='Messenger' isActive />
+          <FeatureFlag featureFlag='enableExplorer'>
+            <Link to='/explorer'>
+              <WorldPanelItem Icon={IconGlobe3} label='Explorer' isActive={false} />
+            </Link>
+          </FeatureFlag>
           <WorldPanelItem Icon={IconDotsGrid} label='More Apps' isActive={false} onClick={this.openModal} />
         </div>
         {this.state.isModalOpen && <MoreAppsModal onClose={this.closeModal} />}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,7 @@ import { desktopInit } from './lib/desktop';
 import { Restricted } from './restricted';
 import { RainbowKitConnect } from './lib/web3/rainbowkit/connect';
 import { RainbowKitProvider } from './lib/web3/rainbowkit/provider';
-import { AppRouter } from './apps/app-router';
+import { App } from './App';
 
 desktopInit();
 runSagas();
@@ -50,7 +50,7 @@ root.render(
                   <Route path='/get-access' exact component={Invite} />
                   <Route path='/login' exact component={LoginPage} />
                   <Route path='/reset-password' exact component={ResetPassword} />
-                  <Route component={AppRouter} />
+                  <Route component={App} />
                 </Switch>
               </RainbowKitConnect>
             </RainbowKitProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,12 +2,11 @@ import './init';
 import React from 'react';
 
 import { createRoot } from 'react-dom/client';
-import { MessengerMain } from './messenger-main';
 import { store, runSagas } from './store';
 import { Provider } from 'react-redux';
 import { EscapeManagerProvider } from '@zer0-os/zos-component-library';
 import * as serviceWorker from './serviceWorker';
-import { Router, Redirect, Route, Switch } from 'react-router-dom';
+import { Router, Route, Switch } from 'react-router-dom';
 import { showReleaseVersionInConsole, initializeErrorBoundary, isElectron } from './utils';
 import { ErrorBoundary } from './components/error-boundary/';
 
@@ -22,6 +21,7 @@ import { desktopInit } from './lib/desktop';
 import { Restricted } from './restricted';
 import { RainbowKitConnect } from './lib/web3/rainbowkit/connect';
 import { RainbowKitProvider } from './lib/web3/rainbowkit/provider';
+import { AppRouter } from './apps/app-router';
 
 desktopInit();
 runSagas();
@@ -31,8 +31,6 @@ initializeErrorBoundary();
 showReleaseVersionInConsole();
 
 export const history = getHistory();
-
-const redirectToRoot = () => <Redirect to={'/'} />;
 
 const container = document.getElementById('platform');
 
@@ -52,9 +50,7 @@ root.render(
                   <Route path='/get-access' exact component={Invite} />
                   <Route path='/login' exact component={LoginPage} />
                   <Route path='/reset-password' exact component={ResetPassword} />
-                  <Route path='/conversation/:conversationId' exact component={MessengerMain} />
-                  <Route path='/' exact component={MessengerMain} />
-                  <Route component={redirectToRoot} />
+                  <Route component={AppRouter} />
                 </Switch>
               </RainbowKitConnect>
             </RainbowKitProvider>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -105,6 +105,14 @@ export class FeatureFlags {
   set enableTimerLogs(value: boolean) {
     this._setBoolean('enableTimerLogs', value);
   }
+
+  get enableExplorer() {
+    return this._getBoolean('enableExplorer', false);
+  }
+
+  set enableExplorer(value: boolean) {
+    this._setBoolean('enableExplorer', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/messenger-main.test.tsx
+++ b/src/messenger-main.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Container, Properties } from './messenger-main';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Main } from './Main';
 
 describe('MessengerMain', () => {
@@ -22,11 +21,6 @@ describe('MessengerMain', () => {
     const provider = wrapper.find(AuthenticationContextProvider);
     expect(provider).toHaveLength(1);
     expect(provider.prop('value')).toEqual({ isAuthenticated: true });
-  });
-
-  it('contains the ZUIProvider', () => {
-    const wrapper = subject();
-    expect(wrapper.find(ZUIProvider)).toHaveLength(1);
   });
 
   it('renders the Main component', () => {

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -3,7 +3,6 @@ import { RootState } from './store/reducer';
 import { connectContainer } from './store/redux-container';
 
 import { Main } from './Main';
-import { ZUIProvider } from '@zero-tech/zui/ZUIProvider';
 import { Provider as AuthenticationContextProvider } from './components/authentication/context';
 import { setActiveConversationId } from './store/chat';
 

--- a/src/messenger-main.tsx
+++ b/src/messenger-main.tsx
@@ -58,15 +58,9 @@ export class Container extends React.Component<Properties> {
 
   render() {
     return (
-      <>
-        <AuthenticationContextProvider value={this.authenticationContext}>
-          {/* See: ZOS-115
-           * @ts-ignore */}
-          <ZUIProvider>
-            <Main />
-          </ZUIProvider>
-        </AuthenticationContextProvider>
-      </>
+      <AuthenticationContextProvider value={this.authenticationContext}>
+        <Main />
+      </AuthenticationContextProvider>
     );
   }
 }


### PR DESCRIPTION
### What does this do?

- Creates a top-level `App` component, which houses all "global UI" (providers, app bar), and renders the `AppSwitcher`.
- Creates an `AppRouter`, which is basically just a `Router` which renders different apps to a container based on `Route`.
- Moves all "global UI" from `Main` to `App`.
- Adds a feature flag (`enableExplorer`) for testing the app switcher.

### Why are we making this change?

So we can add arbitrary "sub apps" to zOS, as per the initial vision of the product.

### How do I test this?

- These changes should deliver 0 perceivable difference to the user. So, all flows should work exactly the same as before.
- Run `FEATURE_FLAGS.enableExplorer = true` in your browser console, and click the `Explorer` option in the app bar. Note: you will have to hit `Back` in your browser to go back to Messenger

---

Please note:
- I used function components because both of these components are very small and don't contain much business logic. I'm happy to rewrite them as class components if need be, 
- I used `@testing-library/react` for unit tests, as we are meant to be moving away from Enzyme.