### PR TITLE
feat(media-messages): auto load attachement details when conversation is active

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -9,7 +9,6 @@ import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import { ContentHighlighter } from '../content-highlighter';
 import { ParentMessage } from './parent-message';
 import { IconAlertCircle } from '@zero-tech/zui/icons';
-import { IconButton } from '@zero-tech/zui/components';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator/Spinner';
 
 describe('message', () => {
@@ -87,18 +86,6 @@ describe('message', () => {
     expect(wrapper.find('.message__placeholder-container').exists()).toBe(true);
   });
 
-  it('calls loadAttachmentDetails when download icon is clicked', () => {
-    const loadAttachmentDetails = jest.fn();
-    const wrapper = subject({
-      messageId: 'test-id',
-      loadAttachmentDetails,
-      media: { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Success },
-    });
-
-    wrapper.find(IconButton).simulate('click');
-    expect(loadAttachmentDetails).toHaveBeenCalled();
-  });
-
   it('renders failed alert icon if media download status is failed', () => {
     const loadAttachmentDetails = jest.fn();
 
@@ -123,16 +110,59 @@ describe('message', () => {
     expect(wrapper).toHaveElement(Spinner);
   });
 
-  it('renders download icon if media download status is not failed or loading', () => {
+  it('calls loadAttachmentDetails if no media url', () => {
     const loadAttachmentDetails = jest.fn();
 
-    const wrapper = subject({
+    subject({ messageId: 'test-id', loadAttachmentDetails, media: { url: null, type: MediaType.Image } });
+
+    expect(loadAttachmentDetails).toHaveBeenCalled();
+  });
+
+  it('calls loadAttachmentDetails if url is a matrix media url', () => {
+    const loadAttachmentDetails = jest.fn();
+    subject({
       messageId: 'test-id',
       loadAttachmentDetails,
-      media: { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Success },
+      media: { url: 'mxc://some-test-matrix-url', type: MediaType.Image },
     });
 
-    expect(wrapper).toHaveElement(IconButton);
+    expect(loadAttachmentDetails).toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if url is defined and not a matrix media url', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({
+      messageId: 'test-id',
+      loadAttachmentDetails,
+      media: { url: 'some-test-url', type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed },
+    });
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if media download status is failed', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({
+      messageId: 'test-id',
+      loadAttachmentDetails,
+      media: { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed },
+    });
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if media download status is loading', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    subject({
+      messageId: 'test-id',
+      loadAttachmentDetails,
+      media: { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Loading },
+    });
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
   });
 
   it('calculates and applies correct dimensions for the placeholder', () => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -20,8 +20,8 @@ import { UserForMention } from '../message-input/utils';
 import EditMessageActions from './edit-message-actions/edit-message-actions';
 import { MessageMenu } from '../../platform-apps/channels/messages-menu';
 import AttachmentCards from '../../platform-apps/channels/attachment-cards';
-import { IconAlertCircle, IconDownload2 } from '@zero-tech/zui/icons';
-import { Avatar, IconButton } from '@zero-tech/zui/components';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+import { Avatar } from '@zero-tech/zui/components';
 import { ContentHighlighter } from '../content-highlighter';
 import { bemClassName } from '../../lib/bem';
 import { Blurhash } from 'react-blurhash';
@@ -173,7 +173,7 @@ export class Message extends React.Component<Properties, State> {
     return { width: finalWidth, height: finalHeight };
   };
 
-  renderPlaceholderContent(hasFailed, isLoading, blurhash, width, height, media) {
+  renderPlaceholderContent(hasFailed, isLoading, blurhash, width, height) {
     return (
       <>
         {hasFailed ? (
@@ -185,16 +185,6 @@ export class Message extends React.Component<Properties, State> {
         )}
 
         {isLoading && <Spinner {...cn('icon', 'loading')} />}
-
-        {!isLoading && !hasFailed && (
-          <IconButton
-            {...cn('icon')}
-            size={32}
-            isFilled
-            Icon={IconDownload2}
-            onClick={this.onLoadAttachmentDetails(media)}
-          />
-        )}
       </>
     );
   }
@@ -210,10 +200,14 @@ export class Message extends React.Component<Properties, State> {
       const isLoading = downloadStatus === MediaDownloadStatus.Loading;
       const hasFailed = downloadStatus === MediaDownloadStatus.Failed;
 
+      if (!hasFailed && !isLoading) {
+        this.props.loadAttachmentDetails({ media, messageId: media.id ?? this.props.messageId.toString() });
+      }
+
       return (
         <div {...cn('placeholder-container')} style={{ width, height }}>
           <div {...cn('placeholder-content')}>
-            {this.renderPlaceholderContent(hasFailed, isLoading, blurhash, width, height, media)}
+            {this.renderPlaceholderContent(hasFailed, isLoading, blurhash, width, height)}
           </div>
         </div>
       );


### PR DESCRIPTION
### What does this do?
- removes 'click to download' functionality for media in active conversation
- ensures media is auto downloaded (calls loadAttachmentDetails) when conversation is active

### Why are we making this change?
- improve UI/UX as click to download adds additional clicks for user, unnecessarily.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
