### PR TITLE
feat(messenger-feed-container): apply border radius to bottom of feed container

### DIFF
--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -11,6 +11,8 @@
   background: var(--Transparencies-Black-translucent, #0000007a);
   backdrop-filter: blur(60px);
 
+  border-radius: 0 0 16px 16px;
+
   &__divider {
     width: 1px;
     height: auto;


### PR DESCRIPTION
### What does this do?
- applies border radius to bottom of feed container

### Why are we making this change?
- improve UI

### How do I test this?
- run tests as usual.
- run UI > create/open social channel > check bottom border radius of feed container

