### PR TITLE
feat(browser-notifications): do not send browser notifications when room is archived

### DIFF
--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -149,6 +149,35 @@ describe('messages saga', () => {
       .run();
   });
 
+  it('does not send a browser notification when the room is archived', async () => {
+    const eventData = {
+      id: 8667728016,
+      sender: { userId: 'sender-id' },
+      createdAt: 1678861267433,
+      type: NotifiableEventType.RoomMessage,
+      roomId: 'room-id-1',
+    };
+
+    const initialState = {
+      normalized: {
+        channels: {
+          'room-id-1': { labels: [DefaultRoomLabels.ARCHIVED] },
+        },
+      },
+    };
+
+    await expectSaga(sendBrowserNotification, eventData as any)
+      .provide([
+        [
+          matchers.call.fn(sendBrowserMessage),
+          undefined,
+        ],
+      ])
+      .not.call(sendBrowserMessage, mapMessage(eventData as any))
+      .withState(initialState)
+      .run();
+  });
+
   it('edit message', async () => {
     const channelId = '0x000000000000000000000000000000000000000A';
     const message = 'update message';

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -536,7 +536,7 @@ export function* sendBrowserNotification(eventData) {
   if (isOwner(yield select(currentUserSelector()), eventData.sender?.userId)) return;
 
   const roomLabels = yield select(roomLabelSelector(eventData?.roomId));
-  if (roomLabels?.includes(DefaultRoomLabels.MUTE)) return;
+  if (roomLabels?.includes(DefaultRoomLabels.MUTE) || roomLabels?.includes(DefaultRoomLabels.ARCHIVED)) return;
 
   if (eventData.type === NotifiableEventType.RoomMessage) {
     yield call(sendBrowserMessage, mapMessage(eventData));


### PR DESCRIPTION
### What does this do?
- prevents browser notifications if a room is tagged as archived

### Why are we making this change?
- there should not be notifications for archived rooms 

### How do I test this?
- run tests as usual
- run ui, archive room and send a message to that room. A browser notification should not be sent.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
