### PR TITLE
call matrix API to update profile `avatar_url` after edit profile

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -677,6 +677,10 @@ export class MatrixClient implements IChatClient {
 
   async editProfile(avatarUrl: string) {
     await this.waitForConnection();
+    if (!avatarUrl) {
+      return;
+    }
+
     await this.matrix.setProfileInfo('avatar_url', { avatar_url: avatarUrl });
   }
 

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -1,5 +1,5 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import { call } from 'redux-saga/effects';
+import { call, spawn } from 'redux-saga/effects';
 import { editProfile as editProfileSaga, updateUserProfile, fetchOwnedZIDs, getLocalUrl } from './saga';
 import { editUserProfile as apiEditUserProfile, fetchOwnedZIDs as apiFetchOwnedZIDs } from './api';
 import { uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
@@ -32,7 +32,7 @@ describe('editProfile', () => {
           call(apiEditUserProfile, { name, profileImage, primaryZID }),
           { success: true },
         ],
-        [call(matrixEditProfile, profileImage), {}],
+        [spawn(matrixEditProfile, profileImage), {}],
         [call(getLocalUrl, image), 'local-image-url'],
       ])
       .call(updateUserProfile, { name, profileImage: 'local-image-url', primaryZID })
@@ -43,7 +43,7 @@ describe('editProfile', () => {
           { profileSummary: { firstName: 'old-name', profileImage: 'old-image' } as any, primaryZID: 'old-zid' }
         )
       )
-      //.call(matrixEditProfile, profileImage)
+      .spawn(matrixEditProfile, profileImage)
       .run();
 
     expect(authentication.user.data.profileSummary.firstName).toEqual('John Doe');
@@ -100,7 +100,7 @@ describe('editProfile', () => {
           call(apiEditUserProfile, { name, primaryZID, profileImage: undefined }),
           { success: true },
         ],
-        [call(matrixEditProfile, undefined), {}],
+        [spawn(matrixEditProfile, undefined), {}],
       ])
       .withReducer(
         rootReducer,

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -1,4 +1,4 @@
-import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, select, spawn, takeLatest } from 'redux-saga/effects';
 import { SagaActionTypes, State, setErrors, setLoadingZIDs, setOwnedZIDs, setState } from '.';
 import {
   editUserProfile as apiEditUserProfile,
@@ -9,7 +9,7 @@ import { ProfileDetailsErrors } from '../registration';
 import cloneDeep from 'lodash/cloneDeep';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { uploadFile } from '../../lib/chat';
+import { uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
 
 export function* getLocalUrl(file) {
   if (!file) {
@@ -41,10 +41,9 @@ export function* editProfile(action) {
       profileImage: profileImage === '' ? undefined : profileImage,
     });
     if (response.success) {
-      // commenting this out for now, this is spurring up a lot of "member events". not sure why.
-      // if (profileImage) {
-      //   yield call(matrixEditProfile, profileImage);
-      // }
+      if (profileImage) {
+        yield spawn(matrixEditProfile, profileImage);
+      }
 
       const localUrl = yield call(getLocalUrl, image);
       yield call(updateUserProfile, { name, profileImage: localUrl, primaryZID });

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -5,7 +5,7 @@ import {
   receiveSearchResults,
   updateUserProfileImageFromCache,
 } from './saga';
-import { call } from 'redux-saga/effects';
+import { call, spawn } from 'redux-saga/effects';
 import { rootReducer } from '../reducer';
 import { denormalize } from '.';
 import { StoreBuilder } from '../test/store';
@@ -213,7 +213,7 @@ describe(updateUserProfileImageFromCache, () => {
           { success: false },
         ],
       ])
-      //.not.call(matrixEditProfile, 'uploaded-image-url')
+      .not.spawn(matrixEditProfile, 'uploaded-image-url')
       .run();
 
     expect(returnValue).toBeUndefined();
@@ -237,11 +237,11 @@ describe(updateUserProfileImageFromCache, () => {
           { success: true },
         ],
         [
-          call(matrixEditProfile, 'uploaded-image-url'),
+          spawn(matrixEditProfile, 'uploaded-image-url'),
           undefined,
         ],
       ])
-      //.call(matrixEditProfile, 'uploaded-image-url')
+      .spawn(matrixEditProfile, 'uploaded-image-url')
       .run();
 
     expect(returnValue).toBe('uploaded-image-url');

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -6,7 +6,7 @@ import { getUserSubHandle } from '../../lib/user';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { downloadFile, uploadFile } from '../../lib/chat';
+import { downloadFile, uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
 import cloneDeep from 'lodash/cloneDeep';
 import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
 import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
@@ -63,7 +63,7 @@ export function* updateUserProfileImageFromCache(currentUser: User) {
       profileImage: profileImageUrl || undefined,
     });
     if (response.success) {
-      //yield call(matrixEditProfile, profileImageUrl); // also update the profile image in the homeserver user directory
+      yield spawn(matrixEditProfile, profileImageUrl); // also update the profile image in the homeserver user directory
       return profileImageUrl;
     } else {
       console.error('Failed to update user profile on registration:', response.error);


### PR DESCRIPTION
### What does this do?

`spawns` the "edit profile" for the matrix user directory, when the user edits their profile image. We spawn it since it triggers a number of membership update events, which can be process in the bg. 