### PR TITLE
refactor(chat-view): improve chat skeleton positioning when loading messages

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -271,10 +271,10 @@ export class ChatView extends React.Component<Properties, State> {
                 <Waypoint onEnter={this.props.onFetchMore} />
               </div>
             )}
-            {this.props.messages.length > 0 && this.renderMessages()}
             {!this.props.hasLoadedMessages && this.props.messagesFetchStatus !== MessagesFetchState.FAILED && (
               <ChatSkeleton conversationId={this.props.id} />
             )}
+            {this.props.messages.length > 0 && this.renderMessages()}
           </div>
 
           {this.props.messagesFetchStatus === MessagesFetchState.FAILED && (


### PR DESCRIPTION
### What does this do?
- improves the positioning of the chat skeleton when loading messages in a room

### Why are we making this change?
- improved UI/UX

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

BEFORE

<img width="850" alt="Screenshot 2024-08-24 at 12 33 10" src="https://github.com/user-attachments/assets/c13c22f9-b0c9-4264-8306-25a5c8a7a8fa">

AFTER 

<img width="850" alt="Screenshot 2024-08-24 at 12 32 44" src="https://github.com/user-attachments/assets/a858fe05-8320-4371-ace3-31897082c969">
