### PR TITLE
feat(conversation-list/tab-list): apply horizontal scroll to tab list

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -36,7 +36,7 @@ $side-padding: 16px;
     gap: 10px;
     overflow-x: auto;
     white-space: nowrap;
-    padding: 8px 16px;
+    padding: 8px 0;
     margin: 0 16px;
 
     &::-webkit-scrollbar-thumb {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -43,12 +43,33 @@ interface State {
 
 export class ConversationListPanel extends React.Component<Properties, State> {
   scrollContainerRef: React.RefObject<ScrollbarContainer>;
+  tabListRef: React.RefObject<HTMLDivElement>;
   state = { filter: '', userSearchResults: [], selectedTab: Tab.All };
 
   constructor(props) {
     super(props);
     this.scrollContainerRef = React.createRef();
+    this.tabListRef = React.createRef();
   }
+
+  componentDidMount() {
+    if (this.tabListRef.current) {
+      this.tabListRef.current.addEventListener('wheel', this.horizontalScroll, { passive: false });
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.tabListRef.current) {
+      this.tabListRef.current.removeEventListener('wheel', this.horizontalScroll);
+    }
+  }
+
+  horizontalScroll = (event) => {
+    if (event.deltaY !== 0) {
+      event.preventDefault();
+      this.tabListRef.current.scrollLeft += event.deltaY;
+    }
+  };
 
   scrollToTop = () => {
     if (this.scrollContainerRef.current) {
@@ -147,12 +168,12 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     const family = this.getConversationsByLabel(DefaultRoomLabels.FAMILY);
 
     return (
-      <div {...cn('tab-list')}>
+      <div {...cn('tab-list')} ref={this.tabListRef}>
         {this.renderTab(Tab.All, 'All', this.getUnreadCount(this.props.conversations))}
         {this.renderTab(Tab.Favorites, 'Favorites', this.getUnreadCount(favorites))}
         {this.renderTab(Tab.Work, 'Work', this.getUnreadCount(work))}
-        {this.renderTab(Tab.Social, 'Social', this.getUnreadCount(social))}
         {this.renderTab(Tab.Family, 'Family', this.getUnreadCount(family))}
+        {this.renderTab(Tab.Social, 'Social', this.getUnreadCount(social))}
       </div>
     );
   }


### PR DESCRIPTION
### What does this do?
- applies horizontal scroll to tab list
- re-orders list items
- removes some padding

### Why are we making this change?
- as requested
- improved ui/ux

### How do I test this?
- run tests as usual
- run ui and test scroll on tab list

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/user-attachments/assets/c8e3ae46-4c2c-46e2-8520-e0530193b527

