### PR TITLE
fix: post width

### DIFF
--- a/src/components/messenger/feed/components/post/styles.module.scss
+++ b/src/components/messenger/feed/components/post/styles.module.scss
@@ -5,4 +5,5 @@
 
 .Post {
   padding: 0;
+  flex: 1;
 }


### PR DESCRIPTION
**Before**
<img width="581" alt="Screenshot 2024-08-22 at 2 25 30 pm" src="https://github.com/user-attachments/assets/9ed70fe3-12f9-42f2-8a66-44525c27a91e">

**After**
<img width="571" alt="Screenshot 2024-08-22 at 2 25 37 pm" src="https://github.com/user-attachments/assets/44fc3f25-ee8d-4bb0-bb4a-3987774d5274">
