### PR TITLE
add `{  h, w }` fields while uploading file

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -994,6 +994,8 @@ describe('matrix client', () => {
             rootMessageId: 'root-message-id',
             width: 800,
             height: 600,
+            w: 800,
+            h: 600,
           },
           optimisticId: 'optimistic-id',
         })
@@ -1066,6 +1068,8 @@ describe('matrix client', () => {
             rootMessageId: 'root-message-id',
             width: 800,
             height: 600,
+            w: 800,
+            h: 600,
           },
           optimisticId: 'optimistic-id',
         })

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -756,6 +756,8 @@ export class MatrixClient implements IChatClient {
         rootMessageId,
         width,
         height,
+        w: width,
+        h: height,
       },
       optimisticId,
     } as any;


### PR DESCRIPTION
### Why are we making this change?

For compatibility with the rust SDK, which mobile is using
