### PR TITLE
fix(messenger-feed): resolve unnecessary image reloads by memoizing functions in media rendering

### DIFF
--- a/src/components/messenger/feed/components/post/index.tsx
+++ b/src/components/messenger/feed/components/post/index.tsx
@@ -43,11 +43,11 @@ export const Post = ({
     [text]
   );
 
-  const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+  const handleImageLoad = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
     const { naturalWidth: width, naturalHeight: height } = event.currentTarget;
     handleMediaAspectRatio(width, height);
     setIsImageLoaded(true);
-  };
+  }, []);
 
   const handleMediaAspectRatio = (width: number, height: number) => {
     const aspectRatio = width / height;
@@ -72,11 +72,11 @@ export const Post = ({
     return { width: finalWidth, height: finalHeight };
   };
 
-  const getPlaceholderDimensions = (w: number, h: number) => {
+  const getPlaceholderDimensions = useCallback((w: number, h: number) => {
     const maxWidth = 420;
     const maxHeight = 520;
     return handlePlaceholderAspectRatio(w, h, maxWidth, maxHeight);
-  };
+  }, []);
 
   const renderMedia = useCallback(
     (media) => {


### PR DESCRIPTION
### What does this do?
- This fixes unnecessary image reloads and reduces redundant network requests by memoizing media rendering functions.

### Why are we making this change?
- To improve performance by preventing images from reloading on every render, reducing network overhead and enhancing user experience.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
