### PR TITLE
refactor(notifications-feed): filter out meow reaction events from notifications mapping

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -170,6 +170,11 @@ export async function mapEventToNotification(event) {
   }
 
   if (type === MatrixConstants.REACTION && !event?.unsigned?.redacted_because) {
+    const isMeowReaction = content['m.relates_to'].key.startsWith('MEOW_');
+    if (isMeowReaction) {
+      return null;
+    }
+
     return {
       ...baseNotification,
       type: 'reaction',


### PR DESCRIPTION
### What does this do?
- filters out meow reaction events from notifications mapping

### Why are we making this change?
- to prevent meow reactions slipping through to notifications mapping

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
