### PR TITLE
chore: `enableLoadMore` default to `true`

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -155,7 +155,7 @@ export class FeatureFlags {
   }
 
   get enableLoadMore() {
-    return this._getBoolean('enableLoadMore', false);
+    return this._getBoolean('enableLoadMore', true);
   }
 
   set enableLoadMore(value: boolean) {


### PR DESCRIPTION
### What does this do?

- Defaults `enableLoadMore` feature flag to `true`
