### PR TITLE
fix: move key prop out of props spread to resolve react error

### DIFF
--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -30,13 +30,12 @@ export class ContentHighlighter extends React.Component<Properties> {
 
       if (match[2] === 'user') {
         const mention = `${match[1]}`.trim();
-        const props: { className: string; key: string } = {
+        const props: { className: string } = {
           ...cn('user-mention'),
-          key: match[3] + index,
         };
 
         return (
-          <span data-variant={this.props.variant} {...props}>
+          <span key={match[3] + index} data-variant={this.props.variant} {...props}>
             {this.props.variant === 'negative' && '@'}
             {mention}
           </span>


### PR DESCRIPTION
### What does this do?
- This change resolves a React error by moving the key prop out of the props spread in the ContentHighlighter component.

### Why are we making this change?
- We are making this change to prevent potential issues caused by improper handling of the key prop.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
