### PR TITLE
refactor: adjust the height of the unread count tag badge

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -87,7 +87,7 @@ $side-padding: 16px;
   &__tab-badge {
     position: absolute;
     right: -10px;
-    top: -2px;
+    top: -4px;
 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### What does this do?
- adjusts the height of the unread count tag badge

### Why are we making this change?
- design request

### How do I test this?
- run tests as usual
- run ui and check unread count tag badge (as per below)

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE

<img width="286" alt="Screenshot 2024-08-02 at 07 45 56" src="https://github.com/user-attachments/assets/faca7ec8-83cb-41d1-b813-4bfa509a779f">


AFTER

<img width="286" alt="Screenshot 2024-08-02 at 07 45 03" src="https://github.com/user-attachments/assets/9b7c8848-f394-49d6-91c5-a8023d993652">
