### PR TITLE
fix: `undefined` `primaryZid` handling

### DIFF
--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -90,7 +90,7 @@ export function* sendPostIrys(action) {
 
   try {
     const user = yield select(currentUserSelector());
-    const userZid = user.primaryZID.split('0://')[1];
+    const userZid = user.primaryZID?.split('0://')?.[1];
 
     // If user does not have a primary ZID
     if (!userZid || userZid.trim() === '') {


### PR DESCRIPTION
### What does this do?

- If `primaryZid` was `undefined`, it would throw `Cannot read properties of null (reading 'split')`, which is not helpful for the user.
