### PR TITLE
Add core saga logic to link a new wallet for email associated ZERO account

### DIFF
--- a/src/components/messenger/user-profile/account-management-panel/container.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.test.tsx
@@ -1,5 +1,5 @@
 import { Container } from './container';
-import { Errors, AccountManagementState } from '../../../../store/account-management';
+import { Errors, AccountManagementState, State } from '../../../../store/account-management';
 import { RootState } from '../../../../store/reducer';
 import { ConnectionStatus } from '../../../../lib/web3';
 
@@ -55,6 +55,14 @@ describe('Container', () => {
 
         expect(props.isWalletConnected).toEqual(false);
       });
+    });
+
+    it('addWalletState', () => {
+      const props = subject({
+        accountManagement: { state: State.NONE } as any,
+      });
+
+      expect(props.addWalletState).toEqual(State.NONE);
     });
 
     describe('errors', () => {

--- a/src/components/messenger/user-profile/account-management-panel/container.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.tsx
@@ -4,7 +4,14 @@ import { RootState } from '../../../../store/reducer';
 import { connectContainer } from '../../../../store/redux-container';
 
 import { AccountManagementPanel } from './index';
-import { openAddEmailAccountModal, closeAddEmailAccountModal, Errors } from '../../../../store/account-management';
+import {
+  openAddEmailAccountModal,
+  closeAddEmailAccountModal,
+  reset,
+  Errors,
+  addNewWallet,
+  State,
+} from '../../../../store/account-management';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
 import { ConnectionStatus } from '../../../../lib/web3';
 
@@ -20,9 +27,12 @@ export interface Properties extends PublicProperties {
   canAddEmail: boolean;
   isWalletConnected: boolean;
   connectedWallet: string;
+  addWalletState: State;
 
   openAddEmailAccountModal: () => void;
   closeAddEmailAccountModal: () => void;
+  addNewWallet: () => void;
+  onReset: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -41,6 +51,7 @@ export class Container extends React.Component<Properties> {
       isAddEmailModalOpen: accountManagement.isAddEmailAccountModalOpen,
       isWalletConnected: status === ConnectionStatus.Connected,
       connectedWallet: value?.address,
+      addWalletState: accountManagement.state,
       currentUser: {
         userId: currentUser?.id,
         firstName: currentUser?.profileSummary.firstName,
@@ -57,6 +68,8 @@ export class Container extends React.Component<Properties> {
     return {
       openAddEmailAccountModal,
       closeAddEmailAccountModal,
+      addNewWallet,
+      onReset: reset,
     };
   }
 
@@ -81,9 +94,12 @@ export class Container extends React.Component<Properties> {
         canAddEmail={this.props.canAddEmail}
         isWalletConnected={this.props.isWalletConnected}
         connectedWallet={this.props.connectedWallet}
+        addWalletState={this.props.addWalletState}
         onOpenAddEmailModal={() => this.props.openAddEmailAccountModal()}
         onCloseAddEmailModal={() => this.props.closeAddEmailAccountModal()}
+        onAddNewWallet={this.props.addNewWallet}
         onBack={this.props.onClose}
+        reset={this.props.onReset}
       />
     );
   }

--- a/src/store/account-management/api.ts
+++ b/src/store/account-management/api.ts
@@ -1,0 +1,20 @@
+import { post } from '../../lib/api/rest';
+
+export async function linkNewWalletToZEROAccount(token) {
+  try {
+    const response = await post('/api/v2/accounts/add-wallet').send({ web3Token: token });
+    return {
+      success: true,
+      response: response.body,
+    };
+  } catch (error: any) {
+    if (error?.response?.status === 400) {
+      return {
+        success: false,
+        response: error.response.body.code,
+        error: error.response.body.message,
+      };
+    }
+    throw error;
+  }
+}

--- a/src/store/account-management/index.ts
+++ b/src/store/account-management/index.ts
@@ -1,20 +1,29 @@
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Connectors } from '../../lib/web3';
+//import { Connectors } from '../../lib/web3';
 
 export enum SagaActionTypes {
   AddNewWallet = 'Wallets/addNewWallet',
   AddEmailAccount = 'Wallets/addEmailAccount',
   OpenAddEmailAccountModal = 'Wallets/openAddEmailAccountModal',
   CloseAddEmailAccountModal = 'Wallets/closeAddEmailAccountModal',
+  Reset = 'Wallets/reset',
 }
 
 export type AccountManagementState = {
+  state: State;
   errors: string[];
   isAddEmailAccountModalOpen: boolean;
   successMessage: string;
 };
 
+export enum State {
+  NONE,
+  INPROGRESS,
+  LOADED,
+}
+
 export const initialState: AccountManagementState = {
+  state: State.NONE,
   errors: [],
   isAddEmailAccountModalOpen: false,
   successMessage: '',
@@ -24,10 +33,11 @@ export enum Errors {
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
 }
 
-export const addNewWallet = createAction<{ connector: Connectors }>(SagaActionTypes.AddNewWallet);
+export const addNewWallet = createAction(SagaActionTypes.AddNewWallet);
 export const addEmailAccount = createAction<{ email: string; password: string }>(SagaActionTypes.AddEmailAccount);
 export const openAddEmailAccountModal = createAction(SagaActionTypes.OpenAddEmailAccountModal);
 export const closeAddEmailAccountModal = createAction(SagaActionTypes.CloseAddEmailAccountModal);
+export const reset = createAction(SagaActionTypes.Reset);
 
 const slice = createSlice({
   name: 'accountManagement',
@@ -42,11 +52,14 @@ const slice = createSlice({
     ) => {
       state.isAddEmailAccountModalOpen = action.payload;
     },
+    setState: (state, action: PayloadAction<AccountManagementState['state']>) => {
+      state.state = action.payload;
+    },
     setSuccessMessage: (state, action: PayloadAction<AccountManagementState['successMessage']>) => {
       state.successMessage = action.payload;
     },
   },
 });
 
-export const { setErrors, setAddEmailAccountModalStatus, setSuccessMessage } = slice.actions;
+export const { setErrors, setAddEmailAccountModalStatus, setSuccessMessage, setState } = slice.actions;
 export const { reducer } = slice;


### PR DESCRIPTION
### What does this do?

- adds core saga logic when user is trying to add a new wallet to their email linked ZERO account
- adds backend integration
- updates some UI logic 