### PR TITLE
do not edit matrix avatar_url during edit profile

### DIFF
--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -43,7 +43,7 @@ describe('editProfile', () => {
           { profileSummary: { firstName: 'old-name', profileImage: 'old-image' } as any, primaryZID: 'old-zid' }
         )
       )
-      .call(matrixEditProfile, profileImage)
+      //.call(matrixEditProfile, profileImage)
       .run();
 
     expect(authentication.user.data.profileSummary.firstName).toEqual('John Doe');

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -9,7 +9,7 @@ import { ProfileDetailsErrors } from '../registration';
 import cloneDeep from 'lodash/cloneDeep';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
+import { uploadFile } from '../../lib/chat';
 
 export function* getLocalUrl(file) {
   if (!file) {
@@ -41,9 +41,10 @@ export function* editProfile(action) {
       profileImage: profileImage === '' ? undefined : profileImage,
     });
     if (response.success) {
-      if (profileImage) {
-        yield call(matrixEditProfile, profileImage);
-      }
+      // commenting this out for now, this is spurring up a lot of "member events". not sure why.
+      // if (profileImage) {
+      //   yield call(matrixEditProfile, profileImage);
+      // }
 
       const localUrl = yield call(getLocalUrl, image);
       yield call(updateUserProfile, { name, profileImage: localUrl, primaryZID });

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -213,7 +213,7 @@ describe(updateUserProfileImageFromCache, () => {
           { success: false },
         ],
       ])
-      .not.call(matrixEditProfile, 'uploaded-image-url')
+      //.not.call(matrixEditProfile, 'uploaded-image-url')
       .run();
 
     expect(returnValue).toBeUndefined();
@@ -241,7 +241,7 @@ describe(updateUserProfileImageFromCache, () => {
           undefined,
         ],
       ])
-      .call(matrixEditProfile, 'uploaded-image-url')
+      //.call(matrixEditProfile, 'uploaded-image-url')
       .run();
 
     expect(returnValue).toBe('uploaded-image-url');

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -6,7 +6,7 @@ import { getUserSubHandle } from '../../lib/user';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { downloadFile, uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
+import { downloadFile, uploadFile } from '../../lib/chat';
 import cloneDeep from 'lodash/cloneDeep';
 import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
 import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
@@ -63,7 +63,7 @@ export function* updateUserProfileImageFromCache(currentUser: User) {
       profileImage: profileImageUrl || undefined,
     });
     if (response.success) {
-      yield call(matrixEditProfile, profileImageUrl); // also update the profile image in the homeserver user directory
+      //yield call(matrixEditProfile, profileImageUrl); // also update the profile image in the homeserver user directory
       return profileImageUrl;
     } else {
       console.error('Failed to update user profile on registration:', response.error);


### PR DESCRIPTION
### What does this do?

After a user edits their profile Image, we save it in the API database. AND, we also call matrixClient to update the avatar_url in the user directory. This PR skips the latter for now.

### Why are we making this change?

This is because the `matrixEditProfile` call is spurring up a lot of events (like membership update, joins etc), which is causing the web client to process all these events. Which is impacting performance.
