### PR TITLE
feat(media): update media handling for unencrypted rooms

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -74,12 +74,47 @@ describe('message', () => {
     expect(wrapper.find('.message__image-placeholder').exists()).toBe(true);
   });
 
+  it('renders image placeholder if matrix media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    const wrapper = subject({
+      loadAttachmentDetails,
+      media: { id: '1', url: 'mxc://some-test-matrix-url', type: MediaType.Image },
+    });
+
+    expect(wrapper.find('.message__image-placeholder').exists()).toBe(true);
+  });
+
   it('calls loadAttachmentDetails if no media url', () => {
     const loadAttachmentDetails = jest.fn();
 
     subject({ messageId: 'test-id', loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
 
     expect(loadAttachmentDetails).toHaveBeenCalled();
+  });
+
+  it('calls loadAttachmentDetails if url is a matrix media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({
+      messageId: 'test-id',
+      loadAttachmentDetails,
+      media: { url: 'mxc://some-test-matrix-url', type: MediaType.Image },
+    });
+
+    expect(loadAttachmentDetails).toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if url is defined and not a matrix media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({
+      messageId: 'test-id',
+      loadAttachmentDetails,
+      media: { url: 'some-test-url', type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed },
+    });
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
   });
 
   it('does not call loadAttachmentDetails if media download status is failed', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -170,8 +170,9 @@ export class Message extends React.Component<Properties, State> {
   renderMedia(media) {
     const { type, url, name, downloadStatus } = media;
     const { width, height } = this.getPlaceholderDimensions(media.width, media.height);
+    const isMatrixUrl = url?.startsWith('mxc://');
 
-    if (!url) {
+    if (!url || isMatrixUrl) {
       if (downloadStatus !== MediaDownloadStatus.Failed) {
         this.props.loadAttachmentDetails({ media, messageId: media.id ?? this.props.messageId.toString() });
       }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -745,31 +745,30 @@ export class MatrixClient implements IChatClient {
   }
 
   async uploadFileMessage(roomId: string, media: File, rootMessageId: string = '', optimisticId = '', isPost = false) {
-    const isEncrypted = this.matrix.isRoomEncrypted(roomId);
+    const room = this.matrix.getRoom(roomId);
+    const isEncrypted = room?.hasEncryptionStateEvent();
 
     const { width, height } = await getImageDimensions(media);
 
     let file;
+    let url;
+
     if (isEncrypted) {
-      const encryptedFileInfo = await encryptFile(media); // Call encryptFile if the room is encrypted
-      const uploadedFileUrl = await this._uploadFile(encryptedFileInfo.file);
+      // For encrypted rooms, encrypt the file and use the `file` object
+      const encryptedFileInfo = await encryptFile(media);
+      url = await this._uploadFile(encryptedFileInfo.file);
       file = {
-        url: uploadedFileUrl,
+        url,
         ...encryptedFileInfo.info,
       };
     } else {
-      const uploadedFileUrl = await this._uploadFile(media); // Directly upload the file without encryption
-      file = {
-        url: uploadedFileUrl,
-        mimetype: media.type,
-        size: media.size,
-      };
+      // For unencrypted rooms, directly upload the file and use `url`
+      url = await this._uploadFile(media);
     }
 
-    const content = {
+    const content: any = {
       body: '',
       msgtype: MsgType.Image,
-      file,
       info: {
         mimetype: media.type,
         size: media.size,
@@ -780,9 +779,19 @@ export class MatrixClient implements IChatClient {
         height,
         w: width,
         h: height,
+        // Optional: blurhash and thumbnail fields (null or undefined for now)
+        'xyz.amorgan.blurhash': null,
+        thumbnail_url: null,
+        thumbnail_info: null,
       },
       optimisticId,
-    } as any;
+    };
+
+    if (isEncrypted) {
+      content.file = file;
+    } else {
+      content.url = url;
+    }
 
     let messageResult;
     if (isPost) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -624,8 +624,11 @@ const inProgress = {};
 export function* loadAttachmentDetails(action) {
   const { media, messageId } = action.payload;
 
-  // Check conditions to skip processing
-  if (inProgress[messageId] || media.url || media.downloadStatus === MediaDownloadStatus.Failed) {
+  if (
+    inProgress[messageId] ||
+    (media.url && !media.url.startsWith('mxc://')) ||
+    media.downloadStatus === MediaDownloadStatus.Failed
+  ) {
     return;
   }
 
@@ -635,7 +638,7 @@ export function* loadAttachmentDetails(action) {
     // Set status to 'LOADING'
     yield put(updateMediaStatus(messageId, media, MediaDownloadStatus.Loading));
 
-    const blob = yield call(decryptFile, media.file, media.mimetype);
+    const blob = yield call(decryptFile, media.file || { url: media.url }, media.mimetype);
     const url = URL.createObjectURL(blob);
 
     if (!url) {


### PR DESCRIPTION
### What does this do?
- updates media (payload) handling for unencrypted rooms by ensuring Matrix URLs are processed and skipping unnecessary file decryption for non-encrypted media.

### Why are we making this change?
- payload update to work when receiving and sending to mobile devices, as a result some updates here required to handle the changes.

### How do I test this?
- run tests as usual.
- run UI and send images in encrypted/non-encrypted rooms.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
