### PR TITLE
fix(messenger-feed): re-position and fix waypoint for visibility and trigger loading more posts in feed view

### DIFF
--- a/src/components/messenger/feed/feed-view-container/feed-view.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.tsx
@@ -71,7 +71,9 @@ export class FeedView extends React.Component<Properties> {
                 />
 
                 {this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && this.state.shouldRenderWaypoint && (
-                  <Waypoint onEnter={this.props.onFetchMore} />
+                  <div {...cn('waypoint')}>
+                    <Waypoint onEnter={this.props.onFetchMore} />
+                  </div>
                 )}
               </>
             ) : (

--- a/src/components/messenger/feed/feed-view-container/styles.scss
+++ b/src/components/messenger/feed/feed-view-container/styles.scss
@@ -7,4 +7,10 @@
     box-sizing: border-box;
     color: var(--color-greyscale-10);
   }
+
+  &__waypoint {
+    overflow-anchor: none;
+    position: relative;
+    bottom: 700px;
+  }
 }


### PR DESCRIPTION
### What does this do?
- This ensures the Waypoint is properly visible and triggers the fetchMore function to load more posts in the feed view.

### Why are we making this change?
- The Waypoint was not triggering as expected due to insufficient DOM presence, causing posts to not load as the user scrolled to the bottom of the feed.

### How do I test this?
- run tests as usual
- check feed UI renders more posts when scrolling to bottom of fetched posts

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
