### PR TITLE
Support ability to Add a wallet to an email account (UI)

### DIFF
--- a/src/components/messenger/user-profile/account-management-panel/container.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.test.tsx
@@ -1,6 +1,7 @@
 import { Container } from './container';
 import { Errors, AccountManagementState } from '../../../../store/account-management';
 import { RootState } from '../../../../store/reducer';
+import { ConnectionStatus } from '../../../../lib/web3';
 
 describe('Container', () => {
   describe('mapState', () => {
@@ -28,6 +29,32 @@ describe('Container', () => {
       });
 
       expect(props.successMessage).toEqual('success');
+    });
+
+    it('connectedWallet', () => {
+      const props = subject({
+        web3: { value: { address: 'address123' } } as any,
+      });
+
+      expect(props.connectedWallet).toEqual('address123');
+    });
+
+    describe('isWalletConnected', () => {
+      it('connected', () => {
+        const props = subject({
+          web3: { status: ConnectionStatus.Connected } as any,
+        });
+
+        expect(props.isWalletConnected).toEqual(true);
+      });
+
+      it('disconnected', () => {
+        const props = subject({
+          web3: { status: ConnectionStatus.Disconnected } as any,
+        });
+
+        expect(props.isWalletConnected).toEqual(false);
+      });
     });
 
     describe('errors', () => {

--- a/src/components/messenger/user-profile/account-management-panel/container.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.tsx
@@ -6,6 +6,7 @@ import { connectContainer } from '../../../../store/redux-container';
 import { AccountManagementPanel } from './index';
 import { openAddEmailAccountModal, closeAddEmailAccountModal, Errors } from '../../../../store/account-management';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
+import { ConnectionStatus } from '../../../../lib/web3';
 
 export interface PublicProperties {
   onClose?: () => void;
@@ -17,6 +18,8 @@ export interface Properties extends PublicProperties {
   successMessage: string;
   currentUser: any;
   canAddEmail: boolean;
+  isWalletConnected: boolean;
+  connectedWallet: string;
 
   openAddEmailAccountModal: () => void;
   closeAddEmailAccountModal: () => void;
@@ -24,7 +27,10 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
-    const { accountManagement } = state;
+    const {
+      accountManagement,
+      web3: { status, value },
+    } = state;
 
     const currentUser = currentUserSelector(state);
     const primaryEmail = currentUser?.profileSummary.primaryEmail;
@@ -33,6 +39,8 @@ export class Container extends React.Component<Properties> {
       error: Container.mapErrors(accountManagement.errors),
       successMessage: accountManagement.successMessage,
       isAddEmailModalOpen: accountManagement.isAddEmailAccountModalOpen,
+      isWalletConnected: status === ConnectionStatus.Connected,
+      connectedWallet: value?.address,
       currentUser: {
         userId: currentUser?.id,
         firstName: currentUser?.profileSummary.firstName,
@@ -71,6 +79,8 @@ export class Container extends React.Component<Properties> {
         isAddEmailModalOpen={this.props.isAddEmailModalOpen}
         currentUser={this.props.currentUser}
         canAddEmail={this.props.canAddEmail}
+        isWalletConnected={this.props.isWalletConnected}
+        connectedWallet={this.props.connectedWallet}
         onOpenAddEmailModal={() => this.props.openAddEmailAccountModal()}
         onCloseAddEmailModal={() => this.props.closeAddEmailAccountModal()}
         onBack={this.props.onClose}

--- a/src/components/messenger/user-profile/account-management-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.test.tsx
@@ -6,6 +6,11 @@ import { bem } from '../../../../lib/bem';
 import { Button } from '@zero-tech/zui/components/Button';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 
+const featureFlags = { enableAddWallets: true };
+jest.mock('../../../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
+
 // Mock the ConnectButton from rainbowkit
 jest.mock('@rainbow-me/rainbowkit', () => ({
   ConnectButton: {

--- a/src/components/messenger/user-profile/account-management-panel/index.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { bemClassName } from '../../../../lib/bem';
 import { PanelHeader } from '../../list/panel-header';
 import { Button, Variant as ButtonVariant } from '@zero-tech/zui/components/Button';
-import { Alert, Modal, IconButton } from '@zero-tech/zui/components';
+import { Alert, Modal as ZuiModal, IconButton } from '@zero-tech/zui/components';
 
 import { IconPlus } from '@zero-tech/zui/icons';
 import './styles.scss';
@@ -12,6 +12,8 @@ import { CitizenListItem } from '../../../citizen-list-item';
 import { IconXClose } from '@zero-tech/zui/icons';
 import { CreateEmailAccountContainer } from '../../../../authentication/create-email-account/container';
 import { ScrollbarContainer } from '../../../scrollbar-container';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { Color, Modal, Variant } from '../../../modal';
 
 const cn = bemClassName('account-management-panel');
 
@@ -21,24 +23,58 @@ export interface Properties {
   successMessage: string;
   currentUser: any;
   canAddEmail: boolean;
+  isWalletConnected: boolean;
+  connectedWallet: string;
 
   onBack: () => void;
   onOpenAddEmailModal: () => void;
   onCloseAddEmailModal: () => void;
 }
 
-export class AccountManagementPanel extends React.Component<Properties> {
+interface State {
+  isUserLinkingNewWallet: boolean;
+}
+
+export class AccountManagementPanel extends React.Component<Properties, State> {
+  state = {
+    isUserLinkingNewWallet: false,
+  };
+
+  setIsUserLinkingNewWallet = (isUserLinkingNewWallet: boolean) => {
+    this.setState({ isUserLinkingNewWallet });
+  };
+
   back = () => {
     this.props.onBack();
   };
 
-  // note: hiding this for now
   renderAddNewWalletButton = () => {
+    const handleAddWallet = (account, openConnectModal) => {
+      this.setIsUserLinkingNewWallet(true);
+
+      if (!account?.address) {
+        // Prompt user to connect their wallet if none is connected
+        openConnectModal();
+      }
+
+      // Otherwise, wallet is already connected, proceed to the next step
+    };
+
     return (
       <div {...cn('add-wallet')}>
-        <Button variant={ButtonVariant.Secondary} onPress={() => {}} startEnhancer={<IconPlus size={20} isFilled />}>
-          Add new wallet
-        </Button>
+        <ConnectButton.Custom>
+          {({ account, openConnectModal }) => {
+            return (
+              <Button
+                variant={ButtonVariant.Secondary}
+                onPress={() => handleAddWallet(account, openConnectModal)}
+                startEnhancer={<IconPlus size={20} isFilled />}
+              >
+                Add wallet
+              </Button>
+            );
+          }}
+        </ConnectButton.Custom>
       </div>
     );
   };
@@ -61,6 +97,8 @@ export class AccountManagementPanel extends React.Component<Properties> {
             </Alert>
           </div>
         )}
+
+        {wallets.length === 0 && this.renderAddNewWalletButton()}
       </div>
     );
   };
@@ -101,7 +139,7 @@ export class AccountManagementPanel extends React.Component<Properties> {
 
   renderAddEmailAccountModal = () => {
     return (
-      <Modal
+      <ZuiModal
         open={this.props.isAddEmailModalOpen}
         onOpenChange={(isOpen) => {
           isOpen ? this.props.onOpenAddEmailModal() : this.props.onCloseAddEmailModal();
@@ -120,6 +158,38 @@ export class AccountManagementPanel extends React.Component<Properties> {
           </div>
 
           <CreateEmailAccountContainer addAccount />
+        </div>
+      </ZuiModal>
+    );
+  };
+
+  renderLinkNewWalletModal = () => {
+    const onClose = () => {
+      this.setIsUserLinkingNewWallet(false);
+    };
+
+    return (
+      <Modal
+        title='Link Wallet'
+        primaryText='Link Wallet'
+        primaryVariant={Variant.Primary}
+        primaryColor={Color.Highlight}
+        secondaryText='Cancel'
+        secondaryVariant={Variant.Secondary}
+        secondaryColor={Color.Red}
+        onPrimary={() => {}}
+        onSecondary={onClose}
+        onClose={onClose}
+        isProcessing={false}
+      >
+        <div {...cn('link-new-wallet-modal')}>
+          You have a wallet connected by the address{' '}
+          <b>
+            <i>{this.props.connectedWallet}</i>
+          </b>
+          <br />
+          <br />
+          Do you want to link this wallet with your ZERO account?
         </div>
       </Modal>
     );
@@ -152,6 +222,7 @@ export class AccountManagementPanel extends React.Component<Properties> {
             </div>
 
             {this.renderAddEmailAccountModal()}
+            {this.state.isUserLinkingNewWallet && this.props.isWalletConnected && this.renderLinkNewWalletModal()}
           </div>
         </ScrollbarContainer>
       </div>

--- a/src/components/messenger/user-profile/account-management-panel/index.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.tsx
@@ -14,6 +14,7 @@ import { CreateEmailAccountContainer } from '../../../../authentication/create-e
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { Color, Modal, Variant } from '../../../modal';
+import { featureFlags } from '../../../../lib/feature-flags';
 
 const cn = bemClassName('account-management-panel');
 
@@ -98,7 +99,7 @@ export class AccountManagementPanel extends React.Component<Properties, State> {
           </div>
         )}
 
-        {wallets.length === 0 && this.renderAddNewWalletButton()}
+        {featureFlags.enableAddWallets && wallets.length === 0 && this.renderAddNewWalletButton()}
       </div>
     );
   };

--- a/src/components/messenger/user-profile/account-management-panel/styles.scss
+++ b/src/components/messenger/user-profile/account-management-panel/styles.scss
@@ -80,6 +80,10 @@
     padding-bottom: 0px;
   }
 
+  &__link-new-wallet-modal {
+    width: 420px;
+  }
+
   &__add-email-body {
     width: 300px;
 

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -121,6 +121,14 @@ export class FeatureFlags {
   set enableCollapseableMenu(value: boolean) {
     this._setBoolean('enableCollapseableMenu', value);
   }
+
+  get enableAddWallets() {
+    return this._getBoolean('enableAddWallets', false);
+  }
+
+  set enableAddWallets(value: boolean) {
+    this._setBoolean('enableAddWallets', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/lib/web3/rainbowkit/connect.vitest.tsx
+++ b/src/lib/web3/rainbowkit/connect.vitest.tsx
@@ -7,16 +7,22 @@ import { watchAccount } from '@wagmi/core';
 
 import { Container, Properties } from './connect';
 import { ConnectionStatus } from '..';
+import { config } from '../../../config';
 
 vi.mock('@wagmi/core', () => ({
   watchAccount: vi.fn(),
 }));
 
 const defaultProps: Properties = {
+  address: '',
+
   setAddress: vi.fn(),
   setChain: vi.fn(),
   setConnectionStatus: vi.fn(),
+  updateConnector: vi.fn(),
 };
+
+const chainId = config.supportedChainId;
 
 const render = (props: Partial<Properties>) => {
   return renderWithProviders(<Container {...defaultProps} {...props} />, {});
@@ -50,15 +56,15 @@ describe(Container, () => {
 
     it('should call setChain with account.chainId', () => {
       render({});
-      const account = { chainId: 1, isConnected: true };
+      const account = { chainId, isConnected: true };
       mockWatchAccount(account);
-      expect(defaultProps.setChain).toHaveBeenCalledWith(1);
+      expect(defaultProps.setChain).toHaveBeenCalledWith(chainId);
       expect(defaultProps.setChain).toHaveBeenCalledTimes(1);
     });
 
     it('should call setConnectionStatus with Disconnected if account is not connected', () => {
       render({});
-      const account = { chainId: 1, isConnected: false };
+      const account = { chainId, isConnected: false };
       mockWatchAccount(account);
       expect(defaultProps.setConnectionStatus).toHaveBeenCalledWith(ConnectionStatus.Disconnected);
       expect(defaultProps.setConnectionStatus).toHaveBeenCalledTimes(1);
@@ -66,10 +72,26 @@ describe(Container, () => {
 
     it('should call setConnectionStatus with Connected if account is connected', () => {
       render({});
-      const account = { chainId: 1, isConnected: true };
+      const account = { chainId, isConnected: true };
       mockWatchAccount(account);
       expect(defaultProps.setConnectionStatus).toHaveBeenCalledWith(ConnectionStatus.Connected);
       expect(defaultProps.setConnectionStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call setAddress with account.address if address is empty', () => {
+      render({ address: undefined });
+      const account = { chainId, isConnected: true, address: '0x123' };
+      mockWatchAccount(account);
+      expect(defaultProps.setAddress).toHaveBeenCalledWith('0x123');
+      expect(defaultProps.setAddress).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call setAddress with account.address if account is changed', () => {
+      render({ address: '0x456' });
+      const account = { chainId, isConnected: true, address: '0x123' };
+      mockWatchAccount(account);
+      expect(defaultProps.setAddress).toHaveBeenCalledWith('0x123');
+      expect(defaultProps.setAddress).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/store/web3/index.ts
+++ b/src/store/web3/index.ts
@@ -9,7 +9,7 @@ export enum SagaActionTypes {
   SetConnectionError = 'web3/saga/setConnectionError',
 }
 
-export const updateConnector = createAction<Connectors | WalletType>(SagaActionTypes.UpdateConnector);
+export const updateConnector = createAction<Connectors | WalletType | string>(SagaActionTypes.UpdateConnector);
 export const setAddress = createAction<string>(SagaActionTypes.SetAddress);
 export const setConnectionError = createAction<string>(SagaActionTypes.SetConnectionError);
 


### PR DESCRIPTION
### What does this do?

Adds UI for supporting "Add Wallet", if a user has signed in via an email account. This is currently feature flagged under `enableAddWallets` key.

- User can click on `+ Add Wallet` button to link a new wallet
- If metamask is already connected, then just directly show the Modal (sc)
- otherwise, user is prompted to connect their wallet first, and then the modal is shown
- this also fixes some of the global state management using rainbowKit/connect. we weren't storing the `walletAddress`, and the `connectedId` correctly in our redux state before.

(Add wallets button)
<img width="314" alt="image" src="https://github.com/user-attachments/assets/7c4751bb-65ad-48ef-9ba1-c30c8d2f4c49">


(if wallet is already connected)
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/e46d538e-8588-463e-9a47-a566af91596c">

(if not, connect wallet first)
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/e36c516d-588b-4587-8d48-0996f10563e9">
<img width="1264" alt="image" src="https://github.com/user-attachments/assets/f62fa143-f01c-4094-ad24-1de23eadb25c">

Follow ups
- Saga logic
- backend integration
