### PR TITLE
refactor(messenger-chat-container): remove message input footer gradient and align container bottom

### DIFF
--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -177,7 +177,6 @@ export class Container extends React.Component<Properties> {
               {this.renderTypingIndicators()}
             </div>
           </div>
-          <div className='direct-message-chat__footer-gradient'></div>
 
           {this.isLeaveGroupDialogOpen && this.renderLeaveGroupDialog()}
           {this.props.isJoiningConversation && <JoiningConversationDialog />}

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -68,15 +68,6 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     backdrop-filter: blur(32px);
   }
 
-  &__footer-gradient {
-    position: absolute;
-    bottom: 0px;
-    width: 100%;
-    height: 64px;
-    background: linear-gradient(0deg, rgba(0, 0, 0, 0.75) 0px, rgba(0, 0, 0, 0.492172) 22px, rgba(0, 0, 0, 0) 64px);
-    z-index: 2;
-  }
-
   &__typing-indicator {
     font-size: 13px;
     font-style: italic;
@@ -136,6 +127,7 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     flex-grow: 1;
     overflow: hidden;
     width: 100%;
+    margin-bottom: 16px;
 
     .direct-message-chat__content {
       height: 100vh;


### PR DESCRIPTION
### What does this do?
- removes message input footer gradient and align container bottom

### Why are we making this change?
- improve ui

### How do I test this?
- run tests as usual.
- run UI > check message input is aligned at the bottom with other containers
