### PR TITLE
refactor(messenger-feed-container): add separate feed view container resolving unnecessary componentdidmount/didupdate triggers

### DIFF
--- a/src/components/messenger/feed/feed-view-container/feed-view-container.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view-container.test.tsx
@@ -1,0 +1,220 @@
+import { RootState } from '../../../../store/reducer';
+import { shallow } from 'enzyme';
+import { Container as FeedViewContainer } from './feed-view-container';
+import { FeedView } from './feed-view';
+import { MessageSendStatus } from '../../../../store/messages';
+
+describe('FeedViewContainer', () => {
+  const subject = (props: any = {}) => {
+    const allProps = {
+      channel: null,
+      channelId: '',
+      user: {
+        isLoading: false,
+        data: null,
+      },
+      activeConversationId: '',
+
+      fetchPosts: () => undefined,
+      ...props,
+    };
+
+    return shallow(<FeedViewContainer {...allProps} />);
+  };
+
+  it('does not render child if channel is not loaded', () => {
+    const wrapper = subject({ channel: null });
+
+    expect(wrapper.find(FeedView).exists()).toStrictEqual(false);
+  });
+
+  it('passes postMessages to child', () => {
+    const messages = [
+      { id: 'post-one', message: 'First post', isPost: true, sendStatus: MessageSendStatus.SUCCESS },
+      { id: 'post-two', message: 'Second post', isPost: true, sendStatus: MessageSendStatus.SUCCESS },
+    ];
+
+    const wrapper = subject({ channel: { messages } });
+
+    expect(wrapper.find(FeedView).prop('postMessages')).toStrictEqual(messages.reverse());
+  });
+
+  it('passes empty array for postMessages to child when channel has no messages', () => {
+    const wrapper = subject({ channel: { id: 'channel-id' } });
+
+    expect(wrapper.find(FeedView).prop('postMessages')).toStrictEqual([]);
+  });
+
+  it('fetches posts on mount', () => {
+    const fetchPosts = jest.fn();
+
+    subject({ fetchPosts, channelId: 'the-channel-id', channel: { hasLoadedMessages: false } });
+
+    expect(fetchPosts).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
+  });
+
+  it('fetches posts when channel id is set or updated', () => {
+    const fetchPosts = jest.fn();
+
+    const wrapper = subject({
+      fetchPosts,
+      channelId: '',
+      channel: { name: 'first channel', shouldSyncChannels: false },
+    });
+
+    wrapper.setProps({ channelId: 'the-channel-id' });
+
+    expect(fetchPosts).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
+  });
+
+  it('should call fetchMorePosts with reference timestamp when hasMorePosts is true', () => {
+    const fetchPosts = jest.fn();
+    const messages = [
+      {
+        id: 'post-one',
+        message: 'First post',
+        createdAt: 1658776625730,
+        isPost: true,
+        sendStatus: MessageSendStatus.SUCCESS,
+      },
+      {
+        id: 'post-two',
+        message: 'Second post',
+        createdAt: 1659016677502,
+        isPost: true,
+        sendStatus: MessageSendStatus.SUCCESS,
+      },
+    ];
+
+    const wrapper = subject({
+      fetchPosts,
+      channelId: 'the-channel-id',
+      channel: { hasMorePosts: true, name: 'first channel', messages },
+    });
+
+    wrapper.find(FeedView).prop('onFetchMore')();
+
+    expect(fetchPosts).toHaveBeenLastCalledWith({
+      channelId: 'the-channel-id',
+      referenceTimestamp: 1658776625730,
+    });
+  });
+
+  it('should not call fetchMorePosts when hasMorePosts is false', () => {
+    const fetchPosts = jest.fn();
+    const messages = [
+      {
+        id: 'post-one',
+        message: 'First post',
+        createdAt: 1658776625730,
+        isPost: true,
+        sendStatus: MessageSendStatus.SUCCESS,
+      },
+      {
+        id: 'post-two',
+        message: 'Second post',
+        createdAt: 1659016677502,
+        isPost: true,
+        sendStatus: MessageSendStatus.SUCCESS,
+      },
+    ];
+
+    const wrapper = subject({
+      fetchPosts,
+      channelId: 'the-channel-id',
+      channel: { hasMorePosts: false, name: 'first channel', messages },
+    });
+
+    wrapper.find(FeedView).prop('onFetchMore')();
+
+    expect(fetchPosts).not.toHaveBeenLastCalledWith({
+      channelId: 'the-channel-id',
+      referenceTimestamp: 1658776625730,
+    });
+  });
+
+  describe('mapState', () => {
+    const getState = (state: any) =>
+      ({
+        normalized: {
+          ...(state.normalized || {}),
+        },
+        authentication: {
+          user: {
+            data: null,
+          },
+        },
+        chat: {
+          activeConversationId: '1',
+        },
+      } as RootState);
+
+    test('channel', () => {
+      const state = getState({
+        normalized: {
+          channels: {
+            'the-id': { id: 'the-id', name: 'the channel' },
+            'the-second-id': { id: 'the-second-id', name: 'the second channel' },
+            'the-third-id': { id: 'the-third-id', name: 'the third channel' },
+          },
+        },
+      });
+
+      const props = FeedViewContainer.mapState(state, { channelId: 'the-second-id' });
+
+      expect(props.channel).toMatchObject({
+        id: 'the-second-id',
+        name: 'the second channel',
+      });
+    });
+
+    test('postMessages', () => {
+      const state = getState({
+        normalized: {
+          messages: {
+            'post-one': { id: 'post-one', message: 'First post', isPost: true, sendStatus: MessageSendStatus.SUCCESS },
+            'post-two': { id: 'post-two', message: 'Second post', isPost: true, sendStatus: MessageSendStatus.SUCCESS },
+          },
+          channels: {
+            'the-id': { id: 'the-id', name: 'the channel' },
+            'the-second-id': {
+              id: 'the-second-id',
+              name: 'the second channel',
+              hasMorePosts: true,
+              messages: [
+                'post-one',
+                'post-two',
+              ],
+            },
+            'the-third-id': { id: 'the-third-id', name: 'the third channel' },
+          },
+        },
+      });
+
+      const { channel } = FeedViewContainer.mapState(state, { channelId: 'the-second-id' });
+
+      expect(channel.messages).toIncludeAllPartialMembers([
+        { id: 'post-one', message: 'First post' },
+        { id: 'post-two', message: 'Second post' },
+      ]);
+
+      expect(channel.hasMorePosts).toEqual(true);
+    });
+
+    test('channel with no id set', () => {
+      const state = getState({
+        normalized: {
+          channels: {
+            'the-id': { id: 'the-id', name: 'the channel' },
+            'the-second-id': { id: 'the-second-id', name: 'the second channel' },
+            'the-third-id': { id: 'the-third-id', name: 'the third channel' },
+          },
+        },
+      });
+
+      const props = FeedViewContainer.mapState(state, { channelId: '' });
+
+      expect(props.channel).toBeNull();
+    });
+  });
+});

