### PR TITLE
feat(message-menu): add download functionality to message menu

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -612,5 +612,19 @@ describe('message', () => {
       expect(messageMenuProps.canDownload).toBe(false);
       expect(messageMenuProps.isMediaMessage).toBe(false);
     });
+
+    it('disables download option for gif images', () => {
+      const wrapper = subject({
+        message: 'the message',
+        media: { url: 'https://image.com/image.gif', type: MediaType.Image, mimetype: 'image/gif' },
+      });
+
+      const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+      wrapper.simulate('contextmenu', mockEvent);
+
+      const messageMenuProps = wrapper.find(MessageMenu).props();
+      expect(messageMenuProps.canDownload).toBe(false);
+      expect(messageMenuProps.isMediaMessage).toBe(true);
+    });
   });
 });

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -584,4 +584,33 @@ describe('message', () => {
       expect(onImageClick).not.toHaveBeenCalled();
     });
   });
+
+  describe('MessageMenu', () => {
+    it('enables download option for media messages', () => {
+      const wrapper = subject({
+        message: 'the message',
+        media: { url: 'https://image.com/image.png', type: MediaType.Image },
+      });
+
+      const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+      wrapper.simulate('contextmenu', mockEvent);
+
+      const messageMenuProps = wrapper.find(MessageMenu).props();
+      expect(messageMenuProps.canDownload).toBe(true);
+      expect(messageMenuProps.isMediaMessage).toBe(true);
+    });
+
+    it('disables download option for non-media messages', () => {
+      const wrapper = subject({
+        message: 'the message',
+      });
+
+      const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+      wrapper.simulate('contextmenu', mockEvent);
+
+      const messageMenuProps = wrapper.find(MessageMenu).props();
+      expect(messageMenuProps.canDownload).toBe(false);
+      expect(messageMenuProps.isMediaMessage).toBe(false);
+    });
+  });
 });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -114,6 +114,17 @@ export class Message extends React.Component<Properties, State> {
     download(attachment.url);
   };
 
+  downloadImage = (media) => () => {
+    if (!media || !media.url) return;
+
+    const link = document.createElement('a');
+    link.href = media.url;
+    link.download = media.name || 'image';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   renderAttachment(attachment) {
     return (
       <div {...cn('attachment')} onClick={this.openAttachment.bind(this, attachment)}>
@@ -385,6 +396,10 @@ export class Message extends React.Component<Properties, State> {
     );
   };
 
+  canDownload = (): boolean => {
+    return this.props.media?.type === MediaType.Image;
+  };
+
   onInfo = () => {
     this.props.onInfo(this.props.messageId);
   };
@@ -405,10 +420,12 @@ export class Message extends React.Component<Properties, State> {
       canDelete: this.canDeleteMessage(),
       canReply: this.canReply(),
       canViewInfo: this.canViewInfo(),
+      canDownload: this.canDownload(),
       onDelete: this.deleteMessage,
       onEdit: this.toggleEdit,
       onReply: this.onReply,
       onInfo: this.onInfo,
+      onDownload: this.downloadImage(this.props.media),
       isMediaMessage: this.isMediaMessage(),
       isMenuOpen: isMessageMenuOpen,
       onOpenChange: this.handleOpenMenu,
@@ -450,10 +467,12 @@ export class Message extends React.Component<Properties, State> {
       canDelete: this.canDeleteMessage(),
       canReply: this.canReply(),
       canViewInfo: this.canViewInfo(),
+      canDownload: this.canDownload(),
       onDelete: this.deleteMessage,
       onEdit: this.toggleEdit,
       onReply: this.onReply,
       onInfo: this.onInfo,
+      onDownload: this.downloadImage(this.props.media),
       isMediaMessage: this.isMediaMessage(),
       isMenuOpen: isDropdownMenuOpen,
       onOpenChange: this.handleOpenMenu,

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -397,7 +397,7 @@ export class Message extends React.Component<Properties, State> {
   };
 
   canDownload = (): boolean => {
-    return this.props.media?.type === MediaType.Image;
+    return this.props.media?.type === MediaType.Image && this.props.media?.mimetype !== 'image/gif';
   };
 
   onInfo = () => {

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -140,4 +140,30 @@ describe('Message Menu', () => {
       expect(onInfo).toHaveBeenCalled();
     });
   });
+
+  describe('Download Button', () => {
+    it('should render when canDownload is true and onDownload is provided', () => {
+      const onDownload = jest.fn();
+      const wrapper = subject({ canDownload: true, onDownload }) as ShallowWrapper;
+
+      const dropdownMenu = wrapper.find('DropdownMenu');
+      const items = dropdownMenu.prop('items') as { id: string; onSelect: () => void }[];
+      const downloadItem = items.find((item) => item.id === 'download');
+
+      expect(downloadItem).toBeDefined();
+    });
+
+    it('should call onDownload when download button is clicked', () => {
+      const onDownload = jest.fn();
+      const wrapper = subject({ canDownload: true, onDownload }) as ShallowWrapper;
+
+      const dropdownMenu = wrapper.find('DropdownMenu');
+      const items = dropdownMenu.prop('items') as { id: string; onSelect: () => void }[];
+      const downloadItem = items.find((item) => item.id === 'download');
+
+      downloadItem.onSelect();
+
+      expect(onDownload).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -2,7 +2,14 @@ import React, { createRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { DropdownMenu } from '@zero-tech/zui/components';
-import { IconDotsHorizontal, IconEdit5, IconFlipBackward, IconInfoCircle, IconTrash4 } from '@zero-tech/zui/icons';
+import {
+  IconDotsHorizontal,
+  IconEdit5,
+  IconFlipBackward,
+  IconInfoCircle,
+  IconTrash4,
+  IconDownload2,
+} from '@zero-tech/zui/icons';
 
 import classNames from 'classnames';
 import './styles.scss';
@@ -13,6 +20,7 @@ export interface Properties {
   canDelete: boolean;
   canReply?: boolean;
   canViewInfo?: boolean;
+  canDownload?: boolean;
   isMenuOpen?: boolean;
   isMenuFlying?: boolean;
 
@@ -22,6 +30,7 @@ export interface Properties {
   onEdit?: () => void;
   onReply?: () => void;
   onInfo?: () => void;
+  onDownload?: () => void;
 }
 
 export class MessageMenu extends React.Component<Properties> {
@@ -68,6 +77,13 @@ export class MessageMenu extends React.Component<Properties> {
         id: 'info',
         label: this.renderMenuOption(<IconInfoCircle size={20} />, 'Info'),
         onSelect: this.onInfo,
+      });
+    }
+    if (this.props.onDownload && this.props.canDownload) {
+      menuItems.push({
+        id: 'download',
+        label: this.renderMenuOption(<IconDownload2 size={20} />, 'Download'),
+        onSelect: this.props.onDownload,
       });
     }
     if (this.props.onDelete && this.props.canDelete) {

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -45,6 +45,7 @@ export interface Media {
   width: number;
   downloadStatus?: MediaDownloadStatus;
   blurhash?: string;
+  mimetype?: string;
 }
 
 export interface MessagesResponse {


### PR DESCRIPTION
What does this do?
Adds the ability to download media files (images, videos, etc.) directly from the message context menu in chat conversations.

Why are we making this change?
To improve user experience by providing an easy and intuitive way for users to save media content shared in conversations without having to open the media in a new tab or use browser-specific methods.

Run UI and right click image message to test
