### PR TITLE
Fix issue where displayname is not updated (via matrix sdk) upon registration

### DIFF
--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -139,7 +139,13 @@ describe(fetchCurrentUserProfileImage, () => {
     const initialState = new StoreBuilder().withCurrentUser(currentUser).withRegistration({ isFirstTimeLogin: true });
 
     await expectSaga(fetchCurrentUserProfileImage)
-      .provide([[call(updateUserProfileImageFromCache, expect.anything()), '']])
+      .provide([
+        [call(updateUserProfileImageFromCache, expect.anything()), ''],
+        [
+          spawn(matrixEditProfile, { displayName: 'Alice' }),
+          undefined,
+        ],
+      ])
       .withReducer(rootReducer, initialState.build())
       .call(updateUserProfileImageFromCache, currentUser)
       .run();
@@ -180,7 +186,7 @@ describe(fetchCurrentUserProfileImage, () => {
 });
 
 describe(updateUserProfileImageFromCache, () => {
-  it('returns undefined if no profile image is found', async () => {
+  it('updates only displayname & returns undefined if no profile image is found', async () => {
     const currentUser: any = {
       id: 'user-id-1',
       profileSummary: { firstName: 'Alice' },
@@ -189,7 +195,15 @@ describe(updateUserProfileImageFromCache, () => {
 
     mockIdb.put('profileImage', undefined);
 
-    const { returnValue } = await expectSaga(updateUserProfileImageFromCache, currentUser).run();
+    const { returnValue } = await expectSaga(updateUserProfileImageFromCache, currentUser)
+      .provide([
+        [
+          spawn(matrixEditProfile, { displayName: 'Alice' }),
+          undefined,
+        ],
+      ])
+      .spawn(matrixEditProfile, { displayName: 'Alice' })
+      .run();
 
     expect(returnValue).toBeUndefined();
   });

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -75,6 +75,9 @@ export function* updateUserProfileImageFromCache(currentUser: User) {
     } else {
       console.error('Failed to update user profile on registration:', response.error);
     }
+  } else {
+    // only update the displayname if the user hasn't uploaded a profile image during registration
+    yield spawn(matrixEditProfile, { displayName: name });
   }
 
   return undefined;


### PR DESCRIPTION
### What does this do?

Fixes the bug where the matrix user displayname was not being updated to the "actual name". This was happening in the case if the user doesn't upload a profile image upon registration. 