### PR TITLE
feat(posts/message-saga): send browser notifications when event is post event

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -244,6 +244,7 @@ function convertToNotifiableEventType(eventType) {
   switch (eventType) {
     case EventType.RoomMessageEncrypted:
     case EventType.RoomMessage:
+    case CustomEventType.ROOM_POST:
       return NotifiableEventType.RoomMessage;
     default:
       return '';


### PR DESCRIPTION
### What does this do?
- sends browser notifications when event is post event

### Why are we making this change?
- add notification for posts

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
