### PR TITLE
feat(conversation-list-panel): filter archived conversations from search

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -358,6 +358,19 @@ describe('ConversationListPanel', () => {
         'convo-4',
       ]);
     });
+
+    it('filters archived conversations', () => {
+      const archivedConversations = [
+        stubConversation({ name: 'convo-1', labels: [] }),
+        stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.ARCHIVED] }),
+        stubConversation({ name: 'convo-3', labels: [DefaultRoomLabels.ARCHIVED] }),
+      ];
+      const wrapper = subject({ conversations: archivedConversations as any });
+
+      wrapper.find('Input').simulate('change', 'convo');
+      const displayChatNames = renderedConversations(wrapper).map((c) => c.name);
+      expect(displayChatNames).toStrictEqual(['convo-1']);
+    });
   });
 
   it('selecting an existing conversation announces click event', async function () {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -111,6 +111,10 @@ export class ConversationListPanel extends React.Component<Properties, State> {
   }
 
   get filteredConversations() {
+    const archivedConversationIds = this.props.conversations
+      .filter((c) => c.labels?.includes(DefaultRoomLabels.ARCHIVED))
+      .map((c) => c.id);
+
     if (!this.state.filter) {
       return this.getTabConversations()[this.state.selectedTab];
     }
@@ -119,7 +123,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     const directMatches = getDirectMatches(this.props.conversations, searchRegEx);
     const indirectMatches = getIndirectMatches(this.props.conversations, searchRegEx);
 
-    return [...directMatches, ...indirectMatches];
+    return [...directMatches, ...indirectMatches].filter((c) => !archivedConversationIds.includes(c.id));
   }
 
   openExistingConversation = (id: string) => {


### PR DESCRIPTION
### What does this do?
- removes archived conversations from search results

### Why are we making this change?
- archived conversations should not appear when searching existing conversations

### How do I test this?
- run tests as usual.
- run the ui and follow the steps outlined in demo below.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  


https://github.com/user-attachments/assets/d97693ab-5fd0-4c04-8ae1-1bec502af415




