### PR TITLE
feat(matrix-client): implement send emoji message reaction and get message emoji reactions

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,6 +23,7 @@ export interface RealtimeChatEvents {
   readReceiptReceived: (messageId: string, userId: string, roomId: string) => void;
   roomLabelChange: (roomId: string, labels: string[]) => void;
   postMessageReactionChange: (roomId: string, reaction: any) => void;
+  messageEmojiReactionChange: (roomId: string, reaction: any) => void;
 }
 
 export interface MatrixKeyBackupInfo {
@@ -382,8 +383,16 @@ export async function sendMeowReactionEvent(
   return chat.get().matrix.sendMeowReactionEvent(roomId, postMessageId, postOwnerId, meowAmount);
 }
 
+export async function sendEmojiReactionEvent(roomId: string, messageId: string, key: string) {
+  return chat.get().matrix.sendEmojiReactionEvent(roomId, messageId, key);
+}
+
 export async function getPostMessageReactions(roomId: string) {
   return chat.get().matrix.getPostMessageReactions(roomId);
+}
+
+export async function getMessageEmojiReactions(roomId: string) {
+  return chat.get().matrix.getMessageEmojiReactions(roomId);
 }
 
 export async function uploadFile(file: File): Promise<string> {

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -23,6 +23,7 @@ export enum Events {
   ReadReceiptReceived = 'chat/message/readReceiptReceived',
   RoomLabelChange = 'chat/channel/roomLabelChange',
   PostMessageReactionChange = 'chat/message/postMessageReactionChange',
+  MessageEmojiReactionChange = 'chat/message/messageEmojiReactionChange',
 }
 
 let theBus;
@@ -96,6 +97,8 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const roomLabelChange = (roomId, labels) => emit({ type: Events.RoomLabelChange, payload: { roomId, labels } });
     const postMessageReactionChange = (roomId, reaction) =>
       emit({ type: Events.PostMessageReactionChange, payload: { roomId, reaction } });
+    const messageEmojiReactionChange = (roomId, reaction) =>
+      emit({ type: Events.MessageEmojiReactionChange, payload: { roomId, reaction } });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -115,6 +118,7 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
       readReceiptReceived,
       roomLabelChange,
       postMessageReactionChange,
+      messageEmojiReactionChange,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -112,6 +112,7 @@ export enum SagaActionTypes {
   DeleteMessage = 'messages/saga/deleteMessage',
   EditMessage = 'messages/saga/editMessage',
   LoadAttachmentDetails = 'messages/saga/loadAttachmentDetails',
+  SendEmojiReaction = 'messages/saga/sendEmojiReaction',
 }
 
 const fetch = createAction<Payload>(SagaActionTypes.Fetch);
@@ -119,6 +120,9 @@ const send = createAction<SendPayload>(SagaActionTypes.Send);
 const deleteMessage = createAction<Payload>(SagaActionTypes.DeleteMessage);
 const editMessage = createAction<EditPayload>(SagaActionTypes.EditMessage);
 const loadAttachmentDetails = createAction<{ media: Media }>(SagaActionTypes.LoadAttachmentDetails);
+const sendEmojiReaction = createAction<{ roomId: string; messageId: string; key: string }>(
+  SagaActionTypes.SendEmojiReaction
+);
 
 const slice = createNormalizedSlice({
   name: 'messages',
@@ -126,4 +130,4 @@ const slice = createNormalizedSlice({
 
 export const { receiveNormalized, receive } = slice.actions;
 export const { normalize, denormalize, schema } = slice;
-export { fetch, send, deleteMessage, editMessage, removeAll, loadAttachmentDetails };
+export { fetch, send, deleteMessage, editMessage, removeAll, loadAttachmentDetails, sendEmojiReaction };


### PR DESCRIPTION
### What does this do?
- implements ability for sending and receiving emoji reaction events (matrix-client).

### Why are we making this change?
- to enable reactions on messages.

### How do I test this?
- run tests as usual.
- Note :: this is not yet wired up to UI.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
