### PR TITLE
refactor(create-group-flow): remove ability to create social channel group

### DIFF
--- a/src/components/messenger/list/group-details-panel/group-type-dialog/index.tsx
+++ b/src/components/messenger/list/group-details-panel/group-type-dialog/index.tsx
@@ -39,12 +39,6 @@ export class GroupTypeDialog extends React.Component<Properties> {
             Super Groups are designed to accommodate larger communities and are not encrypted by default. Check this box
             if you are creating a room intended for larger groups (10+ people).
           </p>
-
-          <h3 {...cn('section-header')}>Social Channel</h3>
-          <p {...cn('section-content')}>
-            Social Channels are designed for an interactive social experience with a feed, posts, and live chat. Check
-            this box for rooms where communities can share updates and chat in one space.
-          </p>
         </div>
 
         <div {...cn('footer')}>

--- a/src/components/messenger/list/group-details-panel/group-type-menu/index.test.tsx
+++ b/src/components/messenger/list/group-details-panel/group-type-menu/index.test.tsx
@@ -39,16 +39,6 @@ describe(GroupTypeMenu, () => {
     expect(onSelect).toHaveBeenCalledOnce();
   });
 
-  it('publishes onSelect event when social channel is selected', () => {
-    const onSelect = jest.fn();
-    const wrapper = subject({ onSelect });
-
-    selectInputItem(wrapper, SelectInput, 'social-channel');
-
-    expect(onSelect).toHaveBeenCalledWith(GroupType.SOCIAL);
-    expect(onSelect).toHaveBeenCalledOnce();
-  });
-
   it('publishes onOpen event when icon button is clicked', () => {
     const onOpen = jest.fn();
     const wrapper = subject({ onOpen });

--- a/src/components/messenger/list/group-details-panel/group-type-menu/index.tsx
+++ b/src/components/messenger/list/group-details-panel/group-type-menu/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { IconInfoCircle, IconLock1, IconMonitor2, IconUsers1 } from '@zero-tech/zui/icons';
-import { featureFlags } from '../../../../../lib/feature-flags';
+import { IconInfoCircle, IconLock1, IconUsers1 } from '@zero-tech/zui/icons';
 import { IconButton, SelectInput } from '@zero-tech/zui/components';
 import { GroupType } from '..';
 
@@ -59,13 +58,6 @@ export class GroupTypeMenu extends React.Component<Properties, State> {
       onSelect: () => this.selectType(GroupType.SUPER),
     });
 
-    featureFlags.enableChannels &&
-      menuItems.push({
-        id: 'social-channel',
-        label: this.renderMenuItem(<IconMonitor2 size={20} />, 'Social Channel'),
-        onSelect: () => this.selectType(GroupType.SOCIAL),
-      });
-
     return menuItems;
   }
 
@@ -75,8 +67,6 @@ export class GroupTypeMenu extends React.Component<Properties, State> {
         return 'Encrypted Group';
       case GroupType.SUPER:
         return 'Super Group';
-      case GroupType.SOCIAL:
-        return 'Social Channel';
       default:
         return '';
     }

--- a/src/components/messenger/list/group-details-panel/index.tsx
+++ b/src/components/messenger/list/group-details-panel/index.tsx
@@ -30,7 +30,6 @@ interface State {
 export enum GroupType {
   ENCRYPTED = 'encrypted',
   SUPER = 'super',
-  SOCIAL = 'social',
 }
 
 export class GroupDetailsPanel extends React.Component<Properties, State> {


### PR DESCRIPTION
### What does this do?
- removes ability to create social group channel

### Why are we making this change?
- we are/will be restricting users from creating a social channel based on token gated access control rules for these types of groups.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
