### PR TITLE
Parse `avatar_url` if it is stored in matrix user_directory (and not zero-api)

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -85,6 +85,7 @@ export interface IChatClient {
   editProfile(avatarUrl: string): Promise<any>;
   getAccessToken(): string | null;
   mxcUrlToHttp(mxcUrl: string): string;
+  getProfileInfo(userId: string): Promise<{ avatar_url?: string; displayname?: string }>;
 }
 
 export class Chat {
@@ -398,4 +399,11 @@ export function getAccessToken(): string | null {
 
 export function mxcUrlToHttp(mxcUrl: string): string {
   return chat.get().matrix.mxcUrlToHttp(mxcUrl);
+}
+
+export function getProfileInfo(userId: string): Promise<{
+  avatar_url?: string;
+  displayname?: string;
+}> {
+  return chat.get().matrix.getProfileInfo(userId);
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1542,15 +1542,13 @@ export class MatrixClient implements IChatClient {
   }
 
   private getOtherMembersFromRoom(room: Room): string[] {
-    const members = room
+    return room
       .getMembers()
       .filter(
         (member) => member.membership === MembershipStateType.Join || member.membership === MembershipStateType.Invite
       )
       .filter((member) => member.userId !== this.userId)
       .map((member) => member.userId);
-
-    return members;
   }
 
   private async getRoomsUserIsIn() {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -684,6 +684,11 @@ export class MatrixClient implements IChatClient {
     await this.matrix.setProfileInfo('avatar_url', { avatar_url: avatarUrl });
   }
 
+  async getProfileInfo(userId: string) {
+    await this.waitForConnection();
+    return await this.matrix.getProfileInfo(userId);
+  }
+
   async sendMessagesByChannelId(
     channelId: string,
     message: string,
@@ -1537,13 +1542,15 @@ export class MatrixClient implements IChatClient {
   }
 
   private getOtherMembersFromRoom(room: Room): string[] {
-    return room
+    const members = room
       .getMembers()
       .filter(
         (member) => member.membership === MembershipStateType.Join || member.membership === MembershipStateType.Invite
       )
       .filter((member) => member.userId !== this.userId)
       .map((member) => member.userId);
+
+    return members;
   }
 
   private async getRoomsUserIsIn() {

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -27,15 +27,6 @@ import { getUserReadReceiptPreference } from '../user-profile/saga';
 import { featureFlags } from '../../lib/feature-flags';
 import { createUnencryptedConversation as createUnencryptedMatrixConversation } from '../../lib/chat';
 
-function* getProfileImage(user) {
-  let profileImage = user.profileImage;
-  if (!profileImage || typeof profileImage !== 'string' || profileImage.includes('res.cloudinary.com')) {
-    return '';
-  }
-
-  return yield call(downloadFile, user.profileImage);
-}
-
 export function* mapToZeroUsers(channels: any[]) {
   let allMatrixIds = [];
   for (const channel of channels) {
@@ -46,7 +37,6 @@ export function* mapToZeroUsers(channels: any[]) {
   const zeroUsers = yield call(getZEROUsers, allMatrixIds);
   const zeroUsersMap = {};
   for (const user of zeroUsers) {
-    user.profileImage = yield call(getProfileImage, user);
     zeroUsersMap[user.matrixId] = user;
   }
 

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -6,7 +6,12 @@ import { getUserSubHandle } from '../../lib/user';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
 import { currentUserSelector } from '../authentication/saga';
 import { setUser } from '../authentication';
-import { downloadFile, uploadFile, editProfile as matrixEditProfile } from '../../lib/chat';
+import {
+  downloadFile,
+  uploadFile,
+  editProfile as matrixEditProfile,
+  getProfileInfo as matrixGetProfileInfo,
+} from '../../lib/chat';
 import cloneDeep from 'lodash/cloneDeep';
 import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
 import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
@@ -90,6 +95,10 @@ export function* fetchCurrentUserProfileImage() {
     profileImageUrl = yield call(updateUserProfileImageFromCache, currentUser);
   } else {
     profileImageUrl = currentUser.profileSummary?.profileImage;
+    if (!profileImageUrl) {
+      const profileInfo = yield call(matrixGetProfileInfo, currentUser.matrixId);
+      profileImageUrl = profileInfo?.avatar_url;
+    }
   }
 
   if (!profileImageUrl) {


### PR DESCRIPTION
### What does this do?

Currently the new iOS app uploads `{ user_name, profileInfo }` to matrix, instead of the ZERO-API. So, the profile Image is not coming in from the API (always). 

This PR handles the case if we have a profile avatar_url from the matrix-client itself, and not just the ZERO-API.