### PR TITLE
fix(chat-view-container): correctly filter out reaction admin messages from chat

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -10,6 +10,7 @@ import {
   EditMessageOptions,
   loadAttachmentDetails,
   Media,
+  AdminMessageType,
 } from '../../store/messages';
 import { Channel, ConversationStatus, denormalize, onReply } from '../../store/channels';
 import { ChatView } from './chat-view';
@@ -153,7 +154,9 @@ export class Container extends React.Component<Properties> {
   get messages() {
     const allMessages = this.channel?.messages || [];
 
-    const chatMessages = allMessages.filter((message) => !message.isPost);
+    const chatMessages = allMessages.filter(
+      (message) => !message.isPost && (!message.admin || message.admin?.type !== AdminMessageType.REACTION)
+    );
 
     const messagesById = mapMessagesById(chatMessages);
     const messagesByRootId = mapMessagesByRootId(chatMessages);

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Waypoint } from 'react-waypoint';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Message as MessageModel, MediaType, EditMessageOptions, Media, AdminMessageType } from '../../store/messages';
+import { Message as MessageModel, MediaType, EditMessageOptions, Media } from '../../store/messages';
 import InvertedScroll from '../inverted-scroll';
 import { Lightbox } from '@zer0-os/zos-component-library';
 import { User } from '../../store/authentication/types';
@@ -140,7 +140,7 @@ export class ChatView extends React.Component<Properties, State> {
 
   renderMessageGroup(groupMessages) {
     return groupMessages.map((message, index) => {
-      if (message.isAdmin && message.admin.type !== AdminMessageType.REACTION) {
+      if (message.isAdmin) {
         return <AdminMessageContainer key={message.optimisticId || message.id} message={message} />;
       } else {
         const messageRenderProps = getMessageRenderProps(


### PR DESCRIPTION
### What does this do?
- fixes issue so we correctly filter out reaction admin messages from chat

### Why are we making this change?
- we do not want to see admin messages in the messenger chat stating that a reaction has been made by a user, this should only render in the conversation list preview.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
