### PR TITLE
Upload image messages to the homeserver instead of s3

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -83,6 +83,7 @@ export interface IChatClient {
   uploadFile(file: File): Promise<string>;
   downloadFile(fileUrl: string): Promise<any>;
   editProfile(avatarUrl: string): Promise<any>;
+  getAccessToken(): string | null;
 }
 
 export class Chat {
@@ -388,4 +389,8 @@ export async function downloadFile(fileUrl: string) {
 
 export async function editProfile(avatarUrl: string) {
   return chat.get().matrix.editProfile(avatarUrl);
+}
+
+export function getAccessToken(): string | null {
+  return chat.get().matrix.getAccessToken();
 }


### PR DESCRIPTION
### What does this do?

This PR handles the final piece of image migrations from cloudinary to our homeserver. We now upload the image messages to our homeserver, directly instead of uploading them to s3. 

We also ensure backwards compatibility, since the old messages (which were uploaded to s3), should also be visible.
