### PR TITLE
feat(message/parent-message): scroll and highlight parent message when clicking reply

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -176,6 +176,22 @@ export class Message extends React.Component<Properties, State> {
     }
   };
 
+  scrollToMessage = (messageId: string) => {
+    const messageElement = document.querySelector(`[data-message-id="${messageId}"]`);
+    const messageBlock = messageElement?.querySelector('.message__block');
+    if (messageBlock) {
+      messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      messageBlock.classList.add('message__block--parent-message-highlight');
+      setTimeout(() => {
+        messageBlock.classList.remove('message__block--parent-message-highlight');
+      }, 3000);
+    }
+  };
+
+  onParentMessageClick = (messageId: string) => {
+    this.scrollToMessage(messageId);
+  };
+
   renderAttachment(attachment) {
     return (
       <div {...cn('attachment')} onClick={this.openAttachment.bind(this, attachment)}>
@@ -639,6 +655,8 @@ export class Message extends React.Component<Properties, State> {
         senderLastName={this.props.parentSenderLastName}
         mediaUrl={this.props.parentMessageMediaUrl}
         mediaName={this.props.parentMessageMediaName}
+        messageId={this.props.parentMessageId}
+        onMessageClick={this.onParentMessageClick}
       />
     );
   }
@@ -652,6 +670,7 @@ export class Message extends React.Component<Properties, State> {
         })}
         onContextMenu={this.handleContextMenu}
         ref={this.wrapperRef}
+        data-message-id={this.props.messageId}
       >
         {this.props.showSenderAvatar && (
           <div {...cn('left')}>

--- a/src/components/message/parent-message/index.test.tsx
+++ b/src/components/message/parent-message/index.test.tsx
@@ -16,6 +16,8 @@ describe(ParentMessage, () => {
       senderLastName: '',
       mediaUrl: '',
       mediaName: '',
+      messageId: 'message-id',
+      onMessageClick: () => {},
 
       ...props,
     };
@@ -63,5 +65,13 @@ describe(ParentMessage, () => {
     const wrapper = subject({ senderIsCurrentUser: true, senderFirstName: 'Jackie', senderLastName: 'Chan' });
 
     expect(wrapper.find(c('header'))).toHaveText('You');
+  });
+
+  it('calls onMessageClick when the parent message is clicked', function () {
+    const onMessageClick = jest.fn();
+    const wrapper = subject({ messageId: 'message-id', onMessageClick });
+
+    wrapper.simulate('click');
+    expect(onMessageClick).toHaveBeenCalledWith('message-id');
   });
 });

--- a/src/components/message/parent-message/index.tsx
+++ b/src/components/message/parent-message/index.tsx
@@ -15,9 +15,17 @@ export interface Properties {
   senderLastName: string;
   mediaUrl: string;
   mediaName: string;
+  messageId: string;
+  onMessageClick: (messageId: string) => void;
 }
 
 export class ParentMessage extends React.PureComponent<Properties> {
+  onClick = () => {
+    if (this.props.messageId) {
+      this.props.onMessageClick(this.props.messageId);
+    }
+  };
+
   get name() {
     if (this.props.senderIsCurrentUser) {
       return 'You';
@@ -32,7 +40,7 @@ export class ParentMessage extends React.PureComponent<Properties> {
     }
 
     return (
-      <div {...cn('')}>
+      <div {...cn('')} onClick={this.onClick} role='button' tabIndex={0}>
         <div {...cn('parent-message')}>
           <IconCornerDownRight size={16} />
 

--- a/src/components/message/parent-message/styles.scss
+++ b/src/components/message/parent-message/styles.scss
@@ -5,6 +5,7 @@
 .parent-message-container {
   display: flex;
   padding: 8px 8px 0px 8px;
+  cursor: pointer;
 
   &__parent-message {
     display: flex;

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -73,6 +73,11 @@
     &--reply {
       min-width: 300px;
     }
+
+    &--parent-message-highlight {
+      animation: background-highlight 7s ease-in-out forwards;
+      transform-origin: center;
+    }
   }
 
   &__block-body {
@@ -314,5 +319,12 @@
     justify-content: center;
     font-size: 12px;
     line-height: 14px;
+  }
+}
+
+@keyframes background-highlight {
+  from,
+  to {
+    background-color: theme.$color-greyscale-4;
   }
 }


### PR DESCRIPTION
### What does this do?
- This feature scrolls to and temporarily highlights a parent message when clicking on its quoted reply in a chat conversation.

### Why are we making this change?
- To improve user experience by making it easier to find and reference the original message that was replied to, providing better context in threaded conversations.

### How do I test this?
- run tests as usual.
- run UI and click the parent message on a reply

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
