### PR TITLE
feat(posts): apply post sender display sub handle data to author prop/attribute to display zid or wallet address

### DIFF
--- a/src/components/messenger/feed/components/posts/index.tsx
+++ b/src/components/messenger/feed/components/posts/index.tsx
@@ -12,6 +12,7 @@ export const Posts = ({ postMessages }) => {
             text={post.message}
             nickname={post.sender.firstName}
             timestamp={post.createdAt}
+            author={post.sender.displaySubHandle}
           />
         </li>
       ))}


### PR DESCRIPTION
### What does this do?
- applies post sender display sub handle data to author prop/attribute to display zid or wallet address

### Why are we making this change?
- as per design requirement

### How do I test this?
- run tests as usual
- run ui > open social channel > check displaySubHandle (if one exists for user) as per screenshot below

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



<img width="467" alt="Screenshot 2024-08-24 at 13 47 58" src="https://github.com/user-attachments/assets/b9757cd7-2070-4b7f-aba6-2a59be640116">

