### PR TITLE
feat(group-management): update / handle group management for token gated social channels

### DIFF
--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -193,7 +193,9 @@ describe(DirectMessageChat, () => {
   describe('mapState', () => {
     describe('canLeaveRoom', () => {
       it('is false when only when one other member', () => {
-        const state = new StoreBuilder().withActiveConversation(stubConversation({ otherMembers: [stubUser()] }));
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ otherMembers: [stubUser()], isSocialChannel: false })
+        );
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
       });
@@ -201,7 +203,11 @@ describe(DirectMessageChat, () => {
       it('is false when user is admin', () => {
         const state = new StoreBuilder()
           .withActiveConversation(
-            stubConversation({ otherMembers: [stubUser(), stubUser()], adminMatrixIds: ['current-user-matrix-id'] })
+            stubConversation({
+              otherMembers: [stubUser(), stubUser()],
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: false,
+            })
           )
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -214,6 +214,20 @@ describe(DirectMessageChat, () => {
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
       });
 
+      it('is false when user is admin and conversation is social channel', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              otherMembers: [stubUser(), stubUser()],
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
+      });
+
       it('is true when user is not admin and more than one other member', () => {
         const state = new StoreBuilder()
           .withActiveConversation(
@@ -223,18 +237,38 @@ describe(DirectMessageChat, () => {
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
       });
+
+      it('is true when the conversation is a social channel and has multiple members', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ otherMembers: [stubUser(), stubUser()], isSocialChannel: true }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
+      });
+
+      it('is false when the conversation is a social channel and has only one member', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ otherMembers: [stubUser()], isSocialChannel: true }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
+      });
     });
 
     describe('canEdit', () => {
       it('is false when one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: true }));
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: true, isSocialChannel: false })
+        );
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
       });
 
       it('is false when current user is not room admin', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'] }))
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: false })
+          )
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
@@ -242,7 +276,9 @@ describe(DirectMessageChat, () => {
 
       it('is true when current user is room admin', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'] }))
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: false })
+          )
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
@@ -250,23 +286,53 @@ describe(DirectMessageChat, () => {
 
       it('is true when current user is room moderator', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ isOneOnOne: false, moderatorIds: ['current-user-id'] }))
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, moderatorIds: ['current-user-id'], isSocialChannel: false })
+          )
           .withCurrentUser(stubAuthenticatedUser({ id: 'current-user-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
+
+      it('is true when the conversation is a social channel and user is an admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              isOneOnOne: true,
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
+
+      it('is false when the conversation is a social channel and current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: true })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
       });
     });
 
     describe('canAddMembers', () => {
       it('is false when one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: true }));
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: true, isSocialChannel: false })
+        );
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
       });
 
       it('is false when current user is not room admin', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'] }))
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: false })
+          )
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
@@ -274,22 +340,63 @@ describe(DirectMessageChat, () => {
 
       it('is true when current user is room admin', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'] }))
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: false })
+          )
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+
+      it('is true when the conversation is a social channel and user is an admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              isOneOnOne: true,
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+
+      it('is false when the conversation is a social channel and current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: true })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
       });
     });
 
     describe('canViewDetails', () => {
       it('is false when one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: true }));
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: true, isSocialChannel: false })
+        );
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: false }));
       });
 
       it('is true when not a one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(stubConversation({ isOneOnOne: false }));
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: false, isSocialChannel: false })
+        );
+
+        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
+      });
+
+      it('is true when the conversation is a social channel', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({
+            isOneOnOne: false,
+            isSocialChannel: true,
+          })
+        );
 
         expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
       });

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -80,10 +80,11 @@ export class Container extends React.Component<Properties> {
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
     const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.id) ?? false;
 
