### PR TITLE
feat(redesign-background): add and wire up default lights out background and selection

### DIFF
--- a/src/components/messenger/user-profile/settings-panel/index.tsx
+++ b/src/components/messenger/user-profile/settings-panel/index.tsx
@@ -56,6 +56,12 @@ export class SettingsPanel extends React.Component<Properties> {
     const mainBackgroundItems = [];
 
     mainBackgroundItems.push({
+      id: MainBackground.StaticLightsOut,
+      label: this.renderSelectInputLabel('Lights Out (Static)'),
+      onSelect: () => this.setMainBackground(MainBackground.StaticLightsOut),
+    });
+
+    mainBackgroundItems.push({
       id: MainBackground.StaticGreenParticles,
       label: this.renderSelectInputLabel('Green Particle (Static)'),
       onSelect: () => this.setMainBackground(MainBackground.StaticGreenParticles),

--- a/src/components/messenger/user-profile/settings-panel/utils.test.ts
+++ b/src/components/messenger/user-profile/settings-panel/utils.test.ts
@@ -2,6 +2,10 @@ import { MainBackground } from '../../../../store/background';
 import { translateBackgroundValue } from './utils';
 
 describe('translateBackgroundValue', () => {
+  it('should return "Lights Out (Static)" for MainBackground.StaticLightsOut', () => {
+    expect(translateBackgroundValue(MainBackground.StaticLightsOut)).toBe('Lights Out (Static)');
+  });
+
   it('should return "Green Particle (Static)" for MainBackground.StaticGreenParticles', () => {
     expect(translateBackgroundValue(MainBackground.StaticGreenParticles)).toBe('Green Particle (Static)');
   });

--- a/src/components/messenger/user-profile/settings-panel/utils.ts
+++ b/src/components/messenger/user-profile/settings-panel/utils.ts
@@ -2,6 +2,8 @@ import { MainBackground } from '../../../../store/background';
 
 export function translateBackgroundValue(value) {
   switch (value) {
+    case MainBackground.StaticLightsOut:
+      return 'Lights Out (Static)';
     case MainBackground.StaticGreenParticles:
       return 'Green Particle (Static)';
     case MainBackground.AnimatedGreenParticles:

--- a/src/main.scss
+++ b/src/main.scss
@@ -62,6 +62,10 @@ $border-color-hover: theme-zui.$color-primary-7;
       background-image: url(cloudAsset('AbstractBGwithoutShine.jpg'));
     }
 
+    &.static-lights-out {
+      background: rgba(0, 0, 0, 1);
+    }
+
     &.animated {
       position: relative;
 

--- a/src/store/background/index.ts
+++ b/src/store/background/index.ts
@@ -5,6 +5,7 @@ export enum SagaActionTypes {
 }
 
 export enum MainBackground {
+  StaticLightsOut = 'static-lights-out',
   StaticGreenParticles = 'static-green-particles',
   AnimatedGreenParticles = 'animated-green-particles',
   AnimatedBlackParticles = 'animated-black-particles',
@@ -20,8 +21,7 @@ export interface BackgroundState {
 
 const initialState: BackgroundState = {
   selectedMainBackground:
-    (localStorage.getItem('mainBackground:selectedMainBackground') as MainBackground) ||
-    MainBackground.StaticGreenParticles,
+    (localStorage.getItem('mainBackground:selectedMainBackground') as MainBackground) || MainBackground.StaticLightsOut,
 };
 
 const slice = createSlice({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,8 +21,10 @@ export function getMainBackgroundClass(selectedMainBackground) {
     case MainBackground.AnimatedBlackParticles:
       return 'animated';
     case MainBackground.StaticGreenParticles:
-    default:
       return 'static-green-particles';
+    case MainBackground.StaticLightsOut:
+    default:
+      return 'static-lights-out';
   }
 }
 


### PR DESCRIPTION
### What does this do?
- Add new Lights Out (Static) default background. Add option to Settings background dropdown menu on user profile settings panel. Add logic for selection and adjust existing logic to continue to handle static green particle background (but no longer as default).

### Why are we making this change?
- redesign task

### How do I test this?
- run tests as usual
- run UI > check default is lights out background > check settings panel to change background

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?


https://github.com/user-attachments/assets/e3318707-0aca-43dc-9005-6db22b1975ac

