### PR TITLE
feat: add support for creating unencrypted channels

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -330,3 +330,7 @@ export async function removeRoomFromLabel(roomId: string, label: string) {
 export async function getRoomTags(conversations: Partial<Channel>[]) {
   return await chat.get().matrix.getRoomTags(conversations);
 }
+
+export async function createChannel(users: User[], name: string, image: File, optimisticId: string) {
+  return chat.get().matrix.createChannel(users, name, image, optimisticId);
+}

--- a/src/store/channels-list/saga.createChannel.test.ts
+++ b/src/store/channels-list/saga.createChannel.test.ts
@@ -1,0 +1,72 @@
+import { testSaga } from 'redux-saga-test-plan';
+
+import {
+  createChannel,
+  createOptimisticConversation,
+  receiveCreatedConversation,
+  handleCreateConversationError,
+  userSelector,
+} from './saga';
+
+import { chat } from '../../lib/chat';
+import { createChannel as createMatrixChannel } from '../../lib/chat';
+import { openConversation } from '../channels/saga';
+
+describe(createChannel, () => {
+  it('creates the channel - full success flow', async () => {
+    const otherUserIds = ['user-1'];
+    const name = 'channel name';
+    const image = { name: 'file' } as File;
+
+    const stubOptimisticChannel = { id: 'optimistic-id' };
+    const stubReceivedChannel = { id: 'new-channel-id' };
+
+    const chatClient = {
+      supportsOptimisticCreateConversation: () => undefined,
+      createChannel: () => undefined,
+    };
+
+    testSaga(createChannel, otherUserIds, name, image)
+      .next()
+      .call(chat.get)
+      .next(chatClient)
+      .call(chatClient.supportsOptimisticCreateConversation)
+      .next(true)
+      .call(createOptimisticConversation, otherUserIds, name, image)
+      .next(stubOptimisticChannel)
+      .call(openConversation, stubOptimisticChannel.id)
+      .next()
+      .select(userSelector, otherUserIds)
+      .next([{ userId: 'user-1' }])
+      .call(createMatrixChannel, [{ userId: 'user-1' }], name, image, 'optimistic-id')
+      .next(stubReceivedChannel)
+      .call(receiveCreatedConversation, stubReceivedChannel, stubOptimisticChannel)
+      .next()
+      .isDone();
+  });
+
+  it('handles creation error', async () => {
+    const otherUserIds = ['user-1'];
+    const name = 'name';
+    const image = { name: 'file' } as File;
+
+    const stubOptimisticConversation = { id: 'optimistic-id' };
+
+    const chatClient = {
+      supportsOptimisticCreateConversation: () => undefined,
+    };
+
+    testSaga(createChannel, otherUserIds, name, image)
+      .next()
+      .call(chat.get)
+      .next(chatClient)
+      .call(chatClient.supportsOptimisticCreateConversation)
+      .next(true)
+      .next(stubOptimisticConversation)
+      .next()
+      .throw(new Error('simulated error'))
+      .call(handleCreateConversationError, stubOptimisticConversation)
+      .next()
+      .isDone();
+  });
+});

--- a/src/store/create-conversation/index.ts
+++ b/src/store/create-conversation/index.ts
@@ -8,12 +8,14 @@ export enum SagaActionTypes {
   Cancel = 'create-conversation/cancel',
   MembersSelected = 'create-conversation/members-selected',
   CreateConversation = 'create-conversation/create',
+  CreateChannel = 'create-conversation/create-channel',
 }
 
 export const startCreateConversation = createAction(SagaActionTypes.Start);
 export const back = createAction(SagaActionTypes.Back);
 export const membersSelected = createAction<MembersSelectedPayload>(SagaActionTypes.MembersSelected);
 export const createConversation = createAction<CreateMessengerConversation>(SagaActionTypes.CreateConversation);
+export const createChannel = createAction<CreateMessengerConversation>(SagaActionTypes.CreateChannel);
 
 export enum Stage {
   None = 'none',

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -4,6 +4,7 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { expectSaga } from '../../test/saga';
 import {
   createConversation,
+  createChannel,
   groupMembersSelected,
   performGroupMembersSelected,
   reset,
@@ -11,7 +12,11 @@ import {
 } from './saga';
 import { setGroupCreating, Stage, setFetchingConversations, setStage } from '.';
 
-import { channelsReceived, createConversation as performCreateConversation } from '../channels-list/saga';
+import {
+  channelsReceived,
+  createConversation as performCreateConversation,
+  createChannel as performCreateChannel,
+} from '../channels-list/saga';
 import { rootReducer } from '../reducer';
 import { StoreBuilder } from '../test/store';
 import { fetchConversationsWithUsers } from '../../lib/chat';
@@ -171,6 +176,24 @@ describe('create conversation saga', () => {
         .put(setGroupCreating(true))
         .next()
         .call(performCreateConversation, ['test'], 'test name', {})
+        .next()
+        .put(setGroupCreating(false));
+    });
+  });
+
+  describe('createChannel', () => {
+    it('manages the creating status while performing the actual create', async () => {
+      const testPayload = {
+        userIds: ['test'],
+        name: 'test name',
+        image: {},
+      };
+
+      return testSaga(createChannel, { payload: testPayload })
+        .next()
+        .put(setGroupCreating(true))
+        .next()
+        .call(performCreateChannel, ['test'], 'test name', {})
         .next()
         .put(setGroupCreating(false));
     });


### PR DESCRIPTION
### What does this do?
This PR introduces the functionality to create unencrypted "Social Channels" within the platform, alongside the existing encrypted group conversations. It updates the client and server logic to support the creation, management, and user invitation for these channels. Additionally, it extends the existing Redux saga workflows to handle the creation of both encrypted conversations and unencrypted channels, including relevant tests to ensure the new functionality works as expected.

### Why are we making this change?
We are making this change to enhance the platform's flexibility by allowing users to create Social Channels that are better suited for larger communities and public interactions. Unlike private encrypted conversations, these channels are unencrypted, making them more efficient and scalable for broader audiences.

### How do I test this?
- run tests as usual.
- create a group flow > select Social Channel > create group > test between two different users i.e. log out of one, send messages, log back in, check you can read messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


