### PR TITLE
feat(message-menu): add copy functionality to message menu

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -626,5 +626,30 @@ describe('message', () => {
       expect(messageMenuProps.canDownload).toBe(false);
       expect(messageMenuProps.isMediaMessage).toBe(true);
     });
+
+    it('enables copy option for media messages', () => {
+      const wrapper = subject({
+        message: 'the message',
+        media: { url: 'https://image.com/image.png', type: MediaType.Image },
+      });
+
+      const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+      wrapper.simulate('contextmenu', mockEvent);
+
+      const messageMenuProps = wrapper.find(MessageMenu).props();
+      expect(messageMenuProps.canCopy).toBe(true);
+    });
+
+    it('does not enable copy option for non-media messages', () => {
+      const wrapper = subject({
+        message: 'the message',
+      });
+
+      const mockEvent = { clientX: 100, clientY: 200, preventDefault: jest.fn() };
+      wrapper.simulate('contextmenu', mockEvent);
+
+      const messageMenuProps = wrapper.find(MessageMenu).props();
+      expect(messageMenuProps.canCopy).toBe(false);
+    });
   });
 });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -125,6 +125,22 @@ export class Message extends React.Component<Properties, State> {
     document.body.removeChild(link);
   };
 
+  copyImage = (media) => async () => {
+    if (!media?.url) return;
+
+    try {
+      const response = await fetch(media.url);
+      const blob = await response.blob();
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          [blob.type]: blob,
+        }),
+      ]);
+    } catch (err) {
+      console.error('Failed to copy image:', err);
+    }
+  };
+
   renderAttachment(attachment) {
     return (
       <div {...cn('attachment')} onClick={this.openAttachment.bind(this, attachment)}>
@@ -400,6 +416,10 @@ export class Message extends React.Component<Properties, State> {
     return this.props.media?.type === MediaType.Image && this.props.media?.mimetype !== 'image/gif';
   };
 
+  canCopy = (): boolean => {
+    return this.props.media?.type === MediaType.Image && this.props.media?.mimetype !== 'image/gif';
+  };
+
   onInfo = () => {
     this.props.onInfo(this.props.messageId);
   };
@@ -421,11 +441,13 @@ export class Message extends React.Component<Properties, State> {
       canReply: this.canReply(),
       canViewInfo: this.canViewInfo(),
       canDownload: this.canDownload(),
+      canCopy: this.canCopy(),
       onDelete: this.deleteMessage,
       onEdit: this.toggleEdit,
       onReply: this.onReply,
       onInfo: this.onInfo,
       onDownload: this.downloadImage(this.props.media),
+      onCopy: this.copyImage(this.props.media),
       isMediaMessage: this.isMediaMessage(),
       isMenuOpen: isMessageMenuOpen,
       onOpenChange: this.handleOpenMenu,
@@ -468,11 +490,13 @@ export class Message extends React.Component<Properties, State> {
       canReply: this.canReply(),
       canViewInfo: this.canViewInfo(),
       canDownload: this.canDownload(),
+      canCopy: this.canCopy(),
       onDelete: this.deleteMessage,
       onEdit: this.toggleEdit,
       onReply: this.onReply,
       onInfo: this.onInfo,
       onDownload: this.downloadImage(this.props.media),
+      onCopy: this.copyImage(this.props.media),
       isMediaMessage: this.isMediaMessage(),
       isMenuOpen: isDropdownMenuOpen,
       onOpenChange: this.handleOpenMenu,

--- a/src/platform-apps/channels/messages-menu/index.test.tsx
+++ b/src/platform-apps/channels/messages-menu/index.test.tsx
@@ -166,4 +166,30 @@ describe('Message Menu', () => {
       expect(onDownload).toHaveBeenCalled();
     });
   });
+
+  describe('Copy Button', () => {
+    it('should render when canCopy is true and onCopy is provided', () => {
+      const onCopy = jest.fn();
+      const wrapper = subject({ canCopy: true, onCopy }) as ShallowWrapper;
+
+      const dropdownMenu = wrapper.find('DropdownMenu');
+      const items = dropdownMenu.prop('items') as { id: string; onSelect: () => void }[];
+      const copyItem = items.find((item) => item.id === 'copy');
+
+      expect(copyItem).toBeDefined();
+    });
+
+    it('should call onCopy when copy button is clicked', () => {
+      const onCopy = jest.fn();
+      const wrapper = subject({ canCopy: true, onCopy }) as ShallowWrapper;
+
+      const dropdownMenu = wrapper.find('DropdownMenu');
+      const items = dropdownMenu.prop('items') as { id: string; onSelect: () => void }[];
+      const copyItem = items.find((item) => item.id === 'copy');
+
+      copyItem.onSelect();
+
+      expect(onCopy).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -9,6 +9,7 @@ import {
   IconInfoCircle,
   IconTrash4,
   IconDownload2,
+  IconCopy2,
 } from '@zero-tech/zui/icons';
 
 import classNames from 'classnames';
@@ -21,6 +22,7 @@ export interface Properties {
   canReply?: boolean;
   canViewInfo?: boolean;
   canDownload?: boolean;
+  canCopy?: boolean;
   isMenuOpen?: boolean;
   isMenuFlying?: boolean;
 
@@ -31,6 +33,7 @@ export interface Properties {
   onReply?: () => void;
   onInfo?: () => void;
   onDownload?: () => void;
+  onCopy?: () => void;
 }
 
 export class MessageMenu extends React.Component<Properties> {
@@ -84,6 +87,13 @@ export class MessageMenu extends React.Component<Properties> {
         id: 'download',
         label: this.renderMenuOption(<IconDownload2 size={20} />, 'Download'),
         onSelect: this.props.onDownload,
+      });
+    }
+    if (this.props.onCopy && this.props.canCopy) {
+      menuItems.push({
+        id: 'copy',
+        label: this.renderMenuOption(<IconCopy2 size={20} />, 'Copy'),
+        onSelect: this.props.onCopy,
       });
     }
     if (this.props.onDelete && this.props.canDelete) {


### PR DESCRIPTION
What does this do?
Adds the ability to copy media files (images, videos, etc.) directly from the message context menu in chat conversations.

Why are we making this change?
To improve user experience by providing an easy and intuitive way for users to save media content shared in conversations without having to open the media in a new tab or use browser-specific methods.

Run UI and right click image message to test

