### PR TITLE
[Fix] Profile avatars not showing up during global user search

### DIFF
--- a/src/components/messenger/group-management/container.test.tsx
+++ b/src/components/messenger/group-management/container.test.tsx
@@ -121,5 +121,21 @@ describe(Container, () => {
         expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canEditGroup: false }));
       });
     });
+
+    it('gets users', () => {
+      const state = new StoreBuilder()
+        .managingGroup({})
+        .withUsers({ userId: 'user-id-1', matrixId: 'matrix-id-1', firstName: 'Jack' })
+        .withUsers({ userId: 'user-id-2', matrixId: 'matrix-id-2', firstName: 'Jill' });
+
+      const users = Container.mapState(state.build()).users;
+
+      expect(users['user-id-1']).toEqual(
+        expect.objectContaining({ userId: 'user-id-1', matrixId: 'matrix-id-1', firstName: 'Jack' })
+      );
+      expect(users['user-id-2']).toEqual(
+        expect.objectContaining({ userId: 'user-id-2', matrixId: 'matrix-id-2', firstName: 'Jill' })
+      );
+    });
   });
 });

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -54,7 +54,7 @@ describe('messenger-list', () => {
       onAddLabel: () => null,
       onRemoveLabel: () => null,
       createUnencryptedConversation: () => null,
-
+      users: {},
       ...props,
     };
 
@@ -130,6 +130,19 @@ describe('messenger-list', () => {
 
     const searchResults = await wrapper.find(CreateConversationPanel).prop('search')('jac');
 
+    expect(searchResults).toStrictEqual([{ id: 'user-id', image: 'image-url', profileImage: 'image-url' }]);
+  });
+
+  it('maps local profile image to search results', async function () {
+    when(mockSearchMyNetworksByName)
+      .calledWith('jac')
+      .mockResolvedValue([{ id: 'user-id', profileImage: 'mxc://contentId' }]);
+    const wrapper = subject({
+      stage: Stage.InitiateConversation,
+      users: { 'user-id': { profileImage: 'image-url' } } as any,
+    });
+
+    const searchResults = await wrapper.find(CreateConversationPanel).prop('search')('jac');
     expect(searchResults).toStrictEqual([{ id: 'user-id', image: 'image-url', profileImage: 'image-url' }]);
   });
 


### PR DESCRIPTION
### What does this do?

Previously, profile avatars were not showing up during "global user search". This was because, for existing users, we have locally downloaded and saved the blob url, but the API was returning the mxc:// url, this PR updates the logic to map the `profileImage`/`image` key to local blob url, before displaying the search results in the frontend

<img width="302" alt="image" src="https://github.com/user-attachments/assets/09fe4a91-3914-4d92-afb3-57b1703ebe86">

