### PR TITLE
feat: add menu class names to handle and improve select input dropdown menu width sizes

### DIFF
--- a/src/components/edit-profile/styles.scss
+++ b/src/components/edit-profile/styles.scss
@@ -58,8 +58,9 @@
   &__zid-select-menu {
     max-height: 220px;
     overflow-y: auto;
+    overflow-x: hidden;
 
-    width: 100%;
+    width: 222px;
   }
 
   &__zid-menu-item-option {

--- a/src/components/messenger/list/group-details-panel/group-type-menu/index.tsx
+++ b/src/components/messenger/list/group-details-panel/group-type-menu/index.tsx
@@ -86,6 +86,7 @@ export class GroupTypeMenu extends React.Component<Properties, State> {
             label=''
             value={selectedGroupType}
             itemSize='compact'
+            menuClassName='group-type-menu__dropdown'
           />
         </div>
         <div {...cn('select-input-label-container')} onClick={this.open}>

--- a/src/components/messenger/list/group-details-panel/group-type-menu/styles.scss
+++ b/src/components/messenger/list/group-details-panel/group-type-menu/styles.scss
@@ -33,4 +33,8 @@
   &__icon-button {
     @include glass-text-secondary-color;
   }
+
+  &__dropdown {
+    width: 222px;
+  }
 }

--- a/src/components/messenger/user-profile/settings-panel/index.tsx
+++ b/src/components/messenger/user-profile/settings-panel/index.tsx
@@ -120,6 +120,7 @@ export class SettingsPanel extends React.Component<Properties> {
                   placeholder='Select Background'
                   value={selectedBackgroundLabel}
                   itemSize='compact'
+                  menuClassName='settings-panel__dropdown'
                 />
               </div>
             </div>

--- a/src/components/messenger/user-profile/settings-panel/styles.scss
+++ b/src/components/messenger/user-profile/settings-panel/styles.scss
@@ -95,4 +95,8 @@
     left: 22px;
     color: theme.$color-secondary-11;
   }
+
+  &__dropdown {
+    width: 222px;
+  }
 }


### PR DESCRIPTION
### What does this do?
- add width to select input dropdown menu to align with width of the select input

### Why are we making this change?
- as per design

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="416" alt="Screenshot 2024-08-14 at 10 49 59" src="https://github.com/user-attachments/assets/c05f4ca2-2261-4fbe-acb3-f52582cfcd5b">

