### PR TITLE
feat: handle selected label on load

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -12,6 +12,7 @@ describe('ConversationListPanel', () => {
       conversations: [],
       myUserId: '',
       activeConversationId: '',
+      isLabelDataLoaded: true,
       search: () => undefined,
       onConversationClick: () => null,
       onCreateConversation: () => null,
@@ -99,6 +100,26 @@ describe('ConversationListPanel', () => {
     const tabs = wrapper.find('.messages-list__tab');
     expect(tabs.at(0)).toHaveElement(IconStar1);
     expect(tabs.at(1)).toHaveText('All');
+  });
+
+  it('sets selectedTab to Favorites if there are favorite and non-archived conversations', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE] }),
+      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.FAVORITE, DefaultRoomLabels.ARCHIVED] }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    expect(wrapper.state('selectedTab')).toEqual('favorites');
+  });
+
+  it('sets selectedTab to All if there are no favorite and non-archived conversations', function () {
+    const conversations = [
+      stubConversation({ name: 'convo-1' }),
+      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.ARCHIVED] }),
+    ];
+    const wrapper = subject({ conversations: conversations as any });
+
+    expect(wrapper.state('selectedTab')).toEqual('all');
   });
 
   it('renders default state when label list is empty', function () {

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -20,6 +20,7 @@ export interface Properties {
   conversations: Channel[];
   myUserId: string;
   activeConversationId: string;
+  isLabelDataLoaded: boolean;
 
   search: (input: string) => any;
   onCreateConversation: (userId: string) => void;
@@ -58,11 +59,32 @@ export class ConversationListPanel extends React.Component<Properties, State> {
     if (this.tabListRef.current) {
       this.tabListRef.current.addEventListener('wheel', this.horizontalScroll, { passive: false });
     }
+
+    this.setInitialTab();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isLabelDataLoaded !== this.props.isLabelDataLoaded) {
+      this.setInitialTab();
+    }
   }
 
   componentWillUnmount() {
     if (this.tabListRef.current) {
       this.tabListRef.current.removeEventListener('wheel', this.horizontalScroll);
+    }
+  }
+
+  setInitialTab() {
+    if (this.props.isLabelDataLoaded) {
+      const favoriteConversations = this.props.conversations.filter(
+        (c) => c.labels?.includes(DefaultRoomLabels.FAVORITE) && !c.labels?.includes(DefaultRoomLabels.ARCHIVED)
+      );
+      if (favoriteConversations.length > 0) {
+        this.setState({ selectedTab: Tab.Favorites });
+      } else {
+        this.setState({ selectedTab: Tab.All });
+      }
     }
   }
 
@@ -224,11 +246,12 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             />
           </div>
 
-          {this.renderTabList()}
+          {this.props.isLabelDataLoaded && this.renderTabList()}
 
           <ScrollbarContainer variant='on-hover' ref={this.scrollContainerRef}>
             <div {...cn('item-list')}>
-              {this.filteredConversations.length > 0 &&
+              {this.props.isLabelDataLoaded &&
+                this.filteredConversations.length > 0 &&
                 this.filteredConversations.map((c) => (
                   <ConversationItem
                     key={c.id}

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -246,12 +246,11 @@ export class ConversationListPanel extends React.Component<Properties, State> {
             />
           </div>
 
-          {this.props.isLabelDataLoaded && this.renderTabList()}
+          {this.renderTabList()}
 
           <ScrollbarContainer variant='on-hover' ref={this.scrollContainerRef}>
             <div {...cn('item-list')}>
-              {this.props.isLabelDataLoaded &&
-                this.filteredConversations.length > 0 &&
+              {this.filteredConversations.length > 0 &&
                 this.filteredConversations.map((c) => (
                   <ConversationItem
                     key={c.id}

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -41,6 +41,7 @@ describe('messenger-list', () => {
       isRewardsDialogOpen: false,
       showRewardsTooltip: false,
       hasUnviewedRewards: false,
+      isSecondaryConversationDataLoaded: true,
       closeConversationErrorDialog: () => null,
       startCreateConversation: () => null,
       membersSelected: () => null,

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -60,6 +60,7 @@ export interface Properties extends PublicProperties {
   isRewardsDialogOpen: boolean;
   showRewardsTooltip: boolean;
   hasUnviewedRewards: boolean;
+  isSecondaryConversationDataLoaded: boolean;
 
   startCreateConversation: () => void;
   back: () => void;
@@ -87,7 +88,7 @@ export class Container extends React.Component<Properties, State> {
       createConversation,
       registration,
       authentication: { user },
-      chat: { activeConversationId, joinRoomErrorContent },
+      chat: { activeConversationId, joinRoomErrorContent, isSecondaryConversationDataLoaded },
       rewards,
     } = state;
 
@@ -109,6 +110,7 @@ export class Container extends React.Component<Properties, State> {
       isRewardsDialogOpen: rewards.showRewardsInPopup,
       showRewardsTooltip: rewards.showRewardsInTooltip,
       hasUnviewedRewards: rewards.showNewRewardsIndicator,
+      isSecondaryConversationDataLoaded,
     };
   }
 
@@ -259,6 +261,7 @@ export class Container extends React.Component<Properties, State> {
             activeConversationId={this.props.activeConversationId}
             onAddLabel={this.props.onAddLabel}
             onRemoveLabel={this.props.onRemoveLabel}
+            isLabelDataLoaded={this.props.isSecondaryConversationDataLoaded}
           />
         )}
         {this.props.stage === SagaStage.InitiateConversation && (

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -22,7 +22,7 @@ import { getZEROUsers } from './api';
 import { union } from 'lodash';
 import { uniqNormalizedList } from '../utils';
 import { channelListStatus, rawConversationsList } from './selectors';
-import { setIsConversationsLoaded } from '../chat';
+import { setIsConversationsLoaded, setIsSecondaryConversationDataLoaded } from '../chat';
 import { getUserReadReceiptPreference } from '../user-profile/saga';
 import { featureFlags } from '../../lib/feature-flags';
 
@@ -105,9 +105,11 @@ export function* fetchConversations() {
 }
 
 export function* loadSecondaryConversationData(conversations) {
+  yield put(setIsSecondaryConversationDataLoaded(false));
   yield call(getRoomTags, conversations);
 
   yield put(receive(conversations));
+  yield put(setIsSecondaryConversationDataLoaded(true));
 }
 
 export function userSelector(state, userIds) {

--- a/src/store/chat/index.ts
+++ b/src/store/chat/index.ts
@@ -7,6 +7,7 @@ const initialState: ChatState = {
   isJoiningConversation: false,
   isChatConnectionComplete: false,
   isConversationsLoaded: false,
+  isSecondaryConversationDataLoaded: false,
 };
 
 export enum SagaActionTypes {
@@ -40,6 +41,12 @@ const slice = createSlice({
     setIsConversationsLoaded: (state, action: PayloadAction<ChatState['isConversationsLoaded']>) => {
       state.isConversationsLoaded = action.payload;
     },
+    setIsSecondaryConversationDataLoaded: (
+      state,
+      action: PayloadAction<ChatState['isSecondaryConversationDataLoaded']>
+    ) => {
+      state.isSecondaryConversationDataLoaded = action.payload;
+    },
   },
 });
 
@@ -50,6 +57,7 @@ export const {
   setIsJoiningConversation,
   setIsChatConnectionComplete,
   setIsConversationsLoaded,
+  setIsSecondaryConversationDataLoaded,
 } = slice.actions;
 export const { reducer } = slice;
 export { closeConversationErrorDialog };

--- a/src/store/chat/types.ts
+++ b/src/store/chat/types.ts
@@ -11,4 +11,5 @@ export interface ChatState {
   isJoiningConversation: boolean;
   isChatConnectionComplete: boolean;
   isConversationsLoaded: boolean;
+  isSecondaryConversationDataLoaded: boolean;
 }


### PR DESCRIPTION
### What does this do?
- Sets the initial selected tab to "Favorites" if there are non-archived favorite conversations, otherwise defaults to "All".

### Why are we making this change?
- To ensure that the default view prioritizes favorite conversations while excluding archived ones.

### How do I test this?
- run tests as usual
- run UI > favorite a conversation > refresh > check tabs.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

DEMO


https://github.com/user-attachments/assets/c242855c-380a-4f43-9e1e-5ec1d7e893e3

