### PR TITLE
fix(map-reactions/message-saga): improve mapping of reactions to messages in by handling in mapMessagesAndPreview

### DIFF
--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -53,7 +53,10 @@ describe(fetch, () => {
     const messageResponse = { hasMore: false, messages: [] };
 
     const { storeState } = await subject(fetch, { payload: { channelId: channel.id } })
-      .provide([[matchers.call.fn(chatClient.getMessagesByChannelId), messageResponse]])
+      .provide([
+        [matchers.call.fn(chatClient.getMessagesByChannelId), messageResponse],
+        [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
+      ])
       .withReducer(rootReducer, initialChannelState(channel))
       .run();
 
@@ -62,8 +65,12 @@ describe(fetch, () => {
 
   it('sets hasLoadedMessages on channel', async () => {
     const channel = { id: 'channel-id', hasLoadedMessages: false };
+    const messageResponse = { hasMore: false, messages: [] };
 
     const { storeState } = await subject(fetch, { payload: { channelId: channel.id } })
+      .provide([
+        [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
+      ])
       .withReducer(rootReducer, initialChannelState(channel))
       .run();
 
@@ -86,6 +93,7 @@ describe(fetch, () => {
       .withReducer(rootReducer, initialState as any)
       .provide([
         [call([chatClient, chatClient.getMessagesByChannelId], channel.id, referenceTimestamp), messageResponse],
+        [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
       ])
       .run();
 

--- a/src/store/messages/saga.receiveNewMessage.test.ts
+++ b/src/store/messages/saga.receiveNewMessage.test.ts
@@ -10,6 +10,7 @@ import { denormalize as denormalizeChannel } from '../channels';
 import { expectSaga, stubResponse } from '../../test/saga';
 import { markConversationAsRead } from '../channels/saga';
 import { StoreBuilder } from '../test/store';
+import { getMessageEmojiReactions } from '../../lib/chat';
 
 describe(receiveNewMessage, () => {
   function subject(...args: Parameters<typeof expectSaga>) {
@@ -29,7 +30,11 @@ describe(receiveNewMessage, () => {
     const initialState = new StoreBuilder().withConversationList({ id: channelId, messages: existingMessages });
 
     const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+      ])
       .withReducer(rootReducer, initialState.build())
+
       .run();
 
     const channel = denormalizeChannel(channelId, storeState);
@@ -45,6 +50,9 @@ describe(receiveNewMessage, () => {
       .withUsers({ userId: 'user-1', matrixId: 'matrix-id', firstName: 'the real user' });
 
     const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+      ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -60,6 +68,7 @@ describe(receiveNewMessage, () => {
 
     const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
       .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
         stubResponse(call(getPreview, 'www.google.com'), stubPreview),
       ])
       .withReducer(rootReducer, initialState.build())
@@ -67,6 +76,25 @@ describe(receiveNewMessage, () => {
 
     const channel = denormalizeChannel(channelId, storeState);
     expect(channel.messages[0].preview).toEqual(stubPreview);
+  });
+
+  it('adds the reactions to the message', async () => {
+    const channelId = 'channel-id';
+    const message = { id: 'message-id', message: 'www.google.com' };
+    const stubPreview = { id: 'simulated-preview' };
+    const stubReactions = [{ eventId: 'message-id', key: '😂' }];
+    const initialState = new StoreBuilder().withConversationList({ id: channelId });
+
+    const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), stubReactions),
+        stubResponse(call(getPreview, 'www.google.com'), stubPreview),
+      ])
+      .withReducer(rootReducer, initialState.build())
+      .run();
+
+    const channel = denormalizeChannel(channelId, storeState);
+    expect(channel.messages[0].reactions).toEqual({ '😂': 1 });
   });
 
   it('does nothing if the channel does not exist', async () => {
@@ -82,6 +110,7 @@ describe(receiveNewMessage, () => {
   it('favors the new version if message already exists', async () => {
     const channelId = 'channel-id';
     const message = { id: 'new-message', message: 'the new message' };
+
     const existingMessages = [
       { id: 'new-message', message: 'message_0001' },
       { id: 'other-message', message: 'message_0002' },
@@ -89,6 +118,9 @@ describe(receiveNewMessage, () => {
     const initialState = new StoreBuilder().withConversationList({ id: channelId, messages: existingMessages });
 
     const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+      ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -102,6 +134,9 @@ describe(receiveNewMessage, () => {
     const conversationState = new StoreBuilder().withConversationList({ id: 'channel-id' });
 
     await subject(receiveNewMessage, { payload: { channelId: 'channel-id', message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, 'channel-id'), [{}]),
+      ])
       .withReducer(rootReducer, conversationState.build())
       .not.call(markConversationAsRead, 'channel-id')
       .run();
@@ -125,6 +160,9 @@ describe(receiveNewMessage, () => {
     });
 
     const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+      ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -149,6 +187,9 @@ describe(receiveNewMessage, () => {
     });
 
     const { storeState } = await subject(receiveNewMessage, { payload: { channelId, message } })
+      .provide([
+        stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+      ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -177,6 +218,9 @@ describe(receiveNewMessage, () => {
       const initialState = new StoreBuilder().withConversationList({ id: channelId, messages: existingMessages });
 
       const { storeState } = await subject(batchedReceiveNewMessage, eventPayloads)
+        .provide([
+          stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+        ])
         .withReducer(rootReducer, initialState.build())
         .run();
 
@@ -202,6 +246,10 @@ describe(receiveNewMessage, () => {
       );
 
       const { storeState } = await subject(batchedReceiveNewMessage, eventPayloads)
+        .provide([
+          stubResponse(call(getMessageEmojiReactions, channelId1), [{}]),
+          stubResponse(call(getMessageEmojiReactions, channelId2), [{}]),
+        ])
         .withReducer(rootReducer, initialState.build())
         .run();
 
@@ -226,6 +274,9 @@ describe(receiveNewMessage, () => {
       const initialState = new StoreBuilder().withConversationList({ id: channelId, messages: existingMessages });
 
       const { storeState } = await subject(batchedReceiveNewMessage, eventPayloads)
+        .provide([
+          stubResponse(call(getMessageEmojiReactions, channelId), [{}]),
+        ])
         .withReducer(rootReducer, initialState.build())
         .run();
 

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -9,7 +9,6 @@ import {
   sendBrowserNotification,
   receiveUpdateMessage,
   replaceOptimisticMessage,
-  applyEmojiReactions,
   onMessageEmojiReactionChange,
   updateMessageEmojiReaction,
   sendEmojiReaction,
@@ -289,7 +288,7 @@ describe(receiveUpdateMessage, () => {
     const { storeState } = await expectSaga(receiveUpdateMessage, {
       payload: { channelId: 'channel-1', message: editedMessage },
     })
-      .provide([...successResponses()])
+      .provide([...successResponses(), [call(getMessageEmojiReactions, 'channel-1'), [{}]]])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -307,13 +306,43 @@ describe(receiveUpdateMessage, () => {
       payload: { channelId: 'channel-1', message: editedMessage },
     })
       .provide([
+        [call(getMessageEmojiReactions, 'channel-1'), [{}]],
         [call(getPreview, editedMessage.message), preview],
+
         ...successResponses(),
       ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
     expect(storeState.normalized.messages[message.id]).toEqual({ ...editedMessage, preview });
+  });
+
+  it('adds the reactions if they exist', async () => {
+    const message = { id: 8667728016, message: 'original message' };
+    const editedMessage = { id: 8667728016, message: 'edited message with reaction' };
+    const reactions = [
+      { eventId: 8667728016, key: '😂' },
+      { eventId: 8667728016, key: '👍' },
+    ];
+
+    const expectedReactions = {
+      '😂': 1,
+      '👍': 1,
+    };
+
+    const initialState = new StoreBuilder().withConversationList({ id: 'channel-1', messages: [message] as any });
+
+    const { storeState } = await expectSaga(receiveUpdateMessage, {
+      payload: { channelId: 'channel-1', message: editedMessage },
+    })
+      .provide([
+        [call(getMessageEmojiReactions, 'channel-1'), reactions],
+        ...successResponses(),
+      ])
+      .withReducer(rootReducer, initialState.build())
+      .run();
+
+    expect(storeState.normalized.messages[message.id]).toEqual({ ...editedMessage, reactions: expectedReactions });
   });
 
   function successResponses() {
@@ -389,91 +418,6 @@ describe(replaceOptimisticMessage, () => {
       .run();
 
     expect(returnValue[0].preview).toEqual({ url: 'example.com/old-preview' });
-  });
-});
-
-describe('applyEmojiReactions', () => {
-  it('applies emoji reactions to messages correctly', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-      { id: 'message-2', reactions: {} },
-    ] as any;
-
-    const reactions = [
-      { eventId: 'message-1', key: '😲' },
-      { eventId: 'message-1', key: '❤️' },
-      { eventId: 'message-2', key: '😂' },
-      { eventId: 'message-2', key: '❤️' },
-    ];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: { '😲': 1, '❤️': 1 } },
-      { id: 'message-2', reactions: { '😂': 1, '❤️': 1 } },
-    ]);
-  });
-
-  it('does not modify messages without reactions', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-      { id: 'message-2', reactions: {} },
-    ] as any;
-
-    const reactions = [];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: {} },
-      { id: 'message-2', reactions: {} },
-    ]);
-  });
-
-  it('accumulates reactions for the same key', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-    ] as any;
-
-    const reactions = [
-      { eventId: 'message-1', key: '❤️' },
-      { eventId: 'message-1', key: '❤️' },
-      { eventId: 'message-1', key: '😂' },
-    ];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: { '❤️': 2, '😂': 1 } },
-    ]);
-  });
-
-  it('handles reactions when there are no matching messages', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-    ] as any;
-
-    const reactions = [
-      { eventId: 'message-2', key: '❤️' },
-    ];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: {} },
-    ]);
   });
 });
 


### PR DESCRIPTION
### What does this do?
This change enhances the mapMessagesAndPreview function to include emoji reactions for each message. Specifically, it fetches reactions associated with messages in a channel and adds them to the corresponding message data, allowing reactions to be displayed properly.

### Why are we making this change?
We made this change to fix an issue where reactions were not being displayed on messages. By mapping and including reactions within the mapMessagesAndPreview function, messages now display their respective reactions, providing users with better interactivity and visibility of engagement in the chat.

### How do I test this?
- run tests as usual
- run ui > add reactions to a message > refresh and ensure reactions persist

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