--- a/src/components/messenger/feed/feed-view-container/feed-view-container.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view-container.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { RootState } from '../../../../store/reducer';
+import { connectContainer } from '../../../../store/redux-container';
+import { Payload as PayloadFetchPost } from '../../../../store/posts/saga';
+import { Channel, denormalize } from '../../../../store/channels';
+import { MessageSendStatus } from '../../../../store/messages';
+import { fetchPosts } from '../../../../store/posts';
+import { AuthenticationState } from '../../../../store/authentication/types';
+import { FeedView } from './feed-view';
+
+interface PublicProperties {
+  channelId: string;
+}
+
+export interface Properties extends PublicProperties {
+  channel: Channel;
+  user: AuthenticationState['user'];
+  activeConversationId?: string;
+
+  fetchPosts: (payload: PayloadFetchPost) => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState, props: PublicProperties): Partial<Properties> {
+    const channel = denormalize(props.channelId, state) || null;
+    const {
+      authentication: { user },
+      chat: { activeConversationId },
+    } = state;
+
+    return {
+      channel,
+      user,
+      activeConversationId,
+    };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return {
+      fetchPosts,
+    };
+  }
+
+  componentDidMount() {
+    const { channelId, channel } = this.props;
+    if (channelId && !channel.hasLoadedMessages) {
+      this.props.fetchPosts({ channelId });
+    }
+  }
+
+  componentDidUpdate(prevProps: Properties) {
+    const { channelId } = this.props;
+
+    if (channelId && channelId !== prevProps.channelId) {
+      this.props.fetchPosts({ channelId });
+    }
+
+    if (channelId && prevProps.user.data === null && this.props.user.data !== null) {
+      this.props.fetchPosts({ channelId });
+    }
+  }
+
+  getOldestTimestamp(messages = []) {
+    return messages.reduce((previousTimestamp, message) => {
+      return message.createdAt < previousTimestamp ? message.createdAt : previousTimestamp;
+    }, Date.now());
+  }
+
+  get channel(): Channel {
+    return this.props.channel || ({} as Channel);
+  }
+
+  fetchMorePosts = () => {
+    const { channelId, channel } = this.props;
+
+    if (channel.hasMorePosts) {
+      const referenceTimestamp = this.getOldestTimestamp(this.postMessages);
+      this.props.fetchPosts({ channelId: channelId, referenceTimestamp });
+    }
+  };
+
+  get postMessages() {
+    const messages = this.props.channel?.messages || [];
+    return messages.filter((message) => message.isPost && message.sendStatus === MessageSendStatus.SUCCESS).reverse();
+  }
+
+  render() {
+    if (!this.props.channel) return null;
+
+    return (
+      <>
+        <FeedView
+          postMessages={this.postMessages}
+          fetchPosts={this.props.fetchPosts}
+          onFetchMore={this.fetchMorePosts}
+          hasLoadedMessages={this.channel.hasLoadedMessages ?? false}
+          messagesFetchStatus={this.channel.messagesFetchStatus}
+        />
+      </>
+    );
+  }
+}
+
+export const FeedViewContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { FeedView, Message, Properties } from './feed-view';
+import { Posts } from '../components/posts';
+import { MessagesFetchState } from '../../../../store/channels';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+import { Waypoint } from 'react-waypoint';
+
+describe('FeedView', () => {
+  const POST_MESSAGES_TEST = [
+    { id: 'post-one', message: 'First post', createdAt: 1658776625730, isPost: true },
+    { id: 'post-two', message: 'Second post', createdAt: 1659018545428, isPost: true },
+  ] as any;
+
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps = {
+      postMessages: [],
+      hasLoadedMessages: true,
+      messagesFetchStatus: MessagesFetchState.SUCCESS,
+      fetchPosts: jest.fn(),
+      onFetchMore: jest.fn(),
+      ...props,
+    };
+
+    return shallow(<FeedView {...allProps} />);
+  };
+
+  it('renders posts for each message', () => {
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
+
+    const postsComponent = wrapper.find(Posts);
+    expect(postsComponent.exists()).toBe(true);
+    expect(postsComponent.prop('postMessages')).toEqual(POST_MESSAGES_TEST);
+  });
+
+  it('renders a message when there are no posts', () => {
+    const wrapper = subject({ postMessages: [] });
+
+    expect(wrapper).toHaveElement(Message);
+  });
+
+  it('renders a spinner when messages are loading', () => {
+    const wrapper = subject({ hasLoadedMessages: false });
+
+    expect(wrapper).toHaveElement(Spinner);
+  });
+
+  it('renders a waypoint if posts are present', () => {
+    const onFetchMoreSpy = jest.fn();
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST, onFetchMore: onFetchMoreSpy });
+
+    const waypoint = wrapper.find(Waypoint);
+    expect(waypoint.exists()).toBe(true);
+    expect(wrapper).toHaveElement(Waypoint);
+
+    expect(waypoint.prop('onEnter')).toEqual(onFetchMoreSpy);
+  });
+
+  it('does not render a waypoint if no posts are present', () => {
+    const wrapper = subject({ postMessages: [] });
+
+    expect(wrapper).not.toHaveElement(Waypoint);
+  });
+
+  it('renders a spinner when messages have not been loaded yet', () => {
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST, hasLoadedMessages: false });
+
+    expect(wrapper).toHaveElement(Spinner);
+
+    wrapper.setProps({ hasLoadedMessages: true });
+    expect(wrapper).not.toHaveElement(Spinner);
+  });
+
+  it('renders a message component with children', () => {
+    const wrapper = shallow(<Message>Test Message</Message>);
+
+    expect(wrapper.text()).toEqual('Test Message');
+  });
+});

