### PR TITLE
feat(matrix-client/notifications-saga): track read and unread notifications and attempt to enhance performance

### DIFF
--- a/src/components/notifications-feed/index.test.tsx
+++ b/src/components/notifications-feed/index.test.tsx
@@ -31,6 +31,7 @@ describe('NotificationsFeed', () => {
       error: null,
       fetchNotifications: jest.fn(),
       openNotificationConversation: jest.fn(),
+      markNotificationsAsRead: jest.fn(),
       ...props,
     };
 

--- a/src/components/notifications-feed/index.tsx
+++ b/src/components/notifications-feed/index.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
 import { Notification } from '../../store/notifications';
-import { fetchNotifications, openNotificationConversation } from '../../store/notifications';
+import { fetchNotifications, openNotificationConversation, markNotificationsAsRead } from '../../store/notifications';
 
 import { Header } from '../header';
 import { IconBell1 } from '@zero-tech/zui/icons';
 import { NotificationItem } from './notification-item';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+import { featureFlags } from '../../lib/feature-flags';
 
 import styles from './styles.module.scss';
 
@@ -20,6 +21,7 @@ export interface Properties extends PublicProperties {
 
   fetchNotifications: () => void;
   openNotificationConversation: (roomId: string) => void;
+  markNotificationsAsRead: (roomId: string) => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -39,6 +41,7 @@ export class Container extends React.Component<Properties> {
     return {
       fetchNotifications,
       openNotificationConversation,
+      markNotificationsAsRead,
     };
   }
 
@@ -47,6 +50,9 @@ export class Container extends React.Component<Properties> {
   }
 
   onNotificationClick = (roomId: string) => {
+    if (featureFlags.enableNotificationsReadStatus) {
+      this.props.markNotificationsAsRead(roomId);
+    }
     this.props.openNotificationConversation(roomId);
   };
 

--- a/src/components/notifications-feed/notification-item/index.tsx
+++ b/src/components/notifications-feed/notification-item/index.tsx
@@ -1,6 +1,8 @@
 import { Avatar } from '@zero-tech/zui/components';
 import { Notification } from '../../../store/notifications';
 import { getNotificationContent } from './utils';
+import classNames from 'classnames';
+import { featureFlags } from '../../../lib/feature-flags';
 
 import styles from './styles.module.scss';
 
@@ -14,13 +16,20 @@ export const NotificationItem = ({ notification, onClick }: NotificationProps) =
   const content = getNotificationContent(notification);
   const timestamp = new Date(notification.createdAt).toLocaleString();
 
+  const notificationClasses = classNames(styles.NotificationItem, {
+    [styles.NotificationItemUnread]: !notification.isRead,
+  });
+
   return (
-    <div className={styles.NotificationItem} onClick={() => onClick(notification.roomId)}>
+    <div className={notificationClasses} onClick={() => onClick(notification.roomId)}>
       <Avatar size='medium' imageURL={notification.sender?.profileImage} />
       <div className={styles.Content}>
-        <div className={styles.Message}>{content}</div>
-        <div className={styles.Timestamp}>{timestamp}</div>
+        <div>
+          <div className={styles.Message}>{content}</div>
+          <div className={styles.Timestamp}>{timestamp}</div>
+        </div>
       </div>
+      {featureFlags.enableNotificationsReadStatus && <div className={styles.UnreadDot} />}
     </div>
   );
 };

--- a/src/components/notifications-feed/notification-item/styles.module.scss
+++ b/src/components/notifications-feed/notification-item/styles.module.scss
@@ -1,3 +1,5 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
 .NotificationItem {
   display: flex;
   align-items: center;
@@ -5,23 +7,37 @@
   cursor: pointer;
   transition: background-color 0.2s;
 
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-  }
-
   .Content {
     margin-left: 12px;
     flex: 1;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
 
     .Message {
       font-size: 14px;
-      // color: #333;
+      flex: 1;
     }
 
     .Timestamp {
       font-size: 12px;
       color: #666;
       margin-top: 4px;
+    }
+  }
+
+  .UnreadDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: theme.$color-secondary-11;
+    flex-shrink: 0;
+    display: none;
+  }
+
+  &.NotificationItemUnread {
+    .UnreadDot {
+      display: block;
     }
   }
 }

