### PR TITLE
feat(media-video): add send and receive video message support

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -188,7 +188,7 @@ describe('MessageInput', () => {
     const mimeTypes = {
       'image/*': [],
       // 'text/*': [],
-      // 'video/*': [],
+      'video/*': [],
       // 'application/pdf': [],
       // 'application/zip': [],
       // 'application/msword': [],

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -100,7 +100,7 @@ export class MessageInput extends React.Component<Properties, State> {
     return {
       'image/*': [],
       // 'text/*': [],
-      // 'video/*': [],
+      'video/*': [],
       // 'application/pdf': [],
       // 'application/zip': [],
       // 'application/msword': [],
@@ -278,6 +278,7 @@ export class MessageInput extends React.Component<Properties, State> {
               mediaUrl={reply?.media?.url}
               mediaName={reply?.media?.name}
               onRemove={this.props.onRemoveReply}
+              mediaType={reply?.media?.type}
             />
           )}
         </div>

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -657,6 +657,7 @@ export class Message extends React.Component<Properties, State> {
         mediaName={this.props.parentMessageMediaName}
         messageId={this.props.parentMessageId}
         onMessageClick={this.onParentMessageClick}
+        mediaType={this.props.parentMessageMedia?.type}
       />
     );
   }

--- a/src/components/message/parent-message/index.test.tsx
+++ b/src/components/message/parent-message/index.test.tsx
@@ -16,6 +16,7 @@ describe(ParentMessage, () => {
       senderLastName: '',
       mediaUrl: '',
       mediaName: '',
+      mediaType: '',
       messageId: 'message-id',
       onMessageClick: () => {},
 
@@ -37,10 +38,16 @@ describe(ParentMessage, () => {
     expect(wrapper).not.toHaveElement(ContentHighlighter);
   });
 
-  it('renders media when media url is present', function () {
-    const wrapper = subject({ mediaName: 'test-media-name', mediaUrl: 'test-media-url' });
+  it('renders video when media type is video and url is present', function () {
+    const wrapper = subject({ mediaName: 'test-media-name', mediaUrl: 'test-media-url', mediaType: 'video' });
 
-    expect(wrapper).toHaveElement(c('media-container'));
+    expect(wrapper.find('video')).toHaveProp('src', 'test-media-url');
+  });
+
+  it('renders image when media type is image and url is present', function () {
+    const wrapper = subject({ mediaName: 'test-media-name', mediaUrl: 'test-media-url', mediaType: 'image' });
+
+    expect(wrapper.find('img')).toHaveProp('src', 'test-media-url');
   });
 
   it('does not render media when media url is NOT present', function () {

--- a/src/components/message/parent-message/index.tsx
+++ b/src/components/message/parent-message/index.tsx
@@ -16,6 +16,7 @@ export interface Properties {
   mediaUrl: string;
   mediaName: string;
   messageId: string;
+  mediaType: string;
   onMessageClick: (messageId: string) => void;
 }
 
@@ -46,7 +47,14 @@ export class ParentMessage extends React.PureComponent<Properties> {
 
           {this.props?.mediaName && (
             <div {...cn('media-container')}>
-              {this.props?.mediaUrl && <img {...cn('media')} src={this.props?.mediaUrl} alt={this.props?.mediaName} />}
+              {this.props?.mediaUrl && this.props?.mediaType === 'image' && (
+                <img {...cn('media')} src={this.props?.mediaUrl} alt={this.props?.mediaName} />
+              )}
+
+              {this.props?.mediaUrl && this.props?.mediaType === 'video' && (
+                <video {...cn('media')} src={this.props?.mediaUrl} />
+              )}
+
               {!this.props.mediaUrl && <div {...cn('image-placeholder')} />}
             </div>
           )}

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -125,11 +125,19 @@
   }
 
   &__block-video {
+    position: relative;
+    cursor: pointer;
+    width: 100%;
+
     video {
-      min-height: 186px;
-      width: 100%;
-      border-radius: 8px;
+      display: block;
+      margin: auto;
+      max-width: 100%;
+      max-height: 640px;
+      animation: fadein 1s ease-in forwards;
     }
+
+    animation: fadein 1s ease-in forwards;
   }
 
   &__block-edit {

--- a/src/components/reply-card/reply-card.test.tsx
+++ b/src/components/reply-card/reply-card.test.tsx
@@ -19,6 +19,7 @@ describe('ReplyCard', () => {
       senderLastName: '',
       mediaName: '',
       mediaUrl: '',
+      mediaType: '',
       onRemove: jest.fn(),
       ...props,
     };
@@ -38,10 +39,16 @@ describe('ReplyCard', () => {
     expect(wrapper).not.toHaveElement(ContentHighlighter);
   });
 
-  it('renders media when media url is present', function () {
-    const wrapper = subject({ mediaName: 'test-media-name', mediaUrl: 'test-media-url' });
+  it('renders video when media type is video and url is present', function () {
+    const wrapper = subject({ mediaName: 'test-video.mp4', mediaUrl: 'test-video-url', mediaType: 'video' });
 
-    expect(wrapper).toHaveElement(c('media-container'));
+    expect(wrapper.find('video')).toHaveProp('src', 'test-video-url');
+  });
+
+  it('renders image when media type is image and url is present', function () {
+    const wrapper = subject({ mediaName: 'test-image.jpg', mediaUrl: 'test-image-url', mediaType: 'image' });
+
+    expect(wrapper.find('img')).toHaveProp('src', 'test-image-url');
   });
 
   it('does not render media when media url is NOT present', function () {

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -37,7 +37,6 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
 
   render() {
     const { message } = this.props;
-    console.log('XXXX', this.props.mediaType);
 
     return (
       <div {...cn()}>

--- a/src/components/reply-card/reply-card.tsx
+++ b/src/components/reply-card/reply-card.tsx
@@ -15,6 +15,7 @@ export interface Properties {
   senderLastName: string;
   mediaUrl: string;
   mediaName: string;
+  mediaType: string;
 
   onRemove?: () => void;
 }
@@ -36,14 +37,21 @@ export default class ReplyCard extends React.Component<Properties, undefined> {
 
   render() {
     const { message } = this.props;
+    console.log('XXXX', this.props.mediaType);
 
     return (
       <div {...cn()}>
         <IconCornerDownRight size={16} />
 
-        {this.props.mediaUrl && (
+        {this.props.mediaUrl && this.props.mediaType === 'image' && (
           <div {...cn('media-container')}>
             <img {...cn('media')} src={this.props.mediaUrl} alt={this.props.mediaName} />
+          </div>
+        )}
+
+        {this.props.mediaUrl && this.props.mediaType === 'video' && (
+          <div {...cn('media-container')}>
+            <video {...cn('media')} src={this.props.mediaUrl} />
           </div>
         )}
 

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -4,12 +4,12 @@ import { AdminMessageType, Message, MessageSendStatus } from '../../../store/mes
 import { getObjectDiff, parsePlainBody } from './utils';
 import { PowerLevels } from '../types';
 
-async function parseMediaData(matrixMessage) {
+export async function parseMediaData(matrixMessage) {
   const { content } = matrixMessage;
 
   let media = null;
   try {
-    if (content?.msgtype === MsgType.Image) {
+    if (content?.msgtype === MsgType.Image || content?.msgtype === MsgType.Video) {
       media = await buildMediaObject(content);
     }
   } catch (e) {
@@ -23,18 +23,20 @@ async function parseMediaData(matrixMessage) {
   };
 }
 
-async function buildMediaObject(content) {
+export async function buildMediaObject(content) {
+  const mediaType = content.msgtype === MsgType.Image ? 'image' : 'video';
+
   if (content.file && content.info) {
     return {
       url: null,
-      type: 'image',
+      type: mediaType,
       file: { ...content.file },
       ...content.info,
     };
   } else if (content.url) {
     return {
       url: content.url,
-      type: 'image',
+      type: mediaType,
       ...content.info,
     };
   }
@@ -54,7 +56,7 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
 
   return {
     id: event_id,
-    message: content.msgtype === 'm.image' ? '' : messageContent,
+    message: content.msgtype === MsgType.Image || content.msgtype === MsgType.Video ? '' : messageContent,
     createdAt: origin_server_ts,
     updatedAt: updatedAt,
     sender: {


### PR DESCRIPTION
### What does this do?
- Adds support for uploading and displaying video messages in chat.

### Why are we making this change?
- To provide a better user experience introducing functionality to share video content similar to how we handle images.

### How do I test this?
- run tests as usual.
- run UI and send video file.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
