### PR TITLE
feat(conversation-list/labels): add archive label and handle archived conversations

### DIFF
--- a/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.test.tsx
@@ -97,6 +97,23 @@ describe(MoreMenu, () => {
 
     expectLabelToContainText(workItem, 'Remove from Social');
   });
+
+  it('should display "Archive chat" if conversation is not archived', function () {
+    const wrapper = subject({ labels: [] });
+
+    const workItem = menuItem(wrapper, 'add-m.archived');
+
+    expectLabelToContainText(workItem, 'Archive chat');
+  });
+
+  it('should only show "Unarchive chat" in more menu if conversation is archived', function () {
+    const wrapper = subject({ labels: [DefaultRoomLabels.ARCHIVED] });
+
+    const workItem = menuItem(wrapper, 'unarchive');
+
+    expectLabelToContainText(workItem, 'Unarchive chat');
+    expect(wrapper.find(DropdownMenu).prop('items').length).toBe(1);
+  });
 });
 
 function selectItem(wrapper, id) {

--- a/src/components/messenger/list/conversation-item/more-menu/index.tsx
+++ b/src/components/messenger/list/conversation-item/more-menu/index.tsx
@@ -43,9 +43,19 @@ export class MoreMenu extends React.Component<Properties> {
       [DefaultRoomLabels.WORK]: 'Work',
       [DefaultRoomLabels.FAMILY]: 'Family',
       [DefaultRoomLabels.SOCIAL]: 'Social',
+      [DefaultRoomLabels.ARCHIVED]: 'Archived',
     };
 
     const menuItems = [];
+
+    if (this.props.labels?.includes(DefaultRoomLabels.ARCHIVED)) {
+      menuItems.push({
+        id: 'unarchive',
+        label: this.renderMenuOption(<IconBookmarkX size={20} />, 'Unarchive chat'),
+        onSelect: this.removeLabel(DefaultRoomLabels.ARCHIVED),
+      });
+      return menuItems;
+    }
 
     if (this.props.labels?.includes(DefaultRoomLabels.FAVORITE)) {
       menuItems.push({
@@ -72,7 +82,10 @@ export class MoreMenu extends React.Component<Properties> {
       } else {
         menuItems.push({
           id: `add-${label.toLowerCase()}`,
-          label: this.renderMenuOption(<IconBookmark size={20} />, `Add to ${labelName}`),
+          label: this.renderMenuOption(
+            <IconBookmark size={20} />,
+            label === DefaultRoomLabels.ARCHIVED ? 'Archive chat' : `Add to ${labelName}`
+          ),
           onSelect: this.addLabel(label),
         });
       }

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -162,6 +162,74 @@ describe('ConversationListPanel', () => {
     expect(tabNamed(wrapper, 'Work')).not.toHaveElement('.messages-list__tab-badge');
   });
 
+  it('does not render unread count if count if conversation is archived', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', unreadCount: 3 }),
+      stubConversation({
+        name: 'convo-2',
+        unreadCount: 5,
+        labels: [DefaultRoomLabels.ARCHIVED, DefaultRoomLabels.WORK],
+      }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    const workTab = tabNamed(wrapper, 'Work');
+    expect(workTab).not.toHaveElement('.messages-list__tab-badge');
+
+    const allTab = tabNamed(wrapper, 'All');
+    expect(allTab.find('.messages-list__tab-badge')).toHaveText('3');
+  });
+
+  it('does not render unread count for archived label', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-2', unreadCount: 5, labels: [DefaultRoomLabels.ARCHIVED] }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    const archivedTab = tabNamed(wrapper, 'Archived');
+    expect(archivedTab).not.toHaveElement('.messages-list__tab-badge');
+  });
+
+  it('does not include archived conversations in All unread count total', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', unreadCount: 3 }),
+      stubConversation({ name: 'convo-2', unreadCount: 5, labels: [DefaultRoomLabels.ARCHIVED] }),
+      stubConversation({ name: 'convo-3', unreadCount: 2, labels: [DefaultRoomLabels.WORK] }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    const allTab = tabNamed(wrapper, 'All');
+    expect(allTab.find('.messages-list__tab-badge')).toHaveText('5');
+
+    const workTab = tabNamed(wrapper, 'Work');
+    expect(workTab.find('.messages-list__tab-badge')).toHaveText('2');
+  });
+
+  it('renders conversations in the archived tab', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.ARCHIVED] }),
+      stubConversation({ name: 'convo-2' }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    selectTab(wrapper, 'Archived');
+    expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-1']);
+  });
+
+  it('does not render archived conversations in other tabs', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.ARCHIVED, DefaultRoomLabels.WORK] }),
+      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.WORK] }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    selectTab(wrapper, 'All');
+    expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-2']);
+
+    selectTab(wrapper, 'Work');
+    expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-2']);
+  });
+
   it('renders conversation group names as well in the filtered conversation list', function () {
     const conversations = [
       { id: 'convo-id-1', name: '', otherMembers: [{ firstName: 'test' }] },


### PR DESCRIPTION
### What does this do?
- This PR adds support for archiving conversations in the conversation list and ensures archived conversations are handled correctly by removing their other labels and adjusting unread counts.

### Why are we making this change?
- To provide users with the ability to archive conversations, ensuring that archived conversations do not appear in other lists or affect unread counts, improving organization and usability.

### How do I test this?
- run tests as usual.
- run ui and follow demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



https://github.com/user-attachments/assets/06adff0d-7c0c-4540-aa4e-fc28947b4046

