### PR TITLE
fix(matrix-client/messenger-list): unblock member join events

### DIFF
--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -377,7 +377,7 @@ export class Container extends React.Component<Properties, State> {
 
 function addLastMessageMeta(state: RootState): any {
   return (conversation) => {
-    const sortedMessages = conversation.messages.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
+    const sortedMessages = conversation.messages?.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
 
     const filteredMessages = sortedMessages.filter(
       (message) => message?.admin?.type !== AdminMessageType.MEMBER_AVATAR_CHANGED

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -38,6 +38,7 @@ import { openUserProfile } from '../../../store/user-profile';
 import { Button } from '@zero-tech/zui/components/Button';
 import { IconPlus } from '@zero-tech/zui/icons';
 import { GroupTypeDialog } from './group-details-panel/group-type-dialog';
+import { AdminMessageType } from '../../../store/messages';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -376,9 +377,15 @@ export class Container extends React.Component<Properties, State> {
 
 function addLastMessageMeta(state: RootState): any {
   return (conversation) => {
-    const sortedMessages = conversation.messages?.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
+    const sortedMessages = conversation.messages.sort((a, b) => compareDatesDesc(a.createdAt, b.createdAt)) || [];
 
-    let mostRecentMessage = sortedMessages[0] || conversation.lastMessage;
+    const filteredMessages = sortedMessages.filter(
+      (message) => message?.admin?.type !== AdminMessageType.MEMBER_AVATAR_CHANGED
+    );
+
+    // Use the most recent valid message or fall back to the lastMessage
+    let mostRecentMessage = filteredMessages[0] || conversation.lastMessage;
+
     return {
       ...conversation,
       mostRecentMessage,

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1471,14 +1471,6 @@ export class MatrixClient implements IChatClient {
       }
 
       if (membership === MembershipStateType.Join) {
-        if (
-          event.prev_content?.avatar_url !== event.content?.avatar_url ||
-          event.prev_content?.displayname !== event.content?.displayname
-        ) {
-          // Avatar or display name change, no need to publish or process a join event
-          return;
-        }
-
         const room = this.matrix.getRoom(roomId);
         if (room) {
           this.events.onUserJoinedChannel(await this.mapConversation(room));


### PR DESCRIPTION
### What does this do?
- unblocks join events 
- this also filters admin message previews

### Why are we making this change?
- issues with join events being skipped causing events to be missed

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
