### PR TITLE
fix(posts-saga): remove receiveChannel from reset function to prevent interference with message state

### DIFF
--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -294,13 +294,7 @@ function* refetchPosts(action) {
   yield put({ type: SagaActionTypes.FetchPosts, payload: { channelId } });
 }
 
-function* reset(action) {
-  yield call(receiveChannel, {
-    id: action.payload.conversationId,
-    // messages: [],
-    hasMorePosts: true,
-    hasLoadedMessages: false,
-  });
+function* reset(_action) {
   yield put(setError(undefined));
   yield put(setIsSubmitting(false));
   yield put(setInitialCount(undefined));


### PR DESCRIPTION
### What does this do?
- removes receiveChannel from reset function

### Why are we making this change?
- to prevent interference with message state when opening conversations. this was causing messages to be removed from local state and then refetched, which had a significant impact on performance. refetching is not required.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
