### PR TITLE
refactor(conversation-list-panel): render favorites (star icon) first in tab list even if list is empty

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -89,7 +89,7 @@ describe('ConversationListPanel', () => {
     expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-4']);
   });
 
-  it('renders Favorites tab first if it has conversations', function () {
+  it('renders Favorites tab first', function () {
     const conversations = [
       stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE], unreadCount: 0 }),
       stubConversation({ name: 'convo-2', unreadCount: 0 }),
@@ -99,18 +99,6 @@ describe('ConversationListPanel', () => {
     const tabs = wrapper.find('.messages-list__tab');
     expect(tabs.at(0)).toHaveElement(IconStar1);
     expect(tabs.at(1)).toHaveText('All');
-  });
-
-  it('renders Favorites tab second if it does not have conversations', function () {
-    const conversations = [
-      stubConversation({ name: 'convo-1', unreadCount: 0 }),
-      stubConversation({ name: 'convo-2', unreadCount: 0 }),
-    ];
-    const wrapper = subject({ conversations: conversations as any });
-
-    const tabs = wrapper.find('.messages-list__tab');
-    expect(tabs.at(0)).toHaveText('All');
-    expect(tabs.at(1)).toHaveElement(IconStar1);
   });
 
   it('renders default state when label list is empty', function () {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -189,10 +189,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
 
     return (
       <div {...cn('tab-list')} ref={this.tabListRef}>
-        {tabConversations[Tab.Favorites].length > 0
-          ? [tabs[0], tabs[1]].map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))
-          : [tabs[1], tabs[0]].map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))}
-        {tabs.slice(2).map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))}
+        {tabs.map((tab) => this.renderTab(tab.id, tab.label, tab.unreadCount))}
       </div>
     );
   }


### PR DESCRIPTION
### What does this do?
- renders favorites (star icon) first in tab list even if list is empty

### Why are we making this change?
- prevent the movement of elements i.e. updating the existing functionality where Favorites star icon and All tab switched places based on length of conversations in list.

### How do I test this?
- run tests as usual.
- run ui and check tab list order.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  
<img width="332" alt="Screenshot 2024-08-02 at 06 58 03" src="https://github.com/user-attachments/assets/987834a5-b580-45d2-ac82-c87825b51c90">
