### PR TITLE
refactor(messenger-feed): remove inline padding

### DIFF
--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   width: 100%;
   max-width: 504px;
-  margin: 0 8px;
   box-sizing: border-box;
   pointer-events: auto;
   position: relative;


### PR DESCRIPTION
### What does this do?
- removes messenger feed right and left padding

### Why are we making this change?
- correct container spacing as per designs

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