-    const canLeaveRoom = (!isCurrentUserRoomAdmin && hasMultipleMembers) || (isSocialChannel && hasMultipleMembers);
-    const canEdit = (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !directMessage?.isOneOnOne;
-    const canAddMembers = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
-    const canViewDetails = !directMessage?.isOneOnOne;
+    const canLeaveRoom = !isCurrentUserRoomAdmin && hasMultipleMembers;
+    const canEdit =
+      (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && (!directMessage?.isOneOnOne || isSocialChannel);
+    const canAddMembers = isCurrentUserRoomAdmin && (!directMessage?.isOneOnOne || isSocialChannel);
+    const canViewDetails = !directMessage?.isOneOnOne || isSocialChannel;
     const channel = rawChannelSelector(activeConversationId)(state);
 
     return {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -75,9 +75,12 @@ export class Container extends React.Component<Properties> {
 
     const directMessage = denormalize(activeConversationId, state);
     const currentUser = currentUserSelector(state);
+    const hasMultipleMembers = (directMessage?.otherMembers || []).length > 1;
+    const isSocialChannel = directMessage?.isSocialChannel;
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
     const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.id) ?? false;
-    const canLeaveRoom = !isCurrentUserRoomAdmin && (directMessage?.otherMembers || []).length > 1;
+
+    const canLeaveRoom = (!isCurrentUserRoomAdmin && hasMultipleMembers) || (isSocialChannel && hasMultipleMembers);
     const canEdit = (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !directMessage?.isOneOnOne;
     const canAddMembers = isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
     const canViewDetails = !directMessage?.isOneOnOne;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1274,7 +1274,6 @@ export class MatrixClient implements IChatClient {
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
     const groupType = this.getRoomGroupType(room);
-    const isSocialChannel = groupType === 'social';
 
     featureFlags.enableTimerLogs && console.time(`xxxgetUpToLatestUserMessageFromRoom${room.roomId}`);
     const messages = await this.getUpToLatestUserMessageFromRoom(room);
@@ -1290,8 +1289,7 @@ export class MatrixClient implements IChatClient {
       icon: avatarUrl,
       // Even if a member leaves they stay in the member list so this will still be correct
       // as zOS considers any conversation to have ever had more than 2 people to not be 1 on 1
-      // If isSocialChannel is true, then it is not a 1 on 1
-      isOneOnOne: isSocialChannel ? false : room.getMembers().length === 2,
+      isOneOnOne: room.getMembers().length === 2,
       otherMembers: otherMembers,
       memberHistory: memberHistory,
       lastMessage: null,
@@ -1302,7 +1300,7 @@ export class MatrixClient implements IChatClient {
       adminMatrixIds: admins,
       moderatorIds: mods,
       labels: [],
-      isSocialChannel,
+      isSocialChannel: groupType === 'social',
     };
 
     featureFlags.enableTimerLogs && console.timeEnd(`xxxmapConversation${room.roomId}`);

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1274,6 +1274,7 @@ export class MatrixClient implements IChatClient {
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
     const groupType = this.getRoomGroupType(room);
+    const isSocialChannel = groupType === 'social';
 
     featureFlags.enableTimerLogs && console.time(`xxxgetUpToLatestUserMessageFromRoom${room.roomId}`);
     const messages = await this.getUpToLatestUserMessageFromRoom(room);
@@ -1289,7 +1290,8 @@ export class MatrixClient implements IChatClient {
       icon: avatarUrl,
       // Even if a member leaves they stay in the member list so this will still be correct
       // as zOS considers any conversation to have ever had more than 2 people to not be 1 on 1
-      isOneOnOne: room.getMembers().length === 2,
+      // If isSocialChannel is true, then it is not a 1 on 1
+      isOneOnOne: isSocialChannel ? false : room.getMembers().length === 2,
       otherMembers: otherMembers,
       memberHistory: memberHistory,
       lastMessage: null,
@@ -1300,7 +1302,7 @@ export class MatrixClient implements IChatClient {
       adminMatrixIds: admins,
       moderatorIds: mods,
       labels: [],
-      isSocialChannel: groupType === 'social',
+      isSocialChannel,
     };
 
     featureFlags.enableTimerLogs && console.timeEnd(`xxxmapConversation${room.roomId}`);


### PR DESCRIPTION
### What does this do?
- handles group management when conversation is a social channel, i.e. canEdit, canView, canAddMembers.

### Why are we making this change?
- updates required so group management is enabled for social channels.

### How do I test this?
- run tests as usual.
- create a social channel and test group management controls.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
