### PR TITLE
feat(notifications): use room unread count to process notifications

### DIFF
--- a/src/components/app-bar/container.tsx
+++ b/src/components/app-bar/container.tsx
@@ -1,8 +1,8 @@
 import { useRouteMatch } from 'react-router-dom';
 import { AppBar as AppBarComponent } from './';
 
-export const AppBar = () => {
+export const AppBar = ({ hasUnreadNotifications }: { hasUnreadNotifications: boolean }) => {
   const match = useRouteMatch('/:app');
 
-  return <AppBarComponent activeApp={match?.params?.app ?? ''} />;
+  return <AppBarComponent activeApp={match?.params?.app ?? ''} hasUnreadNotifications={hasUnreadNotifications} />;
 };

--- a/src/components/app-bar/container.vitest.tsx
+++ b/src/components/app-bar/container.vitest.tsx
@@ -15,7 +15,7 @@ vi.mock('./', () => ({
 const renderComponent = (route: string | undefined = '/') => {
   render(
     <MemoryRouter initialEntries={[route]}>
-      <AppBar />
+      <AppBar hasUnreadNotifications={false} />
     </MemoryRouter>
   );
 };

--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -15,6 +15,7 @@ const cn = bemClassName('app-bar');
 
 export interface Properties {
   activeApp: string | undefined;
+  hasUnreadNotifications: boolean;
 }
 
 interface State {
@@ -27,6 +28,17 @@ export class AppBar extends React.Component<Properties, State> {
   openModal = () => this.setState({ isModalOpen: true });
   closeModal = () => this.setState({ isModalOpen: false });
 
+  renderNotificationIcon = () => {
+    const { hasUnreadNotifications } = this.props;
+
+    return (
+      <div {...cn('notification-icon-wrapper')}>
+        <IconBell1 size={24} />
+        {hasUnreadNotifications && <div {...cn('notification-dot')} />}
+      </div>
+    );
+  };
+
   render() {
     const { activeApp } = this.props;
     const isActive = checkActive(activeApp);
@@ -37,7 +49,12 @@ export class AppBar extends React.Component<Properties, State> {
           <AppLink Icon={IconMessageSquare2} isActive={isActive('conversation')} label='Messenger' to='/conversation' />
           <AppLink Icon={IconGlobe3} isActive={isActive('explorer')} label='Explorer' to='/explorer' />
           {featureFlags.enableNotificationsApp && (
-            <AppLink Icon={IconBell1} isActive={isActive('notifications')} label='Notifications' to='/notifications' />
+            <AppLink
+              Icon={this.renderNotificationIcon}
+              isActive={isActive('notifications')}
+              label='Notifications'
+              to='/notifications'
+            />
           )}
           <WorldPanelItem Icon={IconDotsGrid} label='More Apps' isActive={false} onClick={this.openModal} />
         </div>

--- a/src/components/app-bar/index.vitest.tsx
+++ b/src/components/app-bar/index.vitest.tsx
@@ -25,6 +25,7 @@ vi.mock('./world-panel-item', () => ({
 
 const DEFAULT_PROPS: Properties = {
   activeApp: undefined,
+  hasUnreadNotifications: false,
 };
 
 const renderComponent = (props: Partial<Properties>) => {

--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -15,4 +15,18 @@
   pointer-events: all;
 
   @include main-background;
+
+  &__notification-icon-wrapper {
+    position: relative;
+  }
+
+  &__notification-dot {
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: theme.$color-secondary-11;
+  }
 }

--- a/src/components/notifications-feed/notification-item/styles.module.scss
+++ b/src/components/notifications-feed/notification-item/styles.module.scss
@@ -18,11 +18,6 @@
       font-size: 14px;
       flex: 1;
     }
-    .Timestamp {
-      font-size: 12px;
-      color: #666;
-      margin-top: 4px;
-    }
   }
 
   .UnreadDot {
@@ -31,12 +26,6 @@
     border-radius: 50%;
     background-color: theme.$color-secondary-11;
     flex-shrink: 0;
-    display: none;
-  }
-
-  &.NotificationItemUnread {
-    .UnreadDot {
-      display: block;
-    }
+    display: block;
   }
 }

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -18,6 +18,7 @@ import { rootReducer } from '../reducer';
 import { ConversationStatus, DefaultRoomLabels, denormalize as denormalizeChannel } from '../channels';
 import { StoreBuilder } from '../test/store';
 import { addRoomToLabel, chat, removeRoomFromLabel, sendTypingEvent } from '../../lib/chat';
+import { getHistory } from '../../lib/browser';
 
 const userId = 'user-id';
 
@@ -52,6 +53,13 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), mockChatClient],
           [matchers.call.fn(mockChatClient.markRoomAsRead), 200],
+          [
+            matchers.call.fn(getHistory),
+            {
+              push: jest.fn(),
+              location: { pathname: '/conversation/channel-id' },
+            },
+          ],
         ])
         .withReducer(rootReducer, state)
         .call(markAllMessagesAsRead, channelId, userId)
@@ -69,6 +77,13 @@ describe('channels list saga', () => {
         .provide([
           [matchers.call.fn(chat.get), mockChatClient],
           [matchers.call.fn(mockChatClient.markRoomAsRead), 200],
+          [
+            matchers.call.fn(getHistory),
+            {
+              push: jest.fn(),
+              location: { pathname: '/conversation/channel-id' },
+            },
+          ],
         ])
         .withReducer(rootReducer, state)
         .not.call(markAllMessagesAsRead, channelId, userId)


### PR DESCRIPTION
### What does this do?
- uses room unread count to process notifications
- refactors notification items and feed to align with unread count functionality

### Why are we making this change?
- better performance and simpler solution for notifications app

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
