### PR TITLE
fix(joining-conversation): add generic error handling to joinRoom to prevent hanging state on unexpected errors

### DIFF
--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -34,8 +34,8 @@ describe(Main, () => {
     expect(wrapper).not.toHaveElement(JoiningConversationDialog);
   });
 
-  it('renders direct message chat component when not a social channel and conversations loaded', () => {
-    const wrapper = subject({ context: { isAuthenticated: true } });
+  it('renders direct message chat component when not a social channel, conversations loaded and is valid', () => {
+    const wrapper = subject({ context: { isAuthenticated: true }, isValidConversation: true });
 
     expect(wrapper).toHaveElement(MessengerChat);
   });
@@ -51,13 +51,24 @@ describe(Main, () => {
     expect(wrapper).not.toHaveElement(MessengerChat);
   });
 
+  it('should not render messenger chat container when is not valid conversation', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isSocialChannel: false,
+      isValidConversation: false,
+      isConversationsLoaded: false,
+    });
+
+    expect(wrapper).not.toHaveElement(MessengerFeed);
+  });
+
   it('renders messenger feed container when is social channel, conversations loaded and is valid conversation', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: true, isValidConversation: true });
 
     expect(wrapper).toHaveElement(MessengerFeed);
   });
 
-  it('should not render messenger feed container when is not social channel', () => {
+  it('should not render messenger feed container when is not social channel ', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: false, isValidConversation: true });
 
     expect(wrapper).not.toHaveElement(MessengerFeed);

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -52,10 +52,9 @@ export class Container extends React.Component<Properties> {
             <div className={styles.Split}>
               {this.props.isJoiningConversation && <JoiningConversationDialog />}
 
-              {this.props.isConversationsLoaded && this.props.isSocialChannel && this.props.isValidConversation && (
-                <MessengerFeed />
-              )}
-              {this.props.isConversationsLoaded && !this.props.isSocialChannel && <MessengerChat />}
+              {this.props.isConversationsLoaded &&
+                this.props.isValidConversation &&
+                (this.props.isSocialChannel ? <MessengerFeed /> : <MessengerChat />)}
             </div>
             {this.props.isConversationsLoaded && <Sidekick variant='secondary' />}
 

--- a/src/store/chat/api.ts
+++ b/src/store/chat/api.ts
@@ -1,4 +1,5 @@
 import { post } from '../../lib/api/rest';
+import { JoinRoomApiErrorCode } from './utils';
 
 export async function joinRoom(aliasOrId: string): Promise<{ success: boolean; response: any; message: string }> {
   try {
@@ -18,6 +19,10 @@ export async function joinRoom(aliasOrId: string): Promise<{ success: boolean; r
         message: error.response.body.message,
       };
     }
-    throw error;
+    return {
+      success: false,
+      response: JoinRoomApiErrorCode.UNKNOWN_ERROR,
+      message: '',
+    };
   }
 }


### PR DESCRIPTION
### What does this do?
Adds generic error handling to the joinRoom function to ensure that all errors, including server errors (e.g., 500), are handled gracefully by returning a consistent response.

### Why are we making this change?
To prevent the join room process from hanging when an unexpected error occurs, providing a better user experience and more reliable state management.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