--- a/src/components/messenger/feed/feed-view-container/feed-view.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.tsx
@@ -1,0 +1,56 @@
+import React, { ReactNode } from 'react';
+import { Waypoint } from 'react-waypoint';
+
+import { Posts } from '../components/posts';
+import { MessagesFetchState } from '../../../../store/channels';
+import { Message as MessageModel } from '../../../../store/messages';
+import { Payload as PayloadFetchPosts } from '../../../../store/posts/saga';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+
+import { bemClassName } from '../../../../lib/bem';
+import './styles.scss';
+
+const cn = bemClassName('feed-view');
+
+export interface Properties {
+  postMessages: MessageModel[];
+  hasLoadedMessages: boolean;
+  messagesFetchStatus: MessagesFetchState;
+
+  fetchPosts: (payload: PayloadFetchPosts) => void;
+  onFetchMore: () => void;
+}
+
+export class FeedView extends React.Component<Properties> {
+  render() {
+    return (
+      <div {...cn('')}>
+        {this.props.hasLoadedMessages && (
+          <>
+            {this.props.postMessages.length > 0 ? (
+              <>
+                <Posts postMessages={this.props.postMessages} />
+
+                {this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && (
+                  <Waypoint onEnter={this.props.onFetchMore} />
+                )}
+              </>
+            ) : (
+              <Message>Nobody has posted here yet</Message>
+            )}
+          </>
+        )}
+
+        {!this.props.hasLoadedMessages && (
+          <Message>
+            <Spinner />
+          </Message>
+        )}
+      </div>
+    );
+  }
+}
+
+export const Message = ({ children }: { children: ReactNode }) => {
+  return <div {...cn('message')}>{children}</div>;
+};

