### PR TITLE
feat: move conversation header higher up the DOM tree

### DIFF
--- a/src/apps/messenger/Main.module.scss
+++ b/src/apps/messenger/Main.module.scss
@@ -1,5 +1,15 @@
 .Split {
+  position: relative;
   display: flex;
   width: 100%;
   gap: 8px;
+}
+
+.Header {
+  left: 0;
+  pointer-events: all !important;
+  position: absolute;
+  top: 16px;
+  width: calc(100% - 16px) !important;
+  z-index: 1000;
 }

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -10,6 +10,7 @@ import { DevPanelContainer } from '../../components/dev-panel/container';
 import { FeatureFlag } from '../../components/feature-flag';
 
 import styles from './Main.module.scss';
+import { ConversationHeader } from '../../components/messenger/chat/conversation-header/container';
 
 export interface Properties {
   context: {
@@ -34,6 +35,8 @@ export class Container extends React.Component<Properties> {
             <Sidekick />
 
             <div className={styles.Split}>
+              <ConversationHeader className={styles.Header} />
+
               <FeatureFlag featureFlag='enableChannels'>
                 <MessengerFeed />
               </FeatureFlag>

--- a/src/components/messenger/chat/conversation-header/container.test.tsx
+++ b/src/components/messenger/chat/conversation-header/container.test.tsx
@@ -1,0 +1,218 @@
+import { ConversationHeader } from './container';
+
+import { StoreBuilder, stubAuthenticatedUser, stubConversation, stubUser } from '../../../../store/test/store';
+
+describe('ConversationHeader', () => {
+  describe('mapState', () => {
+    describe('canLeaveRoom', () => {
+      it('is false when only when one other member', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ otherMembers: [stubUser()], isSocialChannel: false })
+        );
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
+      });
+
+      it('is false when user is admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              otherMembers: [stubUser(), stubUser()],
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: false,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
+      });
+
+      it('is false when user is admin and conversation is social channel', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              otherMembers: [stubUser(), stubUser()],
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
+      });
+
+      it('is true when user is not admin and more than one other member', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ otherMembers: [stubUser(), stubUser()], adminMatrixIds: ['other-user-matrix-id'] })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
+      });
+
+      it('is true when the conversation is a social channel and has multiple members', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ otherMembers: [stubUser(), stubUser()], isSocialChannel: true }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
+      });
+
+      it('is false when the conversation is a social channel and has only one member', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(stubConversation({ otherMembers: [stubUser()], isSocialChannel: true }))
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
+      });
+    });
+
+    describe('canEdit', () => {
+      it('is false when one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: true, isSocialChannel: false })
+        );
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
+      });
+
+      it('is false when current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: false })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
+      });
+
+      it('is true when current user is room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: false })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
+
+      it('is true when current user is room moderator', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, moderatorIds: ['current-user-id'], isSocialChannel: false })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ id: 'current-user-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
+
+      it('is true when the conversation is a social channel and user is an admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              isOneOnOne: true,
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
+      });
+
+      it('is false when the conversation is a social channel and current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: true })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
+      });
+    });
+
+    describe('canAddMembers', () => {
+      it('is false when one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: true, isSocialChannel: false })
+        );
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+
+      it('is false when current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: false })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+
+      it('is true when current user is room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: false })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+
+      it('is true when the conversation is a social channel and user is an admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              isOneOnOne: true,
+              adminMatrixIds: ['current-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
+      });
+
+      it('is false when the conversation is a social channel and current user is not room admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: true })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
+      });
+    });
+
+    describe('canViewDetails', () => {
+      it('is false when one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: true, isSocialChannel: false })
+        );
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: false }));
+      });
+
+      it('is true when not a one on one conversation', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({ isOneOnOne: false, isSocialChannel: false })
+        );
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
+      });
+
+      it('is true when the conversation is a social channel', () => {
+        const state = new StoreBuilder().withActiveConversation(
+          stubConversation({
+            isOneOnOne: false,
+            isSocialChannel: true,
+          })
+        );
+
+        expect(ConversationHeader.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
+      });
+    });
+  });
+});

