### PR TITLE
feat: allow click when already voted

### DIFF
--- a/src/components/messenger/feed/components/post/actions/meow/meow-action.module.scss
+++ b/src/components/messenger/feed/components/post/actions/meow/meow-action.module.scss
@@ -22,8 +22,6 @@
 }
 
 .Voted {
-  pointer-events: none;
-
   background: var(--color-secondary-6);
 
   border-radius: 4px;


### PR DESCRIPTION
### What does this do?

- Removes logic which disables `pointer-events` when user has already MEOW'd a post.

Note: this requires [API changes](https://github.com/zer0-os/zos-api/pull/130) to be merged.