### PR TITLE
Creating a new user, or editing an existing profile should update matrix user `displayname` as well (in user directory)

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -2,7 +2,7 @@ import { EditMessageOptions, Message, MessagesResponse } from '../../store/messa
 import { Channel, User as UserModel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
-import { ParentMessage, User } from './types';
+import { MatrixProfileInfo, ParentMessage, User } from './types';
 import { MemberNetworks } from '../../store/users/types';
 
 export interface RealtimeChatEvents {
@@ -82,7 +82,7 @@ export interface IChatClient {
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
   uploadFile(file: File): Promise<string>;
   downloadFile(fileUrl: string): Promise<any>;
-  editProfile(avatarUrl: string): Promise<any>;
+  editProfile(profileInfo: MatrixProfileInfo): Promise<void>;
   getAccessToken(): string | null;
   mxcUrlToHttp(mxcUrl: string): string;
   getProfileInfo(userId: string): Promise<{ avatar_url?: string; displayname?: string }>;
@@ -389,8 +389,8 @@ export async function downloadFile(fileUrl: string) {
   return chat.get().matrix.downloadFile(fileUrl);
 }
 
-export async function editProfile(avatarUrl: string) {
-  return chat.get().matrix.editProfile(avatarUrl);
+export async function editProfile(profileInfo: MatrixProfileInfo) {
+  return chat.get().matrix.editProfile(profileInfo);
 }
 
 export function getAccessToken(): string | null {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1292,11 +1292,6 @@ export class MatrixClient implements IChatClient {
       await this.waitForSync();
       featureFlags.enableTimerLogs && console.timeEnd('xxxWaitForSync');
 
-      console.log(
-        'matrix client initialized ------------------------->>>> ',
-        await this.matrix.getProfileInfo(opts.userId)
-      );
-
       featureFlags.enableTimerLogs && console.timeEnd('xxxinitializeClient');
       return opts.userId;
     }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -30,7 +30,7 @@ import {
 import { ConversationStatus, Channel, User as UserModel } from '../../store/channels';
 import { EditMessageOptions, Message, MessagesResponse } from '../../store/messages';
 import { FileUploadResult } from '../../store/messages/saga';
-import { ParentMessage, PowerLevels, User } from './types';
+import { MatrixProfileInfo, ParentMessage, PowerLevels, User } from './types';
 import { config } from '../../config';
 import { get, post } from '../api/rest';
 import { MemberNetworks } from '../../store/users/types';
@@ -680,13 +680,15 @@ export class MatrixClient implements IChatClient {
     return URL.createObjectURL(blob);
   }
 
-  async editProfile(avatarUrl: string) {
+  async editProfile(profileInfo: MatrixProfileInfo = {}) {
     await this.waitForConnection();
-    if (!avatarUrl) {
-      return;
+    if (profileInfo.displayName) {
+      await this.matrix.setDisplayName(profileInfo.displayName);
     }
 
-    await this.matrix.setProfileInfo('avatar_url', { avatar_url: avatarUrl });
+    if (profileInfo.avatarUrl) {
+      await this.matrix.setAvatarUrl(profileInfo.avatarUrl);
+    }
   }
 
   async getProfileInfo(userId: string) {
@@ -1289,6 +1291,11 @@ export class MatrixClient implements IChatClient {
       featureFlags.enableTimerLogs && console.time('xxxWaitForSync');
       await this.waitForSync();
       featureFlags.enableTimerLogs && console.timeEnd('xxxWaitForSync');
+
+      console.log(
+        'matrix client initialized ------------------------->>>> ',
+        await this.matrix.getProfileInfo(opts.userId)
+      );
 
       featureFlags.enableTimerLogs && console.timeEnd('xxxinitializeClient');
       return opts.userId;

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -4,6 +4,11 @@ export interface ChatMessage {
   [key: string]: any;
 }
 
+export interface MatrixProfileInfo {
+  avatarUrl?: string;
+  displayName?: string;
+}
+
 export interface ParentMessage {
   messageId: number;
   userId: string;

--- a/src/store/edit-profile/saga.test.ts
+++ b/src/store/edit-profile/saga.test.ts
@@ -32,7 +32,7 @@ describe('editProfile', () => {
           call(apiEditUserProfile, { name, profileImage, primaryZID }),
           { success: true },
         ],
-        [spawn(matrixEditProfile, profileImage), {}],
+        [spawn(matrixEditProfile, { avatarUrl: profileImage, displayName: name }), {}],
         [call(getLocalUrl, image), 'local-image-url'],
       ])
       .call(updateUserProfile, { name, profileImage: 'local-image-url', primaryZID })
@@ -43,7 +43,7 @@ describe('editProfile', () => {
           { profileSummary: { firstName: 'old-name', profileImage: 'old-image' } as any, primaryZID: 'old-zid' }
         )
       )
-      .spawn(matrixEditProfile, profileImage)
+      .spawn(matrixEditProfile, { avatarUrl: profileImage, displayName: name })
       .run();
 
     expect(authentication.user.data.profileSummary.firstName).toEqual('John Doe');
@@ -100,7 +100,7 @@ describe('editProfile', () => {
           call(apiEditUserProfile, { name, primaryZID, profileImage: undefined }),
           { success: true },
         ],
-        [spawn(matrixEditProfile, undefined), {}],
+        [spawn(matrixEditProfile, { avatarUrl: '', displayName: name }), {}],
       ])
       .withReducer(
         rootReducer,

--- a/src/store/edit-profile/saga.ts
+++ b/src/store/edit-profile/saga.ts
@@ -41,9 +41,7 @@ export function* editProfile(action) {
       profileImage: profileImage === '' ? undefined : profileImage,
     });
     if (response.success) {
-      if (profileImage) {
-        yield spawn(matrixEditProfile, profileImage);
-      }
+      yield spawn(matrixEditProfile, { avatarUrl: profileImage, displayName: name });
 
       const localUrl = yield call(getLocalUrl, image);
       yield call(updateUserProfile, { name, profileImage: localUrl, primaryZID });

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -213,7 +213,7 @@ describe(updateUserProfileImageFromCache, () => {
           { success: false },
         ],
       ])
-      .not.spawn(matrixEditProfile, 'uploaded-image-url')
+      .not.spawn(matrixEditProfile, { avatarUrl: 'uploaded-image-url', displayName: 'Alice' })
       .run();
 
     expect(returnValue).toBeUndefined();
@@ -237,11 +237,11 @@ describe(updateUserProfileImageFromCache, () => {
           { success: true },
         ],
         [
-          spawn(matrixEditProfile, 'uploaded-image-url'),
+          spawn(matrixEditProfile, { avatarUrl: 'uploaded-image-url', displayName: 'Alice' }),
           undefined,
         ],
       ])
-      .spawn(matrixEditProfile, 'uploaded-image-url')
+      .spawn(matrixEditProfile, { avatarUrl: 'uploaded-image-url', displayName: 'Alice' })
       .run();
 
     expect(returnValue).toBe('uploaded-image-url');

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -68,7 +68,9 @@ export function* updateUserProfileImageFromCache(currentUser: User) {
       profileImage: profileImageUrl || undefined,
     });
     if (response.success) {
-      yield spawn(matrixEditProfile, profileImageUrl); // also update the profile image in the homeserver user directory
+      // also update the profile image & name in the homeserver user directory
+      yield spawn(matrixEditProfile, { avatarUrl: profileImageUrl, displayName: name });
+
       return profileImageUrl;
     } else {
       console.error('Failed to update user profile on registration:', response.error);


### PR DESCRIPTION
Mobile is using matrix's user directory to show the displayname and avatar url, instead of the ZERO API. Earlier we had the user hash, instead of the display name in the matrix user profile, this PR updates that, for a new user created, or an existing one.