--- a/src/components/notifications-feed/styles.module.scss
+++ b/src/components/notifications-feed/styles.module.scss
@@ -50,6 +50,10 @@
         padding: 16px 18px 16px 18px;
 
         border-bottom: 1px solid rgba(52, 56, 60, 0.75);
+
+        &:hover {
+          background-color: rgba(253, 252, 253, 0.05);
+        }
       }
     }
   }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -428,3 +428,11 @@ export function getProfileInfo(userId: string): Promise<{
 export function getNotifications(): Promise<any[]> {
   return chat.get().matrix.getNotifications();
 }
+
+export async function getNotificationReadStatus() {
+  return await chat.get().matrix.getNotificationReadStatus();
+}
+
+export async function setNotificationReadStatus(roomId: string) {
+  return await chat.get().matrix.setNotificationReadStatus(roomId);
+}

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -69,6 +69,8 @@ export class MatrixClient implements IChatClient {
   private initializationTimestamp: number;
   private secretStorageKey: string;
 
+  private readonly NOTIFICATION_READ_EVENT = 'org.zero.notifications.read';
+
   constructor(private sdk = { createClient }, private sessionStorage = new SessionStorage()) {
     this.addConnectionAwaiter();
   }
@@ -341,6 +343,34 @@ export class MatrixClient implements IChatClient {
     return await get('/api/v2/users/searchInNetworksByName', { filter, limit: 50, isMatrixEnabled: true })
       .catch((_error) => null)
       .then((response) => response?.body || []);
+  }
+
+  async getNotificationReadStatus(): Promise<Record<string, number>> {
+    await this.waitForConnection();
+    try {
+      const event = await this.matrix.getAccountData(this.NOTIFICATION_READ_EVENT);
+      return event?.getContent()?.readNotifications || {};
+    } catch (error) {
+      console.error('Error getting notification read status:', error);
+      return {};
+    }
+  }
+
+  async setNotificationReadStatus(roomId: string): Promise<void> {
+    await this.waitForConnection();
+    try {
+      const currentContent = await this.getNotificationReadStatus();
+      const updatedContent = {
+        readNotifications: {
+          ...currentContent,
+          [roomId]: Date.now(),
+        },
+      };
+
+      await this.matrix.setAccountData(this.NOTIFICATION_READ_EVENT, updatedContent);
+    } catch (error) {
+      console.error('Error setting notification read status:', error);
+    }
   }
 
   async searchMentionableUsersForChannel(channelId: string, search: string, channelMembers: UserModel[]) {
@@ -1688,6 +1718,11 @@ export class MatrixClient implements IChatClient {
     const currentUserId = this.matrix.getUserId();
     const currentUserUuid = currentUserId.split(':')[0].substring(1);
 
+    let readStatus = {};
+    if (featureFlags.enableNotificationsReadStatus) {
+      readStatus = await this.getNotificationReadStatus();
+    }
+
     const filteredEvents = events.filter((event) => {
       const relatesTo = event.content && event.content['m.relates_to'];
       const isDM = this.matrix.getRoom(event.room_id)?.getMembers().length === 2;
@@ -1718,7 +1753,14 @@ export class MatrixClient implements IChatClient {
       return isDM && event.type === 'm.room.message';
     });
 
-    const notifications = await Promise.all(filteredEvents.map((event) => mapEventToNotification(event)));
+    const notifications = await Promise.all(
+      filteredEvents.map((event) => {
+        const roomReadTimestamp = readStatus[event.room_id] || 0;
+        const isRead = featureFlags.enableNotificationsReadStatus ? event.origin_server_ts <= roomReadTimestamp : false;
+
+        return mapEventToNotification(event, isRead);
+      })
+    );
 
     return notifications.filter((notification) => notification !== null);
   }

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -142,13 +142,14 @@ export async function mapEventToPostMessage(matrixMessage, sdkMatrixClient: SDKM
   };
 }
 
-export async function mapEventToNotification(event) {
+export async function mapEventToNotification(event, isRead: boolean = false) {
   const { event_id, room_id, origin_server_ts, sender, content, type } = event;
 
   const baseNotification = {
     id: event_id,
     roomId: room_id,
     createdAt: origin_server_ts,
+    isRead,
     sender: {
       userId: sender,
     },

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -145,6 +145,14 @@ export class FeatureFlags {
   set enableNotificationsApp(value: boolean) {
     this._setBoolean('enableNotificationsApp', value);
   }
+
+  get enableNotificationsReadStatus() {
+    return this._getBoolean('enableNotificationsReadStatus', false);
+  }
+
+  set enableNotificationsReadStatus(value: boolean) {
+    this._setBoolean('enableNotificationsReadStatus', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/notifications/index.ts
+++ b/src/store/notifications/index.ts
@@ -3,6 +3,7 @@ import { createAction, createSlice } from '@reduxjs/toolkit';
 export enum SagaActionTypes {
   FetchNotifications = 'notifications/saga/fetchNotifications',
   OpenNotificationConversation = 'notifications/saga/openNotificationConversation',
+  MarkNotificationsAsRead = 'notifications/saga/markNotificationsAsRead',
 }
 
 export interface Notification {
@@ -10,6 +11,7 @@ export interface Notification {
   type: 'reply' | 'mention' | 'direct_message' | 'reaction';
   roomId: string;
   createdAt: number;
+  isRead?: boolean;
   sender?: {
     userId: string;
     firstName?: string;
@@ -38,6 +40,7 @@ export const initialState: NotificationsState = {
 
 export const fetchNotifications = createAction(SagaActionTypes.FetchNotifications);
 export const openNotificationConversation = createAction<string>(SagaActionTypes.OpenNotificationConversation);
+export const markNotificationsAsRead = createAction<string>(SagaActionTypes.MarkNotificationsAsRead);
 
 const slice = createSlice({
   name: 'notifications',
@@ -54,8 +57,24 @@ const slice = createSlice({
     setError: (state, action) => {
       state.error = action.payload;
     },
+
+    markAsRead: (state, action) => {
+      const roomId = action.payload;
+      const hasUnreadNotifications = state.items.some(
+        (notification) => notification.roomId === roomId && !notification.isRead
+      );
+
+      if (hasUnreadNotifications) {
+        state.items = state.items.map((notification) => {
+          if (notification.roomId === roomId) {
+            return { ...notification, isRead: true };
+          }
+          return notification;
+        });
+      }
+    },
   },
 });
 
-export const { setNotifications, setLoading, setError } = slice.actions;
+export const { setNotifications, setLoading, setError, markAsRead } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/notifications/saga.test.ts
+++ b/src/store/notifications/saga.test.ts
@@ -53,8 +53,10 @@ describe('notifications saga', () => {
             items: existingNotifications,
           },
         })
+        .provide([
+          [call(getNotifications), existingNotifications],
+        ])
         .put(setLoading(true))
-        .put(setNotifications(existingNotifications.slice(0, 50))) // Only first 50 notifications
         .put(setLoading(false))
         .run();
     });

--- a/src/store/notifications/saga.test.ts
+++ b/src/store/notifications/saga.test.ts
@@ -39,7 +39,7 @@ describe('notifications saga', () => {
         .run();
     });
 
-    it('uses existing notifications if they are recent and sufficient', async () => {
+    it('uses existing notifications if they are recent and they are sufficient', async () => {
       const now = Date.now();
       const existingNotifications = Array.from({ length: 51 }, (_, i) => ({
         id: `${i}`,
@@ -53,10 +53,8 @@ describe('notifications saga', () => {
             items: existingNotifications,
           },
         })
-        .provide([
-          [call(getNotifications), existingNotifications],
-        ])
         .put(setLoading(true))
+        .put(setNotifications(existingNotifications.slice(0, 50))) // Only first 50 notifications
         .put(setLoading(false))
         .run();
     });


### PR DESCRIPTION
### What does this do?
- tracks read and unread notifications and attempts to enhance performance due to number of network requests

### Why are we making this change?
- to highlight to a user which notifications are yet to be considered as read or unread

### How do I test this?
- run tests as usual
- run ui, enable feature flag for notifications read status, check notifications.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
