### PR TITLE
Display profile Images (avatar) for users displaying during global search

### DIFF
--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -77,13 +77,18 @@ describe(receiveSearchResults, () => {
       user3,
     ])
       .withReducer(rootReducer)
+      .provide([
+        [call(downloadFile, 'image-url-1'), 'downloaded-image-url-1'],
+        [call(downloadFile, 'image-url-2'), 'downloaded-image-url-2'],
+        [call(downloadFile, 'image-url-3'), 'downloaded-image-url-3'],
+      ])
       .run();
 
     expect(denormalize(user1.id, storeState)).toEqual(
       expect.objectContaining({
         userId: user1.id,
         firstName: user1.name,
-        profileImage: user1.profileImage,
+        profileImage: 'downloaded-image-url-1',
         primaryZID: user1.primaryZID,
         displaySubHandle: 'zid-1',
       })
@@ -92,7 +97,7 @@ describe(receiveSearchResults, () => {
       expect.objectContaining({
         userId: user2.id,
         firstName: user2.name,
-        profileImage: user2.profileImage,
+        profileImage: 'downloaded-image-url-2',
         primaryZID: user2.primaryZID,
         displaySubHandle: '0x1234...6789',
       })
@@ -101,7 +106,7 @@ describe(receiveSearchResults, () => {
       expect.objectContaining({
         userId: user3.id,
         firstName: user3.name,
-        profileImage: user3.profileImage,
+        profileImage: 'downloaded-image-url-3',
         primaryZID: user3.primaryZID,
         displaySubHandle: '',
       })

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -33,6 +33,12 @@ export function* receiveSearchResults(searchResults) {
         displaySubHandle: getUserSubHandle(r.primaryZID, r.primaryWalletAddress),
       };
     });
+
+  // fetch the profile images from the homeserver for new search result users
+  for (const user of mappedUsers) {
+    user.profileImage = yield call(downloadFile, user.profileImage);
+  }
+
   yield put(receive(mappedUsers));
 }
 


### PR DESCRIPTION
### What does this do?

When you search for users in the search bar, it fetches the users from the API which has the profileImage urls for each user. But since profileImages are uploaded to the homeserver now, those urls will be "authenticated". So we need to download them using the matrixClient.accessToken and then display those in the UI (after local downlaod)

<img width="386" alt="image" src="https://github.com/user-attachments/assets/49755cc0-c064-41c8-a145-d227815b12d7">
