### PR TITLE
refactor(group-management-state): flip secondary sidekick default open state

### DIFF
--- a/src/store/group-management/index.ts
+++ b/src/store/group-management/index.ts
@@ -108,7 +108,7 @@ export const initialState: GroupManagementState = {
     stage: MemberManagementDialogStage.CLOSED,
     error: '',
   },
-  isSecondarySidekickOpen: false,
+  isSecondarySidekickOpen: true,
 };
 
 const slice = createSlice({


### PR DESCRIPTION
### What does this do?
- flips secondary sidekick default open state

### Why are we making this change?
- have open by default now there is more horizontal space to fill

### How do I test this?
- run tests as usual
- run ui as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
