### PR TITLE
feat: add basic messenger feed container

### DIFF
--- a/src/components/messenger/feed/index.test.tsx
+++ b/src/components/messenger/feed/index.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Container as MessengerFeed, Properties } from '.';
+import { StoreBuilder, stubConversation } from '../../../store/test/store';
+
+describe(MessengerFeed, () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      isSocialChannel: false,
+      ...props,
+    };
+
+    return shallow(<MessengerFeed {...allProps} />);
+  };
+
+  it('renders Messenger Feed when isSocialChannel is true', () => {
+    const wrapper = subject({ isSocialChannel: true });
+    expect(wrapper);
+  });
+
+  it('does not render Messenger Feed when isSocialChannel is false', () => {
+    const wrapper = subject({ isSocialChannel: false });
+    expect(wrapper).not.toHaveText('Messenger Feed');
+  });
+
+  describe('mapState', () => {
+    it('sets isSocialChannel to true when the current channel is social', () => {
+      const state = new StoreBuilder().withActiveConversation(stubConversation({ isSocialChannel: true })).build();
+
+      expect(MessengerFeed.mapState(state)).toEqual(expect.objectContaining({ isSocialChannel: true }));
+    });
+
+    it('sets isSocialChannel to false when the current channel is not social', () => {
+      const state = new StoreBuilder().withActiveConversation(stubConversation({ isSocialChannel: false })).build();
+
+      expect(MessengerFeed.mapState(state)).toEqual(expect.objectContaining({ isSocialChannel: false }));
+    });
+  });
+});

--- a/src/components/messenger/feed/index.tsx
+++ b/src/components/messenger/feed/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { RootState } from '../../../store/reducer';
+import { connectContainer } from '../../../store/redux-container';
+import { rawChannelSelector } from '../../../store/channels/saga';
+
+import { bemClassName } from '../../../lib/bem';
+import './styles.scss';
+
+const cn = bemClassName('messenger-feed');
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  isSocialChannel: boolean;
+}
+
+export class Container extends React.Component<Properties> {
+  constructor(props: Properties) {
+    super(props);
+  }
+
+  static mapState(state: RootState): Partial<Properties> {
+    const {
+      chat: { activeConversationId },
+    } = state;
+
+    const currentChannel = rawChannelSelector(activeConversationId)(state);
+
+    return { isSocialChannel: currentChannel?.isSocialChannel };
+  }
+
+  static mapActions(): Partial<Properties> {
+    return {};
+  }
+
+  render() {
+    const { isSocialChannel } = this.props;
+
+    if (!isSocialChannel) {
+      return null;
+    }
+
+    return <div {...cn('')}>Messenger Feed</div>;
+  }
+}
+
+export const MessengerFeed = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -1,0 +1,3 @@
+.messenger-feed {
+  display: block;
+}


### PR DESCRIPTION
### What does this do?
- adds a messenger feed container

### Why are we making this change?
- Feed will be part of the new Channels feature

### How do I test this?
- run tests as usual.
- the ui for this is not yet wired up.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