--- a/src/components/messenger/feed/feed-view-container/styles.scss
+++ b/src/components/messenger/feed/feed-view-container/styles.scss
@@ -1,0 +1,10 @@
+.feed-view {
+  &__message {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    padding: 16px;
+    box-sizing: border-box;
+    color: var(--color-greyscale-10);
+  }
+}

--- a/src/components/messenger/feed/index.test.tsx
+++ b/src/components/messenger/feed/index.test.tsx
@@ -12,7 +12,6 @@ describe(MessengerFeed, () => {
       isSocialChannel: false,
       isJoiningConversation: false,
       sendPost: jest.fn(),
-      fetchPosts: jest.fn(),
       ...props,
     };
 
@@ -31,7 +30,7 @@ describe(MessengerFeed, () => {
 
     const wrapper = subject({ channel: channel as any, isSocialChannel: false });
 
-    expect(wrapper).not.toHaveElement('CreatePost');
+    expect(wrapper.isEmptyRender()).toBe(true);
   });
 
   it('does not render Messenger Feed when isJoiningConversation is true', () => {
@@ -39,7 +38,7 @@ describe(MessengerFeed, () => {
 
     const wrapper = subject({ channel: channel as any, isSocialChannel: true, isJoiningConversation: true });
 
-    expect(wrapper).not.toHaveElement('CreatePost');
+    expect(wrapper.isEmptyRender()).toBe(true);
   });
 
   it('does not render Messenger Feed when no active conversation id', () => {
@@ -47,7 +46,7 @@ describe(MessengerFeed, () => {
 
     const wrapper = subject({ channel: channel as any, isSocialChannel: true, activeConversationId: null });
 
-    expect(wrapper).not.toHaveElement('CreatePost');
+    expect(wrapper.isEmptyRender()).toBe(true);
   });
 
   describe('mapState', () => {
@@ -61,6 +60,32 @@ describe(MessengerFeed, () => {
       const state = new StoreBuilder().withActiveConversation(stubConversation({ isSocialChannel: false })).build();
 
       expect(MessengerFeed.mapState(state)).toEqual(expect.objectContaining({ isSocialChannel: false }));
+    });
+
+    it('maps isJoiningConversation from state', () => {
+      const state = new StoreBuilder().withChat({ isJoiningConversation: true }).build();
+
+      expect(MessengerFeed.mapState(state)).toEqual(expect.objectContaining({ isJoiningConversation: true }));
+    });
+
+    it('maps activeConversationId from state', () => {
+      const activeConversationId = 'test-conversation-id';
+      const state = new StoreBuilder().withActiveConversationId(activeConversationId).build();
+
+      expect(MessengerFeed.mapState(state)).toEqual(expect.objectContaining({ activeConversationId }));
+    });
+
+    it('maps channel from state', () => {
+      const conversation = stubConversation({ id: 'test-conversation-id' });
+      const state = new StoreBuilder().withActiveConversation(conversation).build();
+
+      expect(MessengerFeed.mapState(state)).toEqual(
+        expect.objectContaining({
+          channel: expect.objectContaining({
+            id: 'test-conversation-id',
+          }),
+        })
+      );
     });
   });
 });

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -11,24 +11,11 @@
   background: var(--Transparencies-Black-translucent, #0000007a);
   backdrop-filter: blur(60px);
 
-  &__feed-view {
-    display: flex;
-  }
-
   &__divider {
     width: 1px;
     height: auto;
     background-color: rgba(245, 245, 245, 0.12);
     margin: 16px;
     align-self: stretch;
-  }
-
-  &__message {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    padding: 16px;
-    box-sizing: border-box;
-    color: var(--color-greyscale-10);
   }
 }


### PR DESCRIPTION
### What does this do?
This refactor separates the MessengerFeed functionality by introducing a new FeedViewContainer, ensuring that component lifecycle methods like componentDidMount and componentDidUpdate are triggered only when necessary. This helps in improving performance and maintaining cleaner code structure.

### Why are we making this change?
The change is made to address performance issues and prevent unnecessary API calls triggered by the componentDidMount and componentDidUpdate methods. By moving the feed-specific logic to a dedicated container, we ensure that these methods are only called when the feed-related data needs to be fetched or updated, resulting in a more efficient and maintainable codebase.

### How do I test this?
- run tests as usual
- run ui > switch conversations and check network tab for messages request

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
