### PR TITLE
refactor(conversation-list/labels): always render unread count

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -62,6 +62,7 @@ $side-padding: 16px;
     position: relative;
     box-sizing: border-box;
     padding: 8px 4px 2px 4px;
+    border-bottom: 1px solid transparent;
 
     @include glass-text-secondary-color;
     font-size: 14px;
@@ -79,10 +80,6 @@ $side-padding: 16px;
       &:hover {
         color: theme.$color-secondary-11;
         cursor: auto;
-      }
-
-      .messages-list__tab-badge {
-        display: none;
       }
     }
   }


### PR DESCRIPTION
### What does this do?
-  updates scss of tab badge to always render even if tab is active
- minor style change to prevent jolting - add border bottom

### Why are we making this change?
- design requested

### How do I test this?
- run tests as usual.
- run UI > click on a tab that has unread count, and check unread count is still displayed

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
<img width="301" alt="Screenshot 2024-07-26 at 13 10 43" src="https://github.com/user-attachments/assets/76deba3d-5fa7-4c13-a7f5-67bb1ae65a32">
