### PR TITLE
fix(chat-message): update extractMentionsFromBody with optional chaining for matches to prevent unwanted error

### DIFF
--- a/src/components/notifications-feed/index.tsx
+++ b/src/components/notifications-feed/index.tsx
@@ -87,7 +87,7 @@ export class Container extends React.Component<Properties> {
   }
 
   renderError() {
-    return <div className={styles.Error}>{'this.props.error'}</div>;
+    return <div className={styles.Error}>{this.props.error}</div>;
   }
 
   render() {
@@ -103,7 +103,7 @@ export class Container extends React.Component<Properties> {
           <div className={styles.Body}>
             <ol className={styles.Notifications}>{notifications.length > 0 && this.renderNotifications()}</ol>
 
-            {notifications.length === 0 && !loading && this.renderNoNotifications()}
+            {notifications.length === 0 && !loading && !error && this.renderNoNotifications()}
             {loading && this.renderLoading()}
             {error && !loading && this.renderError()}
           </div>

--- a/src/components/notifications-feed/index.tsx
+++ b/src/components/notifications-feed/index.tsx
@@ -87,7 +87,8 @@ export class Container extends React.Component<Properties> {
   }
 
   renderError() {
-    return <div className={styles.Error}>{this.props.error}</div>;
+    const { error } = this.props;
+    return error ? <div className={styles.Error}>{error}</div> : null;
   }
 
   render() {
@@ -105,7 +106,7 @@ export class Container extends React.Component<Properties> {
 
             {notifications.length === 0 && !loading && !error && this.renderNoNotifications()}
             {loading && this.renderLoading()}
-            {error && !loading && this.renderError()}
+            {error && this.renderError()}
           </div>
         </div>
       </div>

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -154,8 +154,8 @@ export async function mapEventToNotification(event) {
     },
   };
 
-  if (type === 'm.room.message') {
-    const mentions = extractMentionsFromBody(content.body);
+  if (type === 'm.room.message' && content?.body) {
+    const mentions = content.body ? extractMentionsFromBody(content.body) : [];
     if (mentions.length > 0) {
       return {
         ...baseNotification,

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -210,7 +210,7 @@ export async function mapEventToNotification(event) {
 
 function extractMentionsFromBody(body: string) {
   const mentionRegex = /@\[.*?\]\(user:(.*?)\)/g;
-  const matches = [...body.matchAll(mentionRegex)];
+  const matches = [...body?.matchAll(mentionRegex)];
   return matches.map((match) => match[1]);
 }
 

--- a/src/store/notifications/saga.ts
+++ b/src/store/notifications/saga.ts
@@ -14,6 +14,7 @@ export function* fetchNotifications() {
 
     yield put(setNotifications(notificationsWithSenders));
   } catch (error: any) {
+    console.error('Error fetching notifications:', error);
     yield put(setError(error.message));
   } finally {
     yield put(setLoading(false));


### PR DESCRIPTION
### What does this do?
- fixes error when attempting to extract mentions from message content
- uses optional chaining

### Why are we making this change?
- prevent unwanted error

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
