### PR TITLE
refactor: rename publish channel type change to publish group type change for consistency

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1001,7 +1001,7 @@ export class MatrixClient implements IChatClient {
       }
 
       if (event.type === CustomEventType.GROUP_TYPE) {
-        this.publishChannelTypeChange(event);
+        this.publishGroupTypeChange(event);
       }
 
       if (event.type === EventType.RoomRedaction) {
@@ -1150,7 +1150,7 @@ export class MatrixClient implements IChatClient {
     this.events.onRoomAvatarChanged(event.room_id, event.content?.url);
   };
 
-  private publishChannelTypeChange = (event) => {
+  private publishGroupTypeChange = (event) => {
     this.events.onRoomGroupTypeChanged(event.room_id, event.content?.group_type);
   };
 


### PR DESCRIPTION
### What does this do?
- rename method - publishChannelTypeChange -> publishGroupTypeChange

### Why are we making this change?
- improve naming

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
