### PR TITLE
fix(matrix-client/messages-saga): bypass encrypting files during upload if non encrypted room

### DIFF
--- a/src/lib/chat/matrix/media.ts
+++ b/src/lib/chat/matrix/media.ts
@@ -66,21 +66,30 @@ export async function encryptFile(file: File): Promise<{ info: encrypt.IEncrypte
 
 // https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/utils/DecryptFile.ts#L50
 export async function decryptFile(encryptedFile, mimetype): Promise<Blob> {
+  // Determine if the file is encrypted by checking for encryption-related fields
+  const isEncrypted = !!(encryptedFile.key && encryptedFile.iv && encryptedFile.hashes?.sha256);
+
+  // Get the signed URL for the file
   const signedUrl = await getAttachmentUrl({ key: encryptedFile.url });
 
-  // Download the encrypted file as an array buffer.
+  // Download the file as an array buffer
   const response = await fetch(signedUrl);
   if (!response.ok) {
     throw new Error(`Error occurred while downloading file ${encryptedFile.url}: ${await response.text()}`);
   }
   const responseData: ArrayBuffer = await response.arrayBuffer();
 
-  try {
-    // Decrypt the array buffer using the information taken from the event content.
-    const dataArray = await encrypt.decryptAttachment(responseData, encryptedFile);
-    // Turn the array into a Blob and give it the correct MIME-type.
-    return new Blob([dataArray], { type: mimetype });
-  } catch (e) {
-    throw new Error(`Error occurred while decrypting file ${encryptedFile.url}: ${e}`);
+  if (isEncrypted) {
+    try {
+      // Decrypt the array buffer using the information taken from the event content
+      const dataArray = await encrypt.decryptAttachment(responseData, encryptedFile);
+      // Turn the array into a Blob and give it the correct MIME-type
+      return new Blob([dataArray], { type: mimetype });
+    } catch (e) {
+      throw new Error(`Error occurred while decrypting file ${encryptedFile.url}: ${e}`);
+    }
+  } else {
+    // For non-encrypted files, directly create a Blob from the downloaded data
+    return new Blob([responseData], { type: mimetype });
   }
 }


### PR DESCRIPTION
### What does this do?
- This update bypasses the encryption process for file uploads in non-encrypted rooms, optimizing performance and ensuring correct file handling.

### Why are we making this change?
- We are making this change to prevent unnecessary encryption in non-encrypted rooms, improving the efficiency of file uploads and maintaining consistent behavior across different room types.

### How do I test this?
- run ui and send images in non encrypted rooms then refresh

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
