### PR TITLE
Download `thumbnails` of profile images during initial load

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -82,7 +82,11 @@ export interface IChatClient {
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
   uploadFile(file: File): Promise<string>;
   downloadFile(fileUrl: string): Promise<any>;
-  batchDownloadFiles(fileUrls: string[], batchSize: number): Promise<{ [fileUrl: string]: string }>;
+  batchDownloadFiles(
+    fileUrls: string[],
+    isThumbnail: boolean,
+    batchSize: number
+  ): Promise<{ [fileUrl: string]: string }>;
   editProfile(profileInfo: MatrixProfileInfo): Promise<void>;
   getAccessToken(): string | null;
   mxcUrlToHttp(mxcUrl: string): string;
@@ -392,9 +396,10 @@ export async function downloadFile(fileUrl: string) {
 
 export async function batchDownloadFiles(
   fileUrls: string[],
+  isThumbnail: boolean = false,
   batchSize: number = 20
 ): Promise<{ [fileUrl: string]: string }> {
-  return chat.get().matrix.batchDownloadFiles(fileUrls, batchSize);
+  return chat.get().matrix.batchDownloadFiles(fileUrls, isThumbnail, batchSize);
 }
 
 export async function editProfile(profileInfo: MatrixProfileInfo) {

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -374,11 +374,15 @@ describe('channels list saga', () => {
       return [
         [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
         [
-          call(batchDownloadFiles, [
-            'mxc://profile-image-url-1',
-            'mxc://profile-image-url-2',
-            'mxc://profile-image-url-3',
-          ]),
+          call(
+            batchDownloadFiles,
+            [
+              'mxc://profile-image-url-1',
+              'mxc://profile-image-url-2',
+              'mxc://profile-image-url-3',
+            ],
+            true
+          ),
           {
             'mxc://profile-image-url-1': 'blob://profile-image-url-1',
             'mxc://profile-image-url-2': 'blob://profile-image-url-2',


### PR DESCRIPTION
### What does this do?

Downloads the thumbnails (in batches of 20 each), instead of the actual image to improve performance
