### PR TITLE
Update user's primaryZID after adding new wallet

### DIFF
--- a/src/store/account-management/api.ts
+++ b/src/store/account-management/api.ts
@@ -1,6 +1,16 @@
 import { post } from '../../lib/api/rest';
+import { Wallet } from '../authentication/types';
 
-export async function linkNewWalletToZEROAccount(token) {
+export interface LinkNewWalletToZEROAccountResponse {
+  success: boolean;
+  response: {
+    wallet: Wallet;
+    primaryZID?: string;
+  };
+  error?: string;
+}
+
+export async function linkNewWalletToZEROAccount(token): Promise<LinkNewWalletToZEROAccountResponse> {
   try {
     const response = await post('/api/v2/accounts/add-wallet').send({ web3Token: token });
     return {

--- a/src/store/account-management/saga.test.ts
+++ b/src/store/account-management/saga.test.ts
@@ -207,7 +207,7 @@ describe(linkNewWalletToZEROAccount, () => {
         [call(getSignedToken), { success: true, token: 'some_token' }],
         [
           call(apiLinkNewWalletToZEROAccount, 'some_token'),
-          { success: true, response: { wallet: { id: 'wallet_id', address: 'some_wallet_address' } } },
+          { success: true, response: { wallet: { id: 'wallet_id', publicAddress: 'some_wallet_address' } } },
         ],
       ])
       .withReducer(rootReducer, initialState)
@@ -215,6 +215,70 @@ describe(linkNewWalletToZEROAccount, () => {
 
     expect(accountManagement.errors).toEqual([]);
     expect(accountManagement.successMessage).toEqual('Wallet added successfully');
-    expect(user.data.wallets).toStrictEqual([{ id: 'wallet_id', address: 'some_wallet_address' }]);
+    expect(user.data.wallets).toStrictEqual([{ id: 'wallet_id', publicAddress: 'some_wallet_address' }]);
+  });
+
+  it('updates primaryZID if provided in response', async () => {
+    const initialState = new StoreBuilder()
+      .withCurrentUser({
+        id: 'user-id',
+        profileSummary: { primaryEmail: 'test@zero.tech', wallets: [] },
+      } as any)
+      .build();
+
+    const {
+      storeState: {
+        authentication: { user },
+      },
+    } = await expectSaga(linkNewWalletToZEROAccount)
+      .provide([
+        [call(getSignedToken), { success: true, token: 'some_token' }],
+        [
+          call(apiLinkNewWalletToZEROAccount, 'some_token'),
+          {
+            success: true,
+            response: {
+              wallet: { id: 'wallet_id', publicAddress: 'some_wallet_address' },
+              primaryZID: '0://developer',
+            },
+          },
+        ],
+      ])
+      .withReducer(rootReducer, initialState)
+      .run();
+
+    expect(user.data.primaryZID).toEqual('0://developer');
+  });
+
+  it('derives primaryZID from publicAddress if not provided in response', async () => {
+    const initialState = new StoreBuilder()
+      .withCurrentUser({
+        id: 'user-id',
+        profileSummary: { primaryEmail: 'test@zero.tech', wallets: [] },
+      } as any)
+      .build();
+
+    const {
+      storeState: {
+        authentication: { user },
+      },
+    } = await expectSaga(linkNewWalletToZEROAccount)
+      .provide([
+        [call(getSignedToken), { success: true, token: 'some_token' }],
+        [
+          call(apiLinkNewWalletToZEROAccount, 'some_token'),
+          {
+            success: true,
+            response: {
+              wallet: { id: 'wallet_id', publicAddress: '0x64afb118ee48b732179be1c471537e2a6d4a63fe' },
+              primaryZID: null,
+            },
+          },
+        ],
+      ])
+      .withReducer(rootReducer, initialState)
+      .run();
+
+    expect(user.data.primaryZID).toEqual('0x64af...63fe');
   });
 });


### PR DESCRIPTION
### What does this do?

If you add a new wallet, and your wallet has some zid's, then the backend now will set that user's "default zid", and return that in the response. This PR updates the saga logic to update the local redux state with that `ZID`. 

If none is present in the API response, then primary ZID is derived from the wallet address (eg. `0x64af...63fe`)
