### PR TITLE
chore: `enableComments` flag default to `true`

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -163,7 +163,7 @@ export class FeatureFlags {
   }
 
   get enableComments() {
-    return this._getBoolean('enableComments', false);
+    return this._getBoolean('enableComments', true);
   }
 
   set enableComments(value: boolean) {


### PR DESCRIPTION
# What does this do?

- Sets `enableComments` feature flag to `true`.
- It doesn't remove the feature flag in case we need to disable comments at some point in the near future.