### PR TITLE
add featureFlag (`postImageMessagesToMatrix`) to post image messages to matrix

### DIFF
--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -22,6 +22,12 @@ jest.mock('./matrix/media', () => {
   };
 });
 
+const featureFlags = { postImageMessagesToMatrix: true };
+
+jest.mock('../../lib/feature-flags', () => ({
+  featureFlags: featureFlags,
+}));
+
 const stubRoom = (attrs = {}) => ({
   roomId: 'some-id',
   getAvatarUrl: () => '',

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -129,6 +129,14 @@ export class FeatureFlags {
   set enableMeows(value: boolean) {
     this._setBoolean('enableMeows', value);
   }
+
+  get postImageMessagesToMatrix() {
+    return this._getBoolean('postImagesToMatrix', false);
+  }
+
+  set postImageMessagesToMatrix(value: boolean) {
+    this._setBoolean('postImagesToMatrix', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?

Reverts the change effectively to upload image messages to matrix. If you do want to send messages to matrix, use `postImageMessagesToMatrix` feature flag.