### PR TITLE
refactor: move Messenger files to `apps/messenger/`

### DIFF
--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { MessengerMain } from '../messenger-main';
+import { MessengerApp } from './messenger';
 import { ExplorerApp } from './explorer';
 
 const redirectToRoot = () => <Redirect to={'/'} />;
@@ -13,8 +13,8 @@ const redirectToRoot = () => <Redirect to={'/'} />;
 export const AppRouter = () => {
   return (
     <Switch>
-      <Route path='/conversation/:conversationId' exact component={MessengerMain} />
-      <Route path='/' exact component={MessengerMain} />
+      <Route path='/conversation/:conversationId' exact component={MessengerApp} />
+      <Route path='/' exact component={MessengerApp} />
       <Route path='/explorer' component={ExplorerApp} />
       <Route component={redirectToRoot} />
     </Switch>

--- a/src/apps/app-router.vitest.tsx
+++ b/src/apps/app-router.vitest.tsx
@@ -4,9 +4,9 @@ import { AppRouter } from './app-router';
 import { vi } from 'vitest';
 import { renderWithProviders } from '../test-utils';
 
-vi.mock('../messenger-main', () => ({
-  MessengerMain: () => {
-    return <div data-testid='messenger-main' />;
+vi.mock('./messenger', () => ({
+  MessengerApp: () => {
+    return <div data-testid='messenger-app' />;
   },
 }));
 
@@ -21,16 +21,16 @@ const renderComponent = (route: string | undefined = '/') => {
 describe(AppRouter, () => {
   it('should render MessengerMain component when route is /', () => {
     renderComponent('/');
-    expect(screen.getByTestId('messenger-main')).toBeTruthy();
+    expect(screen.getByTestId('messenger-app')).toBeTruthy();
   });
 
   it('should render MessengerMain component when route is /conversation/:conversationId', () => {
     renderComponent('/conversation/123');
-    expect(screen.getByTestId('messenger-main')).toBeTruthy();
+    expect(screen.getByTestId('messenger-app')).toBeTruthy();
   });
 
   it('should redirect to / when route is invalid', () => {
     renderComponent('/foo-bar');
-    expect(screen.getByTestId('messenger-main')).toBeTruthy();
+    expect(screen.getByTestId('messenger-app')).toBeTruthy();
   });
 });

--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { Container as Main, Properties } from './Main';
-import { MessengerChat } from './components/messenger/chat';
+import { MessengerChat } from '../../components/messenger/chat';
 
 describe(Main, () => {
   const subject = (props: Partial<Properties> = {}) => {

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { RootState } from './store/reducer';
-import { connectContainer } from './store/redux-container';
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
 
-import { Sidekick } from './components/sidekick/index';
-import { withContext as withAuthenticationContext } from './components/authentication/context';
-import { MessengerChat } from './components/messenger/chat';
-import { DevPanelContainer } from './components/dev-panel/container';
-import { FeatureFlag } from './components/feature-flag';
+import { Sidekick } from '../../components/sidekick/index';
+import { withContext as withAuthenticationContext } from '../../components/authentication/context';
+import { MessengerChat } from '../../components/messenger/chat';
+import { DevPanelContainer } from '../../components/dev-panel/container';
+import { FeatureFlag } from '../../components/feature-flag';
 
 export interface Properties {
   context: {

--- a/src/apps/messenger/index.tsx
+++ b/src/apps/messenger/index.tsx
@@ -1,0 +1,2 @@
+export { MessengerMain as MessengerApp } from './messenger-main';
+export type { Properties as MessengerProperties } from './messenger-main';

--- a/src/apps/messenger/messenger-main.test.tsx
+++ b/src/apps/messenger/messenger-main.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Container, Properties } from './messenger-main';
-import { Provider as AuthenticationContextProvider } from './components/authentication/context';
+import { Provider as AuthenticationContextProvider } from '../../components/authentication/context';
 import { Main } from './Main';
 
 describe('MessengerMain', () => {

--- a/src/apps/messenger/messenger-main.tsx
+++ b/src/apps/messenger/messenger-main.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { RootState } from './store/reducer';
-import { connectContainer } from './store/redux-container';
+import { RootState } from '../../store/reducer';
+import { connectContainer } from '../../store/redux-container';
 
 import { Main } from './Main';
-import { Provider as AuthenticationContextProvider } from './components/authentication/context';
-import { setActiveConversationId } from './store/chat';
+import { Provider as AuthenticationContextProvider } from '../../components/authentication/context';
+import { setActiveConversationId } from '../../store/chat';
 
 export interface Properties {
   isAuthenticated: boolean;


### PR DESCRIPTION
This is a very minor change.

- Clears up the `src` directory.
- Is consistent with putting all apps in `apps/` - this lets us keep all app entry-points in the same place.