### PR TITLE
feat(feed-view): handle loading state and add loading spinner to indicate more posts loading when triggering fetchMore on posts

### DIFF
--- a/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.test.tsx
@@ -74,6 +74,18 @@ describe('FeedView', () => {
     expect(wrapper).not.toHaveElement(Spinner);
   });
 
+  it('renders a spinner when messagesFetchStatus is equal to MORE_IN_PROGRESS', () => {
+    const wrapper = subject({
+      postMessages: POST_MESSAGES_TEST,
+      messagesFetchStatus: MessagesFetchState.MORE_IN_PROGRESS,
+    });
+
+    expect(wrapper).toHaveElement(Spinner);
+
+    wrapper.setProps({ messagesFetchStatus: MessagesFetchState.SUCCESS });
+    expect(wrapper).not.toHaveElement(Spinner);
+  });
+
   it('renders a message component with children', () => {
     const wrapper = shallow(<Message>Test Message</Message>);
 

--- a/src/components/messenger/feed/feed-view-container/feed-view.tsx
+++ b/src/components/messenger/feed/feed-view-container/feed-view.tsx
@@ -51,7 +51,7 @@ export class FeedView extends React.Component<Properties> {
           </>
         )}
 
-        {!this.props.hasLoadedMessages && (
+        {(!this.props.hasLoadedMessages || this.props.messagesFetchStatus === MessagesFetchState.MORE_IN_PROGRESS) && (
           <Message>
             <Spinner />
           </Message>

--- a/src/components/messenger/feed/feed-view-container/styles.scss
+++ b/src/components/messenger/feed/feed-view-container/styles.scss
@@ -3,7 +3,7 @@
     width: 100%;
     display: flex;
     justify-content: center;
-    padding: 16px;
+    padding: 16px 16px 32px 16px;
     box-sizing: border-box;
     color: var(--color-greyscale-10);
   }


### PR DESCRIPTION
### What does this do?
- when triggering fetching more posts, add loading state condition and render loading spinner

### Why are we making this change?
- improve ui / ux by indicating loading of fetching more posts

### How do I test this?
- run tests as usual.
- run ui and load more posts on social channels

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
