### PR TITLE
feat(notifications-app): add tabs and filter notifications

### DIFF
--- a/src/components/notifications-feed/styles.module.scss
+++ b/src/components/notifications-feed/styles.module.scss
@@ -89,4 +89,28 @@
     padding: 24px;
     border-bottom: 1px solid rgba(52, 56, 60, 0.75);
   }
+
+  .TabContainer {
+    border-bottom: 1px solid rgb(52, 56, 60);
+  }
+
+  .ToggleGroup {
+    background-color: transparent;
+
+    & > button {
+      font-size: 14px;
+      background-color: transparent;
+      padding: 16px;
+      border-radius: 0 !important;
+
+      &:hover {
+        background-color: rgba(253, 252, 253, 0.05);
+      }
+
+      &[data-state='on'] {
+        background-color: rgba(253, 252, 253, 0.05);
+        color: theme.$color-secondary-11;
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What does this do?
- adds tabs and filter notifications

### Why are we making this change?
- to be able to switch between All, Highlights, Muted notifications

### How do I test this?
- run tests as usual
- run ui and check notifications app

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
