### PR TITLE
feat(app-main): remove empty side space for 2560 x 1600 resolution

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -31,7 +31,6 @@ $border-color-hover: theme-zui.$color-primary-7;
     display: flex;
     justify-content: space-between;
     margin: 0 auto;
-    max-width: 1700px;
     width: 100%;
   }
 


### PR DESCRIPTION
### What does this do?
-  removes empty side space for 2560 x 1600 resolution

### Why are we making this change?
- as requested (n3o)

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

<img width="1184" alt="Screenshot 2024-09-16 at 07 24 20" src="https://github.com/user-attachments/assets/d41a4da6-53f1-4db8-a850-ae7bdf7e9dd3">

