### PR TITLE
refactor(feed-header): remove top stroke

### DIFF
--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   width: 100%;
   max-width: 504px;
-  margin: 0 8px;
   box-sizing: border-box;
   pointer-events: auto;
   position: relative;

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -13,7 +13,8 @@
     box-sizing: border-box;
     z-index: 3;
     width: 99.2%;
-    border: 1px solid rgba(52, 56, 60);
+    border-inline: 1px solid rgba(52, 56, 60);
+    border-bottom: 1px solid rgba(52, 56, 60);
     padding-right: 2px;
 
     &--message-loading {


### PR DESCRIPTION
### What does this do?
-  removes top stroke from messenger feed conversation header

### Why are we making this change?
- as per design

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
