### PR TITLE
feat(rewards): add meow transfer functionality with error handling and state management updates

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -360,3 +360,12 @@ export async function sendPostByChannelId(channelId: string, message: string, op
 export async function getPostMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
   return chat.get().matrix.getPostMessagesByChannelId(channelId, lastCreatedAt);
 }
+
+export async function sendMeowReactionEvent(
+  roomId: string,
+  postMessageId: string,
+  postOwnerId: string,
+  meowAmount: number
+) {
+  return chat.get().matrix.sendMeowReactionEvent(roomId, postMessageId, postOwnerId, meowAmount);
+}

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -5,7 +5,7 @@ import { uploadImage as _uploadImage } from '../../store/channels-list/api';
 import { when } from 'jest-when';
 import { config } from '../../config';
 import { PowerLevels } from './types';
-import { MatrixConstants, ReadReceiptPreferenceType } from './matrix/types';
+import { MatrixConstants, ReactionKeys, ReadReceiptPreferenceType } from './matrix/types';
 import { DefaultRoomLabels } from '../../store/channels';
 
 jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
@@ -649,6 +649,26 @@ describe('matrix client', () => {
       const result = await client.sendPostsByChannelId('channel-id', 'post-message');
 
       expect(result).toMatchObject({ id: '$80dh3P6kQKgA0IIrdkw5AW0vSXXcRMT2PPIGVg9nEvU' });
+    });
+  });
+
+  describe('sendMeowReactionEvent', () => {
+    it('sends a meow reaction event successfully', async () => {
+      const sendEvent = jest.fn().mockResolvedValue({});
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ sendEvent })) });
+
+      await client.connect(null, 'token');
+      await client.sendMeowReactionEvent('channel-id', 'post-message-id', 'post-owner-id', 10);
+
+      expect(sendEvent).toHaveBeenCalledWith('channel-id', MatrixConstants.REACTION, {
+        'm.relates_to': {
+          rel_type: MatrixConstants.ANNOTATION,
+          event_id: 'post-message-id',
+          key: ReactionKeys.MEOW,
+        },
+        amount: 10,
+        postOwnerId: 'post-owner-id',
+      });
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -41,6 +41,7 @@ import {
   IN_ROOM_MEMBERSHIP_STATES,
   MatrixConstants,
   MembershipStateType,
+  ReactionKeys,
   ReadReceiptPreferenceType,
 } from './matrix/types';
 import { constructFallbackForParentMessage, getFilteredMembersForAutoComplete, setAsDM } from './matrix/utils';
