### PR TITLE
refactor: allow group creation with the same members

### DIFF
--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -80,54 +80,11 @@ describe('create conversation saga', () => {
   describe(performGroupMembersSelected, () => {
     function subject(...args: Parameters<typeof expectSaga>) {
       return expectSaga(...args)
-        .provide([
-          [matchers.call.fn(channelsReceived), null],
-          [matchers.call.fn(fetchConversationsWithUsers), []],
-          [matchers.call.fn(openConversation), null],
-        ])
+        .provide([])
         .withReducer(rootReducer, defaultState());
     }
 
-    it('calls the chat api with all users', async () => {
-      const initialState = new StoreBuilder()
-        .withCurrentUser({ id: 'current-user-id' })
-        .withUsers({ userId: 'other-user-id' });
-
-      return subject(performGroupMembersSelected, [{ value: 'other-user-id' }] as any)
-        .withReducer(rootReducer, initialState.build())
-        .call.like({
-          fn: fetchConversationsWithUsers,
-          args: [[{ userId: 'current-user-id' }, { userId: 'other-user-id' }]],
-        })
-        .run();
-    });
-
-    it('saves first existing conversation', async () => {
-      await subject(performGroupMembersSelected, [])
-        .provide([[matchers.call.fn(fetchConversationsWithUsers), [{ id: 'convo-1' }, { id: 'convo-2' }]]])
-        .call(channelsReceived, { payload: { channels: [{ id: 'convo-1' }] } })
-        .run();
-    });
-
-    it('opens the existing conversation', async () => {
-      await subject(performGroupMembersSelected, [])
-        .provide([[matchers.call.fn(fetchConversationsWithUsers), [{ id: 'convo-1' }]]])
-        .call(openConversation, 'convo-1')
-        .run();
-    });
-
-    it('returns to initial state when existing conversation selected', async () => {
-      const initialState = defaultState({ stage: Stage.InitiateConversation });
-
-      const { returnValue } = await subject(performGroupMembersSelected, [])
-        .provide([[matchers.call.fn(fetchConversationsWithUsers), [{ id: 'convo-1' }]]])
-        .withReducer(rootReducer, initialState)
-        .run();
-
-      expect(returnValue).toEqual(Stage.None);
-    });
-
-    it('moves to group details stage if no existing conversations found', async () => {
+    it('moves to group details stage', async () => {
       const users = [{ value: 'user-1' }, { value: 'user-2' }];
       const initialState = defaultState({ stage: Stage.InitiateConversation });
 

--- a/src/store/create-conversation/saga.test.ts
+++ b/src/store/create-conversation/saga.test.ts
@@ -13,14 +13,12 @@ import {
 import { setGroupCreating, Stage, setFetchingConversations, setStage } from '.';
 
 import {
-  channelsReceived,
   createConversation as performCreateConversation,
   createChannel as performCreateChannel,
 } from '../channels-list/saga';
 import { rootReducer } from '../reducer';
 import { StoreBuilder } from '../test/store';
 import { fetchConversationsWithUsers } from '../../lib/chat';
-import { openConversation } from '../channels/saga';
 
 describe('create conversation saga', () => {
   describe('startConversation', () => {

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -31,24 +31,8 @@ export function* groupMembersSelected(action) {
 }
 
 export function* performGroupMembersSelected(userSelections: { value: string; label: string; image?: string }[]) {
-  const currentUser = yield select(currentUserSelector);
-  const userIds = [
-    currentUser.id,
-    ...userSelections.map((o) => o.value),
-  ];
-  const users = yield select((state) => denormalizeUsers(userIds, state));
-
-  const existingConversations = yield call(fetchConversationsWithUsers, users);
-
-  if (existingConversations.length === 0) {
-    yield put(setGroupUsers(userSelections));
-    return Stage.GroupDetails;
-  } else {
-    const selectedConversation = existingConversations[0];
-    yield call(channelsReceived, { payload: { channels: [selectedConversation] } });
-    yield call(openConversation, selectedConversation.id);
-    return Stage.None;
-  }
+  yield put(setGroupUsers(userSelections));
+  return Stage.GroupDetails;
 }
 
 export function* createConversation(action) {

--- a/src/store/create-conversation/saga.ts
+++ b/src/store/create-conversation/saga.ts
@@ -1,14 +1,10 @@
 import { put, call, select, race, take, fork, spawn } from 'redux-saga/effects';
 import { SagaActionTypes, Stage, setFetchingConversations, setGroupCreating, setGroupUsers, setStage } from '.';
 import {
-  channelsReceived,
   createConversation as performCreateConversation,
   createChannel as performCreateChannel,
 } from '../channels-list/saga';
 import { Events, getAuthChannel } from '../authentication/channels';
-import { currentUserSelector } from '../authentication/selectors';
-import { fetchConversationsWithUsers } from '../../lib/chat';
-import { denormalize as denormalizeUsers } from '../users';
 import { denormalizeConversations } from '../channels-list';
 import { openConversation } from '../channels/saga';
 


### PR DESCRIPTION
### What does this do?
-  allows group creation with the same members.
- removes logic from the relevant saga function.

### Why are we making this change?
- to allow users to create a new unencrypted group but bypass/override our previous rule of only being able to create a new group if one does not exist with the same members

### How do I test this?
- run tests as usual
- try creating a new group with same users as another group

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
