### PR TITLE
fix(posts-header): fix width when message loading for scrollbar hack

### DIFF
--- a/src/components/messenger/feed/index.tsx
+++ b/src/components/messenger/feed/index.tsx
@@ -78,7 +78,7 @@ export class Container extends React.Component<Properties> {
 
     return (
       <div {...cn('')}>
-        <div {...cn('header-position')}>
+        <div {...cn('header-position', !this.props.channel?.hasLoadedMessages && 'message-loading')}>
           <div {...cn('header')}>
             <ConversationHeader />
           </div>

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -16,6 +16,10 @@
     width: 99.2%;
     border: 1px solid rgba(52, 56, 60);
     padding-right: 2px;
+
+    &--message-loading {
+      width: 100%;
+    }
   }
 
   &__header {


### PR DESCRIPTION
### What does this do?
- fixes width when message loading for scrollbar hack

### Why are we making this change?
- UI error - quick fix for scrollbar hack until further improvements

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
