### PR TITLE
feat(messenger-chat/conversation-previews): handle reaction events sent from mobile device

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Waypoint } from 'react-waypoint';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Message as MessageModel, MediaType, EditMessageOptions, Media } from '../../store/messages';
+import { Message as MessageModel, MediaType, EditMessageOptions, Media, AdminMessageType } from '../../store/messages';
 import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
@@ -140,7 +140,7 @@ export class ChatView extends React.Component<Properties, State> {
 
   renderMessageGroup(groupMessages) {
     return groupMessages.map((message, index) => {
-      if (message.isAdmin && !message.isPost) {
+      if (message.isAdmin && message.admin.type !== AdminMessageType.REACTION) {
         return <AdminMessageContainer key={message.optimisticId || message.id} message={message} />;
       } else {
         const messageRenderProps = getMessageRenderProps(

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -140,7 +140,7 @@ export class ChatView extends React.Component<Properties, State> {
 
   renderMessageGroup(groupMessages) {
     return groupMessages.map((message, index) => {
-      if (message.isAdmin) {
+      if (message.isAdmin && !message.isPost) {
         return <AdminMessageContainer key={message.optimisticId || message.id} message={message} />;
       } else {
         const messageRenderProps = getMessageRenderProps(

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -250,6 +250,19 @@ describe(adminMessageText, () => {
 
       expect(adminText).toEqual('Courtney reacted with 10 MEOW');
     });
+
+    it('translates message if amount is not found', () => {
+      const state = getState('current-user', { 'admin-user-id': { id: 'admin-user-id', firstName: 'Courtney' } });
+      const message = {
+        message: 'some message',
+        isAdmin: true,
+        admin: { type: AdminMessageType.REACTION, userId: 'admin-user-id' },
+      } as any;
+
+      const adminText = adminMessageText(message, state);
+
+      expect(adminText).toEqual('Courtney sent a reaction');
+    });
   });
 });
 

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -94,12 +94,21 @@ export function adminMessageText(message: Message, state: RootState) {
 }
 
 function translateReaction(admin: { userId?: string; amount?: string }, currentUser, state: RootState) {
-  if (admin.userId === currentUser.id) {
+  const user = denormalizeUser(admin.userId, state);
+
+  if (!admin.amount && admin.userId === currentUser.id) {
+    return 'You sent a reaction';
+  }
+
+  if (!admin.amount && user?.firstName) {
+    return `${user.firstName} sent a reaction`;
+  }
+
+  if (admin.amount && admin.userId === currentUser.id) {
     return `You reacted with ${admin.amount} MEOW`;
   }
 
-  const user = denormalizeUser(admin.userId, state);
-  return user?.firstName ? `${user.firstName} reacted with ${admin.amount} MEOW` : null;
+  return admin.amount && user?.firstName ? `${user.firstName} reacted with ${admin.amount} MEOW` : null;
 }
 
 function translateJoinedZero(admin: { inviteeId?: string; inviterId?: string }, currentUser, state: RootState) {


### PR DESCRIPTION
### What does this do?
- handles reaction events sent from mobile device

### Why are we making this change?
- web does not currently handle the same reaction events as mobile. as a result this causes some undefined admin messages and preview on web, therefore these changes are made to handle these i.e. filter out the reaction message and add a basic preview message.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
