### PR TITLE
Upload groupIcons to the homeserver instead of cloudinary

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -10,11 +10,6 @@ import { DefaultRoomLabels } from '../../store/channels';
 
 jest.mock('./matrix/utils', () => ({ setAsDM: jest.fn().mockResolvedValue(undefined) }));
 
-const mockUploadImage = jest.fn();
-jest.mock('../../store/channels-list/api', () => {
-  return { uploadImage: (...args) => mockUploadImage(...args) };
-});
-
 const mockEncryptFile = jest.fn();
 const mockGetImageDimensions = jest.fn();
 jest.mock('./matrix/media', () => {
@@ -436,8 +431,9 @@ describe('matrix client', () => {
 
     it('uploads the image', async () => {
       const createRoom = jest.fn().mockResolvedValue({ room_id: 'new-room-id' });
-      when(mockUploadImage).calledWith(expect.anything()).mockResolvedValue({ url: 'upload-url' });
-      const client = await subject({ createRoom });
+      const uploadContent = jest.fn().mockResolvedValue({ content_uri: 'upload-url' });
+      const mxcUrlToHttp = jest.fn().mockReturnValue('upload-url');
+      const client = await subject({ createRoom, uploadContent, mxcUrlToHttp });
 
       await client.createConversation(
         [{ userId: 'id', matrixId: '@somebody.else' }],
@@ -574,8 +570,10 @@ describe('matrix client', () => {
 
     it('uploads the image', async () => {
       const createRoom = jest.fn().mockResolvedValue({ room_id: 'new-room-id' });
-      when(mockUploadImage).calledWith(expect.anything()).mockResolvedValue({ url: 'upload-url' });
-      const client = await subject({ createRoom });
+      const uploadContent = jest.fn().mockResolvedValue({ content_uri: 'upload-url' });
+      const mxcUrlToHttp = jest.fn().mockReturnValue('upload-url');
+
+      const client = await subject({ createRoom, uploadContent, mxcUrlToHttp });
 
       await client.createUnencryptedConversation(
         [{ userId: 'id', matrixId: '@somebody.else' }],

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -45,7 +45,6 @@ import {
   ReadReceiptPreferenceType,
 } from './matrix/types';
 import { constructFallbackForParentMessage, getFilteredMembersForAutoComplete, setAsDM } from './matrix/utils';
-import { uploadImage } from '../../store/channels-list/api';
 import { SessionStorage } from './session-storage';
 import { encryptFile, getImageDimensions } from './matrix/media';
 import { uploadAttachment } from '../../store/messages/api';
@@ -116,7 +115,7 @@ export class MatrixClient implements IChatClient {
     await this.waitForConnection();
 
     const room = this.matrix.getRoom(roomId);
-    return this.getRoomAvatar(room);
+    return await this.getRoomAvatar(room);
   }
 
   async getRoomGroupTypeById(roomId: string) {
@@ -1370,7 +1369,7 @@ export class MatrixClient implements IChatClient {
     const otherMembers = this.getOtherMembersFromRoom(room).map((userId) => this.mapUser(userId));
     const memberHistory = this.getMemberHistoryFromRoom(room).map((userId) => this.mapUser(userId));
     const name = this.getRoomName(room);
-    const avatarUrl = this.getRoomAvatar(room);
+    const avatarUrl = await this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
     const groupType = this.getRoomGroupType(room);
 
@@ -1435,9 +1434,13 @@ export class MatrixClient implements IChatClient {
     return roomNameEvent?.getContent()?.name || '';
   }
 
-  private getRoomAvatar(room: Room): string {
+  private async getRoomAvatar(room: Room): Promise<string> {
     const roomAvatarEvent = this.getLatestEvent(room, EventType.RoomAvatar);
-    return roomAvatarEvent?.getContent()?.url || '';
+    const url = roomAvatarEvent?.getContent()?.url;
+    if (url) {
+      return await this.downloadFile(url);
+    }
+    return '';
   }
 
   private getRoomCreatedAt(room: Room): number {
@@ -1504,7 +1507,7 @@ export class MatrixClient implements IChatClient {
   private async uploadCoverImage(image) {
     if (image) {
       try {
-        return (await uploadImage(image)).url;
+        return await this.uploadFile(image);
       } catch (error) {
         // For now, we will just ignore the error and continue to create the room
         // No reason for the image upload to block the room creation

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -377,7 +377,12 @@ export function* roomNameChanged(id: string, name: string) {
 }
 
 export function* roomAvatarChanged(id: string, url: string) {
-  yield call(receiveChannel, { id, icon: url });
+  if (!url) {
+    return;
+  }
+
+  const localImageUrl = yield call(downloadFile, url);
+  yield call(receiveChannel, { id, icon: localImageUrl });
 }
 
 export function* roomGroupTypeChanged(id: string, type: string) {

--- a/src/store/group-management/saga.test.ts
+++ b/src/store/group-management/saga.test.ts
@@ -21,10 +21,9 @@ import {
 } from '.';
 import { expectSaga } from '../../test/saga';
 import { rootReducer } from '../reducer';
-import { chat, removeUserAsModerator, setUserAsModerator } from '../../lib/chat';
+import { chat, removeUserAsModerator, setUserAsModerator, uploadFile } from '../../lib/chat';
 import { denormalize as denormalizeUsers } from '../users';
 import { EditConversationState } from './types';
-import { uploadImage } from '../registration/api';
 import { throwError } from 'redux-saga-test-plan/providers';
 
 describe('Group Management Saga', () => {
@@ -319,9 +318,9 @@ describe('Group Management Saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.editRoomNameAndIcon), {}],
-          [matchers.call.fn(uploadImage), { url: 'image-url' }],
+          [matchers.call.fn(uploadFile), 'image-url'],
         ])
-        .call(uploadImage, image)
+        .call(uploadFile, image)
         .call([chatClient, chatClient.editRoomNameAndIcon], roomId, name, 'image-url')
         .put(setEditConversationState(EditConversationState.SUCCESS))
         .put(setEditConversationImageError(''))
@@ -335,7 +334,7 @@ describe('Group Management Saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.editRoomNameAndIcon), {}],
-          [matchers.call.fn(uploadImage), throwError(new Error('Image upload failed'))],
+          [matchers.call.fn(uploadFile), throwError(new Error('Image upload failed'))],
         ])
         .put(setEditConversationImageError('Failed to upload image, please try again...'))
         .run();
@@ -347,7 +346,7 @@ describe('Group Management Saga', () => {
         .provide([
           [matchers.call.fn(chat.get), chatClient],
           [matchers.call.fn(chatClient.editRoomNameAndIcon), throwError(new Error('matrix API error'))],
-          [matchers.call.fn(uploadImage), { url: 'image-url' }],
+          [matchers.call.fn(uploadFile), 'image-url'],
         ])
         .put(setEditConversationGeneralError('An unknown error has occurred'))
         .put(setEditConversationState(EditConversationState.LOADED))

--- a/src/store/group-management/saga.ts
+++ b/src/store/group-management/saga.ts
@@ -4,6 +4,7 @@ import {
   chat,
   setUserAsModerator as matrixSetUserAsModerator,
   removeUserAsModerator as matrixRemoveUserAsModerator,
+  uploadFile,
 } from '../../lib/chat';
 import { Events, getAuthChannel } from '../authentication/channels';
 import { denormalize as denormalizeUsers } from '../users';
@@ -27,7 +28,6 @@ import {
   MemberManagementAction,
 } from './index';
 import { EditConversationState } from './types';
-import { uploadImage } from '../registration/api';
 import { isSecondarySidekickOpenSelector } from './selectors';
 import { closeOverview as closeMessageInfo } from '../message-info/saga';
 
@@ -224,8 +224,7 @@ export function* editConversationNameAndIcon(action) {
     let imageUrl = '';
     if (image) {
       try {
-        const uploadResult = yield call(uploadImage, image);
-        imageUrl = uploadResult.url;
+        imageUrl = yield call(uploadFile, image);
       } catch (error) {
         yield put(setEditConversationImageError('Failed to upload image, please try again...'));
         return;


### PR DESCRIPTION
### What does this do?

When you're creating or editing the group profile picture, it uploads it to cloudinary. This PR migrates that upload method from cloudinary to the homeserver itself (since we've recently disabled our cloudinary account).
