### PR TITLE
feat(posts-saga): add posts store saga and actions

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -346,3 +346,11 @@ export async function createUnencryptedConversation(
 ) {
   return chat.get().matrix.createUnencryptedConversation(users, name, image, optimisticId, groupType);
 }
+
+export async function sendPostByChannelId(channelId: string, message: string, optimisticId?: string) {
+  return chat.get().matrix.sendPostsByChannelId(channelId, message, optimisticId);
+}
+
+export async function getPostMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
+  return chat.get().matrix.getPostMessagesByChannelId(channelId, lastCreatedAt);
+}

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -50,13 +50,9 @@ import { encryptFile, getImageDimensions } from './matrix/media';
 import { uploadAttachment } from '../../store/messages/api';
 import { featureFlags } from '../feature-flags';
 import { logger } from 'matrix-js-sdk/lib/logger';
+import { PostsResponse } from '../../store/posts';
 
 export const USER_TYPING_TIMEOUT = 5000; // 5s
-
-export interface PostsResponse {
-  hasMore: boolean;
-  postMessages: Message[];
-}
 
 export class MatrixClient implements IChatClient {
   private matrix: SDKMatrixClient = null;

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -103,6 +103,36 @@ export function mapEventToAdminMessage(matrixMessage): Message {
     hidePreview: false,
     preview: null,
     sendStatus: MessageSendStatus.SUCCESS,
+    isPost: false,
+  };
+}
+
+export function mapEventToPostMessage(matrixMessage, sdkMatrixClient: SDKMatrixClient) {
+  const { event_id, content, origin_server_ts, sender: senderId } = matrixMessage;
+
+  const senderData = sdkMatrixClient.getUser(senderId);
+
+  return {
+    id: event_id,
+    message: content.body,
+    createdAt: origin_server_ts,
+    updatedAt: 0,
+    optimisticId: content.optimisticId,
+
+    sender: {
+      userId: senderId,
+      firstName: senderData?.displayName,
+      lastName: '',
+      profileImage: '',
+      profileId: '',
+    },
+
+    isAdmin: false,
+    mentionedUsers: [],
+    hidePreview: false,
+    preview: null,
+    sendStatus: MessageSendStatus.SUCCESS,
+    isPost: true,
   };
 }
 

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -26,6 +26,7 @@ export enum MatrixConstants {
 export enum CustomEventType {
   USER_JOINED_INVITER_ON_ZERO = 'user_joined_inviter_on_zero',
   GROUP_TYPE = 'm.room.group_type',
+  ROOM_POST = 'm.room.post',
 }
 
 export enum DecryptErrorConstants {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -52,6 +52,7 @@ export interface Channel {
   otherMembers: User[];
   memberHistory: User[];
   hasMore: boolean;
+  hasMorePosts?: boolean;
   createdAt: number;
   lastMessage: Message;
   unreadCount?: number;
@@ -75,6 +76,7 @@ export const CHANNEL_DEFAULTS = {
   otherMembers: [],
   memberHistory: [],
   hasMore: true,
+  hasMorePosts: true,
   createdAt: 0,
   lastMessage: null,
   unreadCount: 0,

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -309,6 +309,7 @@ const CHANNEL_DEFAULTS = {
   otherMembers: [],
   memberHistory: [],
   hasMore: true,
+  hasMorePosts: true,
   createdAt: 0,
   lastMessage: null,
   unreadCount: 0,

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -88,6 +88,7 @@ export interface Message {
   rootMessageId?: string;
   sendStatus: MessageSendStatus;
   readBy?: User[];
+  isPost: boolean;
 }
 
 export interface EditMessageOptions {

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -60,6 +60,7 @@ export function createOptimisticMessageObject(
     preview: null,
     media,
     sendStatus: MessageSendStatus.IN_PROGRESS,
+    isPost: false,
   };
 }
 

--- a/src/store/posts/index.ts
+++ b/src/store/posts/index.ts
@@ -1,0 +1,29 @@
+import { Payload, PostPayload } from './saga';
+import { createAction, createSlice } from '@reduxjs/toolkit';
+
+import { Message } from '../messages';
+
+export interface PostsResponse {
+  hasMore: boolean;
+  postMessages: Message[];
+}
+
+export enum SagaActionTypes {
+  SendPost = 'posts/saga/sendPost',
+  FetchPosts = 'posts/saga/fetchPosts',
+}
+
+export type PostsState = {};
+
+export const initialState: PostsState = {};
+
+export const sendPost = createAction<PostPayload>(SagaActionTypes.SendPost);
+export const fetchPosts = createAction<Payload>(SagaActionTypes.FetchPosts);
+
+const slice = createSlice({
+  name: 'posts',
+  initialState,
+  reducers: {},
+});
+
+export const { reducer } = slice;

--- a/src/store/posts/saga.test.ts
+++ b/src/store/posts/saga.test.ts
@@ -1,0 +1,177 @@
+import { call, select } from 'redux-saga/effects';
+import { expectSaga, testSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
+
+import { sendPost, createOptimisticPost } from './saga';
+import { sendPostByChannelId } from '../../lib/chat';
+import { rawMessagesSelector } from '../messages/saga';
+import { currentUserSelector } from '../authentication/saga';
+import { MessageSendStatus, receive as receiveMessage } from '../messages';
+import { fetchPosts } from './saga';
+import { rootReducer } from '../reducer';
+import { StoreBuilder } from '../test/store';
+import { denormalize as denormalizeChannel } from '../channels';
+import { ConversationStatus, denormalize } from '../channels';
+import { getPostMessagesByChannelId } from '../../lib/chat';
+import { mapMessageSenders } from '../messages/utils.matrix';
+
+describe(sendPost, () => {
+  it('creates optimistic post then sends the post successfully', async () => {
+    const channelId = 'channel-id';
+    const message = 'New post content';
+
+    const optimisticPost = { optimisticId: 'optimistic-id', message };
+
+    testSaga(sendPost, { payload: { channelId, message } })
+      .next()
+      .call(createOptimisticPost, channelId, message)
+      .next({ optimisticPost })
+      .call(sendPostByChannelId, channelId, message, 'optimistic-id')
+      .next()
+      .isDone();
+  });
+
+  it('handles failure when sending the post', async () => {
+    const channelId = 'channel-id';
+    const message = 'New post content';
+    const optimisticPost = { optimisticId: 'optimistic-id', message };
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    testSaga(sendPost, { payload: { channelId, message } })
+      .next()
+      .call(createOptimisticPost, channelId, message)
+      .next({ optimisticPost })
+      .call(sendPostByChannelId, channelId, message, 'optimistic-id')
+      .throw(new Error('Failed to send post'))
+      .put(receiveMessage({ id: 'optimistic-id', sendStatus: MessageSendStatus.FAILED }))
+      .next()
+      .isDone();
+
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe(createOptimisticPost, () => {
+  it('creates an optimistic post and updates the channel state', async () => {
+    const channelId = 'channel-id';
+    const postText = 'This is an optimistic post';
+
+    const storeBuilder = new StoreBuilder();
+    const { storeState, returnValue } = await expectSaga(createOptimisticPost, channelId, postText)
+      .withReducer(rootReducer, storeBuilder.build())
+      .provide([
+        [select(rawMessagesSelector(channelId)), []],
+        [select(currentUserSelector), { id: 'user-id' }],
+      ])
+      .run();
+
+    const channel = denormalizeChannel(channelId, storeState);
+    expect(channel.messages[0].message).toEqual(postText);
+    expect(channel.messages[0].id).not.toBeNull();
+    expect(channel.messages[0].sender).not.toBeNull();
+    expect(returnValue.optimisticPost).toEqual(expect.objectContaining({ message: postText }));
+  });
+});
+
+describe(fetchPosts, () => {
+  function subject(...args: Parameters<typeof expectSaga>) {
+    return expectSaga(...args).provide([
+      [matchers.call.fn(getPostMessagesByChannelId), { postMessages: [] }],
+    ]);
+  }
+
+  it('adds newly fetched posts to channel', async () => {
+    const existingMessages = [
+      { id: 'second-page', message: 'old', isPost: true },
+      { id: 'first-page', message: 'fresh', isPost: true },
+    ];
+    const channel = { id: 'channel-id', messages: existingMessages };
+    const postResponse = {
+      postMessages: [
+        { id: 'first-page', message: 'fresh', isPost: true },
+        { id: 'brand-new', message: 'new', isPost: true },
+      ],
+    };
+
+    const { storeState } = await subject(fetchPosts, { payload: { channelId: channel.id } })
+      .provide([
+        [call(getPostMessagesByChannelId, channel.id), postResponse],
+        [matchers.call.fn(mapMessageSenders), postResponse.postMessages],
+      ])
+      .withReducer(rootReducer, initialChannelState(channel) as any)
+      .run();
+
+    expect(denormalize(channel.id, storeState).messages).toIncludeSameMembers([
+      { id: 'second-page', message: 'old', isPost: true },
+      { id: 'first-page', message: 'fresh', isPost: true },
+      { id: 'brand-new', message: 'new', isPost: true },
+    ]);
+  });
+
+  it('sets hasMorePosts on channel', async () => {
+    const channel = { id: 'channel-id', hasMorePosts: true, messages: [] };
+    const postResponse = { hasMore: false, postMessages: [] };
+
+    const { storeState } = await subject(fetchPosts, { payload: { channelId: channel.id } })
+      .provide([[call(getPostMessagesByChannelId, channel.id), postResponse]])
+      .withReducer(rootReducer, initialChannelState(channel))
+      .run();
+
+    expect(denormalize(channel.id, storeState).hasMorePosts).toBe(false);
+  });
+
+  it('sets hasLoadedMessages on channel', async () => {
+    const channel = { id: 'channel-id', hasLoadedMessages: false };
+
+    const { storeState } = await subject(fetchPosts, { payload: { channelId: channel.id } })
+      .provide([[call(getPostMessagesByChannelId, channel.id), { postMessages: [] }]])
+      .withReducer(rootReducer, initialChannelState(channel))
+      .run();
+
+    expect(denormalize(channel.id, storeState).hasLoadedMessages).toBe(true);
+  });
+
+  it('prepends post message ids to channels state when referenceTimestamp included', async () => {
+    const postResponse = {
+      postMessages: [
+        { id: 'the-second-post-message-id', message: 'the second post', isPost: true },
+        { id: 'the-third-post-message-id', message: 'the third post', isPost: true },
+      ],
+    };
+
+    const channel = { id: 'channel-id', messages: [{ id: 'the-first-post-message-id', isPost: true }] };
+    const initialState = initialChannelState(channel);
+
+    const referenceTimestamp = 1658776625730;
+    const { storeState } = await subject(fetchPosts, { payload: { channelId: channel.id, referenceTimestamp } })
+      .withReducer(rootReducer, initialState as any)
+      .provide([
+        [call(getPostMessagesByChannelId, channel.id, referenceTimestamp), postResponse],
+        [call(mapMessageSenders, postResponse.postMessages, channel.id), undefined], // Ensure senders are mapped
+      ])
+      .run();
+
+    expect(denormalize(channel.id, storeState).messages.map((m) => m.id)).toEqual([
+      'the-second-post-message-id',
+      'the-third-post-message-id',
+      'the-first-post-message-id',
+    ]);
+  });
+
+  it('does not fetch posts if channel is not yet created', async () => {
+    const channelId = 'channel-id';
+
+    const initialState = initialChannelState({ id: channelId, conversationStatus: ConversationStatus.CREATING });
+
+    await subject(fetchPosts, { payload: { channelId } })
+      .withReducer(rootReducer, initialState)
+      .not.call.fn(getPostMessagesByChannelId)
+      .run();
+  });
+
+  function initialChannelState(channel) {
+    channel.conversationStatus = channel.conversationStatus ?? ConversationStatus.CREATED;
+    return new StoreBuilder().withConversationList(channel).build();
+  }
+});

--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -1,0 +1,94 @@
+import { takeLatest, call, put, select } from 'redux-saga/effects';
+import uniqBy from 'lodash.uniqby';
+
+import { SagaActionTypes } from '.';
+import { MessageSendStatus, receive as receiveMessage } from '../messages';
+import { getPostMessagesByChannelId, sendPostByChannelId } from '../../lib/chat';
+import { rawMessagesSelector } from '../messages/saga';
+import { currentUserSelector } from '../authentication/saga';
+import { createOptimisticPostObject } from './utils';
+import { rawChannelSelector, receiveChannel } from '../channels/saga';
+import { ConversationStatus, MessagesFetchState } from '../channels';
+import { mapMessageSenders } from '../messages/utils.matrix';
+
+export interface Payload {
+  channelId: string;
+  referenceTimestamp?: number;
+  messageId?: number;
+}
+
+export interface PostPayload {
+  channelId?: string;
+  message?: string;
+  optimisticId?: string;
+}
+
+export function* sendPost(action) {
+  const { channelId, message } = action.payload;
+
+  const { optimisticPost } = yield call(createOptimisticPost, channelId, message);
+
+  try {
+    yield call(sendPostByChannelId, channelId, message, optimisticPost.optimisticId);
+  } catch (error) {
+    console.error('Failed to send post:', error);
+    yield put(receiveMessage({ id: optimisticPost.optimisticId, sendStatus: MessageSendStatus.FAILED }));
+  }
+}
+
+export function* createOptimisticPost(channelId, postText) {
+  const existingMessages = yield select(rawMessagesSelector(channelId));
+  const currentUser = yield select(currentUserSelector());
+
+  const optimisticPost = createOptimisticPostObject(postText, currentUser);
+
+  yield call(receiveChannel, { id: channelId, messages: [...existingMessages, optimisticPost] });
+
+  return { optimisticPost };
+}
+
+export function* fetchPosts(action) {
+  const { channelId, referenceTimestamp } = action.payload;
+  const channel = yield select(rawChannelSelector(channelId));
+
+  if (channel.conversationStatus !== ConversationStatus.CREATED) {
+    return;
+  }
+
+  let postsResponse;
+  let posts;
+
+  try {
+    if (referenceTimestamp) {
+      yield call(receiveChannel, { id: channelId, messagesFetchStatus: MessagesFetchState.MORE_IN_PROGRESS });
+      postsResponse = yield call(getPostMessagesByChannelId, channelId, referenceTimestamp);
+    } else {
+      yield call(receiveChannel, { id: channelId, messagesFetchStatus: MessagesFetchState.IN_PROGRESS });
+      postsResponse = yield call(getPostMessagesByChannelId, channelId);
+    }
+
+    yield call(mapMessageSenders, postsResponse.postMessages, channelId);
+
+    const existingMessages = yield select(rawMessagesSelector(channelId));
+    const existingPosts = existingMessages.filter((message) => message.isPost);
+
+    posts = uniqBy([...postsResponse.postMessages, ...existingPosts], (p) => p.id ?? p);
+
+    // Updates the channel's state with the fetched posts and existing non-post messages
+    const nonPostMessages = existingMessages.filter((message) => !message.isPost);
+    yield call(receiveChannel, {
+      id: channelId,
+      messages: uniqBy([...posts, ...nonPostMessages], (m) => m.id ?? m),
+      hasMorePosts: postsResponse.hasMore,
+      hasLoadedMessages: true,
+      messagesFetchStatus: MessagesFetchState.SUCCESS,
+    });
+  } catch (error) {
+    yield call(receiveChannel, { id: channelId, messagesFetchStatus: MessagesFetchState.FAILED });
+  }
+}
+
+export function* saga() {
+  yield takeLatest(SagaActionTypes.SendPost, sendPost);
+  yield takeLatest(SagaActionTypes.FetchPosts, fetchPosts);
+}

--- a/src/store/posts/utils.ts
+++ b/src/store/posts/utils.ts
@@ -1,0 +1,31 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { Message, MessageSendStatus } from './../messages';
+import { User } from './../authentication/types';
+
+export function createOptimisticPostObject(postText: string, user: User): Message {
+  const id = uuidv4();
+
+  return {
+    createdAt: Date.now(),
+    hidePreview: false,
+    id,
+    optimisticId: id,
+    mentionedUsers: [],
+    message: postText,
+    isAdmin: false,
+    sender: {
+      userId: user.id,
+      firstName: user.profileSummary.firstName,
+      lastName: user.profileSummary.lastName,
+      profileImage: user.profileSummary.profileImage,
+      profileId: user.profileId,
+      primaryZID: user.primaryZID,
+    },
+    updatedAt: 0,
+    preview: null,
+    media: null,
+    sendStatus: MessageSendStatus.IN_PROGRESS,
+    isPost: true,
+  };
+}

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -22,6 +22,7 @@ import { reducer as messageInfo } from './message-info';
 import { reducer as userProfile } from './user-profile';
 import { reducer as background } from './background';
 import { reducer as accountManagement } from './account-management';
+import { reducer as posts } from './posts';
 
 export const rootReducer = combineReducers({
   pageload,
@@ -46,6 +47,7 @@ export const rootReducer = combineReducers({
   userProfile,
   background,
   accountManagement,
+  posts,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -23,6 +23,7 @@ import { saga as messageInfo } from './message-info/saga';
 import { saga as userProfile } from './user-profile/saga';
 import { saga as background } from './background/saga';
 import { saga as accountManagement } from './account-management/saga';
+import { saga as posts } from './posts/saga';
 
 export function* rootSaga() {
   const allSagas = {
@@ -49,6 +50,7 @@ export function* rootSaga() {
     userProfile,
     background,
     accountManagement,
+    posts,
   };
 
   yield all(


### PR DESCRIPTION
### What does this do?
- adds posts store saga, reducer and actions (sendPost, fetchPosts)
- adds test coverage

### Why are we making this change?
- separation of posts and messages

### How do I test this?
- run tests as usual
- this saga is not yet wired up

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
