### PR TITLE
feat: hide chat from social channels with layout modifications

### DIFF
--- a/src/apps/messenger/Main.module.scss
+++ b/src/apps/messenger/Main.module.scss
@@ -1,14 +1,7 @@
 .Split {
   position: relative;
   display: flex;
+  justify-content: flex-start;
   width: 100%;
-  gap: 18px;
-}
-
-.Actions {
-  right: 7px;
-  pointer-events: all !important;
-  position: absolute;
-  top: 7px;
-  z-index: 1000;
+  min-width: 580px;
 }

--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import { Container as Main, Properties } from './Main';
 import { MessengerChat } from '../../components/messenger/chat';
 import { MessengerFeed } from '../../components/messenger/feed';
+import { JoiningConversationDialog } from '../../components/joining-conversation-dialog';
 
 describe(Main, () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -14,19 +15,43 @@ describe(Main, () => {
       isValidConversation: false,
       isSocialChannel: false,
       isJoiningConversation: false,
+      isConversationsLoaded: true,
       ...props,
     };
 
     return shallow(<Main {...allProps} />);
   };
 
-  it('renders direct message chat component', () => {
+  it('renders JoiningConversationDialog when isJoiningConversation is true', () => {
+    const wrapper = subject({ context: { isAuthenticated: true }, isJoiningConversation: true });
+
+    expect(wrapper).toHaveElement(JoiningConversationDialog);
+  });
+
+  it('does not render JoiningConversationDialog when isJoiningConversation is false', () => {
+    const wrapper = subject({ context: { isAuthenticated: true }, isJoiningConversation: false });
+
+    expect(wrapper).not.toHaveElement(JoiningConversationDialog);
+  });
+
+  it('renders direct message chat component when not a social channel and conversations loaded', () => {
     const wrapper = subject({ context: { isAuthenticated: true } });
 
     expect(wrapper).toHaveElement(MessengerChat);
   });
 
-  it('renders messenger feed container when is social channel and is valid conversation', () => {
+  it('should not render messenger chat container when conversations have not loaded', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isSocialChannel: true,
+      isValidConversation: true,
+      isConversationsLoaded: false,
+    });
+
+    expect(wrapper).not.toHaveElement(MessengerChat);
+  });
+
+  it('renders messenger feed container when is social channel, conversations loaded and is valid conversation', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: true, isValidConversation: true });
 
     expect(wrapper).toHaveElement(MessengerFeed);
@@ -34,6 +59,17 @@ describe(Main, () => {
 
   it('should not render messenger feed container when is not social channel', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: false, isValidConversation: true });
+
+    expect(wrapper).not.toHaveElement(MessengerFeed);
+  });
+
+  it('should not render messenger feed container when conversations have not loaded', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isSocialChannel: true,
+      isValidConversation: true,
+      isConversationsLoaded: false,
+    });
 
     expect(wrapper).not.toHaveElement(MessengerFeed);
   });

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -8,10 +8,10 @@ import { MessengerChat } from '../../components/messenger/chat';
 import { MessengerFeed } from '../../components/messenger/feed';
 import { DevPanelContainer } from '../../components/dev-panel/container';
 import { FeatureFlag } from '../../components/feature-flag';
+import { denormalize } from '../../store/channels';
+import { JoiningConversationDialog } from '../../components/joining-conversation-dialog';
 
 import styles from './Main.module.scss';
