### PR TITLE
feat(messages): add download status state to media object to prevent repeated decryption attempts on re-renders

### DIFF
--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -31,12 +31,19 @@ export enum MediaType {
   File = 'file',
 }
 
+export enum MediaDownloadStatus {
+  Success = 'SUCCESS',
+  Failed = 'FAILED',
+  Loading = 'LOADING',
+}
+
 export interface Media {
   height: number;
   name: string;
   type: MediaType;
   url: string;
   width: number;
+  downloadStatus?: MediaDownloadStatus;
 }
 
 export interface MessagesResponse {


### PR DESCRIPTION
### What does this do?
- This change adds a downloadStatus to the media object to prevent repeated decryption attempts during re-renders.

### Why are we making this change?
- We are making this change to improve performance and avoid unnecessary processing by ensuring that failed or already processed media files are not re-attempted for decryption.

### How do I test this?
- run tests as usual
- run UI and check redux state - ensure that loadAttachmentDetails is not run on re-render

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
