### PR TITLE
refactor(notifications-feed): remove outdated meow reaction system notifications

### DIFF
--- a/src/components/notifications-feed/notification-item/utils.test.ts
+++ b/src/components/notifications-feed/notification-item/utils.test.ts
@@ -29,20 +29,7 @@ describe('Notification Feed Utils', () => {
       expect(getNotificationContent(notification)).toBe('Bob mentioned you in conversation');
     });
 
-    it('returns correct message for MEOW reaction notification', () => {
-      const notification = {
-        type: 'reaction',
-        sender: { firstName: 'Alice' },
-        content: {
-          reactionKey: 'MEOW_1',
-          amount: 100,
-        },
-      } as any;
-
-      expect(getNotificationContent(notification)).toBe('Alice reacted to your post with 100 MEOW');
-    });
-
-    it('returns correct message for non-MEOW reaction notification', () => {
+    it('returns correct message for reaction notification', () => {
       const notification = {
         type: 'reaction',
         sender: { firstName: 'Charlie' },

--- a/src/components/notifications-feed/notification-item/utils.ts
+++ b/src/components/notifications-feed/notification-item/utils.ts
@@ -10,13 +10,8 @@ export function getNotificationContent(notification: Notification): string {
       return `${senderName} sent you a direct message`;
     case 'mention':
       return `${senderName} mentioned you in conversation`;
-    case 'reaction': {
-      const isMeowReaction = notification?.content?.reactionKey?.startsWith('MEOW_');
-      if (isMeowReaction) {
-        return `${senderName} reacted to your post with ${notification.content?.amount} MEOW`;
-      }
+    case 'reaction':
       return `${senderName} reacted to your message with ${notification?.content?.reactionKey}`;
-    }
     default:
       return `${senderName} interacted with you`;
   }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -170,14 +170,12 @@ export async function mapEventToNotification(event) {
   }
 
   if (type === MatrixConstants.REACTION && !event?.unsigned?.redacted_because) {
-    const isMeowReaction = content['m.relates_to'].key.startsWith('MEOW_');
     return {
       ...baseNotification,
       type: 'reaction',
       content: {
         reactionKey: content['m.relates_to'].key,
         targetEventId: content['m.relates_to'].event_id,
-        amount: isMeowReaction ? content.amount : undefined,
       },
     };
   }


### PR DESCRIPTION
### What does this do?
- removes outdated meow reaction system notifications

### Why are we making this change?
- meows and posts are no longer handled via the matrix events system therefore they need to be re-wired for notifications app.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
