### PR TITLE
fix(matrix-client/reactions/edits): add conditional event decryption to fetched events and apply reactions

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -312,7 +312,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 10px;
+    font-size: 12px;
     line-height: 14px;
   }
 }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -477,6 +477,11 @@ export class MatrixClient implements IChatClient {
       hasMore = await this.matrix.paginateEventTimeline(liveTimeline, { backwards: true, limit: 50 });
     }
 
+    const isEncrypted = room?.hasEncryptionStateEvent();
+    if (isEncrypted) {
+      await room.decryptAllEvents();
+    }
+
     const effectiveEvents = events.map((event) => event.getEffectiveEvent());
     const messages = await this.getAllChatMessagesFromRoom(effectiveEvents);
 
@@ -551,7 +556,7 @@ export class MatrixClient implements IChatClient {
     const events = room.getLiveTimeline().getEvents();
 
     const result = events
-      .filter((event) => event.getType() === MatrixConstants.REACTION)
+      .filter((event) => event.getType() === MatrixConstants.REACTION && !event?.event?.unsigned?.redacted_because)
       .map((event) => {
         const content = event.getContent();
         const relatesTo = content[MatrixConstants.RELATES_TO];

--- a/src/store/messages/saga.fetch.test.ts
+++ b/src/store/messages/saga.fetch.test.ts
@@ -53,7 +53,10 @@ describe(fetch, () => {
     const messageResponse = { hasMore: false, messages: [] };
 
     const { storeState } = await subject(fetch, { payload: { channelId: channel.id } })
-      .provide([[matchers.call.fn(chatClient.getMessagesByChannelId), messageResponse]])
+      .provide([
+        [matchers.call.fn(chatClient.getMessagesByChannelId), messageResponse],
+        [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
+      ])
       .withReducer(rootReducer, initialChannelState(channel))
       .run();
 
@@ -62,8 +65,12 @@ describe(fetch, () => {
 
   it('sets hasLoadedMessages on channel', async () => {
     const channel = { id: 'channel-id', hasLoadedMessages: false };
+    const messageResponse = { hasMore: false, messages: [] };
 
     const { storeState } = await subject(fetch, { payload: { channelId: channel.id } })
+      .provide([
+        [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
+      ])
       .withReducer(rootReducer, initialChannelState(channel))
       .run();
 
@@ -86,6 +93,7 @@ describe(fetch, () => {
       .withReducer(rootReducer, initialState as any)
       .provide([
         [call([chatClient, chatClient.getMessagesByChannelId], channel.id, referenceTimestamp), messageResponse],
+        [matchers.call.fn(mapMessagesAndPreview), messageResponse.messages],
       ])
       .run();
 

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -9,7 +9,6 @@ import {
   sendBrowserNotification,
   receiveUpdateMessage,
   replaceOptimisticMessage,
-  applyEmojiReactions,
   onMessageEmojiReactionChange,
   updateMessageEmojiReaction,
   sendEmojiReaction,
@@ -289,7 +288,7 @@ describe(receiveUpdateMessage, () => {
     const { storeState } = await expectSaga(receiveUpdateMessage, {
       payload: { channelId: 'channel-1', message: editedMessage },
     })
-      .provide([...successResponses()])
+      .provide([...successResponses(), [call(getMessageEmojiReactions, 'channel-1'), [{}]]])
       .withReducer(rootReducer, initialState.build())
       .run();
 
@@ -300,6 +299,33 @@ describe(receiveUpdateMessage, () => {
     const message = { id: 8667728016, message: 'original message' };
     const editedMessage = { id: 8667728016, message: 'edited message: www.example.com' };
     const preview = { id: 'fdf2ce2b-062e-4a83-9c27-03f36c81c0c0', type: 'link' };
+    const initialState = new StoreBuilder().withConversationList({ id: 'channel-1', messages: [message] as any });
+    const { storeState } = await expectSaga(receiveUpdateMessage, {
+      payload: { channelId: 'channel-1', message: editedMessage },
+    })
+      .provide([
+        [call(getMessageEmojiReactions, 'channel-1'), [{}]],
+        [call(getPreview, editedMessage.message), preview],
+
+        ...successResponses(),
+      ])
+      .withReducer(rootReducer, initialState.build())
+      .run();
+    expect(storeState.normalized.messages[message.id]).toEqual({ ...editedMessage, preview });
+  });
+
+  it('adds the reactions if they exist', async () => {
+    const message = { id: 8667728016, message: 'original message' };
+    const editedMessage = { id: 8667728016, message: 'edited message with reaction' };
+    const reactions = [
+      { eventId: 8667728016, key: '😂' },
+      { eventId: 8667728016, key: '👍' },
+    ];
+
+    const expectedReactions = {
+      '😂': 1,
+      '👍': 1,
+    };
 
     const initialState = new StoreBuilder().withConversationList({ id: 'channel-1', messages: [message] as any });
 
@@ -307,13 +333,13 @@ describe(receiveUpdateMessage, () => {
       payload: { channelId: 'channel-1', message: editedMessage },
     })
       .provide([
-        [call(getPreview, editedMessage.message), preview],
+        [call(getMessageEmojiReactions, 'channel-1'), reactions],
         ...successResponses(),
       ])
       .withReducer(rootReducer, initialState.build())
       .run();
 
-    expect(storeState.normalized.messages[message.id]).toEqual({ ...editedMessage, preview });
+    expect(storeState.normalized.messages[message.id]).toEqual({ ...editedMessage, reactions: expectedReactions });
   });
 
   function successResponses() {
@@ -389,91 +415,6 @@ describe(replaceOptimisticMessage, () => {
       .run();
 
     expect(returnValue[0].preview).toEqual({ url: 'example.com/old-preview' });
-  });
-});
-
-describe('applyEmojiReactions', () => {
-  it('applies emoji reactions to messages correctly', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-      { id: 'message-2', reactions: {} },
-    ] as any;
-
-    const reactions = [
-      { eventId: 'message-1', key: '😲' },
-      { eventId: 'message-1', key: '❤️' },
-      { eventId: 'message-2', key: '😂' },
-      { eventId: 'message-2', key: '❤️' },
-    ];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: { '😲': 1, '❤️': 1 } },
-      { id: 'message-2', reactions: { '😂': 1, '❤️': 1 } },
-    ]);
-  });
-
-  it('does not modify messages without reactions', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-      { id: 'message-2', reactions: {} },
-    ] as any;
-
-    const reactions = [];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: {} },
-      { id: 'message-2', reactions: {} },
-    ]);
-  });
-
-  it('accumulates reactions for the same key', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-    ] as any;
-
-    const reactions = [
-      { eventId: 'message-1', key: '❤️' },
-      { eventId: 'message-1', key: '❤️' },
-      { eventId: 'message-1', key: '😂' },
-    ];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: { '❤️': 2, '😂': 1 } },
-    ]);
-  });
-
-  it('handles reactions when there are no matching messages', async () => {
-    const roomId = 'room-id';
-    const messages = [
-      { id: 'message-1', reactions: {} },
-    ] as any;
-
-    const reactions = [
-      { eventId: 'message-2', key: '❤️' },
-    ];
-
-    await expectSaga(applyEmojiReactions, roomId, messages)
-      .provide([[call(getMessageEmojiReactions, roomId), reactions]])
-      .run();
-
-    expect(messages).toEqual([
-      { id: 'message-1', reactions: {} },
-    ]);
   });
 });
 


### PR DESCRIPTION
What does this do?
This change enhances the mapMessagesAndPreview function to include emoji reactions for each message. Specifically, it fetches reactions associated with messages in a channel and adds them to the corresponding message data, allowing reactions to be displayed properly.

This also adds a conditional event decryption for when we fetch more messages

Why are we making this change?
We made this change to fix an issue where reactions were not being displayed on messages. By mapping and including reactions within the mapMessagesAndPreview function, messages now display their respective reactions, providing users with better interactivity and visibility of engagement in the chat.
