### PR TITLE
fix(messenger-chat-container/main): only render messenger chat container when the conversation is valid and not joining (active)

### DIFF
--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -34,8 +34,8 @@ describe(Main, () => {
     expect(wrapper).not.toHaveElement(JoiningConversationDialog);
   });
 
-  it('renders direct message chat component when not a social channel and conversations loaded', () => {
-    const wrapper = subject({ context: { isAuthenticated: true } });
+  it('renders direct message chat component when not a social channel, conversations loaded and is valid', () => {
+    const wrapper = subject({ context: { isAuthenticated: true }, isValidConversation: true });
 
     expect(wrapper).toHaveElement(MessengerChat);
   });
@@ -51,13 +51,24 @@ describe(Main, () => {
     expect(wrapper).not.toHaveElement(MessengerChat);
   });
 
+  it('should not render messenger chat container when is not valid conversation', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isSocialChannel: false,
+      isValidConversation: false,
+      isConversationsLoaded: false,
+    });
+
+    expect(wrapper).not.toHaveElement(MessengerFeed);
+  });
+
   it('renders messenger feed container when is social channel, conversations loaded and is valid conversation', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: true, isValidConversation: true });
 
     expect(wrapper).toHaveElement(MessengerFeed);
   });
 
-  it('should not render messenger feed container when is not social channel', () => {
+  it('should not render messenger feed container when is not social channel ', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: false, isValidConversation: true });
 
     expect(wrapper).not.toHaveElement(MessengerFeed);

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -52,10 +52,9 @@ export class Container extends React.Component<Properties> {
             <div className={styles.Split}>
               {this.props.isJoiningConversation && <JoiningConversationDialog />}
 
-              {this.props.isConversationsLoaded && this.props.isSocialChannel && this.props.isValidConversation && (
-                <MessengerFeed />
-              )}
-              {this.props.isConversationsLoaded && !this.props.isSocialChannel && <MessengerChat />}
+              {this.props.isConversationsLoaded &&
+                this.props.isValidConversation &&
+                (this.props.isSocialChannel ? <MessengerFeed /> : <MessengerChat />)}
             </div>
             {this.props.isConversationsLoaded && <Sidekick variant='secondary' />}
 


### PR DESCRIPTION
### What does this do?
This update ensures that MessengerFeed and MessengerChat components are only rendered when a conversation is not in the process of being joined. It also simplifies the component's logic by reducing redundant checks and improving readability.

### Why are we making this change?
We are making this change to prevent inconsistent UI states by ensuring that users do not see the chat or feed components while a conversation is still being joined. The simplification also improves code maintainability and readability, reducing the risk of errors.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
