### PR TITLE
refactor(posts-saga): implement start polling function and conditions to stop polling when polling channel is no longer active

### DIFF
--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -22,6 +22,7 @@ import { userByMatrixIdSelector } from '../users/selectors';
 import { rawChannel } from './selectors';
 import cloneDeep from 'lodash/cloneDeep';
 import { getHistory } from '../../lib/browser';
+import { startPollingPosts } from '../posts/saga';
 
 export const rawChannelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}']`, null);
@@ -74,6 +75,7 @@ export function* openConversation(conversationId) {
   yield call(setActiveConversation, conversationId);
   yield spawn(markConversationAsRead, conversationId);
   yield call(resetConversationManagement);
+  yield call(startPollingPosts, conversationId);
 }
 
 export function* unreadCountUpdated(action) {

--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -275,7 +275,19 @@ function* pollPosts(action) {
     } else {
       yield put(setCount(count));
     }
-    yield delay(5000);
+
+    const activeConversationId = yield select((state) => state.chat.activeConversationId);
+    // Only continue polling if we're still in the same conversation
+    if (activeConversationId === channelId) {
+      yield delay(5000);
+      yield put({ type: SagaActionTypes.PollPosts, payload: { channelId } });
+    }
+  }
+}
+
+export function* startPollingPosts(channelId: string) {
+  const channel = yield select(rawChannelSelector(channelId));
+  if (channel?.conversationStatus === ConversationStatus.CREATED) {
     yield put({ type: SagaActionTypes.PollPosts, payload: { channelId } });
   }
 }


### PR DESCRIPTION
### What does this do?
- implements start polling function and adds conditions to stop polling when polling channel is no longer active

### Why are we making this change?
- performance optimisations

### How do I test this?
- run tests as usual
- run UI and check polling starts/stops if social channel is active

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
