### PR TITLE
feat(feed-view): implement and test conditional waypoint rendering based on content height in feedview component

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -223,7 +223,7 @@ export class Container extends React.Component<Properties> {
             )}
           </div>
 
-          {!this.props.isJoiningConversation && (
+          {/* {!this.props.isJoiningConversation && (
             <ChatViewContainer
               key={this.props.directMessage.optimisticId || this.props.directMessage.id} // Render new component for a new chat
               channelId={this.props.activeConversationId}
@@ -231,7 +231,7 @@ export class Container extends React.Component<Properties> {
               showSenderAvatar={!this.isOneOnOne()}
               ref={this.chatViewContainerRef}
             />
-          )}
+          )} */}
 
           <div className='direct-message-chat__footer-position'>
             <div className='direct-message-chat__footer'>

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -223,7 +223,7 @@ export class Container extends React.Component<Properties> {
             )}
           </div>
 
-          {/* {!this.props.isJoiningConversation && (
+          {!this.props.isJoiningConversation && (
             <ChatViewContainer
               key={this.props.directMessage.optimisticId || this.props.directMessage.id} // Render new component for a new chat
               channelId={this.props.activeConversationId}
@@ -231,7 +231,7 @@ export class Container extends React.Component<Properties> {
               showSenderAvatar={!this.isOneOnOne()}
               ref={this.chatViewContainerRef}
             />
-          )} */}
+          )}
 
           <div className='direct-message-chat__footer-position'>
             <div className='direct-message-chat__footer'>

--- a/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
@@ -45,15 +45,33 @@ describe('FeedView', () => {
     expect(wrapper).toHaveElement(Spinner);
   });
 
-  it('renders a waypoint if posts are present', () => {
+  it('renders a waypoint if posts are present and content exceeds viewport height', () => {
     const onFetchMoreSpy = jest.fn();
     const wrapper = subject({ postMessages: POST_MESSAGES_TEST, onFetchMore: onFetchMoreSpy });
 
+    wrapper.setState({ shouldRenderWaypoint: true });
+
     const waypoint = wrapper.find(Waypoint);
     expect(waypoint.exists()).toBe(true);
-    expect(wrapper).toHaveElement(Waypoint);
-
     expect(waypoint.prop('onEnter')).toEqual(onFetchMoreSpy);
+  });
+
+  it('does not render a waypoint if content does not exceed viewport height', () => {
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
+
+    wrapper.setState({ shouldRenderWaypoint: false });
+
+    expect(wrapper.find(Waypoint).exists()).toBe(false);
+  });
+
+  it('renders a waypoint if posts are present and content height changes after update', () => {
+    const onFetchMoreSpy = jest.fn();
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST, onFetchMore: onFetchMoreSpy });
+
+    wrapper.setState({ shouldRenderWaypoint: true });
+
+    const waypoint = wrapper.find(Waypoint);
+    expect(waypoint.exists()).toBe(true);
   });
 
   it('does not render a waypoint if no posts are present', () => {
@@ -75,5 +93,32 @@ describe('FeedView', () => {
     const wrapper = shallow(<Message>Test Message</Message>);
 
     expect(wrapper.text()).toEqual('Test Message');
+  });
+
+  it('updates shouldRenderWaypoint state based on content height after mount', () => {
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
+
+    const instance = wrapper.instance() as FeedView;
+    jest.spyOn(instance, 'checkContentHeight');
+
+    instance.componentDidMount();
+
+    expect(instance.checkContentHeight).toHaveBeenCalled();
+  });
+
+  it('updates shouldRenderWaypoint state based on content height after update', () => {
+    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
+
+    const instance = wrapper.instance() as FeedView;
+    jest.spyOn(instance, 'checkContentHeight');
+
+    wrapper.setProps({
+      postMessages: [
+        ...POST_MESSAGES_TEST,
+        { id: 'post-three', message: 'Third post', createdAt: 1659018545429, isPost: true },
+      ],
+    });
+
+    expect(instance.checkContentHeight).toHaveBeenCalled();
   });
 });

--- a/src/components/messenger/feed/feed-view-container/feed-view.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.tsx
@@ -22,16 +22,51 @@ export interface Properties {
 }
 
 export class FeedView extends React.Component<Properties> {
+  contentRef: React.RefObject<HTMLDivElement>;
+
+  state = {
+    shouldRenderWaypoint: false,
+  };
+
+  constructor(props: Properties) {
+    super(props);
+    this.contentRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.checkContentHeight();
+  }
+
+  componentDidUpdate(prevProps: Properties) {
+    if (
+      prevProps.postMessages !== this.props.postMessages ||
+      prevProps.hasLoadedMessages !== this.props.hasLoadedMessages
+    ) {
+      this.checkContentHeight();
+    }
+  }
+
+  checkContentHeight() {
+    if (this.contentRef.current) {
+      const contentHeight = this.contentRef.current.clientHeight;
+      const viewportHeight = window.innerHeight;
+
+      this.setState({
+        shouldRenderWaypoint: contentHeight > viewportHeight,
+      });
+    }
+  }
+
   render() {
     return (
-      <div {...cn('')}>
+      <div {...cn('')} ref={this.contentRef}>
         {this.props.hasLoadedMessages && (
           <>
             {this.props.postMessages.length > 0 ? (
               <>
                 <Posts postMessages={this.props.postMessages} />
 
-                {this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && (
+                {this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && this.state.shouldRenderWaypoint && (
                   <Waypoint onEnter={this.props.onFetchMore} />
                 )}
               </>


### PR DESCRIPTION
### What does this do?
This PR refactors the FeedView component to conditionally render the Waypoint based on the content height relative to the viewport. Additionally, it updates the tests to cover this new behavior, ensuring that the Waypoint only triggers when the user scrolls and the content exceeds the viewport height.

### Why are we making this change?
The change addresses an issue where the Waypoint was being triggered immediately when there were only a few posts, causing unnecessary data fetching. By rendering the Waypoint only when needed, we improve performance and ensure that additional posts are fetched only when the user scrolls down to view more content.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
