### PR TITLE
fix: error handling for link preview

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -420,7 +420,16 @@ export class Message extends React.Component<Properties, State> {
 
   renderLinkPreview() {
     const { preview, hidePreview, media, parentMessageText } = this.props;
-    if (!preview || hidePreview || media || parentMessageText) {
+    console.log('XXXpreview', preview);
+    if (
+      !preview?.title ||
+      !preview?.description ||
+      !preview?.type ||
+      !preview?.url ||
+      hidePreview ||
+      media ||
+      parentMessageText
+    ) {
       return;
     }
 

--- a/src/store/messages/api.ts
+++ b/src/store/messages/api.ts
@@ -30,9 +30,19 @@ export async function uploadAttachment(file: File): Promise<AttachmentUploadResu
   };
 }
 
-export async function getLinkPreviews(link: string): Promise<LinkPreview> {
+export async function getLinkPreviews(link: string): Promise<{ success: boolean; body?: LinkPreview }> {
   const filter: any = { url: link };
 
-  const response = await get<any>('/linkPreviews', filter);
-  return response.body;
+  try {
+    const response = await get<any>('/linkPreviews', filter);
+    return {
+      success: true,
+      body: response.body,
+    };
+  } catch (error) {
+    console.error('Failed to fetch link preview:', error);
+    return {
+      success: false,
+    };
+  }
 }

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -185,7 +185,7 @@ describe(createOptimisticPreview, () => {
 
     const { storeState } = await expectSaga(createOptimisticPreview, channelId, optimisticMessage)
       // stub empty response to retain the initial, optmistic preview
-      .provide([[call(getLinkPreviews, 'http://example.com'), null]])
+      .provide([[call(getLinkPreviews, 'http://example.com'), { success: false }]])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -201,7 +201,12 @@ describe(createOptimisticPreview, () => {
     const initialState = new StoreBuilder().withConversationList({ id: channelId, messages: [optimisticMessage] });
 
     const { storeState } = await expectSaga(createOptimisticPreview, channelId, optimisticMessage)
-      .provide([stubResponse(call(getLinkPreviews, 'http://example.com'), linkPreview)])
+      .provide([
+        stubResponse(call(getLinkPreviews, 'http://example.com'), {
+          success: true,
+          body: linkPreview,
+        }),
+      ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -218,7 +223,12 @@ describe(createOptimisticPreview, () => {
     const initialState = new StoreBuilder().withConversationList({ id: channelId, messages: [receivedMessage] });
 
     const { storeState } = await expectSaga(createOptimisticPreview, channelId, optimisticMessage)
-      .provide([stubResponse(call(getLinkPreviews, 'http://example.com'), linkPreview)])
+      .provide([
+        stubResponse(call(getLinkPreviews, 'http://example.com'), {
+          success: true,
+          body: linkPreview,
+        }),
+      ])
       .withReducer(rootReducer, initialState.build())
       .run();
 

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -512,7 +512,12 @@ export function* getPreview(message) {
 
   const firstUrl = getFirstUrl(message);
   if (firstUrl) {
-    return yield call(getLinkPreviews, firstUrl);
+    const previewResult = yield call(getLinkPreviews, firstUrl);
+    if (previewResult.success) {
+      return previewResult.body;
+    } else {
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
### What does this do?
- adds error handling for link preview

### Why are we making this change?
- resolve error thrown when there is a bad preview url

### How do I test this?
- run tests as usual.
- run ui and enter a bad url

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
