### PR TITLE
refactor(conversation-item): remove prefix for one on one conversations

### DIFF
--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -49,7 +49,6 @@ export class AppBar extends React.Component<Properties, State> {
       <>
         <div {...cn('')}>
           <AppLink Icon={IconMessageSquare2} isActive={isActive('conversation')} label='Messenger' to='/conversation' />
-          <AppLink Icon={IconGlobe3} isActive={isActive('explorer')} label='Explorer' to='/explorer' />
           {featureFlags.enableNotificationsApp && (
             <AppLink
               Icon={this.renderNotificationIcon}
@@ -58,6 +57,7 @@ export class AppBar extends React.Component<Properties, State> {
               to='/notifications'
             />
           )}
+          <AppLink Icon={IconGlobe3} isActive={isActive('explorer')} label='Explorer' to='/explorer' />
           <WorldPanelItem Icon={IconDotsGrid} label='More Apps' isActive={false} onClick={this.openModal} />
         </div>
         {this.state.isModalOpen && <MoreAppsModal onClose={this.closeModal} />}

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -389,7 +389,7 @@ function addLastMessageMeta(state: RootState): any {
     return {
       ...conversation,
       mostRecentMessage,
-      messagePreview: getMessagePreview(mostRecentMessage, state),
+      messagePreview: getMessagePreview(mostRecentMessage, state, conversation.isOneOnOne),
       previewDisplayDate: previewDisplayDate(mostRecentMessage?.createdAt),
     };
   };

--- a/src/lib/chat/chat-message.test.ts
+++ b/src/lib/chat/chat-message.test.ts
@@ -389,6 +389,30 @@ describe(getMessagePreview, () => {
 
     expect(preview).toEqual('Admin: System update or change occurred');
   });
+
+  it('does not add prefix for one-on-one conversations', function () {
+    const state = new StoreBuilder().withCurrentUser({ id: 'current-user' }).build();
+
+    const preview = getMessagePreview(
+      { message: 'some message', sender: { userId: 'another-user', firstName: 'Jack' } } as Message,
+      state,
+      true // isOneOnOne
+    );
+
+    expect(preview).toEqual('some message');
+  });
+
+  it('adds prefix for group conversations', function () {
+    const state = new StoreBuilder().withCurrentUser({ id: 'current-user' }).build();
+
+    const preview = getMessagePreview(
+      { message: 'some message', sender: { userId: 'another-user', firstName: 'Jack' } } as Message,
+      state,
+      false // isOneOnOne
+    );
+
+    expect(preview).toEqual('Jack: some message');
+  });
 });
 
 describe(previewDisplayDate, () => {

--- a/src/lib/chat/chat-message.ts
+++ b/src/lib/chat/chat-message.ts
@@ -22,13 +22,13 @@ export function previewDisplayDate(timestamp: number, currentDate = moment()) {
   return messageDate.format('MMM D, YYYY');
 }
 
-export function getMessagePreview(message: Message, state: RootState) {
+export function getMessagePreview(message: Message, state: RootState, isOneOnOne: boolean = false) {
   if (!message) {
     return 'Admin: System update or change occurred';
   }
 
   if (message.sendStatus === MessageSendStatus.FAILED) {
-    return 'You: Failed to send';
+    return isOneOnOne ? 'Failed to send' : 'You: Failed to send';
   }
 
   if (message.isAdmin) {
@@ -36,15 +36,21 @@ export function getMessagePreview(message: Message, state: RootState) {
   }
 
   if (message.isPost) {
-    let prefix = previewPrefix(message.sender, state);
-    return `${prefix}: shared a new post`;
+    let prefix = previewPrefix(message.sender, state, isOneOnOne);
+    return prefix ? `${prefix}: shared a new post` : 'shared a new post';
   }
 
-  let prefix = previewPrefix(message.sender, state);
-  return `${prefix}: ${message.message || getMediaPreview(message)}`;
+  let prefix = previewPrefix(message.sender, state, isOneOnOne);
+  return prefix
+    ? `${prefix}: ${message.message || getMediaPreview(message)}`
+    : `${message.message || getMediaPreview(message)}`;
 }
 
-function previewPrefix(sender: Message['sender'], state: RootState) {
+function previewPrefix(sender: Message['sender'], state: RootState, isOneOnOne: boolean) {
+  if (isOneOnOne) {
+    return '';
+  }
+
   const user = currentUserSelector()(state);
   return sender.userId === user.id ? 'You' : sender.firstName;
 }


### PR DESCRIPTION
### What does this do?
- removes prefix for one on one conversations

### Why are we making this change?
- design request

### How do I test this?
- run tests as usual
- run UI and check conversation item of one on one conversations

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
