### PR TITLE
feat(messenger-chat/feed): filter messages flagged as posts from chat view and filter into feed

### DIFF
--- a/src/components/chat-view-container/chat-view-container.test.tsx
+++ b/src/components/chat-view-container/chat-view-container.test.tsx
@@ -144,6 +144,22 @@ describe('ChannelViewContainer', () => {
     expect(fetchMessages).toHaveBeenLastCalledWith({ channelId: 'the-channel-id' });
   });
 
+  it('filters out messages with isPost flag', () => {
+    const messages = [
+      { id: 'message-one', message: 'what', isPost: false },
+      { id: 'message-two', message: 'hello', isPost: true },
+      { id: 'message-three', message: 'bye', isPost: true },
+      { id: 'message-four', message: 'morning', isPost: false },
+    ];
+
+    const wrapper = subject({ channel: { messages } });
+
+    expect(wrapper.find(ChatView)).toHaveProp('messages', [
+      { id: 'message-one', message: 'what', isPost: false },
+      { id: 'message-four', message: 'morning', isPost: false },
+    ]);
+  });
+
   it('should call fetchMore with reference timestamp when hasMore is true', () => {
     const fetchMessages = jest.fn();
     const messages = [

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -151,9 +151,13 @@ export class Container extends React.Component<Properties> {
   };
 
   get messages() {
-    const messagesById = mapMessagesById(this.channel?.messages || []);
-    const messagesByRootId = mapMessagesByRootId(this.channel?.messages || []);
-    const messages = linkMessages(this.channel?.messages || [], messagesById, messagesByRootId);
+    const channelMessages = this.channel?.messages || [];
+
+    const filteredMessages = channelMessages.filter((m) => !m.isPost);
+
+    const messagesById = mapMessagesById(filteredMessages);
+    const messagesByRootId = mapMessagesByRootId(filteredMessages);
+    const messages = linkMessages(filteredMessages, messagesById, messagesByRootId);
 
     return messages.sort((a, b) => compareDatesAsc(a.createdAt, b.createdAt));
   }

--- a/src/components/messenger/feed/index.test.tsx
+++ b/src/components/messenger/feed/index.test.tsx
@@ -3,9 +3,14 @@ import { shallow } from 'enzyme';
 import { Container as MessengerFeed, Properties } from '.';
 import { StoreBuilder, stubConversation } from '../../../store/test/store';
 
+import { bem } from '../../../lib/bem';
+
+const c = bem('.messenger-feed');
+
 describe(MessengerFeed, () => {
   const subject = (props: Partial<Properties>) => {
     const allProps: Properties = {
+      channel: null,
       isSocialChannel: false,
       ...props,
     };
@@ -21,6 +26,25 @@ describe(MessengerFeed, () => {
   it('does not render Messenger Feed when isSocialChannel is false', () => {
     const wrapper = subject({ isSocialChannel: false });
     expect(wrapper).not.toHaveText('Messenger Feed');
+  });
+
+  it('renders messages as posts when there are messages with isPost flag', () => {
+    const channel = stubConversation({
+      messages: [
+        { id: 1, message: 'Message 1', isPost: false },
+        { id: 2, message: 'Message 2', isPost: true },
+        { id: 3, message: 'Message 3', isPost: true },
+        { id: 4, message: 'Message 4', isPost: false },
+      ] as any,
+    });
+
+    const wrapper = subject({ channel: channel as any, isSocialChannel: true });
+    const feed = wrapper.find(c('feed-view'));
+
+    expect(feed.text()).not.toContain('Message 1');
+    expect(feed.text()).toContain('Message 2');
+    expect(feed.text()).toContain('Message 3');
+    expect(feed.text()).not.toContain('Message 4');
   });
 
   describe('mapState', () => {

--- a/src/components/messenger/feed/index.tsx
+++ b/src/components/messenger/feed/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { RootState } from '../../../store/reducer';
 import { connectContainer } from '../../../store/redux-container';
-import { rawChannelSelector } from '../../../store/channels/saga';
+import { Channel, denormalize } from '../../../store/channels';
+import { Message } from '../../../store/messages';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -11,6 +12,7 @@ const cn = bemClassName('messenger-feed');
 export interface PublicProperties {}
 
 export interface Properties extends PublicProperties {
+  channel: Channel;
   isSocialChannel: boolean;
 }
 
@@ -20,13 +22,19 @@ export class Container extends React.Component<Properties> {
       chat: { activeConversationId },
     } = state;
 
-    const currentChannel = rawChannelSelector(activeConversationId)(state);
+    const currentChannel = denormalize(activeConversationId, state) || null;
 
-    return { isSocialChannel: currentChannel?.isSocialChannel };
+    return { isSocialChannel: currentChannel?.isSocialChannel, channel: currentChannel };
   }
 
   static mapActions(): Partial<Properties> {
     return {};
+  }
+
+  get posts() {
+    const messages = this.props.channel?.messages || [];
+    const posts = messages.filter((message: Message) => message.isPost);
+    return posts;
   }
 
   render() {
@@ -40,7 +48,12 @@ export class Container extends React.Component<Properties> {
       <>
         <div {...cn('')}>
           <>Messenger Feed</>
-          <div {...cn('feed-view')}>Feed View Component</div>
+
+          <div {...cn('feed-view')}>
+            {this.posts.map((post) => (
+              <div key={post.id}>{post.message}</div>
+            ))}
+          </div>
         </div>
         <div {...cn('divider')} />
       </>

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -48,6 +48,8 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
   const senderData = sdkMatrixClient.getUser(senderId);
 
   let messageContent = content.body;
+  let isPost = content['is_post'] || false;
+
   if (parent && parent['m.in_reply_to']) {
     messageContent = parsePlainBody(content.body);
   }
@@ -77,6 +79,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     parentMessageMedia: null,
     parentMessageId: parent ? parent['m.in_reply_to']?.event_id : null,
     isHidden: content?.msgtype === MatrixConstants.BAD_ENCRYPTED_MSGTYPE,
+    isPost: isPost,
     ...(await parseMediaData(matrixMessage)),
   };
 }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -88,6 +88,7 @@ export interface Message {
   rootMessageId?: string;
   sendStatus: MessageSendStatus;
   readBy?: User[];
+  isPost?: boolean;
 }
 
 export interface EditMessageOptions {


### PR DESCRIPTION
### What does this do?
- filters messages flagged as posts from chat view message getter
- filters and maps messages flagged as posts into the MessengerFeed

### Why are we making this change?
- to display 'post' messages in the MessengerFeed container of Social Channels.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

