### PR TITLE
refactor(conversation-list/labels): apply ordering logic to favorites and all labels

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import { ConversationListPanel, Properties } from '.';
 import { Channel, DefaultRoomLabels } from '../../../../store/channels';
 import { stubConversation } from '../../../../store/test/store';
+import { IconStar1 } from '@zero-tech/zui/icons';
 
 describe('ConversationListPanel', () => {
   const subject = (props: Partial<Properties>) => {
@@ -67,13 +68,13 @@ describe('ConversationListPanel', () => {
   it('renders conversations based on selected tab', function () {
     const conversations = [
       stubConversation({ name: 'convo-1' }),
-      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.FAVORITE] }),
-      stubConversation({ name: 'convo-3', labels: [DefaultRoomLabels.FAVORITE] }),
+      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.WORK] }),
+      stubConversation({ name: 'convo-3', labels: [DefaultRoomLabels.WORK] }),
       stubConversation({ name: 'convo-4', labels: [DefaultRoomLabels.FAMILY] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
-    selectTab(wrapper, 'Favorites');
+    selectTab(wrapper, 'Work');
     expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-2', 'convo-3']);
 
     selectTab(wrapper, 'All');
@@ -88,11 +89,35 @@ describe('ConversationListPanel', () => {
     expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-4']);
   });
 
+  it('renders Favorites tab first if it has conversations', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE], unreadCount: 0 }),
+      stubConversation({ name: 'convo-2', unreadCount: 0 }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    const tabs = wrapper.find('.messages-list__tab');
+    expect(tabs.at(0)).toHaveElement(IconStar1);
+    expect(tabs.at(1)).toHaveText('All');
+  });
+
+  it('renders Favorites tab second if it does not have conversations', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', unreadCount: 0 }),
+      stubConversation({ name: 'convo-2', unreadCount: 0 }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    const tabs = wrapper.find('.messages-list__tab');
+    expect(tabs.at(0)).toHaveText('All');
+    expect(tabs.at(1)).toHaveElement(IconStar1);
+  });
+
   it('renders default state when label list is empty', function () {
     const conversations = [stubConversation({ name: 'convo-1' })];
     const wrapper = subject({ conversations: conversations as any });
 
-    selectTab(wrapper, 'Favorites');
+    selectTab(wrapper, 'Work');
 
     expect(wrapper).toHaveElement('.messages-list__label-preview');
   });
@@ -101,7 +126,7 @@ describe('ConversationListPanel', () => {
     const conversations = [stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE] })];
     const wrapper = subject({ conversations: conversations as any });
 
-    selectTab(wrapper, 'Favorites');
+    selectTab(wrapper, 'All');
 
     expect(wrapper).not.toHaveElement('.messages-list__label-preview');
   });
