### PR TITLE
feat(notifications): implement room unread highlight tracking and wire up to notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,14 @@ import { denormalizeConversations } from './store/channels-list';
 import { DefaultRoomLabels } from './store/channels';
 
 export const App = () => {
-  const { isAuthenticated, mainClassName, videoBackgroundSrc, wrapperClassName, hasUnreadNotifications } = useAppMain();
+  const {
+    isAuthenticated,
+    mainClassName,
+    videoBackgroundSrc,
+    wrapperClassName,
+    hasUnreadNotifications,
+    hasUnreadHighlights,
+  } = useAppMain();
 
   return (
     // See: ZOS-115
@@ -25,7 +32,7 @@ export const App = () => {
             {videoBackgroundSrc && <VideoBackground src={videoBackgroundSrc} />}
             <div className={wrapperClassName}>
               <DialogManager />
-              <AppBar hasUnreadNotifications={hasUnreadNotifications} />
+              <AppBar hasUnreadNotifications={hasUnreadNotifications} hasUnreadHighlights={hasUnreadHighlights} />
               <AppRouter />
             </div>
           </>
@@ -44,7 +51,17 @@ const useAppMain = () => {
     const conversations = denormalizeConversations(state);
     return conversations.some(
       (channel) =>
-        channel.unreadCount > 0 &&
+        channel.unreadCount?.total > 0 &&
+        !channel.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
+        !channel.labels?.includes(DefaultRoomLabels.MUTE)
+    );
+  });
+
+  const hasUnreadHighlights = useSelector((state: RootState) => {
+    const conversations = denormalizeConversations(state);
+    return conversations.some(
+      (channel) =>
+        channel.unreadCount?.highlight > 0 &&
         !channel.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
         !channel.labels?.includes(DefaultRoomLabels.MUTE)
     );
@@ -64,6 +81,7 @@ const useAppMain = () => {
     videoBackgroundSrc,
     wrapperClassName,
     hasUnreadNotifications,
+    hasUnreadHighlights,
   };
 };
 

--- a/src/components/app-bar/container.tsx
+++ b/src/components/app-bar/container.tsx
@@ -1,8 +1,20 @@
 import { useRouteMatch } from 'react-router-dom';
 import { AppBar as AppBarComponent } from './';
 
-export const AppBar = ({ hasUnreadNotifications }: { hasUnreadNotifications: boolean }) => {
+export const AppBar = ({
+  hasUnreadNotifications,
+  hasUnreadHighlights,
+}: {
+  hasUnreadNotifications: boolean;
+  hasUnreadHighlights: boolean;
+}) => {
   const match = useRouteMatch('/:app');
 
-  return <AppBarComponent activeApp={match?.params?.app ?? ''} hasUnreadNotifications={hasUnreadNotifications} />;
+  return (
+    <AppBarComponent
+      activeApp={match?.params?.app ?? ''}
+      hasUnreadNotifications={hasUnreadNotifications}
+      hasUnreadHighlights={hasUnreadHighlights}
+    />
+  );
 };

--- a/src/components/app-bar/container.vitest.tsx
+++ b/src/components/app-bar/container.vitest.tsx
@@ -15,7 +15,7 @@ vi.mock('./', () => ({
 const renderComponent = (route: string | undefined = '/') => {
   render(
     <MemoryRouter initialEntries={[route]}>
-      <AppBar hasUnreadNotifications={false} />
+      <AppBar hasUnreadNotifications={false} hasUnreadHighlights={false} />
     </MemoryRouter>
   );
 };

--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -16,6 +16,7 @@ const cn = bemClassName('app-bar');
 export interface Properties {
   activeApp: string | undefined;
   hasUnreadNotifications: boolean;
+  hasUnreadHighlights: boolean;
 }
 
 interface State {
@@ -29,12 +30,13 @@ export class AppBar extends React.Component<Properties, State> {
   closeModal = () => this.setState({ isModalOpen: false });
 
   renderNotificationIcon = () => {
-    const { hasUnreadNotifications } = this.props;
+    const { hasUnreadNotifications, hasUnreadHighlights } = this.props;
 
     return (
       <div {...cn('notification-icon-wrapper')}>
-        <IconBell1 size={24} />
-        {hasUnreadNotifications && <div {...cn('notification-dot')} />}
+        <IconBell1 size={24} {...cn('notification-icon', hasUnreadHighlights && 'highlight')} />
+        {hasUnreadNotifications && !hasUnreadHighlights && <div {...cn('notification-dot')} />}
+        {hasUnreadHighlights && <div {...cn('highlight-dot')} />}
       </div>
     );
   };

--- a/src/components/app-bar/index.vitest.tsx
+++ b/src/components/app-bar/index.vitest.tsx
@@ -26,6 +26,7 @@ vi.mock('./world-panel-item', () => ({
 const DEFAULT_PROPS: Properties = {
   activeApp: undefined,
   hasUnreadNotifications: false,
+  hasUnreadHighlights: false,
 };
 
 const renderComponent = (props: Partial<Properties>) => {

--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -20,6 +20,12 @@
     position: relative;
   }
 
+  &__notification-icon {
+    &--highlight {
+      color: rgba(255 132 49);
+    }
+  }
+
   &__notification-dot {
     position: absolute;
     top: -2px;
@@ -28,5 +34,15 @@
     height: 8px;
     border-radius: 50%;
     background-color: theme.$color-secondary-11;
+  }
+
+  &__highlight-dot {
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: rgba(255 132 49);
   }
 }

--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -135,6 +135,28 @@
     letter-spacing: 0.32px;
   }
 
+  &__unread-highlight {
+    @include glass-state-default-color;
+    @include glass-glow-highlight-small;
+    @include glass-materials-raised;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 0;
+    flex-shrink: 0;
+    color: rgba(255 132 49);
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    text-align: center;
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 11px;
+    margin-left: 3px;
+    letter-spacing: 0.32px;
+  }
+
   &__content {
     display: flex;
     align-items: center;

--- a/src/components/messenger/list/conversation-item/index.test.tsx
+++ b/src/components/messenger/list/conversation-item/index.test.tsx
@@ -92,27 +92,39 @@ describe(ConversationItem, () => {
 
   it('does not show unread count if there are no unread messages', function () {
     const wrapper = subject({
-      conversation: { id: 'id', unreadCount: 0, otherMembers: [] } as any,
+      conversation: { id: 'id', unreadCount: { total: 0, highlight: 0 }, otherMembers: [] } as any,
     });
 
     expect(wrapper).not.toHaveElement(c('unread-count'));
   });
 
   it('shows unread message count', function () {
-    const wrapper = subject({ conversation: { id: 'id', unreadCount: 7, otherMembers: [] } as any });
+    const wrapper = subject({
+      conversation: { id: 'id', unreadCount: { total: 7, highlight: 0 }, otherMembers: [] } as any,
+    });
 
     expect(wrapper.find(c('unread-count'))).toHaveText('7');
   });
 
   it('renders the message preview', function () {
-    const wrapper = subject({ conversation: { messagePreview: 'I said something here', otherMembers: [] } as any });
+    const wrapper = subject({
+      conversation: {
+        messagePreview: 'I said something here',
+        otherMembers: [],
+        unreadCount: { total: 0, highlight: 0 },
+      } as any,
+    });
 
     expect(wrapper.find(ContentHighlighter)).toHaveProp('message', 'I said something here');
   });
 
   it('renders the otherMembersTyping', function () {
     const wrapper = subject({
-      conversation: { otherMembersTyping: ['Johnny'], otherMembers: [] } as any,
+      conversation: {
+        otherMembersTyping: ['Johnny'],
+        otherMembers: [],
+        unreadCount: { total: 0, highlight: 0 },
+      } as any,
     });
 
     expect(wrapper.find(ContentHighlighter)).toHaveProp('message', 'Johnny is typing...');
@@ -124,6 +136,7 @@ describe(ConversationItem, () => {
         messagePreview: 'I said something here',
         otherMembersTyping: ['Dale', 'Dom'],
         otherMembers: [],
+        unreadCount: { total: 0, highlight: 0 },
       } as any,
     });
 
@@ -131,7 +144,13 @@ describe(ConversationItem, () => {
   });
 
   it('renders the previewDisplayDate', function () {
-    const wrapper = subject({ conversation: { previewDisplayDate: 'Aug 1, 2021', otherMembers: [] } as any });
+    const wrapper = subject({
+      conversation: {
+        previewDisplayDate: 'Aug 1, 2021',
+        otherMembers: [],
+        unreadCount: { total: 0, highlight: 0 },
+      } as any,
+    });
 
     expect(wrapper.find(c('timestamp'))).toHaveText('Aug 1, 2021');
   });
@@ -145,5 +164,6 @@ function convoWith(...otherMembers): any {
   return {
     id: 'convo-id',
     otherMembers,
+    unreadCount: { total: 0, highlight: 0 },
   };
 }

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -122,7 +122,8 @@ export class ConversationItem extends React.Component<Properties, State> {
   render() {
     const { conversation, activeConversationId } = this.props;
     const { previewDisplayDate, otherMembersTyping } = conversation;
-    const hasUnreadMessages = conversation.unreadCount !== 0;
+    const hasUnreadMessages = conversation.unreadCount.total !== 0;
+    const hasUnreadHighlights = conversation.unreadCount.highlight !== 0;
     const isUnread = hasUnreadMessages ? 'true' : 'false';
     const isActive = conversation.id === activeConversationId ? 'true' : 'false';
     const isTyping = (otherMembersTyping || []).length > 0 ? 'true' : 'false';
@@ -161,7 +162,10 @@ export class ConversationItem extends React.Component<Properties, State> {
               <div {...cn('message')} is-unread={isUnread} is-typing={isTyping}>
                 <ContentHighlighter message={this.getMessagePreview()} variant='negative' tabIndex={-1} />
               </div>
-              {hasUnreadMessages && <div {...cn('unread-count')}>{conversation.unreadCount}</div>}
+              {hasUnreadMessages && !hasUnreadHighlights && (
+                <div {...cn('unread-count')}>{conversation.unreadCount.total}</div>
+              )}
+              {hasUnreadHighlights && <div {...cn('unread-highlight')}>{conversation.unreadCount.highlight}</div>}
             </div>
           </div>
         )}

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -33,6 +33,7 @@ describe('ConversationListPanel', () => {
         {
           id: 'test-conversation-id',
           otherMembers: [],
+          unreadCount: { total: 0, highlight: 0 },
         } as any,
       ],
     });
@@ -44,9 +45,24 @@ describe('ConversationListPanel', () => {
 
   it('renders filtered conversation list', function () {
     const conversations = [
-      { id: 'convo-id-1', name: 'convo-1', otherMembers: [{ firstName: 'jack', primaryZID: '0://world.jack' }] },
-      { id: 'convo-id-2', name: 'convo-2', otherMembers: [{ firstName: 'bob', primaryZID: 'world.bob' }] },
-      { id: 'convo-id-3', name: 'convo-3', otherMembers: [{ firstName: 'jacklyn' }] },
+      {
+        id: 'convo-id-1',
+        name: 'convo-1',
+        otherMembers: [{ firstName: 'jack', primaryZID: '0://world.jack' }],
+        unreadCount: { total: 0, highlight: 0 },
+      },
+      {
+        id: 'convo-id-2',
+        name: 'convo-2',
+        otherMembers: [{ firstName: 'bob', primaryZID: 'world.bob' }],
+        unreadCount: { total: 0, highlight: 0 },
+      },
+      {
+        id: 'convo-id-3',
+        name: 'convo-3',
+        otherMembers: [{ firstName: 'jacklyn' }],
+        unreadCount: { total: 0, highlight: 0 },
+      },
     ];
 
     const wrapper = subject({ conversations: conversations as any });
@@ -69,10 +85,14 @@ describe('ConversationListPanel', () => {
 
   it('renders conversations based on selected tab', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1' }),
-      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.WORK] }),
-      stubConversation({ name: 'convo-3', labels: [DefaultRoomLabels.WORK] }),
-      stubConversation({ name: 'convo-4', labels: [DefaultRoomLabels.FAMILY] }),
+      stubConversation({ name: 'convo-1', unreadCount: { total: 0, highlight: 0 } }),
+      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.WORK], unreadCount: { total: 0, highlight: 0 } }),
+      stubConversation({ name: 'convo-3', labels: [DefaultRoomLabels.WORK], unreadCount: { total: 0, highlight: 0 } }),
+      stubConversation({
+        name: 'convo-4',
+        labels: [DefaultRoomLabels.FAMILY],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -93,8 +113,12 @@ describe('ConversationListPanel', () => {
 
   it('renders Favorites tab first', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE], unreadCount: 0 }),
-      stubConversation({ name: 'convo-2', unreadCount: 0 }),
+      stubConversation({
+        name: 'convo-1',
+        labels: [DefaultRoomLabels.FAVORITE],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
+      stubConversation({ name: 'convo-2', unreadCount: { total: 0, highlight: 0 } }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -105,8 +129,16 @@ describe('ConversationListPanel', () => {
 
   it('sets selectedTab to Favorites if there are favorite and non-archived conversations', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE] }),
-      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.FAVORITE, DefaultRoomLabels.ARCHIVED] }),
+      stubConversation({
+        name: 'convo-1',
+        labels: [DefaultRoomLabels.FAVORITE],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
+      stubConversation({
+        name: 'convo-2',
+        labels: [DefaultRoomLabels.FAVORITE, DefaultRoomLabels.ARCHIVED],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -115,8 +147,12 @@ describe('ConversationListPanel', () => {
 
   it('sets selectedTab to All if there are no favorite and non-archived conversations', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1' }),
-      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.ARCHIVED] }),
+      stubConversation({ name: 'convo-1', unreadCount: { total: 0, highlight: 0 } }),
+      stubConversation({
+        name: 'convo-2',
+        labels: [DefaultRoomLabels.ARCHIVED],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -124,7 +160,7 @@ describe('ConversationListPanel', () => {
   });
 
   it('renders default state when label list is empty', function () {
-    const conversations = [stubConversation({ name: 'convo-1' })];
+    const conversations = [stubConversation({ name: 'convo-1', unreadCount: { total: 0, highlight: 0 } })];
     const wrapper = subject({ conversations: conversations as any });
 
     selectTab(wrapper, 'Work');
@@ -133,7 +169,13 @@ describe('ConversationListPanel', () => {
   });
 
   it('does not render default state when label list is empty', function () {
-    const conversations = [stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.FAVORITE] })];
+    const conversations = [
+      stubConversation({
+        name: 'convo-1',
+        labels: [DefaultRoomLabels.FAVORITE],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
+    ];
     const wrapper = subject({ conversations: conversations as any });
 
     selectTab(wrapper, 'All');
@@ -143,11 +185,19 @@ describe('ConversationListPanel', () => {
 
   it('renders tab unread counts', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', unreadCount: 3 }),
-      stubConversation({ name: 'convo-2', unreadCount: 11, labels: [DefaultRoomLabels.FAMILY] }),
-      stubConversation({ name: 'convo-3', unreadCount: 17, labels: [DefaultRoomLabels.FAMILY] }),
-      stubConversation({ name: 'convo-4', unreadCount: 7 }),
-      stubConversation({ name: 'convo-5', unreadCount: 13, labels: [DefaultRoomLabels.WORK] }),
+      stubConversation({ name: 'convo-1', unreadCount: { total: 3, highlight: 0 } }),
+      stubConversation({
+        name: 'convo-2',
+        unreadCount: { total: 11, highlight: 0 },
+        labels: [DefaultRoomLabels.FAMILY],
+      }),
+      stubConversation({
+        name: 'convo-3',
+        unreadCount: { total: 17, highlight: 0 },
+        labels: [DefaultRoomLabels.FAMILY],
+      }),
+      stubConversation({ name: 'convo-4', unreadCount: { total: 7, highlight: 0 } }),
+      stubConversation({ name: 'convo-5', unreadCount: { total: 13, highlight: 0 }, labels: [DefaultRoomLabels.WORK] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -163,8 +213,8 @@ describe('ConversationListPanel', () => {
 
   it('does not render unread count if count is zero', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', unreadCount: 0 }),
-      stubConversation({ name: 'convo-2', unreadCount: 0, labels: [DefaultRoomLabels.WORK] }),
+      stubConversation({ name: 'convo-1', unreadCount: { total: 0, highlight: 0 } }),
+      stubConversation({ name: 'convo-2', unreadCount: { total: 0, highlight: 0 }, labels: [DefaultRoomLabels.WORK] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -174,10 +224,10 @@ describe('ConversationListPanel', () => {
 
   it('does not render unread count if count if conversation is archived', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', unreadCount: 3 }),
+      stubConversation({ name: 'convo-1', unreadCount: { total: 3, highlight: 0 } }),
       stubConversation({
         name: 'convo-2',
-        unreadCount: 5,
+        unreadCount: { total: 5, highlight: 0 },
         labels: [DefaultRoomLabels.ARCHIVED, DefaultRoomLabels.WORK],
       }),
     ];
@@ -192,7 +242,11 @@ describe('ConversationListPanel', () => {
 
   it('does not render unread count for archived label', function () {
     const conversations = [
-      stubConversation({ name: 'convo-2', unreadCount: 5, labels: [DefaultRoomLabels.ARCHIVED] }),
+      stubConversation({
+        name: 'convo-2',
+        unreadCount: { total: 5, highlight: 0 },
+        labels: [DefaultRoomLabels.ARCHIVED],
+      }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -202,9 +256,13 @@ describe('ConversationListPanel', () => {
 
   it('does not include archived conversations in All unread count total', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', unreadCount: 3 }),
-      stubConversation({ name: 'convo-2', unreadCount: 5, labels: [DefaultRoomLabels.ARCHIVED] }),
-      stubConversation({ name: 'convo-3', unreadCount: 2, labels: [DefaultRoomLabels.WORK] }),
+      stubConversation({ name: 'convo-1', unreadCount: { total: 3, highlight: 0 } }),
+      stubConversation({
+        name: 'convo-2',
+        unreadCount: { total: 5, highlight: 0 },
+        labels: [DefaultRoomLabels.ARCHIVED],
+      }),
+      stubConversation({ name: 'convo-3', unreadCount: { total: 2, highlight: 0 }, labels: [DefaultRoomLabels.WORK] }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -217,8 +275,12 @@ describe('ConversationListPanel', () => {
 
   it('renders conversations in the archived tab', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.ARCHIVED] }),
-      stubConversation({ name: 'convo-2' }),
+      stubConversation({
+        name: 'convo-1',
+        labels: [DefaultRoomLabels.ARCHIVED],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
+      stubConversation({ name: 'convo-2', unreadCount: { total: 0, highlight: 0 } }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -228,8 +290,12 @@ describe('ConversationListPanel', () => {
 
   it('does not render archived conversations in other tabs', function () {
     const conversations = [
-      stubConversation({ name: 'convo-1', labels: [DefaultRoomLabels.ARCHIVED, DefaultRoomLabels.WORK] }),
-      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.WORK] }),
+      stubConversation({
+        name: 'convo-1',
+        labels: [DefaultRoomLabels.ARCHIVED, DefaultRoomLabels.WORK],
+        unreadCount: { total: 0, highlight: 0 },
+      }),
+      stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.WORK], unreadCount: { total: 0, highlight: 0 } }),
     ];
     const wrapper = subject({ conversations: conversations as any });
 
@@ -242,8 +308,8 @@ describe('ConversationListPanel', () => {
 
   it('renders conversation group names as well in the filtered conversation list', function () {
     const conversations = [
-      { id: 'convo-id-1', name: '', otherMembers: [{ firstName: 'test' }] },
-      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }] },
+      { id: 'convo-id-1', name: '', otherMembers: [{ firstName: 'test' }], unreadCount: { total: 0, highlight: 0 } },
+      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }], unreadCount: { total: 0, highlight: 0 } },
       {
         id: 'convo-id-3',
         name: 'Test Group',
@@ -251,6 +317,7 @@ describe('ConversationListPanel', () => {
           { firstName: 'name-1' },
           { firstName: 'name-2' },
         ],
+        unreadCount: { total: 0, highlight: 0 },
       },
       {
         id: 'convo-id-4',
@@ -259,6 +326,7 @@ describe('ConversationListPanel', () => {
           { firstName: 'name-1' },
           { firstName: 'name-2' },
         ],
+        unreadCount: { total: 0, highlight: 0 },
       },
     ];
 
@@ -295,16 +363,19 @@ describe('ConversationListPanel', () => {
         id: 'convo-id-1',
         name: 'convo-1',
         otherMembers: [{ firstName: 'jack', primaryZID: '0://world.iamjack' }],
+        unreadCount: { total: 0, highlight: 0 },
       },
       {
         id: 'convo-id-2',
         name: 'convo-2',
         otherMembers: [{ firstName: 'bob', primaryZID: '0://world.bob' }],
+        unreadCount: { total: 0, highlight: 0 },
       },
       {
         id: 'convo-id-3',
         name: 'convo-3',
         otherMembers: [{ firstName: 'jacklyn', primaryZID: '0://world.jacklyn' }],
+        unreadCount: { total: 0, highlight: 0 },
       },
       {
         id: 'convo-id-4',
@@ -313,6 +384,7 @@ describe('ConversationListPanel', () => {
           { firstName: 'user1', primaryZID: '0://world.user1' },
           { firstName: 'user2' },
         ],
+        unreadCount: { total: 0, highlight: 0 },
       },
       {
         id: 'convo-id-5',
@@ -321,6 +393,7 @@ describe('ConversationListPanel', () => {
           { firstName: 'user1', primaryZID: '0://world.user1' },
           { firstName: 'user2', primaryZID: '0://world.user2' },
         ],
+        unreadCount: { total: 0, highlight: 0 },
       },
     ];
 
@@ -383,9 +456,17 @@ describe('ConversationListPanel', () => {
 
     it('filters archived conversations', () => {
       const archivedConversations = [
-        stubConversation({ name: 'convo-1', labels: [] }),
-        stubConversation({ name: 'convo-2', labels: [DefaultRoomLabels.ARCHIVED] }),
-        stubConversation({ name: 'convo-3', labels: [DefaultRoomLabels.ARCHIVED] }),
+        stubConversation({ name: 'convo-1', unreadCount: { total: 0, highlight: 0 } }),
+        stubConversation({
+          name: 'convo-2',
+          labels: [DefaultRoomLabels.ARCHIVED],
+          unreadCount: { total: 0, highlight: 0 },
+        }),
+        stubConversation({
+          name: 'convo-3',
+          labels: [DefaultRoomLabels.ARCHIVED],
+          unreadCount: { total: 0, highlight: 0 },
+        }),
       ];
       const wrapper = subject({ conversations: archivedConversations as any });
 
@@ -398,7 +479,7 @@ describe('ConversationListPanel', () => {
   it('selecting an existing conversation announces click event', async function () {
     const onConversationClick = jest.fn();
     const conversations = [
-      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }] },
+      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }], unreadCount: { total: 0, highlight: 0 } },
     ] as any;
     const wrapper = subject({ conversations, onConversationClick });
 
@@ -412,8 +493,8 @@ describe('ConversationListPanel', () => {
   it('selecting an existing conversation clears the filtered state', async function () {
     const onConversationClick = jest.fn();
     const conversations = [
-      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }] },
-      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'jack' }] },
+      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'bob' }], unreadCount: { total: 0, highlight: 0 } },
+      { id: 'convo-id-2', name: '', otherMembers: [{ firstName: 'jack' }], unreadCount: { total: 0, highlight: 0 } },
     ] as any;
     const wrapper = subject({ conversations, onConversationClick });
 

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -182,7 +182,7 @@ export class ConversationListPanel extends React.Component<Properties, State> {
   getUnreadCount(conversations: Channel[]) {
     const count = conversations
       .filter((c) => !c.labels?.includes(DefaultRoomLabels.ARCHIVED))
-      .reduce((acc, c) => acc + c.unreadCount, 0);
+      .reduce((acc, c) => acc + c.unreadCount.total, 0);
     return count < 99 ? count : '99+';
   }
 

--- a/src/components/notifications-feed/index.test.tsx
+++ b/src/components/notifications-feed/index.test.tsx
@@ -9,13 +9,13 @@ describe('NotificationsFeed', () => {
   const mockConversations: Channel[] = [
     {
       id: 'channel-1',
-      unreadCount: 3,
+      unreadCount: { total: 3, highlight: 0 },
       name: 'Conversation 1',
       lastMessage: { content: 'Hello' },
     },
     {
       id: 'channel-2',
-      unreadCount: 1,
+      unreadCount: { total: 1, highlight: 0 },
       name: 'Conversation 2',
       lastMessage: { content: 'Hi there' },
     },

--- a/src/components/notifications-feed/index.tsx
+++ b/src/components/notifications-feed/index.tsx
@@ -28,7 +28,7 @@ export class Container extends React.Component<Properties> {
 
     const conversations = denormalizeConversations(state).filter(
       (conversation) =>
-        conversation.unreadCount > 0 &&
+        (conversation.unreadCount.total > 0 || conversation.unreadCount?.highlight > 0) &&
         !conversation.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
         !conversation.labels?.includes(DefaultRoomLabels.MUTE)
     );
@@ -60,11 +60,27 @@ export class Container extends React.Component<Properties> {
   renderNotifications() {
     const { conversations } = this.props;
 
-    return conversations.map((conversation) => (
-      <li key={conversation.id}>
-        <NotificationItem conversation={conversation} onClick={this.onNotificationClick} />
-      </li>
-    ));
+    return conversations.flatMap((conversation) => {
+      const notifications = [];
+
+      if (conversation.unreadCount?.total > 0) {
+        notifications.push(
+          <li key={`${conversation.id}-total`}>
+            <NotificationItem conversation={conversation} onClick={this.onNotificationClick} type='total' />
+          </li>
+        );
+      }
+
+      if (conversation.unreadCount?.highlight > 0) {
+        notifications.push(
+          <li key={`${conversation.id}-highlight`}>
+            <NotificationItem conversation={conversation} onClick={this.onNotificationClick} type='highlight' />
+          </li>
+        );
+      }
+
+      return notifications;
+    });
   }
 
   renderNoNotifications() {

--- a/src/components/notifications-feed/notification-item/index.tsx
+++ b/src/components/notifications-feed/notification-item/index.tsx
@@ -5,11 +5,11 @@ import styles from './styles.module.scss';
 
 export interface NotificationProps {
   conversation: Channel;
-
   onClick: (roomId: string) => void;
+  type: 'total' | 'highlight';
 }
 
-export const NotificationItem = ({ conversation, onClick }: NotificationProps) => {
+export const NotificationItem = ({ conversation, onClick, type }: NotificationProps) => {
   const getName = () => {
     return conversation.name || otherMembersToString(conversation.otherMembers);
   };
@@ -24,27 +24,21 @@ export const NotificationItem = ({ conversation, onClick }: NotificationProps) =
     return undefined;
   };
 
-  const notificationMessage = getNotificationMessage(conversation.unreadCount, getName(), conversation.isOneOnOne);
+  const count = type === 'total' ? conversation.unreadCount.total : conversation.unreadCount.highlight;
+  const text = type === 'total' ? 'message' : 'highlight';
+  const notificationText = count === 1 ? text : `${text}s`;
+
+  const message = conversation.isOneOnOne
+    ? `${count} unread ${notificationText} in your conversation with ${getName()}`
+    : `${count} unread ${notificationText} in the ${getName()} channel`;
 
   return (
     <div className={styles.NotificationItem} onClick={() => onClick(conversation.id)}>
       <Avatar size='regular' imageURL={getAvatarUrl()} isGroup={!conversation.isOneOnOne} />
       <div className={styles.Content}>
-        <div>
-          <div className={styles.Message}>{notificationMessage}</div>
-        </div>
+        <div className={styles.Message}>{message}</div>
       </div>
-      <div className={styles.UnreadDot} />
+      <div className={type === 'highlight' ? styles.UnreadDotHighlight : styles.UnreadDot} />
     </div>
   );
-};
-
-const getNotificationMessage = (unreadCount: number, roomName: string, isOneOnOne: boolean) => {
-  const notificationText = unreadCount === 1 ? 'notification' : 'notifications';
-
-  if (isOneOnOne) {
-    return `${unreadCount} unread ${notificationText} in your conversation with ${roomName}`;
-  }
-
-  return `${unreadCount} unread ${notificationText} in the ${roomName} channel`;
 };

--- a/src/components/notifications-feed/notification-item/styles.module.scss
+++ b/src/components/notifications-feed/notification-item/styles.module.scss
@@ -28,4 +28,13 @@
     flex-shrink: 0;
     display: block;
   }
+
+  .UnreadDotHighlight {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: rgba(255 132 49);
+    flex-shrink: 0;
+    display: block;
+  }
 }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -9,7 +9,7 @@ export interface RealtimeChatEvents {
   receiveNewMessage: (channelId: string, message: Message) => void;
   receiveDeleteMessage: (roomId: string, messageId: string) => void;
   onMessageUpdated: (channelId: string, message: Message) => void;
-  receiveUnreadCount: (channelId: string, unreadCount: number) => void;
+  receiveUnreadCount: (channelId: string, unreadCount: { total: number; highlight: number }) => void;
   onUserJoinedChannel: (conversation) => void;
   onUserLeft: (channelId: string, userId: string) => void;
   onRoomNameChanged: (channelId: string, name: string) => void;

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1290,7 +1290,10 @@ export class MatrixClient implements IChatClient {
 
   private handleUnreadNotifications = (roomId, unreadNotifications) => {
     if (unreadNotifications) {
-      this.events.receiveUnreadCount(roomId, unreadNotifications?.total || 0);
+      this.events.receiveUnreadCount(roomId, {
+        total: unreadNotifications?.total || 0,
+        highlight: unreadNotifications?.highlight || 0,
+      });
     }
   };
 
@@ -1564,6 +1567,7 @@ export class MatrixClient implements IChatClient {
     featureFlags.enableTimerLogs && console.timeEnd(`xxxgetUpToLatestUserMessageFromRoom${room.roomId}`);
 
     const unreadCount = room.getUnreadNotificationCount(NotificationCountType.Total);
+    const highlightCount = room.getUnreadNotificationCount(NotificationCountType.Highlight);
 
     const [admins, mods] = this.getRoomAdminsAndMods(room);
     const isSocialChannel = groupType === 'social';
@@ -1579,7 +1583,7 @@ export class MatrixClient implements IChatClient {
       memberHistory: memberHistory,
       lastMessage: null,
       messages,
-      unreadCount,
+      unreadCount: { total: unreadCount, highlight: highlightCount },
       createdAt,
       conversationStatus: ConversationStatus.CREATED,
       adminMatrixIds: admins,

--- a/src/store/channels-list/utils.test.ts
+++ b/src/store/channels-list/utils.test.ts
@@ -7,7 +7,7 @@ describe(toLocalChannel, () => {
       id: 'channel-id',
       name: 'channel-name',
       icon: 'channel-icon',
-      unreadCount: 'unread-count',
+      unreadCount: { total: 1, highlight: 0 },
       createdAt: 1000003,
     };
 

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -55,7 +55,7 @@ export interface Channel {
   hasMorePosts?: boolean;
   createdAt: number;
   lastMessage: Message;
-  unreadCount?: number;
+  unreadCount?: { total: number; highlight: number };
   icon?: string;
   isOneOnOne: boolean;
   hasLoadedMessages: boolean;
@@ -79,7 +79,7 @@ export const CHANNEL_DEFAULTS = {
   hasMorePosts: true,
   createdAt: 0,
   lastMessage: null,
-  unreadCount: 0,
+  unreadCount: { total: 0, highlight: 0 },
   icon: '',
   isOneOnOne: true,
   hasLoadedMessages: false,

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -35,7 +35,7 @@ export function* markAllMessagesAsRead(channelId, userId) {
   const chatClient = yield call(chat.get);
   try {
     yield call([chatClient, chatClient.markRoomAsRead], channelId, userId);
-    yield call(receiveChannel, { id: channelId, unreadCount: 0 });
+    yield call(receiveChannel, { id: channelId, unreadCount: { total: 0, highlight: 0 } });
   } catch (error) {}
 }
 
@@ -48,7 +48,10 @@ export function* markConversationAsRead(conversationId) {
   const history = yield call(getHistory);
   const isMessengerAppActive = history.location.pathname.startsWith('/conversation/');
 
-  if (conversationInfo?.unreadCount > 0 && isMessengerAppActive) {
+  if (
+    (conversationInfo?.unreadCount?.total > 0 || conversationInfo?.unreadCount?.highlight > 0) &&
+    isMessengerAppActive
+  ) {
     yield call(markAllMessagesAsRead, conversationId, currentUser.id);
   }
 }
@@ -74,7 +77,10 @@ export function* openConversation(conversationId) {
 }
 
 export function* unreadCountUpdated(action) {
-  const { channelId, unreadCount } = action.payload;
+  const {
+    channelId,
+    unreadCount: { total, highlight },
+  } = action.payload;
 
   const channel = yield select(rawChannelSelector(channelId));
 
@@ -82,7 +88,7 @@ export function* unreadCountUpdated(action) {
     return;
   }
 
-  yield call(receiveChannel, { id: channelId, unreadCount: unreadCount });
+  yield call(receiveChannel, { id: channelId, unreadCount: { total, highlight } });
 }
 
 export function* onReply(reply: ParentMessage) {

--- a/src/store/channels/types.ts
+++ b/src/store/channels/types.ts
@@ -5,5 +5,5 @@ export interface MarkAsReadPayload {
 
 export interface UnreadCountUpdatedPayload {
   channelId: string;
-  unreadCount: number;
+  unreadCount: { total: number; highlight: number };
 }

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -77,7 +77,10 @@ export function createChatConnection(userId, chatAccessToken, chatClient: Chat) 
     const receiveDeleteMessage = (channelId, messageId) =>
       emit({ type: Events.MessageDeleted, payload: { channelId, messageId } });
     const receiveUnreadCount = (channelId, unreadCount) =>
-      emit({ type: Events.UnreadCountChanged, payload: { channelId, unreadCount } });
+      emit({
+        type: Events.UnreadCountChanged,
+        payload: { channelId, unreadCount: { total: unreadCount.total, highlight: unreadCount.highlight } },
+      });
     const onUserLeft = (channelId, userId) => emit({ type: Events.UserLeftChannel, payload: { channelId, userId } });
     const onUserJoinedChannel = (channel) => emit({ type: Events.UserJoinedChannel, payload: { channel } });
     const onRoomNameChanged = (roomId, name) => emit({ type: Events.RoomNameChanged, payload: { id: roomId, name } });


### PR DESCRIPTION
### What does this do?
- implements room unread highlight tracking and wires up to notifications feed/items

### Why are we making this change?
- to be able to determine if an unread count is total or a highlight 

### How do I test this?
- run tests as usual
- run ui and create some unread notifications between users 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
