### PR TITLE
Update matrix API `avatar_url` after editing a user profile (or during registration)

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -82,6 +82,7 @@ export interface IChatClient {
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
   uploadFile(file: File): Promise<string>;
   downloadFile(fileUrl: string): Promise<any>;
+  editProfile(avatarUrl: string): Promise<any>;
 }
 
 export class Chat {
@@ -383,4 +384,8 @@ export async function uploadFile(file: File): Promise<string> {
 
 export async function downloadFile(fileUrl: string) {
   return chat.get().matrix.downloadFile(fileUrl);
+}
+
+export async function editProfile(avatarUrl: string) {
+  return chat.get().matrix.editProfile(avatarUrl);
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -658,6 +658,11 @@ export class MatrixClient implements IChatClient {
     return URL.createObjectURL(blob);
   }
 
+  async editProfile(avatarUrl: string) {
+    await this.waitForConnection();
+    await this.matrix.setProfileInfo('avatar_url', { avatar_url: avatarUrl });
+  }
+
   async sendMessagesByChannelId(
     channelId: string,
     message: string,

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -2,7 +2,7 @@ import { expectSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import { editProfile as editProfileSaga, updateUserProfile, fetchOwnedZIDs, getLocalUrl } from './saga';
 import { editUserProfile as apiEditUserProfile, fetchOwnedZIDs as apiFetchOwnedZIDs } from './api';
-import { uploadFile } from '../../lib/chat';
+import { uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
 
 import { EditProfileState, State, initialState as initialEditProfileState, setLoadingZIDs } from '.';
 import { rootReducer } from '../reducer';
@@ -32,6 +32,7 @@ describe('editProfile', () => {
           call(apiEditUserProfile, { name, profileImage, primaryZID }),
           { success: true },
         ],
+        [call(matrixEditProfile, profileImage), {}],
         [call(getLocalUrl, image), 'local-image-url'],
       ])
       .call(updateUserProfile, { name, profileImage: 'local-image-url', primaryZID })
@@ -42,6 +43,7 @@ describe('editProfile', () => {
           { profileSummary: { firstName: 'old-name', profileImage: 'old-image' } as any, primaryZID: 'old-zid' }
         )
       )
+      .call(matrixEditProfile, profileImage)
       .run();
 
     expect(authentication.user.data.profileSummary.firstName).toEqual('John Doe');
@@ -98,6 +100,7 @@ describe('editProfile', () => {
           call(apiEditUserProfile, { name, primaryZID, profileImage: undefined }),
           { success: true },
         ],
+        [call(matrixEditProfile, undefined), {}],
       ])
       .withReducer(
         rootReducer,

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -9,7 +9,7 @@ import { ProfileDetailsErrors } from '../registration';
 import cloneDeep from 'lodash/cloneDeep';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { uploadFile } from '../../lib/chat';
+import { uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
 
 export function* getLocalUrl(file) {
   if (!file) {
@@ -41,6 +41,10 @@ export function* editProfile(action) {
       profileImage: profileImage === '' ? undefined : profileImage,
     });
     if (response.success) {
+      if (profileImage) {
+        yield call(matrixEditProfile, profileImage);
+      }
+
       const localUrl = yield call(getLocalUrl, image);
       yield call(updateUserProfile, { name, profileImage: localUrl, primaryZID });
       yield put(setState(State.SUCCESS));

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -9,7 +9,7 @@ import { call } from 'redux-saga/effects';
 import { rootReducer } from '../reducer';
 import { denormalize } from '.';
 import { StoreBuilder } from '../test/store';
-import { downloadFile, uploadFile } from '../../lib/chat';
+import { downloadFile, uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
 import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
 
 const mockIdb = {
@@ -204,6 +204,7 @@ describe(updateUserProfileImageFromCache, () => {
     const file: any = { name: 'Some file', type: 'image/png' };
     mockIdb.put('profileImage', file);
 
+    console.error = jest.fn();
     const { returnValue } = await expectSaga(updateUserProfileImageFromCache, currentUser)
       .provide([
         [call(uploadFile, file), 'uploaded-image-url'],
@@ -212,6 +213,7 @@ describe(updateUserProfileImageFromCache, () => {
           { success: false },
         ],
       ])
+      .not.call(matrixEditProfile, 'uploaded-image-url')
       .run();
 
     expect(returnValue).toBeUndefined();
@@ -234,7 +236,12 @@ describe(updateUserProfileImageFromCache, () => {
           call(apiEditUserProfile, { name: 'Alice', primaryZID: '0://zid', profileImage: 'uploaded-image-url' }),
           { success: true },
         ],
+        [
+          call(matrixEditProfile, 'uploaded-image-url'),
+          undefined,
+        ],
       ])
+      .call(matrixEditProfile, 'uploaded-image-url')
       .run();
 
     expect(returnValue).toBe('uploaded-image-url');

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -6,7 +6,7 @@ import { getUserSubHandle } from '../../lib/user';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { downloadFile, uploadFile } from '../../lib/chat';
+import { downloadFile, uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
 import cloneDeep from 'lodash/cloneDeep';
 import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
 import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
@@ -62,8 +62,8 @@ export function* updateUserProfileImageFromCache(currentUser: User) {
       primaryZID,
       profileImage: profileImageUrl || undefined,
     });
-
     if (response.success) {
+      yield call(matrixEditProfile, profileImageUrl); // also update the profile image in the homeserver user directory
       return profileImageUrl;
     } else {
       console.error('Failed to update user profile on registration:', response.error);


### PR DESCRIPTION
### What does this do?

After a user edits their profile image, we update our API database with the updated profile image. This PR adds support to "also" update the matrixClient's profile :: `avatar_url`. 
