### PR TITLE
feat(edit-conversation-panel): disable edit group name if token gated chat

### DIFF
--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -69,6 +69,10 @@ export class EditConversationPanel extends React.Component<Properties, State> {
     return this.props.otherMembers.length > 1;
   }
 
+  get canEditGroupName() {
+    return !this.props.name.includes('0://');
+  }
+
   get isCurrentUserAdmin() {
     return isUserAdmin(this.props.currentUser, this.props.conversationAdminIds);
   }
@@ -107,6 +111,7 @@ export class EditConversationPanel extends React.Component<Properties, State> {
           onChange={this.trackName}
           placeholder='Group name...'
           {...cn('body-input')}
+          isDisabled={!this.canEditGroupName}
         />
 
         {this.generalError && (


### PR DESCRIPTION
### What does this do?
- disables edit group name if token gated chat

### Why are we making this change?
- improve ui

### How do I test this?
- run tests as usual
- run ui > create/open token gated chat > try editing group name

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
