### PR TITLE
fix(message): fix colour issue on owners message bubble background on windows

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -15,17 +15,7 @@
     flex-direction: row-reverse;
 
     .message__block {
-      background: none !important;
-
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(1, 244, 203, 0.12);
-      }
+      background: rgba(6, 31, 27);
     }
 
     .message__block-body {
@@ -48,8 +38,6 @@
     }
 
     .message__block {
-      background: #111213;
-      backdrop-filter: blur(64px);
       border-radius: var(--border-owner-radius); // set in message__message-row
 
       &--edit {
@@ -77,7 +65,6 @@
 
     border-radius: var(--border-radius); // set in message__message-row
     background: #111213;
-    backdrop-filter: blur(64px);
 
     &--edit {
       width: 100%;


### PR DESCRIPTION
### What does this do?
- removes blur from message bubble backgrounds and applies solid colour background to owners message bubble.

### Why are we making this change?
- faint lines were appearing on windows for the owners message bubble background. These changes fix those.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
