### PR TITLE
feat(messenger-feed): update media handling on posts for unencrypted rooms

### DIFF
--- a/src/components/messenger/feed/components/post/index.tsx
+++ b/src/components/messenger/feed/components/post/index.tsx
@@ -96,8 +96,9 @@ export const Post = ({
     (media) => {
       const { type, url, name, width, height, downloadStatus } = media;
       const placeholderDimensions = getPlaceholderDimensions(width, height);
+      const isMatrixUrl = url?.startsWith('mxc://');
 
-      if (!url) {
+      if (!url || isMatrixUrl) {
         if (downloadStatus !== MediaDownloadStatus.Failed) {
           loadAttachmentDetails({ media, messageId: media.id ?? messageId.toString() });
         }


### PR DESCRIPTION
### What does this do?
- updates media (payload) handling for unencrypted social channels by ensuring Matrix URLs are processed and skipping unnecessary file decryption for non-encrypted media.

### Why are we making this change?
- payload update

### How do I test this?
- run tests as usual.
- run UI and send images in social channels

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
