### PR TITLE
fix(matrix-client): undefined post message reaction event id when processing reactions

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -497,12 +497,21 @@ export class MatrixClient implements IChatClient {
       .filter((event) => event.getType() === MatrixConstants.REACTION)
       .map((event) => {
         const content = event.getContent();
-        return {
-          eventId: content[MatrixConstants.RELATES_TO].event_id,
-          key: content[MatrixConstants.RELATES_TO].key,
-          amount: content.amount || 0,
-        };
-      });
+        const relatesTo = content[MatrixConstants.RELATES_TO];
+
+        if (relatesTo && relatesTo.event_id && relatesTo.key) {
+          return {
+            eventId: relatesTo.event_id,
+            key: relatesTo.key,
+            amount: content.amount || 0,
+          };
+        }
+
+        // If the structure is not as we expect, return null to filter it out
+        console.warn('Invalid reaction event structure:', event);
+        return null;
+      })
+      .filter((reaction) => reaction !== null);
 
     return result;
   }


### PR DESCRIPTION
### What does this do?
- fixes error where there are undefined post message reaction event ids when processing reactions

### Why are we making this change?
- handle event data we are not expecting when applying reactions to post events

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
