### PR TITLE
refactor(mapMatrixMessage): filter out file names from image messages and set message content to an empty string for image types

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -54,7 +54,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
 
   return {
     id: event_id,
-    message: messageContent,
+    message: content.msgtype === 'm.image' ? '' : messageContent,
     createdAt: origin_server_ts,
     updatedAt: updatedAt,
     sender: {


### PR DESCRIPTION
### What does this do?
This update ensures that the file name from image messages is not incorrectly displayed as the message content by filtering it out and setting the content to an empty string for image message types.

### Why are we making this change?
This change prevents unnecessary file names from being rendered as message text in the UI, ensuring that the message content is reserved for actual text and keeping the display cleaner.

### How do I test this?
- run tests as usual
- run UI > Check images received, they should not display file name in message body

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
