### PR TITLE
feat(message-preview): add default fallback if event is not mapped to a message

### DIFF
--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -381,6 +381,14 @@ describe(getMessagePreview, () => {
 
     expect(preview).toEqual('Jack: shared a new post');
   });
+
+  it('returns a system update message if message is null', function () {
+    const state = new StoreBuilder().withCurrentUser({ id: 'current-user' }).build();
+
+    const preview = getMessagePreview(null, state);
+
+    expect(preview).toEqual('Admin: System update or change occurred');
+  });
 });
 
 describe(previewDisplayDate, () => {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -24,7 +24,7 @@ export function previewDisplayDate(timestamp: number, currentDate = moment()) {
 
 export function getMessagePreview(message: Message, state: RootState) {
   if (!message) {
-    return '';
+    return 'Admin: System update or change occurred';
   }
 
   if (message.sendStatus === MessageSendStatus.FAILED) {


### PR DESCRIPTION
### What does this do?
- add default fallback if event is not mapped to a message

### Why are we making this change?
- improves UI - fixes blank message preview

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
