### PR TITLE
Upload `mxc://` urls instead of http via `matrixClient.uploadFile`

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -84,6 +84,7 @@ export interface IChatClient {
   downloadFile(fileUrl: string): Promise<any>;
   editProfile(avatarUrl: string): Promise<any>;
   getAccessToken(): string | null;
+  mxcUrlToHttp(mxcUrl: string): string;
 }
 
 export class Chat {
@@ -393,4 +394,8 @@ export async function editProfile(avatarUrl: string) {
 
 export function getAccessToken(): string | null {
   return chat.get().matrix.getAccessToken();
+}
+
+export function mxcUrlToHttp(mxcUrl: string): string {
+  return chat.get().matrix.mxcUrlToHttp(mxcUrl);
 }

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1038,10 +1038,9 @@ describe('matrix client', () => {
       );
 
       const uploadContent = jest.fn().mockResolvedValue({ content_uri: 'upload-url' });
-      const mxcUrlToHttp = jest.fn().mockReturnValue('upload-url');
 
       const client = subject({
-        createClient: jest.fn(() => getSdkClient({ isRoomEncrypted, sendMessage, uploadContent, mxcUrlToHttp })),
+        createClient: jest.fn(() => getSdkClient({ isRoomEncrypted, sendMessage, uploadContent })),
       });
 
       await client.connect(null, 'token');
@@ -1050,7 +1049,7 @@ describe('matrix client', () => {
       expect(sendMessage).toBeCalledWith(
         roomId,
         expect.objectContaining({
-          body: null,
+          body: '',
           msgtype: 'm.image',
           file: {
             url: 'upload-url',
@@ -1188,9 +1187,8 @@ describe('matrix client', () => {
           content_uri: 'mxc://content-url',
         })
       );
-      const mxcUrlToHttp = jest.fn(() => 'http://example.com/content-url');
 
-      const client = subject({ createClient: jest.fn(() => getSdkClient({ uploadContent, mxcUrlToHttp })) });
+      const client = subject({ createClient: jest.fn(() => getSdkClient({ uploadContent })) });
 
       await client.connect(null, 'token');
       const result = await client.uploadFile(file);
@@ -1200,16 +1198,8 @@ describe('matrix client', () => {
         type: file.type,
         includeFilename: false,
       });
-      expect(mxcUrlToHttp).toHaveBeenCalledWith(
-        'mxc://content-url',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        true,
-        true
-      );
-      expect(result).toBe('http://example.com/content-url');
+
+      expect(result).toBe('mxc://content-url');
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -622,6 +622,10 @@ export class MatrixClient implements IChatClient {
     });
   }
 
+  mxcUrlToHttp(mxcUrl: string): string {
+    return this.matrix.mxcUrlToHttp(mxcUrl, undefined, undefined, undefined, undefined, true, true);
+  }
+
   async uploadFile(file: File): Promise<string> {
     await this.waitForConnection();
 
@@ -631,9 +635,7 @@ export class MatrixClient implements IChatClient {
       includeFilename: false,
     });
 
-    const contentURI = response.content_uri;
-    const httpUrl = this.matrix.mxcUrlToHttp(contentURI, undefined, undefined, undefined, undefined, true, true);
-    return httpUrl;
+    return response.content_uri;
   }
 
   // if the file is uploaded to the homeserver, then we need bearer token to download it
@@ -645,7 +647,7 @@ export class MatrixClient implements IChatClient {
 
     await this.waitForConnection();
 
-    const response = await fetch(fileUrl, {
+    const response = await fetch(this.mxcUrlToHttp(fileUrl), {
       headers: {
         Authorization: `Bearer ${this.getAccessToken()}`,
       },
@@ -743,7 +745,7 @@ export class MatrixClient implements IChatClient {
     }
 
     const content = {
-      body: isEncrypted ? null : '',
+      body: '',
       msgtype: MsgType.Image,
       file,
       info: {

--- a/src/lib/chat/matrix/media.ts
+++ b/src/lib/chat/matrix/media.ts
@@ -1,6 +1,6 @@
 import encrypt from 'matrix-encrypt-attachment';
 import { getAttachmentUrl } from '../../api/attachment';
-import { getAccessToken } from '..';
+import { getAccessToken, mxcUrlToHttp } from '..';
 
 /**
  * Read the file as an ArrayBuffer.
@@ -68,7 +68,7 @@ export async function encryptFile(file: File): Promise<{ info: encrypt.IEncrypte
 export function isFileUploadedToMatrix(url: string): boolean {
   if (!url || typeof url !== 'string') return false;
 
-  return url.includes('_matrix/client/v1/media');
+  return url.startsWith('mxc://');
 }
 
 // https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/utils/DecryptFile.ts#L50
@@ -80,7 +80,7 @@ export async function decryptFile(encryptedFile, mimetype): Promise<Blob> {
   let response;
 
   if (isFileUploadedToMatrix(url)) {
-    response = await fetch(url, {
+    response = await fetch(mxcUrlToHttp(url), {
       headers: {
         Authorization: `Bearer ${getAccessToken()}`,
       },


### PR DESCRIPTION
### What does this do?

When uploading new files (profileImage/groupIcon/image message), we're now uploading the `mxc://..` url directly now. This is because the Rust SDK (which the mobile app is using), is uploading image messages directly with the mxc urls. 