### PR TITLE
fix(feed/chat): separation of chat and feed loading state when submitting messages and posts

### DIFF
--- a/src/components/messenger/feed/index.tsx
+++ b/src/components/messenger/feed/index.tsx
@@ -63,7 +63,9 @@ export class Container extends React.Component<Properties> {
   };
 
   get isSubmitting() {
-    return this.props.channel?.messages.some((message) => message.sendStatus === MessageSendStatus.IN_PROGRESS);
+    return this.props.channel?.messages
+      .filter((message) => message.isPost)
+      .some((message) => message.sendStatus === MessageSendStatus.IN_PROGRESS);
   }
 
   render() {


### PR DESCRIPTION
### What does this do?
- separation of chat and feed loading state when submitting messages and posts

### Why are we making this change?
- when submitting a chat message in a social channel, the 'post' loading state would also be triggered. This is bad UI/UX therefore we are ensuring we only check message send status specifically for post messages when sending a post.

### How do I test this?
- run tests as usual.
- run UI > open/create social channel > send a chat message and check that the create a post submitting status is not rendered.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