@@ -109,8 +134,8 @@ describe('ConversationListPanel', () => {
   it('renders tab unread counts', function () {
     const conversations = [
       stubConversation({ name: 'convo-1', unreadCount: 3 }),
-      stubConversation({ name: 'convo-2', unreadCount: 11, labels: [DefaultRoomLabels.FAVORITE] }),
-      stubConversation({ name: 'convo-3', unreadCount: 17, labels: [DefaultRoomLabels.FAVORITE] }),
+      stubConversation({ name: 'convo-2', unreadCount: 11, labels: [DefaultRoomLabels.FAMILY] }),
+      stubConversation({ name: 'convo-3', unreadCount: 17, labels: [DefaultRoomLabels.FAMILY] }),
       stubConversation({ name: 'convo-4', unreadCount: 7 }),
       stubConversation({ name: 'convo-5', unreadCount: 13, labels: [DefaultRoomLabels.WORK] }),
     ];
@@ -119,7 +144,7 @@ describe('ConversationListPanel', () => {
     const allTab = tabNamed(wrapper, 'All');
     expect(allTab.find('.messages-list__tab-badge')).toHaveText('51');
 
-    const favoritesTab = tabNamed(wrapper, 'Favorites');
+    const favoritesTab = tabNamed(wrapper, 'Family');
     expect(favoritesTab.find('.messages-list__tab-badge')).toHaveText('28');
 
     const workTab = tabNamed(wrapper, 'Work');
@@ -129,12 +154,12 @@ describe('ConversationListPanel', () => {
   it('does not render unread count if count is zero', function () {
     const conversations = [
       stubConversation({ name: 'convo-1', unreadCount: 0 }),
-      stubConversation({ name: 'convo-2', unreadCount: 0, labels: [DefaultRoomLabels.FAVORITE] }),
+      stubConversation({ name: 'convo-2', unreadCount: 0, labels: [DefaultRoomLabels.WORK] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
     expect(tabNamed(wrapper, 'All')).not.toHaveElement('.messages-list__tab-badge');
-    expect(tabNamed(wrapper, 'Favorites')).not.toHaveElement('.messages-list__tab-badge');
+    expect(tabNamed(wrapper, 'Work')).not.toHaveElement('.messages-list__tab-badge');
   });
 
   it('renders conversation group names as well in the filtered conversation list', function () {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -12,6 +12,7 @@ import { getDirectMatches, getIndirectMatches } from './utils';
 
 import { bemClassName } from '../../../../lib/bem';
 import './conversation-list-panel.scss';
+import { IconStar1 } from '@zero-tech/zui/icons';
 
 const cn = bemClassName('messages-list');
 
@@ -148,9 +149,9 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     return count < 99 ? count : '99+';
   }
 
-  renderTab(tab, label, unreadCount) {
+  renderTab(id, label, unreadCount) {
     return (
-      <div {...cn('tab', this.state.selectedTab === tab && 'active')} onClick={() => this.selectTab(tab)}>
+      <div key={id} {...cn('tab', this.state.selectedTab === id && 'active')} onClick={() => this.selectTab(id)}>
         {label}
         {!!unreadCount && (
           <div {...cn('tab-badge')}>
@@ -167,13 +168,20 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     const social = this.getConversationsByLabel(DefaultRoomLabels.SOCIAL);
     const family = this.getConversationsByLabel(DefaultRoomLabels.FAMILY);
 
+    const tabs = [
+      { id: Tab.Favorites, label: <IconStar1 size={16} />, unreadCount: this.getUnreadCount(favorites) },
+      { id: Tab.All, label: 'All', unreadCount: this.getUnreadCount(this.props.conversations) },
+      { id: Tab.Work, label: 'Work', unreadCount: this.getUnreadCount(work) },
+      { id: Tab.Family, label: 'Family', unreadCount: this.getUnreadCount(family) },
+      { id: Tab.Social, label: 'Social', unreadCount: this.getUnreadCount(social) },
+    ];
+
     return (
       <div {...cn('tab-list')} ref={this.tabListRef}>
-        {this.renderTab(Tab.All, 'All', this.getUnreadCount(this.props.conversations))}
-        {this.renderTab(Tab.Favorites, 'Favorites', this.getUnreadCount(favorites))}
-        {this.renderTab(Tab.Work, 'Work', this.getUnreadCount(work))}
-        {this.renderTab(Tab.Family, 'Family', this.getUnreadCount(family))}
-        {this.renderTab(Tab.Social, 'Social', this.getUnreadCount(social))}
+        {favorites.length > 0
+          ? [tabs[0], tabs[1]].map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))
+          : [tabs[1], tabs[0]].map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))}
+        {tabs.slice(2).map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))}
       </div>
     );
   }


### PR DESCRIPTION
### What does this do?
- applies ordering logic to favorites and all labels i.e.:
 ```
 Once >=1 conversation is Favorited, the Favorites list should be the first filter in the label selector. If nothing is favorited it would go back to all.
 ```

```
Can we default 'Favorites' if Favorites List >=1 and then have All second
```


### Why are we making this change?
- design request

### How do I test this?
- run ui as usual and test favorite tagging.
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/user-attachments/assets/8ff6aa62-66e9-493c-937d-ec953a04f8d2

