### PR TITLE
up thumbnail resolution from `32 x 32` to `96 x 96` 

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -717,8 +717,8 @@ export class MatrixClient implements IChatClient {
   }
 
   mxcUrlToHttp(mxcUrl: string, isThumbnail: boolean = false): string {
-    const height = isThumbnail ? 32 : undefined;
-    const width = isThumbnail ? 32 : undefined;
+    const height = isThumbnail ? 96 : undefined;
+    const width = isThumbnail ? 96 : undefined;
     const resizeMethod = isThumbnail ? 'scale' : undefined;
 
     return this.matrix.mxcUrlToHttp(mxcUrl, width, height, resizeMethod, undefined, true, true);


### PR DESCRIPTION
### What does this do?

Before:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/32014a5b-fc3d-431b-a659-6143d00b8961">

After:
<img width="319" alt="image" src="https://github.com/user-attachments/assets/357a7d05-d968-4012-a27b-29b72d35d88a">

