### PR TITLE
fix(matrix-client): add type check for fileUrl in downloadFile method

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -636,7 +636,7 @@ export class MatrixClient implements IChatClient {
   // if the file is uploaded to the homerserver, then we need bearer token to download it
   // since the endpoint to download the file is protected
   async downloadFile(fileUrl: string) {
-    if (!fileUrl || !fileUrl.includes('_matrix/client/v1/media')) {
+    if (typeof fileUrl !== 'string' || !fileUrl || !fileUrl.includes('_matrix/client/v1/media')) {
       return fileUrl;
     }
 


### PR DESCRIPTION
### What does this do?
This adds a type check to ensure fileUrl is a string before proceeding with the download logic.

### Why are we making this change?
To prevent runtime errors when fileUrl is not a string and to handle unexpected input gracefully.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
