### PR TITLE
Download profile avatar after initial load

### DIFF
--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -1,7 +1,7 @@
 import { testSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { batchDownloadFiles, chat, getRoomTags } from '../../lib/chat';
+import { chat, getRoomTags } from '../../lib/chat';
 
 import {
   fetchConversations,
@@ -370,28 +370,6 @@ describe('channels list saga', () => {
       ] as any;
     });
 
-    const getProviders = (zeroUsers) => {
-      return [
-        [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
-        [
-          call(
-            batchDownloadFiles,
-            [
-              'mxc://profile-image-url-1',
-              'mxc://profile-image-url-2',
-              'mxc://profile-image-url-3',
-            ],
-            true
-          ),
-          {
-            'mxc://profile-image-url-1': 'blob://profile-image-url-1',
-            'mxc://profile-image-url-2': 'blob://profile-image-url-2',
-            'mxc://profile-image-url-3': 'blob://profile-image-url-3',
-          },
-        ],
-      ] as any;
-    };
-
     it('calls getZEROUsers by merging all matrixIds', async () => {
       await expectSaga(mapToZeroUsers, rooms)
         .withReducer(rootReducer)
@@ -399,7 +377,7 @@ describe('channels list saga', () => {
         .run();
     });
 
-    it('creates map for zero users and downloads profile images', async () => {
+    it('creates map for zero users', async () => {
       const expectedMap = {
         'matrix-id-1': {
           userId: 'user-1',
@@ -409,7 +387,7 @@ describe('channels list saga', () => {
           lastName: 'last-1',
           primaryZID: 'primary-zid-1',
           displaySubHandle: 'primary-zid-1',
-          profileImage: 'blob://profile-image-url-1',
+          profileImage: 'mxc://profile-image-url-1',
         },
         'matrix-id-2': {
           userId: 'user-2',
@@ -419,7 +397,7 @@ describe('channels list saga', () => {
           lastName: 'last-2',
           primaryZID: 'primary-zid-2',
           displaySubHandle: 'primary-zid-2',
-          profileImage: 'blob://profile-image-url-2',
+          profileImage: 'mxc://profile-image-url-2',
         },
         'matrix-id-3': {
           userId: 'user-3',
@@ -429,13 +407,15 @@ describe('channels list saga', () => {
           lastName: 'last-3',
           primaryZID: '',
           displaySubHandle: '',
-          profileImage: 'blob://profile-image-url-3',
+          profileImage: 'mxc://profile-image-url-3',
         },
       };
 
       await expectSaga(mapToZeroUsers, rooms)
         .withReducer(rootReducer)
-        .provide(getProviders(zeroUsers))
+        .provide([
+          [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
+        ])
         .call(mapChannelMembers, rooms, expectedMap)
         .run();
     });
@@ -445,7 +425,9 @@ describe('channels list saga', () => {
 
       await expectSaga(mapToZeroUsers, rooms)
         .withReducer(rootReducer, initialState.build())
-        .provide(getProviders(zeroUsers))
+        .provide([
+          [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
+        ])
         .run();
 
       expect(rooms[0].memberHistory).toIncludeSameMembers([
@@ -455,7 +437,7 @@ describe('channels list saga', () => {
           profileId: 'profile-1',
           firstName: 'first-1',
           lastName: 'last-1',
-          profileImage: 'blob://profile-image-url-1',
+          profileImage: 'mxc://profile-image-url-1',
           primaryZID: 'primary-zid-1',
           displaySubHandle: 'primary-zid-1',
         },
@@ -465,7 +447,7 @@ describe('channels list saga', () => {
           profileId: 'profile-2',
           firstName: 'first-2',
           lastName: 'last-2',
-          profileImage: 'blob://profile-image-url-2',
+          profileImage: 'mxc://profile-image-url-2',
           primaryZID: 'primary-zid-2',
           displaySubHandle: 'primary-zid-2',
         },
@@ -478,7 +460,7 @@ describe('channels list saga', () => {
           profileId: 'profile-3',
           firstName: 'first-3',
           lastName: 'last-3',
-          profileImage: 'blob://profile-image-url-3',
+          profileImage: 'mxc://profile-image-url-3',
           primaryZID: '',
           displaySubHandle: '',
         },
@@ -496,7 +478,9 @@ describe('channels list saga', () => {
 
       await expectSaga(mapToZeroUsers, rooms)
         .withReducer(rootReducer, initialState.build())
-        .provide(getProviders(zeroUsers))
+        .provide([
+          [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
+        ])
         .run();
 
       expect(rooms[0].messages[0].sender).toStrictEqual({
@@ -504,7 +488,7 @@ describe('channels list saga', () => {
         profileId: 'profile-1',
         firstName: 'first-1',
         lastName: 'last-1',
-        profileImage: 'blob://profile-image-url-1',
+        profileImage: 'mxc://profile-image-url-1',
         primaryZID: 'primary-zid-1',
         displaySubHandle: 'primary-zid-1',
       });
@@ -513,7 +497,7 @@ describe('channels list saga', () => {
         profileId: 'profile-2',
         firstName: 'first-2',
         lastName: 'last-2',
-        profileImage: 'blob://profile-image-url-2',
+        profileImage: 'mxc://profile-image-url-2',
         primaryZID: 'primary-zid-2',
         displaySubHandle: 'primary-zid-2',
       });
@@ -522,7 +506,7 @@ describe('channels list saga', () => {
         profileId: 'profile-3',
         firstName: 'first-3',
         lastName: 'last-3',
-        profileImage: 'blob://profile-image-url-3',
+        profileImage: 'mxc://profile-image-url-3',
         primaryZID: '',
         displaySubHandle: '',
       });
@@ -536,7 +520,9 @@ describe('channels list saga', () => {
 
       await expectSaga(mapToZeroUsers, rooms)
         .withReducer(rootReducer, initialState.build())
-        .provide(getProviders(zeroUsers))
+        .provide([
+          [call(getZEROUsers, ['matrix-id-1', 'matrix-id-2', 'matrix-id-3']), zeroUsers],
+        ])
         .run();
 
       expect(rooms[0].moderatorIds).toIncludeSameMembers(['user-1', 'user-2']);


### PR DESCRIPTION
### What does this do?

To improve initial load performance, we're now downloading and rendering profile avatars after initial load is complete (and user sees the conversations on the UI)
