### PR TITLE
feat(group-management/chat-sagas): open secondary side kick by default if social channel

### DIFF
--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -57,7 +57,7 @@ export class Container extends React.Component<Properties> {
               )}
               {this.props.isConversationsLoaded && !this.props.isSocialChannel && <MessengerChat />}
             </div>
-            <Sidekick variant='secondary' />
+            {this.props.isConversationsLoaded && <Sidekick variant='secondary' />}
 
             <FeatureFlag featureFlag='enableDevPanel'>
               <DevPanelContainer />

--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -20,6 +20,7 @@ import { ERROR_DIALOG_CONTENT, JoinRoomApiErrorCode, translateJoinRoomApiError }
 import { getRoomIdForAlias, isRoomMember } from '../../lib/chat';
 import { joinRoom as apiJoinRoom } from './api';
 import { call } from 'redux-saga/effects';
+import { openSidekickForSocialChannel } from '../group-management/saga';
 
 describe(performValidateActiveConversation, () => {
   function subject(...args: Parameters<typeof expectSaga>) {
@@ -246,6 +247,8 @@ describe(validateActiveConversation, () => {
       .call(waitForChatConnectionCompletion)
       .next(true)
       .call(performValidateActiveConversation, 'convo-1')
+      .next()
+      .spawn(openSidekickForSocialChannel, 'convo-1')
       .next()
       .put(setIsJoiningConversation(false))
       .next()

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -23,6 +23,7 @@ import { openFirstConversation } from '../channels/saga';
 import { translateJoinRoomApiError, parseAlias, isAlias, extractDomainFromAlias } from './utils';
 import { joinRoom as apiJoinRoom } from './api';
 import { rawConversationsList } from '../channels-list/selectors';
+import { openSidekickForSocialChannel } from '../group-management/saga';
 
 function* initChat(userId, token) {
   const { chatConnection, connectionPromise, activate } = createChatConnection(userId, token, chat.get());
@@ -117,6 +118,7 @@ export function* validateActiveConversation(conversationId: string) {
   const isLoaded = yield call(waitForChatConnectionCompletion);
   if (isLoaded) {
     yield call(performValidateActiveConversation, conversationId);
+    yield spawn(openSidekickForSocialChannel, conversationId);
   }
 
   yield put(setIsJoiningConversation(false));

--- a/src/store/group-management/saga.ts
+++ b/src/store/group-management/saga.ts
@@ -30,6 +30,7 @@ import {
 import { EditConversationState } from './types';
 import { isSecondarySidekickOpenSelector } from './selectors';
 import { closeOverview as closeMessageInfo } from '../message-info/saga';
+import { rawChannelSelector } from '../channels/saga';
 
 export function* reset() {
   yield put(setStage(Stage.None));
@@ -263,4 +264,16 @@ export function* toggleIsSecondarySidekick() {
   }
 
   yield put(setSecondarySidekickOpen(!isOpen));
+}
+
+export function* openSidekickForSocialChannel(conversationId) {
+  const channel = yield select(rawChannelSelector(conversationId));
+
+  if (channel?.isSocialChannel) {
+    const isSidekickOpen = yield select(isSecondarySidekickOpenSelector);
+
+    if (!isSidekickOpen) {
+      yield put(setSecondarySidekickOpen(true));
+    }
+  }
 }


### PR DESCRIPTION
### What does this do?
- opens secondary side kick by default if social channel

### Why are we making this change?
- as requested

### How do I test this?
- run tests as usual
- run ui and test by hitting social channel conversation id in url

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
