### PR TITLE
refactor(read-receipts): remove calls for read receipts

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -967,7 +967,6 @@ describe('matrix client', () => {
         event: { event_id: latestEventId },
       };
 
-      const sendReadReceipt = jest.fn().mockResolvedValue(undefined);
       const setRoomReadMarkers = jest.fn().mockResolvedValue(undefined);
       const getLiveTimelineEvents = jest.fn().mockReturnValue([latestEvent]);
       const getRoom = jest.fn().mockReturnValue(
@@ -977,13 +976,12 @@ describe('matrix client', () => {
       );
 
       const client = subject({
-        createClient: jest.fn(() => getSdkClient({ sendReadReceipt, setRoomReadMarkers, getRoom })),
+        createClient: jest.fn(() => getSdkClient({ setRoomReadMarkers, getRoom })),
       });
 
       await client.connect(null, 'token');
       await client.markRoomAsRead(roomId);
 
-      expect(sendReadReceipt).toHaveBeenCalledWith(latestEvent, ReceiptType.ReadPrivate);
       expect(setRoomReadMarkers).toHaveBeenCalledWith(roomId, latestEventId);
     });
   });

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -716,12 +716,6 @@ export class MatrixClient implements IChatClient {
       return;
     }
 
-    const userReceiptPreference = await this.getReadReceiptPreference();
-
-    const receiptType =
-      userReceiptPreference === ReadReceiptPreferenceType.Public ? ReceiptType.Read : ReceiptType.ReadPrivate;
-
-    await this.processSendReadReceipt(room, latestEvent, receiptType);
     await this.matrix.setRoomReadMarkers(roomId, latestEvent.event.event_id);
   }
 

--- a/src/store/message-info/saga.test.ts
+++ b/src/store/message-info/saga.test.ts
@@ -4,7 +4,6 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { openOverview, closeOverview } from './saga';
 import { Stage, setSelectedMessageId, setStage } from './index';
 import { resetConversationManagement } from '../group-management/saga';
-import { mapMessageReadByUsers } from '../messages/saga';
 
 describe('message-info saga', () => {
   const roomId = 'room-id';
@@ -15,11 +14,9 @@ describe('message-info saga', () => {
       await expectSaga(openOverview, { payload: { roomId, messageId } })
         .provide([
           [matchers.call.fn(resetConversationManagement), undefined],
-          [matchers.call.fn(mapMessageReadByUsers), undefined],
         ])
         .put(setStage(Stage.Overview))
         .put(setSelectedMessageId(messageId))
-        .call(mapMessageReadByUsers, messageId, roomId)
         .run();
     });
   });

--- a/src/store/message-info/saga.ts
+++ b/src/store/message-info/saga.ts
@@ -2,7 +2,6 @@ import { call, fork, put, take, takeLatest } from 'redux-saga/effects';
 
 import { SagaActionTypes, Stage, setSelectedMessageId, setStage } from './index';
 import { Events, getAuthChannel } from '../authentication/channels';
-import { mapMessageReadByUsers } from '../messages/saga';
 import { resetConversationManagement } from '../group-management/saga';
 
 function* authWatcher() {
@@ -14,13 +13,11 @@ function* authWatcher() {
 }
 
 export function* openOverview(action) {
-  const { roomId, messageId } = action.payload;
+  const { messageId } = action.payload;
 
   yield call(resetConversationManagement);
   yield put(setStage(Stage.Overview));
   yield put(setSelectedMessageId(messageId));
-
-  yield call(mapMessageReadByUsers, messageId, roomId);
 }
 
 export function* closeOverview() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -174,10 +174,6 @@ export function* fetch(action) {
           break;
         }
       }
-
-      if (latestUserMessage) {
-        yield call(mapMessageReadByUsers, latestUserMessage.id, channelId);
-      }
     }
   } catch (error) {
     yield call(receiveChannel, { id: channelId, messagesFetchStatus: MessagesFetchState.FAILED });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -160,21 +160,6 @@ export function* fetch(action) {
       hasLoadedMessages: true,
       messagesFetchStatus: MessagesFetchState.SUCCESS,
     });
-
-    if (yield select(_isActive(channelId))) {
-      const currentUser = yield select(currentUserSelector());
-
-      let latestUserMessage = null;
-      for (let i = messages?.length - 1; i >= 0; i--) {
-        const msg = messages[i];
-
-        if (msg?.sender?.userId === currentUser?.id) {
-          latestUserMessage = msg;
-
-          break;
-        }
-      }
-    }
   } catch (error) {
     yield call(receiveChannel, { id: channelId, messagesFetchStatus: MessagesFetchState.FAILED });
   }


### PR DESCRIPTION
- removes functionality for read receipts.
- ensures when a user opens the 'message info' panel, that read receipts are not processed
