### PR TITLE
mute cloudinary urls

### DIFF
--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -27,6 +27,15 @@ import { getUserReadReceiptPreference } from '../user-profile/saga';
 import { featureFlags } from '../../lib/feature-flags';
 import { createUnencryptedConversation as createUnencryptedMatrixConversation } from '../../lib/chat';
 
+function* getProfileImage(user) {
+  let profileImage = user.profileImage;
+  if (!profileImage || typeof profileImage !== 'string' || profileImage.includes('res.cloudinary.com')) {
+    return '';
+  }
+
+  return yield call(downloadFile, user.profileImage);
+}
+
 export function* mapToZeroUsers(channels: any[]) {
   let allMatrixIds = [];
   for (const channel of channels) {
@@ -37,7 +46,7 @@ export function* mapToZeroUsers(channels: any[]) {
   const zeroUsers = yield call(getZEROUsers, allMatrixIds);
   const zeroUsersMap = {};
   for (const user of zeroUsers) {
-    user.profileImage = yield call(downloadFile, user.profileImage);
+    user.profileImage = yield call(getProfileImage, user);
     zeroUsersMap[user.matrixId] = user;
   }
 


### PR DESCRIPTION
### What does this do?

Stops the parsing of profile images if it is a cloudinary url (since we have removed that service). This is to prevent GET errors like this in the console:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/6e8161a6-2e85-4d1a-93b4-245d781c35fe">
