### PR TITLE
refactor(reactions): add stop propagation and error logs to reaction selection

### DIFF
--- a/src/components/reaction-menu/index.tsx
+++ b/src/components/reaction-menu/index.tsx
@@ -70,13 +70,20 @@ export class ReactionMenu extends React.Component<Properties, State> {
   };
 
   onSelect = (emojiId) => {
-    if (this.state.isProcessing) return;
+    console.log('Reaction clicked:', emojiId);
+    if (this.state.isProcessing) {
+      console.log('Processing state prevented click');
+      return;
+    }
 
     this.setState({ isProcessing: true }, async () => {
+      console.log('Starting reaction processing');
       try {
         const emojiCharacter = commonEmojiMapping[emojiId];
         if (emojiCharacter) {
+          console.log('Sending reaction:', emojiCharacter);
           await this.props.onSelectReaction(emojiCharacter);
+          console.log('Reaction sent successfully');
           this.setState(
             {
               isReactionTrayOpen: false,
@@ -87,7 +94,10 @@ export class ReactionMenu extends React.Component<Properties, State> {
             }
           );
         }
+      } catch (error) {
+        console.error('Error processing reaction:', error);
       } finally {
+        console.log('Finishing reaction processing');
         this.setState({ isProcessing: false });
       }
     });
@@ -118,7 +128,14 @@ export class ReactionMenu extends React.Component<Properties, State> {
     ];
 
     return commonReactions.map((emojiId) => (
-      <span className='reaction-tray-item' key={emojiId} onClick={() => this.onSelect(emojiId)}>
+      <span
+        className='reaction-tray-item'
+        key={emojiId}
+        onClick={(e) => {
+          e.stopPropagation(); // Stop event from reaching the underlay
+          this.onSelect(emojiId);
+        }}
+      >
         <Emoji emoji={emojiId} size={20} />
       </span>
     ));
@@ -157,7 +174,10 @@ export class ReactionMenu extends React.Component<Properties, State> {
               className='emoji-picker-trigger-icon'
               Icon={IconDotsHorizontal}
               size={20}
-              onClick={this.toggleEmojiPicker}
+              onClick={(e) => {
+                e.stopPropagation();
+                this.toggleEmojiPicker();
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
### What does this do?
Adds debug logging to track the reaction click flow and ensures click events don't bubble up to parent elements by using stopPropagation() in the reaction menu click handlers.

### Why are we making this change?
To diagnose why reaction clicks sometimes fail to register (requiring page refresh) by tracking the execution flow through console logs, while preventing potential event bubbling issues that could cause clicks to be intercepted by parent elements before reaching their intended handlers.

### How do I test this?
- run tests as usual
- run ui and use reactions

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
