### PR TITLE
feat(messenger-feed): add media query to adjust max-width of messenger feed for 2560x1440 screen resolution

### DIFF
--- a/src/apps/messenger/Main.module.scss
+++ b/src/apps/messenger/Main.module.scss
@@ -2,7 +2,7 @@
   position: relative;
   display: flex;
   width: 100%;
-  gap: 45px;
+  gap: 18px;
 }
 
 .Actions {

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -26,4 +26,8 @@
     pointer-events: all !important;
     backdrop-filter: blur(64px);
   }
+
+  @media only screen and (min-width: 2560px) and (min-height: 1440px) {
+    max-width: 594px;
+  }
 }

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   width: 100%;
   max-width: 504px;
-  margin: 0 8px;
   box-sizing: border-box;
   pointer-events: auto;
   position: relative;

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -13,7 +13,8 @@
     box-sizing: border-box;
     z-index: 3;
     width: 99.2%;
-    border: 1px solid rgba(52, 56, 60);
+    border-inline: 1px solid rgba(52, 56, 60);
+    border-bottom: 1px solid rgba(52, 56, 60);
     padding-right: 2px;
 
     &--message-loading {


### PR DESCRIPTION
### What does this do?
- adds media query to adjust max-width of messenger feed for 2560x1440 screen resolution

### Why are we making this change?
- as per design request

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
