### PR TITLE
fix(messenger-feed): remove min-width to allow space for right sidekick

### DIFF
--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   width: 100%;
   max-width: 504px;
-  min-width: 504px;
 
   margin-bottom: 16px;
   padding: 100px 8px 0 8px;


### PR DESCRIPTION
- remove min-width to allow space for right sidekick