### PR TITLE
feat(posts): handle formatting of long body text to improve layout ui

### DIFF
--- a/src/components/messenger/feed/components/post/index.tsx
+++ b/src/components/messenger/feed/components/post/index.tsx
@@ -14,7 +14,15 @@ export interface PostProps {
 }
 
 export const Post = ({ avatarUrl, text, nickname, author, timestamp }: PostProps) => {
-  const multilineText = useMemo(() => text.split('\n').map((line, index) => <p key={index}>{line}</p>), [text]);
+  const multilineText = useMemo(
+    () =>
+      text.split('\n').map((line, index) => (
+        <p key={index} className={styles.Text}>
+          {line}
+        </p>
+      )),
+    [text]
+  );
 
   return (
     <div className={styles.Container}>

--- a/src/components/messenger/feed/components/post/styles.module.scss
+++ b/src/components/messenger/feed/components/post/styles.module.scss
@@ -22,6 +22,11 @@
   }
 }
 
+.Text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .Avatar {
   pointer-events: none;
 }


### PR DESCRIPTION
### What does this do?
- handles formatting of long body text to improve layout ui in Posts.
- sets post body text styles - white space and word break.

### Why are we making this change?
- to improve the UI for posts with long body text

### How do I test this?
- run UI > open/create social channel > create posts with long body text > check width of containers.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