--- a/src/components/messenger/chat/conversation-header/container.tsx
+++ b/src/components/messenger/chat/conversation-header/container.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { RootState } from '../../../../store/reducer';
+import { connectContainer } from '../../../../store/redux-container';
+import { Channel, DefaultRoomLabels, denormalize, onAddLabel, onRemoveLabel } from '../../../../store/channels';
+import { currentUserSelector } from '../../../../store/authentication/selectors';
+import {
+  startAddGroupMember,
+  LeaveGroupDialogStatus,
+  setLeaveGroupStatus,
+  startEditConversation,
+  viewGroupInformation,
+  toggleSecondarySidekick,
+} from '../../../../store/group-management';
+import { ConversationHeader as ConversationHeaderComponent } from './../conversation-header';
+
+import './styles.scss';
+
+export interface PublicProperties {
+  className?: string;
+}
+
+export interface Properties extends PublicProperties {
+  activeConversationId: string;
+  directMessage: Channel;
+  isJoiningConversation: boolean;
+  canLeaveRoom: boolean;
+  canEdit: boolean;
+  canAddMembers: boolean;
+  canViewDetails: boolean;
+  isSecondarySidekickOpen: boolean;
+  startAddGroupMember: () => void;
+  startEditConversation: () => void;
+  leaveGroupDialogStatus: LeaveGroupDialogStatus;
+  setLeaveGroupStatus: (status: LeaveGroupDialogStatus) => void;
+  viewGroupInformation: () => void;
+  toggleSecondarySidekick: () => void;
+  onAddLabel: (payload: { roomId: string; label: string }) => void;
+  onRemoveLabel: (payload: { roomId: string; label: string }) => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState): Partial<Properties> {
+    const {
+      chat: { activeConversationId, isJoiningConversation },
+      groupManagement,
+    } = state;
+
+    const directMessage = denormalize(activeConversationId, state);
+    const currentUser = currentUserSelector(state);
+    const hasMultipleMembers = (directMessage?.otherMembers || []).length > 1;
+    const isSocialChannel = directMessage?.isSocialChannel;
+    const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
+    const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.id) ?? false;
+
+    const canLeaveRoom = !isCurrentUserRoomAdmin && hasMultipleMembers;
+    const canEdit =
+      (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && (!directMessage?.isOneOnOne || isSocialChannel);
+    const canAddMembers = isCurrentUserRoomAdmin && (!directMessage?.isOneOnOne || isSocialChannel);
+    const canViewDetails = !directMessage?.isOneOnOne || isSocialChannel;
+
+    return {
+      activeConversationId,
+      directMessage,
+      leaveGroupDialogStatus: groupManagement.leaveGroupDialogStatus,
+      isJoiningConversation,
+      canLeaveRoom,
+      canEdit,
+      canAddMembers,
+      canViewDetails,
+      isSecondarySidekickOpen: groupManagement.isSecondarySidekickOpen,
+    };
+  }
+
+  static mapActions(): Partial<Properties> {
+    return {
+      startAddGroupMember,
+      startEditConversation,
+      setLeaveGroupStatus,
+      viewGroupInformation,
+      toggleSecondarySidekick,
+      onAddLabel,
+      onRemoveLabel,
+    };
+  }
+
+  isOneOnOne() {
+    return this.props.directMessage?.isOneOnOne;
+  }
+
+  openLeaveGroupDialog = () => {
+    this.props.setLeaveGroupStatus(LeaveGroupDialogStatus.OPEN);
+  };
+
+  muteRoom = () => {
+    this.props.onAddLabel({ roomId: this.props.activeConversationId, label: DefaultRoomLabels.MUTE });
+  };
+
+  unmuteRoom = () => {
+    this.props.onRemoveLabel({ roomId: this.props.activeConversationId, label: DefaultRoomLabels.MUTE });
+  };
+
+  get isMuted() {
+    return this.props.directMessage.labels?.includes(DefaultRoomLabels.MUTE);
+  }
+
+  render() {
+    if (
+      ((!this.props.activeConversationId || !this.props.directMessage) && !this.props.isJoiningConversation) ||
+      !this.props.directMessage
+    ) {
+      return null;
+    }
+
+    return (
+      <ConversationHeaderComponent
+        className={this.props.className}
+        icon={this.props.directMessage.icon}
+        name={this.props.directMessage.name}
+        isOneOnOne={this.isOneOnOne()}
+        otherMembers={this.props.directMessage.otherMembers || []}
+        canAddMembers={this.props.canAddMembers}
+        canLeaveRoom={this.props.canLeaveRoom}
+        canEdit={this.props.canEdit}
+        canViewDetails={this.props.canViewDetails}
+        onLeaveRoom={this.openLeaveGroupDialog}
+        onViewDetails={this.props.viewGroupInformation}
+        onAddMember={this.props.startAddGroupMember}
+        onEdit={this.props.startEditConversation}
+        toggleSecondarySidekick={this.props.toggleSecondarySidekick}
+        isSecondarySidekickOpen={this.props.isSecondarySidekickOpen}
+        isRoomMuted={this.isMuted}
+        onMuteRoom={this.muteRoom}
+        onUnmuteRoom={this.unmuteRoom}
+      />
+    );
+  }
+}
+
+export const ConversationHeader = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/chat/conversation-header/index.tsx
+++ b/src/components/messenger/chat/conversation-header/index.tsx
@@ -14,6 +14,7 @@ import './styles.scss';
 const cn = bemClassName('conversation-header');
 
 export interface Properties {
+  className?: string;
   isOneOnOne: boolean;
   otherMembers: User[];
   icon: string;
@@ -119,6 +120,7 @@ export class ConversationHeader extends React.Component<Properties> {
         title={this.renderTitle()}
         subtitle={this.renderSubTitle()}
         onClick={this.toggleSidekick}
+        className={this.props.className}
         end={
           <>
             <GroupManagementMenu

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -8,9 +8,7 @@ import { MessageInput } from '../../message-input/container';
 import { Media } from '../../message-input/utils';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
 import { JoiningConversationDialog } from '../../joining-conversation-dialog';
-
-import { StoreBuilder, stubAuthenticatedUser, stubConversation, stubUser } from '../../../store/test/store';
-import { ConversationHeader } from './conversation-header';
+import { stubUser } from '../../../store/test/store';
 
 const mockSearchMentionableUsersForChannel = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -27,15 +25,9 @@ describe(DirectMessageChat, () => {
       activeConversationId: '1',
       leaveGroupDialogStatus: LeaveGroupDialogStatus.CLOSED,
       directMessage: { id: '1', otherMembers: [] } as any,
-      canLeaveRoom: false,
-      canEdit: false,
-      canAddMembers: false,
-      canViewDetails: false,
       isSecondarySidekickOpen: false,
-      isRoomMuted: false,
       sendMessage: () => null,
       onRemoveReply: () => null,
-      isCurrentUserRoomAdmin: false,
       isJoiningConversation: false,
       startAddGroupMember: () => null,
       startEditConversation: () => null,
@@ -83,15 +75,6 @@ describe(DirectMessageChat, () => {
     const wrapper = subject({ isJoiningConversation: false });
 
     expect(wrapper).not.toHaveElement(JoiningConversationDialog);
-  });
-
-  it('calls start add group member', async function () {
-    const startAddGroupMember = jest.fn();
-    const wrapper = subject({ startAddGroupMember });
-
-    wrapper.find(ConversationHeader).simulate('addMember');
-
-    expect(startAddGroupMember).toHaveBeenCalledOnce();
   });
 
   describe('leave group dialog', () => {
@@ -187,219 +170,6 @@ describe(DirectMessageChat, () => {
       await input.prop('getUsersForMentions')('bob');
 
       expect(mockSearchMentionableUsersForChannel).toHaveBeenCalledWith('5', 'bob', []);
-    });
-  });
-
-  describe('mapState', () => {
-    describe('canLeaveRoom', () => {
-      it('is false when only when one other member', () => {
-        const state = new StoreBuilder().withActiveConversation(
-          stubConversation({ otherMembers: [stubUser()], isSocialChannel: false })
-        );
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
-      });
-
-      it('is false when user is admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({
-              otherMembers: [stubUser(), stubUser()],
-              adminMatrixIds: ['current-user-matrix-id'],
-              isSocialChannel: false,
-            })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
-      });
-
-      it('is false when user is admin and conversation is social channel', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({
-              otherMembers: [stubUser(), stubUser()],
-              adminMatrixIds: ['current-user-matrix-id'],
-              isSocialChannel: true,
-            })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
-      });
-
-      it('is true when user is not admin and more than one other member', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ otherMembers: [stubUser(), stubUser()], adminMatrixIds: ['other-user-matrix-id'] })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
-      });
-
-      it('is true when the conversation is a social channel and has multiple members', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ otherMembers: [stubUser(), stubUser()], isSocialChannel: true }))
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: true }));
-      });
-
-      it('is false when the conversation is a social channel and has only one member', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ otherMembers: [stubUser()], isSocialChannel: true }))
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canLeaveRoom: false }));
-      });
-    });
-
-    describe('canEdit', () => {
-      it('is false when one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(
-          stubConversation({ isOneOnOne: true, isSocialChannel: false })
-        );
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
-      });
-
-      it('is false when current user is not room admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: false })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
-      });
-
-      it('is true when current user is room admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: false })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
-      });
-
-      it('is true when current user is room moderator', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, moderatorIds: ['current-user-id'], isSocialChannel: false })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ id: 'current-user-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
-      });
-
-      it('is true when the conversation is a social channel and user is an admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({
-              isOneOnOne: true,
-              adminMatrixIds: ['current-user-matrix-id'],
-              isSocialChannel: true,
-            })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: true }));
-      });
-
-      it('is false when the conversation is a social channel and current user is not room admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: true })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canEdit: false }));
-      });
-    });
-
-    describe('canAddMembers', () => {
-      it('is false when one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(
-          stubConversation({ isOneOnOne: true, isSocialChannel: false })
-        );
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
-      });
-
-      it('is false when current user is not room admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: false })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
-      });
-
-      it('is true when current user is room admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: false })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
-      });
-
-      it('is true when the conversation is a social channel and user is an admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({
-              isOneOnOne: true,
-              adminMatrixIds: ['current-user-matrix-id'],
-              isSocialChannel: true,
-            })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
-      });
-
-      it('is false when the conversation is a social channel and current user is not room admin', () => {
-        const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({ isOneOnOne: false, adminMatrixIds: ['other-user-matrix-id'], isSocialChannel: true })
-          )
-          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: false }));
-      });
-    });
-
-    describe('canViewDetails', () => {
-      it('is false when one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(
-          stubConversation({ isOneOnOne: true, isSocialChannel: false })
-        );
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: false }));
-      });
-
-      it('is true when not a one on one conversation', () => {
-        const state = new StoreBuilder().withActiveConversation(
-          stubConversation({ isOneOnOne: false, isSocialChannel: false })
-        );
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
-      });
-
-      it('is true when the conversation is a social channel', () => {
-        const state = new StoreBuilder().withActiveConversation(
-          stubConversation({
-            isOneOnOne: false,
-            isSocialChannel: true,
-          })
-        );
-
-        expect(DirectMessageChat.mapState(state.build())).toEqual(expect.objectContaining({ canViewDetails: true }));
-      });
     });
   });
 });

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -49,21 +49,6 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     }
   }
 
-  &__header-gradient {
-    position: absolute;
-    width: 100%;
-    height: 64px;
-    z-index: 2;
-  }
-
-  &__header-position {
-    position: absolute;
-    width: 100%;
-    padding: 16px 16px 16px 0px;
-    box-sizing: border-box;
-    z-index: 3;
-  }
-
   &__footer-position {
     position: absolute;
     bottom: 0px;


### PR DESCRIPTION
Header now spans the full length of the Messenger container