### PR TITLE
feat: align bottom of feed container with sidekicks and chat containers

### DIFF
--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding-top: 16px;
 
+  margin-bottom: 16px;
   padding: 100px 8px 0 8px;
   box-sizing: border-box;
 


### PR DESCRIPTION
### What does this do?
- aligns bottom of feed container with other sidekicks and chat containers 

### Why are we making this change?
- improved UI

### How do I test this?
- run tests as usual.
- run UI > open/create social channel > check bottom alignment of containers 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