-import { denormalize } from '../../store/channels';
-import { ConversationActionsContainer as ConversationActions } from '../../components/messenger/conversation-actions/container';
 
 export interface Properties {
   context: {
@@ -20,12 +20,13 @@ export interface Properties {
   isValidConversation: boolean;
   isSocialChannel: boolean;
   isJoiningConversation: boolean;
+  isConversationsLoaded: boolean;
 }
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const {
-      chat: { activeConversationId, isJoiningConversation },
+      chat: { activeConversationId, isJoiningConversation, isConversationsLoaded },
     } = state;
 
     const currentChannel = denormalize(activeConversationId, state) || null;
@@ -34,6 +35,7 @@ export class Container extends React.Component<Properties> {
       isValidConversation: !!activeConversationId,
       isSocialChannel: currentChannel?.isSocialChannel,
       isJoiningConversation,
+      isConversationsLoaded,
     };
   }
 
@@ -47,17 +49,13 @@ export class Container extends React.Component<Properties> {
         {this.props.context.isAuthenticated && (
           <>
             <Sidekick />
-
             <div className={styles.Split}>
-              <ConversationActions className={styles.Actions} />
+              {this.props.isJoiningConversation && <JoiningConversationDialog />}
 
-              {this.props.isSocialChannel && !this.props.isJoiningConversation && this.props.isValidConversation && (
-                <FeatureFlag featureFlag='enableChannels'>
-                  <MessengerFeed />
-                </FeatureFlag>
+              {this.props.isConversationsLoaded && this.props.isSocialChannel && this.props.isValidConversation && (
+                <MessengerFeed />
               )}
-
-              <MessengerChat />
+              {this.props.isConversationsLoaded && !this.props.isSocialChannel && <MessengerChat />}
             </div>
             <Sidekick variant='secondary' />
 

--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -13,6 +13,7 @@
   align-items: center;
   justify-content: center;
   pointer-events: all;
+  padding-right: 64px;
 
   @include main-background;
 }

--- a/src/components/header/index.module.scss
+++ b/src/components/header/index.module.scss
@@ -7,6 +7,7 @@
   gap: 8px;
   padding: 12px 18px;
   width: 100%;
+  overflow: hidden;
 
   .Avatar {
     pointer-events: none;
@@ -41,9 +42,12 @@
     line-height: 17px;
     color: theme.$color-greyscale-12;
     margin-bottom: 2px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+
+    > div {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   .Subtitle {

--- a/src/components/joining-conversation-dialog/styles.scss
+++ b/src/components/joining-conversation-dialog/styles.scss
@@ -11,7 +11,7 @@
   width: fit-content;
 
   position: relative;
-  top: 50%;
+  top: 100%;
   left: 50%;
   transform: translate(-50%, -50%);
 

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -7,8 +7,6 @@ import { LeaveGroupDialogStatus } from '../../../store/group-management';
 import { MessageInput } from '../../message-input/container';
 import { Media } from '../../message-input/utils';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
-import { JoiningConversationDialog } from '../../joining-conversation-dialog';
-import { stubUser } from '../../../store/test/store';
 
 const mockSearchMentionableUsersForChannel = jest.fn();
 jest.mock('../../../platform-apps/channels/util/api', () => {
@@ -47,34 +45,6 @@ describe(DirectMessageChat, () => {
     const wrapper = subject({ activeConversationId: '123' });
 
     expect(wrapper.find(ChatViewContainer)).toHaveProp('channelId', '123');
-  });
-
-  it('renders JoiningConversationDialog when isJoiningConversation is true', () => {
-    const wrapper = subject({ isJoiningConversation: true });
-
-    expect(wrapper).toHaveElement(JoiningConversationDialog);
-  });
-
-  it('does not render ChatViewContainer when isJoiningConversation is true', () => {
-    const wrapper = subject({ isJoiningConversation: true });
-
-    expect(wrapper).not.toHaveElement(ChatViewContainer);
-  });
-
-  it('renders ChatViewContainer when isJoiningConversation is false', () => {
-    const wrapper = subject({
-      isJoiningConversation: false,
-      activeConversationId: '123',
-      directMessage: { otherMembers: [stubUser({ firstName: 'Johnny', lastName: 'Sanderson' })] } as Channel,
-    });
-
-    expect(wrapper).toHaveElement(ChatViewContainer);
-  });
-
-  it('does not render JoiningConversationDialog when isJoiningConversation is false', () => {
-    const wrapper = subject({ isJoiningConversation: false });
-
-    expect(wrapper).not.toHaveElement(JoiningConversationDialog);
   });
 
   describe('leave group dialog', () => {

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -15,7 +15,6 @@ import {
   toggleSecondarySidekick,
 } from '../../../store/group-management';
 import { LeaveGroupDialogContainer } from '../../group-management/leave-group-dialog/container';
-import { JoiningConversationDialog } from '../../joining-conversation-dialog';
 import { MessageInput } from '../../message-input/container';
 import { searchMentionableUsersForChannel } from '../../../platform-apps/channels/util/api';
 import { Media } from '../../message-input/utils';
@@ -190,7 +189,6 @@ export class Container extends React.Component<Properties> {
           </div>
 
           {this.isLeaveGroupDialogOpen && this.renderLeaveGroupDialog()}
-          {this.props.isJoiningConversation && <JoiningConversationDialog />}
         </div>
       </div>
     );

--- a/src/components/messenger/chat/styles.scss
+++ b/src/components/messenger/chat/styles.scss
@@ -127,10 +127,6 @@ $title-bar-border-radius: 8px 8px 0px 0px;
     overflow: hidden;
     width: 100%;
 
-    @media (min-width: 2561px) {
-      min-width: 1558px;
-    }
-
     .direct-message-chat__content {
       height: 100vh;
       width: unset;

--- a/src/components/messenger/conversation-actions/index.tsx
+++ b/src/components/messenger/conversation-actions/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { GroupManagementMenu } from '../../group-management-menu';
 import { IconButton } from '@zero-tech/zui/components/IconButton';
-import { IconChevronRight } from '@zero-tech/zui/icons';
+import { IconChevronLeft, IconChevronRight } from '@zero-tech/zui/icons';
 
 import classNames from 'classnames';
 import { bemClassName } from '../../../lib/bem';
@@ -75,7 +75,7 @@ export class ConversationActions extends React.Component<Properties> {
         />
         <IconButton
           {...cn('group-button', this.props.isSecondarySidekickOpen && 'is-active')}
-          Icon={IconChevronRight}
+          Icon={this.props.isSecondarySidekickOpen ? IconChevronRight : IconChevronLeft}
           size={32}
           onClick={this.toggleSidekick}
           isFilled

--- a/src/components/messenger/conversation-header/container.tsx
+++ b/src/components/messenger/conversation-header/container.tsx
@@ -4,6 +4,12 @@ import { connectContainer } from '../../../store/redux-container';
 import { Channel, denormalize } from '../../../store/channels';
 import { toggleSecondarySidekick } from '../../../store/group-management';
 import { ConversationHeader } from '.';
+import { ConversationActionsContainer as ConversationActions } from '../conversation-actions/container';
+
+import { bemClassName } from '../../../lib/bem';
+import './styles.scss';
+
+const cn = bemClassName('conversation-header');
 
 export interface PublicProperties {
   className?: string;
@@ -54,14 +60,19 @@ export class Container extends React.Component<Properties> {
     }
 
     return (
-      <ConversationHeader
-        className={this.props.className}
-        icon={this.props.directMessage.icon}
-        name={this.props.directMessage.name}
-        isOneOnOne={this.isOneOnOne()}
-        otherMembers={this.props.directMessage.otherMembers || []}
-        toggleSecondarySidekick={this.props.toggleSecondarySidekick}
-      />
+      <div {...cn('')}>
+        <ConversationHeader
+          className={this.props.className}
+          icon={this.props.directMessage.icon}
+          name={this.props.directMessage.name}
+          isOneOnOne={this.isOneOnOne()}
+          otherMembers={this.props.directMessage.otherMembers || []}
+          toggleSecondarySidekick={this.props.toggleSecondarySidekick}
+        />
+        <div {...cn('actions-container')}>
+          <ConversationActions />
+        </div>
+      </div>
     );
   }
 }

--- a/src/components/messenger/conversation-header/styles.scss
+++ b/src/components/messenger/conversation-header/styles.scss
@@ -1,0 +1,9 @@
+.conversation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &__actions-container {
+    margin-right: 8px;
+  }
+}

--- a/src/components/messenger/feed/components/post-input/styles.scss
+++ b/src/components/messenger/feed/components/post-input/styles.scss
@@ -3,7 +3,7 @@
 @import '../../../../../glass';
 
 .post-input-container {
-  margin-top: 58px;
+  margin-top: 56px;
   border-inline: 1px solid rgba(52, 56, 60);
 
   &__create-outer {

--- a/src/components/messenger/feed/styles.scss
+++ b/src/components/messenger/feed/styles.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 504px;
+  max-width: 580px;
   box-sizing: border-box;
   pointer-events: auto;
   position: relative;
@@ -12,7 +12,8 @@
     top: 0px;
     box-sizing: border-box;
     z-index: 3;
-    width: 99.2%;
+    width: 100%;
+    max-width: 576px;
     border-inline: 1px solid rgba(52, 56, 60);
     border-bottom: 1px solid rgba(52, 56, 60);
     padding-right: 2px;
@@ -25,6 +26,7 @@
   &__header {
     pointer-events: all !important;
     backdrop-filter: blur(64px);
+    margin-right: 4px;
   }
 
   @media (min-width: 2561px) {

--- a/src/components/messenger/group-management/add-members-panel/styles.scss
+++ b/src/components/messenger/group-management/add-members-panel/styles.scss
@@ -34,7 +34,7 @@ $side-padding: 16px;
   &__submit-button-container {
     display: flex;
     justify-content: center;
-    margin: 16px 16px 0;
+    margin: 16px;
   }
 
   &__submit-button {

--- a/src/components/messenger/list/group-details-panel/group-details-panel.scss
+++ b/src/components/messenger/list/group-details-panel/group-details-panel.scss
@@ -56,7 +56,7 @@ $side-padding: 16px;
   }
 
   &__footer {
-    padding: 16px 16px 0 16px;
+    padding: 16px;
   }
 
   &__create-button {

--- a/src/components/sidekick/styles.scss
+++ b/src/components/sidekick/styles.scss
@@ -26,7 +26,7 @@
 
     &.open {
       transform: translateX(0);
-      max-width: 286px;
+      max-width: 100%;
       padding: 24px 0;
       width: 100%;
       margin-left: 18px;


### PR DESCRIPTION
### What does this do?
- hides the messenger chat if the channel is a social channel.
- makes some layout modifications to address the removal of chat from social channels & attempts to clean up empty space.

### Why are we making this change?
- user feedback suggested the feed and chat was confusing, therefore trialling feed only for social channels and potentially re-add chat further down the line.
- removing chat from social channels will result in performance and stability improvements re matrix events & filtering.

### How do I test this?
- run tests as usual.
- run UI and check out social channels, regular channels

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
