### PR TITLE
fix(feed-view-container): ensure fetch more posts is called by removing waypoint conditional height check restriction

### DIFF
--- a/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
@@ -99,31 +99,4 @@ describe('FeedView', () => {
 
     expect(wrapper.text()).toEqual('Test Message');
   });
-
-  it('updates shouldRenderWaypoint state based on content height after mount', () => {
-    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
-
-    const instance = wrapper.instance() as FeedView;
-    jest.spyOn(instance, 'checkContentHeight');
-
-    instance.componentDidMount();
-
-    expect(instance.checkContentHeight).toHaveBeenCalled();
-  });
-
-  it('updates shouldRenderWaypoint state based on content height after update', () => {
-    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
-
-    const instance = wrapper.instance() as FeedView;
-    jest.spyOn(instance, 'checkContentHeight');
-
-    wrapper.setProps({
-      postMessages: [
-        ...POST_MESSAGES_TEST,
-        { id: 'post-three', message: 'Third post', createdAt: 1659018545429, isPost: true },
-      ],
-    });
-
-    expect(instance.checkContentHeight).toHaveBeenCalled();
-  });
 });

--- a/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
@@ -50,33 +50,13 @@ describe('FeedView', () => {
     expect(wrapper).toHaveElement(Spinner);
   });
 
-  it('renders a waypoint if posts are present and content exceeds viewport height', () => {
+  it('renders a waypoint if posts are present', () => {
     const onFetchMoreSpy = jest.fn();
     const wrapper = subject({ postMessages: POST_MESSAGES_TEST, onFetchMore: onFetchMoreSpy });
-
-    wrapper.setState({ shouldRenderWaypoint: true });
 
     const waypoint = wrapper.find(Waypoint);
     expect(waypoint.exists()).toBe(true);
     expect(waypoint.prop('onEnter')).toEqual(onFetchMoreSpy);
-  });
-
-  it('does not render a waypoint if content does not exceed viewport height', () => {
-    const wrapper = subject({ postMessages: POST_MESSAGES_TEST });
-
-    wrapper.setState({ shouldRenderWaypoint: false });
-
-    expect(wrapper.find(Waypoint).exists()).toBe(false);
-  });
-
-  it('renders a waypoint if posts are present and content height changes after update', () => {
-    const onFetchMoreSpy = jest.fn();
-    const wrapper = subject({ postMessages: POST_MESSAGES_TEST, onFetchMore: onFetchMoreSpy });
-
-    wrapper.setState({ shouldRenderWaypoint: true });
-
-    const waypoint = wrapper.find(Waypoint);
-    expect(waypoint.exists()).toBe(true);
   });
 
   it('does not render a waypoint if no posts are present', () => {

--- a/src/components/messenger/feed/feed-view-container/feed-view.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.tsx
@@ -26,44 +26,9 @@ export interface Properties {
 }
 
 export class FeedView extends React.Component<Properties> {
-  contentRef: React.RefObject<HTMLDivElement>;
-
-  state = {
-    shouldRenderWaypoint: false,
-  };
-
-  constructor(props: Properties) {
-    super(props);
-    this.contentRef = React.createRef();
-  }
-
-  componentDidMount() {
-    this.checkContentHeight();
-  }
-
-  componentDidUpdate(prevProps: Properties) {
-    if (
-      prevProps.postMessages !== this.props.postMessages ||
-      prevProps.hasLoadedMessages !== this.props.hasLoadedMessages
-    ) {
-      this.checkContentHeight();
-    }
-  }
-
-  checkContentHeight() {
-    if (this.contentRef.current) {
-      const contentHeight = this.contentRef.current.clientHeight;
-      const viewportHeight = window.innerHeight;
-
-      this.setState({
-        shouldRenderWaypoint: contentHeight > viewportHeight,
-      });
-    }
-  }
-
   render() {
     return (
-      <div {...cn('')} ref={this.contentRef}>
+      <div {...cn('')}>
         {this.props.hasLoadedMessages && (
           <>
             {this.props.postMessages.length > 0 ? (
@@ -76,10 +41,8 @@ export class FeedView extends React.Component<Properties> {
                   userMeowBalance={this.props.userMeowBalance}
                 />
 
-                {this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && this.state.shouldRenderWaypoint && (
-                  <div {...cn('waypoint')}>
-                    <Waypoint onEnter={this.props.onFetchMore} />
-                  </div>
+                {this.props.messagesFetchStatus === MessagesFetchState.SUCCESS && (
+                  <Waypoint onEnter={this.props.onFetchMore} />
                 )}
               </>
             ) : (

--- a/src/components/messenger/feed/feed-view-container/styles.scss
+++ b/src/components/messenger/feed/feed-view-container/styles.scss
@@ -7,10 +7,4 @@
     box-sizing: border-box;
     color: var(--color-greyscale-10);
   }
-
-  &__waypoint {
-    overflow-anchor: none;
-    position: relative;
-    bottom: 700px;
-  }
 }


### PR DESCRIPTION
### What does this do?
- ensures fetch more posts is called by removing waypoint conditional height check restriction

### Why are we making this change?
- fix empty social channels where posts are not being fetched, potentially caused due to waypoint not working as expected, this attempts to fix the issue.

### How do I test this?
- run tests as usual.
- run ui > open social channel > check posts are fetched and rendered if expected

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
