### PR TITLE
refactor(feed-view-container): prevent post fetches if posts have loaded when switching conversations, and enhance tests

### DIFF
--- a/src/components/messenger/feed/feed-view-container/feed-view-container.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view-container.test.tsx
@@ -45,7 +45,7 @@ describe('FeedViewContainer', () => {
     expect(wrapper.find(FeedView).prop('postMessages')).toStrictEqual([]);
   });
 
-  it('fetches posts on mount', () => {
+  it('fetches posts on mount if posts are not loaded', () => {
     const fetchPosts = jest.fn();
 
     subject({ fetchPosts, channelId: 'the-channel-id', channel: { hasLoadedMessages: false } });
@@ -53,16 +53,52 @@ describe('FeedViewContainer', () => {
     expect(fetchPosts).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
   });
 
-  it('fetches posts when channel id is set or updated', () => {
+  it('does not fetch posts on mount if posts are already loaded', () => {
+    const fetchPosts = jest.fn();
+
+    subject({ fetchPosts, channelId: 'the-channel-id', channel: { hasLoadedMessages: true } });
+
+    expect(fetchPosts).not.toHaveBeenCalled();
+  });
+
+  it('fetches posts when channel id is set or updated if posts are not loaded', () => {
     const fetchPosts = jest.fn();
 
     const wrapper = subject({
       fetchPosts,
       channelId: '',
-      channel: { name: 'first channel', shouldSyncChannels: false },
+      channel: { hasLoadedMessages: false },
     });
 
-    wrapper.setProps({ channelId: 'the-channel-id' });
+    wrapper.setProps({ channelId: 'the-channel-id', channel: { hasLoadedMessages: false } });
+
+    expect(fetchPosts).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
+  });
+
+  it('does not fetch posts when channel id is updated if posts are already loaded', () => {
+    const fetchPosts = jest.fn();
+
+    const wrapper = subject({
+      fetchPosts,
+      channelId: 'the-channel-id',
+      channel: { hasLoadedMessages: true },
+    });
+
+    wrapper.setProps({ channelId: 'new-channel-id', channel: { hasLoadedMessages: true } });
+
+    expect(fetchPosts).not.toHaveBeenCalled();
+  });
+
+  it('fetches posts when user data becomes available', () => {
+    const fetchPosts = jest.fn();
+    const wrapper = subject({
+      fetchPosts,
+      channelId: 'the-channel-id',
+      channel: { hasLoadedMessages: false },
+      user: { isLoading: false, data: null },
+    });
+
+    wrapper.setProps({ user: { isLoading: false, data: { id: 'user-id' } } });
 
     expect(fetchPosts).toHaveBeenCalledWith({ channelId: 'the-channel-id' });
   });

--- a/src/components/messenger/feed/feed-view-container/feed-view-container.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view-container.tsx
@@ -49,9 +49,9 @@ export class Container extends React.Component<Properties> {
   }
 
   componentDidUpdate(prevProps: Properties) {
-    const { channelId } = this.props;
+    const { channel, channelId } = this.props;
 
-    if (channelId && channelId !== prevProps.channelId) {
+    if (channelId && channelId !== prevProps.channelId && !channel.hasLoadedMessages) {
       this.props.fetchPosts({ channelId });
     }
 


### PR DESCRIPTION
### What does this do?
This update prevents unnecessary post fetching in the FeedViewContainer when switching conversations if posts have already been loaded. It also enhances the component and its tests to ensure that data is only fetched when needed, improving performance and reducing redundant network requests.

### Why are we making this change?
We made this change to optimize performance by reducing unnecessary data fetching. This ensures that when users switch between conversations, previously loaded posts aren't fetched again, leading to a more efficient and faster user experience. Additionally, enhancing the tests ensures the reliability and correctness of the implemented logic.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
