### PR TITLE
Upload Profile Images to the (synapse) homeserver instead of cloudinary

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -80,6 +80,8 @@ export interface IChatClient {
   saveSecureBackup: (MatrixKeyBackupInfo) => Promise<void>;
   restoreSecureBackup: (recoveryKey: string) => Promise<void>;
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
+  uploadFile(file: File): Promise<string>;
+  downloadFile(fileUrl: string): Promise<any>;
 }
 
 export class Chat {
@@ -373,4 +375,12 @@ export async function sendMeowReactionEvent(
 
 export async function getPostMessageReactions(roomId: string) {
   return chat.get().matrix.getPostMessageReactions(roomId);
+}
+
+export async function uploadFile(file: File): Promise<string> {
+  return chat.get().matrix.uploadFile(file);
+}
+
+export async function downloadFile(fileUrl: string) {
+  return chat.get().matrix.downloadFile(fileUrl);
 }

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1192,6 +1192,60 @@ describe('matrix client', () => {
     });
   });
 
+  describe('uploadFile', () => {
+    it('uploads a file successfully', async () => {
+      const file: any = { name: 'some-file', type: 'text/plain' };
+
+      const uploadContent = jest.fn(() =>
+        Promise.resolve({
+          content_uri: 'mxc://content-url',
+        })
+      );
+      const mxcUrlToHttp = jest.fn(() => 'http://example.com/content-url');
+
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ uploadContent, mxcUrlToHttp })) });
+
+      await client.connect(null, 'token');
+      const result = await client.uploadFile(file);
+
+      expect(uploadContent).toHaveBeenCalledWith(file, {
+        name: file.name,
+        type: file.type,
+        includeFilename: false,
+      });
+      expect(mxcUrlToHttp).toHaveBeenCalledWith(
+        'mxc://content-url',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        true
+      );
+      expect(result).toBe('http://example.com/content-url');
+    });
+  });
+
+  describe('downloadFile', () => {
+    it('returns null if the fileUrl is null', async () => {
+      const fileUrl = null;
+      const client = subject({ createClient: jest.fn(() => getSdkClient({})) });
+      await client.connect(null, 'token');
+      const result = await client.downloadFile(fileUrl);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the file url if it is not uploaded the homeserver', async () => {
+      const fileUrl = 'http://aws-s3-bucket-1.com/file.txt';
+      const client = subject({ createClient: jest.fn(() => getSdkClient({})) });
+      await client.connect(null, 'token');
+      const result = await client.downloadFile(fileUrl);
+
+      expect(result).toBe(fileUrl);
+    });
+  });
+
   describe('setReadReceiptPreference', () => {
     it('sets read receipt preference successfully', async () => {
       const setAccountData = jest.fn().mockResolvedValue(undefined);

--- a/src/lib/storage/idb.ts
+++ b/src/lib/storage/idb.ts
@@ -1,0 +1,69 @@
+import { openDB } from 'idb';
+
+export class IndexedDBHelper {
+  private dbName: string;
+  private storeName: string;
+  private dbPromise: Promise<any>;
+
+  constructor(dbName, storeName) {
+    this.dbName = dbName; // Name of the database
+    this.storeName = storeName; // Name of the object store
+
+    // Initialize the database
+    this.dbPromise = this.initDB();
+  }
+
+  // Method to initialize the database
+  async initDB() {
+    return openDB(this.dbName, 1, {
+      upgrade: (db) => {
+        // Create an object store if it doesn't exist
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          db.createObjectStore(this.storeName, { keyPath: 'id' });
+        }
+      },
+    });
+  }
+
+  // Method to add or update a record
+  async put(id, value) {
+    const db = await this.dbPromise;
+    return await db.put(this.storeName, { id, value });
+  }
+
+  // Method to retrieve a record by id
+  async get(id) {
+    const db = await this.dbPromise;
+    const record = await db.get(this.storeName, id);
+    return record ? record.value : null;
+  }
+
+  // Method to delete a record by id
+  async delete(id) {
+    const db = await this.dbPromise;
+    return db.delete(this.storeName, id);
+  }
+
+  // Method to get all records
+  async getAll() {
+    const db = await this.dbPromise;
+    const records = await db.getAll(this.storeName);
+    return records.map((record) => record.value);
+  }
+
+  // Method to clear the object store
+  async clear() {
+    const db = await this.dbPromise;
+    return db.clear(this.storeName);
+  }
+}
+
+function createProvider() {
+  return new IndexedDBHelper('zos-db', 'image-store');
+}
+
+let provider;
+export function getProvider(): IndexedDBHelper {
+  provider = provider ?? createProvider();
+  return provider;
+}

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -1,7 +1,7 @@
 import { testSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { chat, getRoomTags } from '../../lib/chat';
+import { chat, downloadFile, getRoomTags } from '../../lib/chat';
 
 import {
   fetchConversations,
@@ -342,6 +342,7 @@ describe('channels list saga', () => {
         lastName: 'last-1',
         primaryZID: 'primary-zid-1',
         displaySubHandle: 'primary-zid-1',
+        profileImage: 'profile-image-url-1',
       },
       {
         userId: 'user-2',
@@ -351,6 +352,7 @@ describe('channels list saga', () => {
         lastName: 'last-2',
         primaryZID: 'primary-zid-2',
         displaySubHandle: 'primary-zid-2',
+        profileImage: 'profile-image-url-2',
       },
       {
         userId: 'user-3',
@@ -360,6 +362,7 @@ describe('channels list saga', () => {
         lastName: 'last-3',
         primaryZID: '',
         displaySubHandle: '',
+        profileImage: 'profile-image-url-3',
       },
     ] as any;
 
@@ -370,7 +373,7 @@ describe('channels list saga', () => {
         .run();
     });
 
-    it('creates map for zero users after fetching from api', async () => {
+    it('creates map for zero users and downloads profile images after fetching from api', async () => {
       const expectedMap = {
         'matrix-id-1': {
           userId: 'user-1',
@@ -380,6 +383,7 @@ describe('channels list saga', () => {
           lastName: 'last-1',
           primaryZID: 'primary-zid-1',
           displaySubHandle: 'primary-zid-1',
+          profileImage: 'profile-image-local-url-1',
         },
         'matrix-id-2': {
           userId: 'user-2',
@@ -389,6 +393,7 @@ describe('channels list saga', () => {
           lastName: 'last-2',
           primaryZID: 'primary-zid-2',
           displaySubHandle: 'primary-zid-2',
+          profileImage: 'profile-image-local-url-2',
         },
         'matrix-id-3': {
           userId: 'user-3',
@@ -398,12 +403,18 @@ describe('channels list saga', () => {
           lastName: 'last-3',
           primaryZID: '',
           displaySubHandle: '',
+          profileImage: 'profile-image-local-url-3',
         },
       };
 
       await expectSaga(mapToZeroUsers, rooms)
         .withReducer(rootReducer)
-        .provide([[call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers]])
+        .provide([
+          [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
+          [call(downloadFile, 'profile-image-url-1'), 'profile-image-local-url-1'],
+          [call(downloadFile, 'profile-image-url-2'), 'profile-image-local-url-2'],
+          [call(downloadFile, 'profile-image-url-3'), 'profile-image-local-url-3'],
+        ])
         .call(mapChannelMembers, rooms, expectedMap)
         .run();
     });
@@ -424,7 +435,7 @@ describe('channels list saga', () => {
           profileId: 'profile-1',
           firstName: 'first-1',
           lastName: 'last-1',
-          profileImage: undefined,
+          profileImage: 'profile-image-local-url-1',
           primaryZID: 'primary-zid-1',
           displaySubHandle: 'primary-zid-1',
         },
@@ -434,7 +445,7 @@ describe('channels list saga', () => {
           profileId: 'profile-2',
           firstName: 'first-2',
           lastName: 'last-2',
-          profileImage: undefined,
+          profileImage: 'profile-image-local-url-2',
           primaryZID: 'primary-zid-2',
           displaySubHandle: 'primary-zid-2',
         },
@@ -448,7 +459,7 @@ describe('channels list saga', () => {
           profileId: 'profile-3',
           firstName: 'first-3',
           lastName: 'last-3',
-          profileImage: undefined,
+          profileImage: 'profile-image-local-url-3',
           primaryZID: '',
           displaySubHandle: '',
         },
@@ -474,7 +485,7 @@ describe('channels list saga', () => {
         profileId: 'profile-1',
         firstName: 'first-1',
         lastName: 'last-1',
-        profileImage: undefined,
+        profileImage: 'profile-image-local-url-1',
         primaryZID: 'primary-zid-1',
         displaySubHandle: 'primary-zid-1',
       });
@@ -483,7 +494,7 @@ describe('channels list saga', () => {
         profileId: 'profile-2',
         firstName: 'first-2',
         lastName: 'last-2',
-        profileImage: undefined,
+        profileImage: 'profile-image-local-url-2',
         primaryZID: 'primary-zid-2',
         displaySubHandle: 'primary-zid-2',
       });
@@ -492,7 +503,7 @@ describe('channels list saga', () => {
         profileId: 'profile-3',
         firstName: 'first-3',
         lastName: 'last-3',
-        profileImage: undefined,
+        profileImage: 'profile-image-local-url-3',
         primaryZID: '',
         displaySubHandle: '',
       });

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -3,7 +3,7 @@ import getDeepProperty from 'lodash.get';
 import uniqBy from 'lodash.uniqby';
 import { fork, put, call, take, all, select, spawn } from 'redux-saga/effects';
 import { receive, denormalizeConversations, setStatus } from '.';
-import { chat, getRoomTags } from '../../lib/chat';
+import { chat, downloadFile, getRoomTags } from '../../lib/chat';
 
 import { AsyncListStatus } from '../normalized';
 import { toLocalChannel, mapChannelMembers, mapChannelMessages } from './utils';
@@ -37,6 +37,7 @@ export function* mapToZeroUsers(channels: any[]) {
   const zeroUsers = yield call(getZEROUsers, allMatrixIds);
   const zeroUsersMap = {};
   for (const user of zeroUsers) {
+    user.profileImage = yield call(downloadFile, user.profileImage);
     zeroUsersMap[user.matrixId] = user;
   }
 
@@ -391,6 +392,8 @@ export function* otherUserJoinedChannel(roomId: string, user: User) {
 
   if (user.userId === user.matrixId) {
     user = yield call(getUserByMatrixId, user.matrixId) || user;
+    const profileImage = yield call(downloadFile, user.profileImage || '');
+    user = { ...user, profileImage };
   }
 
   if (!channel?.otherMembers?.includes(user.userId)) {

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -2,7 +2,8 @@ import { expectSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import { editProfile as editProfileSaga, updateUserProfile, fetchOwnedZIDs } from './saga';
 import { editUserProfile as apiEditUserProfile, fetchOwnedZIDs as apiFetchOwnedZIDs } from './api';
-import { uploadImage } from '../registration/api';
+import { uploadFile } from '../../lib/chat';
+
 import { EditProfileState, State, initialState as initialEditProfileState, setLoadingZIDs } from '.';
 import { rootReducer } from '../reducer';
 import { User } from '../authentication/types';
@@ -24,8 +25,8 @@ describe('editProfile', () => {
     } = await expectSaga(editProfileSaga, { payload: { name, image, primaryZID } })
       .provide([
         [
-          call(uploadImage, image),
-          { url: profileImage },
+          call(uploadFile, image),
+          profileImage,
         ],
         [
           call(apiEditUserProfile, { name, profileImage, primaryZID }),
@@ -55,7 +56,7 @@ describe('editProfile', () => {
     } = await expectSaga(editProfileSaga, { payload: { name, image } })
       .provide([
         [
-          call(uploadImage, image),
+          call(uploadFile, image),
           throwError(new Error('Image upload failed')),
         ],
       ])
@@ -71,7 +72,10 @@ describe('editProfile', () => {
       storeState: { editProfile },
     } = await expectSaga(editProfileSaga, { payload: { name, image, primaryZID } })
       .provide([
-        [call(uploadImage, image), { url: 'profile-image-url' }],
+        [
+          call(uploadFile, image),
+          'profile-image-url',
+        ],
         [
           call(apiEditUserProfile, { name, primaryZID, profileImage: 'profile-image-url' }),
           throwError(new Error('API call failed')),

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -6,10 +6,10 @@ import {
   fetchOwnedZIDs as fetchOwnedZIDsApi,
 } from './api';
 import { ProfileDetailsErrors } from '../registration';
-import { uploadImage } from '../registration/api';
 import cloneDeep from 'lodash/cloneDeep';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
+import { uploadFile } from '../../lib/chat';
 
 export function* editProfile(action) {
   const { name, image, primaryZID } = action.payload;
@@ -19,8 +19,8 @@ export function* editProfile(action) {
     let profileImage = '';
     if (image) {
       try {
-        const uploadResult = yield call(uploadImage, image);
-        profileImage = uploadResult.url;
+        const uploadRes = yield call(uploadFile, image);
+        profileImage = uploadRes;
       } catch (error) {
         yield put(setErrors([ProfileDetailsErrors.FILE_UPLOAD_ERROR]));
         return;

--- a/src/store/registration/api.ts
+++ b/src/store/registration/api.ts
@@ -130,6 +130,7 @@ interface FileResult {
   url: string;
 }
 
+// this is used to upload images to cloudinary
 export async function uploadImage(file: File): Promise<FileResult> {
   const response = await get<ImageApiUploadResponse>('/upload/info');
   const uploadInfo = response.body;

--- a/src/store/test/store.ts
+++ b/src/store/test/store.ts
@@ -9,6 +9,7 @@ import { initialState as authenticationInitialState } from '../authentication';
 import { MatrixState, initialState as initialMatrixState } from '../matrix';
 import { AccountManagementState, initialState as initialAccountManagementState } from '../account-management';
 import { initialState as initialLoginState } from '../login';
+import { RegistrationState, initialState as initialRegistrationState } from '../registration';
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
@@ -27,6 +28,7 @@ export class StoreBuilder {
   activeConversationId: string = '';
   matrix: MatrixState = { ...initialMatrixState };
   accountManagement: AccountManagementState = { ...initialAccountManagementState };
+  registration: RegistrationState = { ...initialRegistrationState };
 
   withActiveConversation(conversation: Partial<Channel>) {
     this.activeConversation = conversation;
@@ -97,6 +99,11 @@ export class StoreBuilder {
     return this;
   }
 
+  withRegistration(data: Partial<RegistrationState>) {
+    this.registration = { ...initialRegistrationState, ...data };
+    return this;
+  }
+
   build() {
     const { result: channelsList, entities: channelEntitities } = normalizeChannel(
       [
@@ -133,6 +140,7 @@ export class StoreBuilder {
       matrix: {
         ...this.matrix,
       },
+      registration: this.registration,
       ...this.otherState,
     } as RootState;
   }

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -1,8 +1,16 @@
-import { call, put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select, spawn, take, takeEvery } from 'redux-saga/effects';
 import { schema, removeAll, receive, SagaActionTypes } from '.';
 import { userByMatrixIdSelector } from './selectors';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
 import { getUserSubHandle } from '../../lib/user';
+import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
+import { currentUserSelector } from '../authentication/saga';
+import { setUser } from '../authentication';
+import { downloadFile, uploadFile } from '../../lib/chat';
+import cloneDeep from 'lodash/cloneDeep';
+import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
+import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
+import { User } from '../authentication/types';
 
 export function* clearUsers() {
   yield put(removeAll({ schema: schema.key }));
@@ -28,7 +36,86 @@ export function* receiveSearchResults(searchResults) {
   yield put(receive(mappedUsers));
 }
 
+/*
+  If the user is logging in for the first time, we fetch the cached image (from indexed-db),
+  and then call the edit profile API to update the profile image in the ZERO-API database.
+  This is because the profile image could not be uploaded to the homeserver during registration
+  (as the matrixClient was not initialized at that time).
+*/
+export function* updateUserProfileImageFromCache(currentUser: User) {
+  const { firstName: name } = currentUser.profileSummary || {};
+  const { primaryZID } = currentUser;
+
+  const provider = yield call(getIndexedDbProvider);
+  const profileImage: File = yield call([provider, provider.get], 'profileImage');
+
+  if (profileImage) {
+    const profileImageUrl = yield call(uploadFile, profileImage);
+    const response = yield call(apiEditUserProfile, {
+      name,
+      primaryZID,
+      profileImage: profileImageUrl || undefined,
+    });
+
+    if (response.success) {
+      return profileImageUrl;
+    } else {
+      console.error('Failed to update user profile on registration:', response.error);
+    }
+  }
+
+  return undefined;
+}
+
+/*
+  Fetch the current user's profile image url from the store, and then fetch the image from the homeserver.
+  This is because the profile image stored in the homerserver (mxc://) is authoritative, and we need the matrix-client
+  access token to fetch the image.
+
+  Also handles the case where the user is logging in for the first time.
+*/
+export function* fetchCurrentUserProfileImage() {
+  const currentUser: User = cloneDeep(yield select(currentUserSelector()));
+  let profileImageUrl: string | undefined;
+
+  const isFirstTimeLogin = yield select((state) => state.registration.isFirstTimeLogin);
+
+  if (isFirstTimeLogin) {
+    profileImageUrl = yield call(updateUserProfileImageFromCache, currentUser);
+  } else {
+    profileImageUrl = currentUser.profileSummary?.profileImage;
+  }
+
+  if (!profileImageUrl) {
+    return;
+  }
+
+  // Download the profile image after getting the url
+  const downloadedImageUrl = yield call(downloadFile, profileImageUrl);
+
+  // Update the profile image in the store
+  const updatedUser = {
+    ...currentUser,
+    profileSummary: {
+      ...currentUser.profileSummary,
+      profileImage: downloadedImageUrl,
+    },
+  };
+
+  yield put(setUser({ data: updatedUser }));
+}
+
+function* listenForUserLogin() {
+  const userChannel = yield call(getAuthChannel);
+  while (true) {
+    yield take(userChannel, AuthEvents.UserLogin);
+    yield call(fetchCurrentUserProfileImage);
+  }
+}
+
 export function* saga() {
+  yield spawn(listenForUserLogin);
+
   yield takeEvery(SagaActionTypes.SearchResults, receiveSearchResultsAction);
 }
 


### PR DESCRIPTION
### What does this do?

Our cloudinary was recently disabled, so new image uploads (profile images, group icons) are failing now. This PR starts to shift image uploads of ZERO from cloudinary/s3 to our own homeserver. 

This PR handles profile Images during these 2 flows
- when a user edits their profile
- when a user registers for the first time (and uploads their profile image)

For the 2nd point, it had to be handled using indexed-db (which we're using as an image cache), because during the time of registration, the matrix client is not initialized and we cannot upload the image to the homeserver at that point of time. So, we're caching the image first, and when the user logs in, we then use the `matrixClient` to upload the image to the homeserver and then call ZERO-API (`editUserProfile`) to update the database. 

Follow ups
- update `avatar_url` in the matrix client API's profile after updating image
- handle profile avatars in global user search
- removed dead code (related to cloudinary)
- update groupIcon uploading as well
