### PR TITLE
refactor(join-room-api): feature flag join room token gated chat api post

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -129,6 +129,14 @@ export class FeatureFlags {
   set enableMeows(value: boolean) {
     this._setBoolean('enableMeows', value);
   }
+
+  get enableTokenGatedChat() {
+    return this._getBoolean('enableTokenGatedChat', false);
+  }
+
+  set enableTokenGatedChat(value: boolean) {
+    this._setBoolean('enableTokenGatedChat', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/chat/api.ts
+++ b/src/store/chat/api.ts
@@ -1,28 +1,36 @@
 import { post } from '../../lib/api/rest';
 import { JoinRoomApiErrorCode } from './utils';
+import { featureFlags } from '../../lib/feature-flags';
 
 export async function joinRoom(aliasOrId: string): Promise<{ success: boolean; response: any; message: string }> {
-  try {
-    const response = await post('/matrix/room/join').send({
-      roomAliasORId: aliasOrId,
-    });
-    return {
-      success: true,
-      response: response.body,
-      message: 'OK',
-    };
-  } catch (error: any) {
-    if (error?.response?.status === 400) {
+  if (featureFlags.enableTokenGatedChat) {
+    try {
+      const response = await post('/matrix/room/join').send({
+        roomAliasORId: aliasOrId,
+      });
+      return {
+        success: true,
+        response: response.body,
+        message: 'OK',
+      };
+    } catch (error: any) {
+      if (error?.response?.status === 400) {
+        return {
+          success: false,
+          response: error.response.body.code,
+          message: error.response.body.message,
+        };
+      }
       return {
         success: false,
-        response: error.response.body.code,
-        message: error.response.body.message,
+        response: JoinRoomApiErrorCode.UNKNOWN_ERROR,
+        message: '',
       };
     }
-    return {
-      success: false,
-      response: JoinRoomApiErrorCode.UNKNOWN_ERROR,
-      message: '',
-    };
   }
+  return {
+    success: false,
+    response: JoinRoomApiErrorCode.ROOM_NOT_FOUND,
+    message: '',
+  };
 }


### PR DESCRIPTION
### What does this do?
- wraps the join room api post for token gated chat in a feature flag to disable for now

### Why are we making this change?
- as requested

### How do I test this?
- run tests as usual.
- run ui and attempt to access a token gated chat - this should fail.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
