### PR TITLE
feat: render messenger feed container when current channel is a social channel (featureFlagged)

### DIFF
--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -5,6 +5,7 @@ import { connectContainer } from '../../store/redux-container';
 import { Sidekick } from '../../components/sidekick/index';
 import { withContext as withAuthenticationContext } from '../../components/authentication/context';
 import { MessengerChat } from '../../components/messenger/chat';
+import { MessengerFeed } from '../../components/messenger/feed';
 import { DevPanelContainer } from '../../components/dev-panel/container';
 import { FeatureFlag } from '../../components/feature-flag';
 
@@ -29,8 +30,14 @@ export class Container extends React.Component<Properties> {
         {this.props.context.isAuthenticated && (
           <>
             <Sidekick />
+
+            <FeatureFlag featureFlag='enableChannels'>
+              <MessengerFeed />
+            </FeatureFlag>
+
             <MessengerChat />
             <Sidekick variant='secondary' />
+
             <FeatureFlag featureFlag='enableDevPanel'>
               <DevPanelContainer />
             </FeatureFlag>

--- a/src/components/messenger/feed/index.tsx
+++ b/src/components/messenger/feed/index.tsx
@@ -15,10 +15,6 @@ export interface Properties extends PublicProperties {
 }
 
 export class Container extends React.Component<Properties> {
-  constructor(props: Properties) {
-    super(props);
-  }
-
   static mapState(state: RootState): Partial<Properties> {
     const {
       chat: { activeConversationId },


### PR DESCRIPTION
### What does this do?
- renders messenger feed container when current channel is a social channel

### Why are we making this change?
- requirement for Channels feature.
- the messenger feed container, that will container the post input component and post component, should render when the current channel is a social channel.

### How do I test this?
- run tests as usual.
- run ui > enableChannels feature flag > create social channel group > check UI contains element with text 'Messenger Feed'

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1182" alt="Screenshot 2024-08-16 at 00 31 23" src="https://github.com/user-attachments/assets/c3237bf5-6b06-43ac-b662-71dc25223fb2">