@@ -461,6 +462,27 @@ export class MatrixClient implements IChatClient {
     const postMessages = await this.getAllPostMessagesFromRoom(events);
 
     return { postMessages, hasMore };
+  }
+
+  async sendMeowReactionEvent(
+    roomId: string,
+    postMessageId: string,
+    postOwnerId: string,
+    meowAmount: number
+  ): Promise<void> {
+    await this.waitForConnection();
+
+    const content = {
+      'm.relates_to': {
+        rel_type: MatrixConstants.ANNOTATION,
+        event_id: postMessageId,
+        key: ReactionKeys.MEOW,
+      },
+      amount: meowAmount,
+      postOwnerId: postOwnerId,
+    };
+
+    await this.matrix.sendEvent(roomId, MatrixConstants.REACTION as any, content);
   }
 
   async getMessageByRoomId(channelId: string, messageId: string) {

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -21,6 +21,12 @@ export enum MatrixConstants {
   REPLACE = 'm.replace',
   BAD_ENCRYPTED_MSGTYPE = 'm.bad.encrypted',
   READ_RECEIPT_PREFERENCE = 'm.read_receipt_preference',
+  REACTION = 'm.reaction',
+  ANNOTATION = 'm.annotation',
+}
+
+export enum ReactionKeys {
+  MEOW = 'MEOW',
 }
 
 export enum CustomEventType {

--- a/src/store/rewards/api.ts
+++ b/src/store/rewards/api.ts
@@ -1,4 +1,4 @@
-import { get } from '../../lib/api/rest';
+import { get, post } from '../../lib/api/rest';
 
 export interface RewardsResp {
   success: boolean;
@@ -23,4 +23,28 @@ export async function fetchCurrentMeowPriceInUSD() {
     success: true,
     response: response.body,
   };
+}
+
+export async function transferMeow(senderUserId: string, recipientUserId: string, amount: string) {
+  try {
+    const response = await post('/rewards/transfer').send({
+      senderUserId,
+      recipientUserId,
+      amount,
+    });
+
+    return {
+      success: true,
+      response: response.body,
+    };
+  } catch (error: any) {
+    if (error?.response?.status === 400) {
+      return {
+        success: false,
+        response: error.response.body.code,
+        error: error.response.body.message,
+      };
+    }
+    throw error;
+  }
 }

--- a/src/store/rewards/api.ts
+++ b/src/store/rewards/api.ts
@@ -1,4 +1,5 @@
 import { get, post } from '../../lib/api/rest';
+import BN from 'bn.js';
 
 export interface RewardsResp {
   success: boolean;
@@ -27,10 +28,12 @@ export async function fetchCurrentMeowPriceInUSD() {
 
 export async function transferMeow(senderUserId: string, recipientUserId: string, amount: string) {
   try {
+    const amountInWei = new BN(amount).mul(new BN('1000000000000000000')).toString();
+
     const response = await post('/rewards/transfer').send({
       senderUserId,
       recipientUserId,
-      amount,
+      amount: amountInWei,
     });
 
     return {

--- a/src/store/rewards/index.ts
+++ b/src/store/rewards/index.ts
@@ -32,9 +32,13 @@ export const initialState: RewardsState = {
 
 export const totalRewardsViewed = createAction(SagaActionTypes.TotalRewardsViewed);
 export const closeRewardsTooltip = createAction(SagaActionTypes.CloseRewardsTooltip);
-export const transferMeow = createAction<{ meowSenderUserId: string; meowRecipientUserId: string; amount: string }>(
-  SagaActionTypes.TransferMeow
-);
+export const transferMeow = createAction<{
+  meowSenderId: string;
+  postOwnerId: string;
+  postMessageId: string;
+  meowAmount: string;
+  roomId: string;
+}>(SagaActionTypes.TransferMeow);
 
 const slice = createSlice({
   name: 'rewards',

--- a/src/store/rewards/index.ts
+++ b/src/store/rewards/index.ts
@@ -3,6 +3,7 @@ import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 export enum SagaActionTypes {
   TotalRewardsViewed = 'rewards/totalRewardsViewed',
   CloseRewardsTooltip = 'registration/closeRewardsTooltip',
+  TransferMeow = 'rewards/transferMeow',
 }
 
 export type RewardsState = {
@@ -13,6 +14,7 @@ export type RewardsState = {
   showRewardsInTooltip: boolean;
   showRewardsInPopup: boolean;
   showNewRewardsIndicator: boolean;
+  transferError: string | null;
 };
 
 export const initialState: RewardsState = {
@@ -23,10 +25,14 @@ export const initialState: RewardsState = {
   showRewardsInTooltip: false,
   showRewardsInPopup: false,
   showNewRewardsIndicator: false,
+  transferError: null,
 };
 
 export const totalRewardsViewed = createAction(SagaActionTypes.TotalRewardsViewed);
 export const closeRewardsTooltip = createAction(SagaActionTypes.CloseRewardsTooltip);
+export const transferMeow = createAction<{ senderUserId: string; recipientUserId: string; amount: string }>(
+  SagaActionTypes.TransferMeow
+);
 
 const slice = createSlice({
   name: 'rewards',
@@ -59,6 +65,9 @@ const slice = createSlice({
     setShowNewRewardsIndicator: (state, action: PayloadAction<RewardsState['showNewRewardsIndicator']>) => {
       state.showNewRewardsIndicator = action.payload;
     },
+    setTransferError: (state, action: PayloadAction<{ error: string }>) => {
+      state.transferError = action.payload.error;
+    },
   },
 });
 
@@ -72,5 +81,6 @@ export const {
   setShowRewardsInTooltip,
   setShowRewardsInPopup,
   setShowNewRewardsIndicator,
+  setTransferError,
 } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/rewards/index.ts
+++ b/src/store/rewards/index.ts
@@ -14,7 +14,8 @@ export type RewardsState = {
   showRewardsInTooltip: boolean;
   showRewardsInPopup: boolean;
   showNewRewardsIndicator: boolean;
-  transferError: string | null;
+  transferLoading: boolean;
+  transferError?: string;
 };
 
 export const initialState: RewardsState = {
@@ -25,12 +26,13 @@ export const initialState: RewardsState = {
   showRewardsInTooltip: false,
   showRewardsInPopup: false,
   showNewRewardsIndicator: false,
+  transferLoading: false,
   transferError: null,
 };
 
 export const totalRewardsViewed = createAction(SagaActionTypes.TotalRewardsViewed);
 export const closeRewardsTooltip = createAction(SagaActionTypes.CloseRewardsTooltip);
-export const transferMeow = createAction<{ senderUserId: string; recipientUserId: string; amount: string }>(
+export const transferMeow = createAction<{ meowSenderUserId: string; meowRecipientUserId: string; amount: string }>(
   SagaActionTypes.TransferMeow
 );
 
@@ -68,6 +70,9 @@ const slice = createSlice({
     setTransferError: (state, action: PayloadAction<{ error: string }>) => {
       state.transferError = action.payload.error;
     },
+    setTransferLoading: (state, action: PayloadAction<RewardsState['transferLoading']>) => {
+      state.transferLoading = action.payload;
+    },
   },
 });
 
@@ -82,5 +87,6 @@ export const {
   setShowRewardsInPopup,
   setShowNewRewardsIndicator,
   setTransferError,
+  setTransferLoading,
 } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/rewards/saga.test.ts
+++ b/src/store/rewards/saga.test.ts
@@ -113,9 +113,9 @@ describe(checkNewRewardsLoaded, () => {
 
 describe(transferMeow, () => {
   it('handles successful MEOW transfer', async () => {
-    const meowSenderUserId = 'sender-id';
-    const meowRecipientUserId = 'recipient-id';
-    const amount = '500000000000000000';
+    const meowSenderId = 'sender-id';
+    const postOwnerId = 'post-owner-id';
+    const meowAmount = '500000000000000000';
 
     const apiResponse = {
       success: true,
@@ -126,22 +126,22 @@ describe(transferMeow, () => {
     };
 
     const { storeState } = await expectSaga(transferMeow, {
-      payload: { meowSenderUserId, meowRecipientUserId, amount },
+      payload: { meowSenderId, postOwnerId, meowAmount },
     })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), apiResponse]])
+      .provide([[call(transferMeowAPI, meowSenderId, postOwnerId, meowAmount), apiResponse]])
       .run();
 
     expect(storeState.rewards.meow).toEqual('500000000000000000');
   });
 
-  it('handles meowSenderUserId is equal to meowRecipientUserId failure', async () => {
-    const meowSenderUserId = 'sender-id';
-    const meowRecipientUserId = 'sender-id';
-    const amount = '500000000000000000';
+  it('handles meowSenderId is equal to postOwnerId failure', async () => {
+    const meowSenderId = 'sender-id';
+    const postOwnerId = 'sender-id';
+    const meowAmount = '500000000000000000';
 
     const { storeState } = await expectSaga(transferMeow, {
-      payload: { meowSenderUserId, meowRecipientUserId, amount },
+      payload: { meowSenderId, postOwnerId, meowAmount },
     })
       .withReducer(rootReducer, initialState())
       .run();
@@ -150,9 +150,9 @@ describe(transferMeow, () => {
   });
 
   it('handles API MEOW transfer failure', async () => {
-    const meowSenderUserId = 'sender-id';
-    const meowRecipientUserId = 'recipient-id';
-    const amount = '500000000000000000';
+    const meowSenderId = 'sender-id';
+    const postOwnerId = 'post-owner-id';
+    const meowAmount = '500000000000000000';
 
     const apiResponse = {
       success: false,
@@ -160,27 +160,27 @@ describe(transferMeow, () => {
     };
 
     const { storeState } = await expectSaga(transferMeow, {
-      payload: { meowSenderUserId, meowRecipientUserId, amount },
+      payload: { meowSenderId, postOwnerId, meowAmount },
     })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), apiResponse]])
+      .provide([[call(transferMeowAPI, meowSenderId, postOwnerId, meowAmount), apiResponse]])
       .run();
 
     expect(storeState.rewards.transferError).toEqual('Transfer failed.');
   });
 
   it('handles unexpected error during MEOW transfer', async () => {
-    const meowSenderUserId = 'sender-id';
-    const meowRecipientUserId = 'recipient-id';
-    const amount = '500000000000000000';
+    const meowSenderId = 'sender-id';
+    const postOwnerId = 'post-owner-id';
+    const meowAmount = '500000000000000000';
 
     const error = new Error('Network error');
 
     const { storeState } = await expectSaga(transferMeow, {
-      payload: { meowSenderUserId, meowRecipientUserId, amount },
+      payload: { meowSenderId, postOwnerId, meowAmount },
     })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), Promise.reject(error)]])
+      .provide([[call(transferMeowAPI, meowSenderId, postOwnerId, meowAmount), Promise.reject(error)]])
       .run();
 
     expect(storeState.rewards.transferError).toEqual('Network error');
@@ -188,8 +188,8 @@ describe(transferMeow, () => {
 
   it('handles transfer loading', async () => {
     const meowSenderUserId = 'sender-id';
-    const meowRecipientUserId = 'recipient-id';
-    const amount = '500000000000000000';
+    const postOwnerId = 'post-owner-id';
+    const meowAmount = '500000000000000000';
 
     const apiResponse = {
       success: true,
@@ -200,10 +200,10 @@ describe(transferMeow, () => {
     };
 
     const { storeState } = await expectSaga(transferMeow, {
-      payload: { meowSenderUserId, meowRecipientUserId, amount },
+      payload: { meowSenderUserId, postOwnerId, meowAmount },
     })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), apiResponse]])
+      .provide([[call(transferMeowAPI, meowSenderUserId, postOwnerId, meowAmount), apiResponse]])
       .run();
 
     expect(storeState.rewards.transferLoading).toEqual(false);

--- a/src/store/rewards/saga.test.ts
+++ b/src/store/rewards/saga.test.ts
@@ -113,8 +113,8 @@ describe(checkNewRewardsLoaded, () => {
 
 describe(transferMeow, () => {
   it('handles successful MEOW transfer', async () => {
-    const senderUserId = 'sender-id';
-    const recipientUserId = 'recipient-id';
+    const meowSenderUserId = 'sender-id';
+    const meowRecipientUserId = 'recipient-id';
     const amount = '500000000000000000';
 
     const apiResponse = {
@@ -125,17 +125,33 @@ describe(transferMeow, () => {
       },
     };
 
-    const { storeState } = await expectSaga(transferMeow, { payload: { senderUserId, recipientUserId, amount } })
+    const { storeState } = await expectSaga(transferMeow, {
+      payload: { meowSenderUserId, meowRecipientUserId, amount },
+    })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, senderUserId, recipientUserId, amount), apiResponse]])
+      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), apiResponse]])
       .run();
 
     expect(storeState.rewards.meow).toEqual('500000000000000000');
   });
 
-  it('handles MEOW transfer failure', async () => {
-    const senderUserId = 'sender-id';
-    const recipientUserId = 'recipient-id';
+  it('handles meowSenderUserId is equal to meowRecipientUserId failure', async () => {
+    const meowSenderUserId = 'sender-id';
+    const meowRecipientUserId = 'sender-id';
+    const amount = '500000000000000000';
+
+    const { storeState } = await expectSaga(transferMeow, {
+      payload: { meowSenderUserId, meowRecipientUserId, amount },
+    })
+      .withReducer(rootReducer, initialState())
+      .run();
+
+    expect(storeState.rewards.transferError).toEqual('Cannot transfer MEOW to yourself.');
+  });
+
+  it('handles API MEOW transfer failure', async () => {
+    const meowSenderUserId = 'sender-id';
+    const meowRecipientUserId = 'recipient-id';
     const amount = '500000000000000000';
 
     const apiResponse = {
@@ -143,27 +159,54 @@ describe(transferMeow, () => {
       error: 'Transfer failed.',
     };
 
-    const { storeState } = await expectSaga(transferMeow, { payload: { senderUserId, recipientUserId, amount } })
+    const { storeState } = await expectSaga(transferMeow, {
+      payload: { meowSenderUserId, meowRecipientUserId, amount },
+    })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, senderUserId, recipientUserId, amount), apiResponse]])
+      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), apiResponse]])
       .run();
 
     expect(storeState.rewards.transferError).toEqual('Transfer failed.');
   });
 
   it('handles unexpected error during MEOW transfer', async () => {
-    const senderUserId = 'sender-id';
-    const recipientUserId = 'recipient-id';
+    const meowSenderUserId = 'sender-id';
+    const meowRecipientUserId = 'recipient-id';
     const amount = '500000000000000000';
 
     const error = new Error('Network error');
 
-    const { storeState } = await expectSaga(transferMeow, { payload: { senderUserId, recipientUserId, amount } })
+    const { storeState } = await expectSaga(transferMeow, {
+      payload: { meowSenderUserId, meowRecipientUserId, amount },
+    })
       .withReducer(rootReducer, initialState())
-      .provide([[call(transferMeowAPI, senderUserId, recipientUserId, amount), Promise.reject(error)]])
+      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), Promise.reject(error)]])
       .run();
 
     expect(storeState.rewards.transferError).toEqual('Network error');
+  });
+
+  it('handles transfer loading', async () => {
+    const meowSenderUserId = 'sender-id';
+    const meowRecipientUserId = 'recipient-id';
+    const amount = '500000000000000000';
+
+    const apiResponse = {
+      success: true,
+      response: {
+        senderBalance: '500000000000000000',
+        recipientBalance: '1000000000000000000',
+      },
+    };
+
+    const { storeState } = await expectSaga(transferMeow, {
+      payload: { meowSenderUserId, meowRecipientUserId, amount },
+    })
+      .withReducer(rootReducer, initialState())
+      .provide([[call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount), apiResponse]])
+      .run();
+
+    expect(storeState.rewards.transferLoading).toEqual(false);
   });
 });
 

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -124,6 +124,8 @@ export function* closeRewardsTooltip() {
 }
 
 export function* transferMeow(action) {
+  yield put(setTransferError({ error: null }));
+
   const { meowSenderUserId, meowRecipientUserId, amount } = action.payload;
 
   if (meowSenderUserId === meowRecipientUserId) {

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -10,8 +10,14 @@ import {
   setMeowPreviousDay,
   setShowRewardsInPopup,
   setShowNewRewardsIndicator,
+  setTransferError,
 } from '.';
-import { RewardsResp, fetchCurrentMeowPriceInUSD as fetchCurrentMeowPriceInUSDAPI, fetchRewards } from './api';
+import {
+  RewardsResp,
+  fetchCurrentMeowPriceInUSD as fetchCurrentMeowPriceInUSDAPI,
+  fetchRewards,
+  transferMeow as transferMeowAPI,
+} from './api';
 import { takeEveryFromBus } from '../../lib/saga';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
 import { featureFlags } from '../../lib/feature-flags';
@@ -116,6 +122,22 @@ export function* closeRewardsTooltip() {
   }
 }
 
+export function* transferMeow(action) {
+  const { senderUserId, recipientUserId, amount } = action.payload;
+
+  try {
+    const result = yield call(transferMeowAPI, senderUserId, recipientUserId, amount);
+
+    if (result.success) {
+      yield put(setMeow(result.response.senderBalance));
+    } else {
+      yield put(setTransferError({ error: result.error }));
+    }
+  } catch (error: any) {
+    yield put(setTransferError({ error: error.message || 'An unexpected error occurred.' }));
+  }
+}
+
 function* clearOnLogout() {
   yield put(setLoading(false));
   yield put(setMeow('0'));
@@ -124,11 +146,13 @@ function* clearOnLogout() {
   yield put(setShowRewardsInTooltip(false));
   yield put(setShowRewardsInPopup(false));
   yield put(setShowNewRewardsIndicator(false));
+  yield put(setTransferError({ error: '' }));
 }
 
 export function* saga() {
   yield takeEvery(SagaActionTypes.TotalRewardsViewed, totalRewardsViewed);
   yield takeEvery(SagaActionTypes.CloseRewardsTooltip, closeRewardsTooltip);
+  yield takeEvery(SagaActionTypes.TransferMeow, transferMeow);
   yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogin, syncRewardsAndTokenPrice);
   yield takeEveryFromBus(yield call(getAuthChannel), AuthEvents.UserLogout, clearOnLogout);
 }

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -126,9 +126,9 @@ export function* closeRewardsTooltip() {
 export function* transferMeow(action) {
   yield put(setTransferError({ error: null }));
 
-  const { meowSenderUserId, meowRecipientUserId, amount } = action.payload;
+  const { meowSenderId, postOwnerId, postMessageId, meowAmount, roomId } = action.payload;
 
-  if (meowSenderUserId === meowRecipientUserId) {
+  if (meowSenderId === postOwnerId) {
     yield put(setTransferError({ error: 'Cannot transfer MEOW to yourself.' }));
     return;
   }
@@ -136,7 +136,7 @@ export function* transferMeow(action) {
   yield put(setTransferLoading(true));
 
   try {
-    const result = yield call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount);
+    const result = yield call(transferMeowAPI, meowSenderId, postOwnerId, meowAmount);
 
     if (result.success) {
       yield put(setMeow(result.response.senderBalance));

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -127,7 +127,7 @@ export function* closeRewardsTooltip() {
 export function* transferMeow(action) {
   yield put(setTransferError({ error: null }));
 
-  const { meowSenderId, postOwnerId, meowAmount } = action.payload;
+  const { meowSenderId, postOwnerId, postMessageId, meowAmount, roomId } = action.payload;
 
   if (meowSenderId === postOwnerId) {
     yield put(setTransferError({ error: 'Cannot transfer MEOW to yourself.' }));
@@ -141,6 +141,8 @@ export function* transferMeow(action) {
 
     if (result.success) {
       yield put(setMeow(result.response.senderBalance));
+
+      yield call(sendMeowReactionEvent, roomId, postMessageId, postOwnerId, meowAmount);
     } else {
       yield put(setTransferError({ error: result.error }));
     }

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -11,6 +11,7 @@ import {
   setShowRewardsInPopup,
   setShowNewRewardsIndicator,
   setTransferError,
+  setTransferLoading,
 } from '.';
 import {
   RewardsResp,
@@ -123,10 +124,17 @@ export function* closeRewardsTooltip() {
 }
 
 export function* transferMeow(action) {
-  const { senderUserId, recipientUserId, amount } = action.payload;
+  const { meowSenderUserId, meowRecipientUserId, amount } = action.payload;
+
+  if (meowSenderUserId === meowRecipientUserId) {
+    yield put(setTransferError({ error: 'Cannot transfer MEOW to yourself.' }));
+    return;
+  }
+
+  yield put(setTransferLoading(true));
 
   try {
-    const result = yield call(transferMeowAPI, senderUserId, recipientUserId, amount);
+    const result = yield call(transferMeowAPI, meowSenderUserId, meowRecipientUserId, amount);
 
     if (result.success) {
       yield put(setMeow(result.response.senderBalance));
@@ -135,6 +143,8 @@ export function* transferMeow(action) {
     }
   } catch (error: any) {
     yield put(setTransferError({ error: error.message || 'An unexpected error occurred.' }));
+  } finally {
+    yield put(setTransferLoading(false));
   }
 }
 

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -22,6 +22,7 @@ import {
 import { takeEveryFromBus } from '../../lib/saga';
 import { getAuthChannel, Events as AuthEvents } from '../authentication/channels';
 import { featureFlags } from '../../lib/feature-flags';
+import { sendMeowReactionEvent } from '../../lib/chat';
 
 const FETCH_REWARDS_INTERVAL = 60 * 60 * 1000; // 1 hour
 const SYNC_MEOW_TOKEN_PRICE_INTERVAL = 2 * 60 * 1000; // every 2 minutes
@@ -126,7 +127,7 @@ export function* closeRewardsTooltip() {
 export function* transferMeow(action) {
   yield put(setTransferError({ error: null }));
 
-  const { meowSenderId, postOwnerId, postMessageId, meowAmount, roomId } = action.payload;
+  const { meowSenderId, postOwnerId, meowAmount } = action.payload;
 
   if (meowSenderId === postOwnerId) {
     yield put(setTransferError({ error: 'Cannot transfer MEOW to yourself.' }));


### PR DESCRIPTION
### What does this do?
- This adds functionality to handle MEOW token 'transfers' between users, including API integration and state management in the frontend.

### Why are we making this change?
- We are implementing the ability for users to transfer MEOW tokens as part of the app's reward and interaction system.

### How do I test this?
- run tests as usual.
- Note:: this is not yet wired up to UI

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
