### PR TITLE
refactor(chat-view-waypoint): adjust position of waypoint for earlier message fetching when scrolling

### DIFF
--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -83,7 +83,7 @@
 .chat-view__infinite-scroll-waypoint {
   overflow-anchor: none;
   position: relative;
-  top: 700px;
+  top: 2000px;
 }
 
 .chat-skeleton {


### PR DESCRIPTION
### What does this do?
- adjusts the position of the waypoint entry in the chat view

### Why are we making this change?
- to begin fetching messages earlier when backwards scrolling through message history.
- attempt to make the scroll experience smoother

### How do I test this?
- run tests as usual.
- run ui and backwards scroll

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
