### PR TITLE
refactor(media-queries): remove min height on media queries

### DIFF
--- a/src/apps/messenger/Main.module.scss
+++ b/src/apps/messenger/Main.module.scss
@@ -2,7 +2,7 @@
   position: relative;
   display: flex;
   width: 100%;
-  gap: 45px;
+  gap: 18px;
 }
 
 .Actions {

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -127,7 +127,7 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     overflow: hidden;
     width: 100%;
 
-    @media only screen and (min-width: 2561px) and (min-height: 1440px) {
+    @media (min-width: 2561px) {
       min-width: 1558px;
     }
 

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -127,6 +127,10 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     overflow: hidden;
     width: 100%;
 
+    @media only screen and (min-width: 2561px) and (min-height: 1440px) {
+      min-width: 1558px;
+    }
+
     .direct-message-chat__content {
       height: 100vh;
       width: unset;

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -26,4 +26,8 @@
     pointer-events: all !important;
     backdrop-filter: blur(64px);
   }
+
+  @media only screen and (min-width: 2560px) and (min-height: 1440px) {
+    max-width: 594px;
+  }
 }

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   width: 100%;
   max-width: 504px;
-  margin: 0 8px;
   box-sizing: border-box;
   pointer-events: auto;
   position: relative;

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -27,7 +27,7 @@
     backdrop-filter: blur(64px);
   }
 
-  @media only screen and (min-width: 2560px) and (min-height: 1440px) {
+  @media (min-width: 2561px) {
     max-width: 594px;
   }
 }

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -13,7 +13,8 @@
     box-sizing: border-box;
     z-index: 3;
     width: 99.2%;
-    border: 1px solid rgba(52, 56, 60);
+    border-inline: 1px solid rgba(52, 56, 60);
+    border-bottom: 1px solid rgba(52, 56, 60);
     padding-right: 2px;
 
     &--message-loading {

--- a/src/main.scss
+++ b/src/main.scss
@@ -33,7 +33,7 @@ $border-color-hover: theme-zui.$color-primary-7;
     margin: 0 auto;
     width: 100%;
 
-    @media only screen and (min-width: 2560px) and (min-height: 1440px) {
+    @media (min-width: 2561px) {
       width: unset;
     }
   }

--- a/src/main.scss
+++ b/src/main.scss
@@ -32,6 +32,10 @@ $border-color-hover: theme-zui.$color-primary-7;
     justify-content: space-between;
     margin: 0 auto;
     width: 100%;
+
+    @media only screen and (min-width: 2560px) and (min-height: 1440px) {
+      width: unset;
+    }
   }
 
   &.messenger-full-screen {


### PR DESCRIPTION
### What does this do?
- removes min height on media queries

### Why are we making this change?
- not required as causes issues by setting a min height, we don't need to be concerned with height

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
