### PR TITLE
feat(dialogs): add account locked dialog

### DIFF
--- a/src/components/account-locked-dialog/container.test.tsx
+++ b/src/components/account-locked-dialog/container.test.tsx
@@ -1,0 +1,9 @@
+import { Container } from './container';
+
+describe(Container, () => {
+  describe('mapActions', () => {
+    it('returns forceLogout action', () => {
+      expect(Container.mapActions({ forceLogout: jest.fn() })).toEqual({ forceLogout: expect.any(Function) });
+    });
+  });
+});

--- a/src/components/account-locked-dialog/container.tsx
+++ b/src/components/account-locked-dialog/container.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { connectContainer } from '../../store/redux-container';
+import { RootState } from '../../store/reducer';
+import { AccountLockedDialog } from '.';
+import { forceLogout } from '../../store/authentication';
+
+export interface PublicProperties {}
+
+export interface Properties extends PublicProperties {
+  forceLogout: () => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(_state: RootState): Partial<Properties> {
+    return {};
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { forceLogout };
+  }
+
+  render() {
+    return <AccountLockedDialog onLogout={this.props.forceLogout} />;
+  }
+}
+
+export const AccountLockedDialogContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/account-locked-dialog/index.test.tsx
+++ b/src/components/account-locked-dialog/index.test.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+
+import { AccountLockedDialog, Properties } from '.';
+import { Modal } from '../modal';
+
+describe(AccountLockedDialog, () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      onLogout: () => null,
+      ...props,
+    };
+
+    return shallow(<AccountLockedDialog {...allProps} />);
+  };
+
+  it('publishes logout event when primary button is clicked', async () => {
+    const onLogout = jest.fn();
+    const wrapper = subject({ onLogout });
+
+    wrapper.find(Modal).simulate('primary');
+
+    expect(onLogout).toHaveBeenCalled();
+  });
+
+  it('publishes logout event when close button is clicked', async () => {
+    const onLogout = jest.fn();
+    const wrapper = subject({ onLogout });
+
+    wrapper.find(Modal).simulate('close');
+
+    expect(onLogout).toHaveBeenCalled();
+  });
+});

--- a/src/components/account-locked-dialog/index.tsx
+++ b/src/components/account-locked-dialog/index.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { Color, Modal, Variant } from '../modal';
+
+export interface Properties {
+  onLogout: () => void;
+}
+
+export class AccountLockedDialog extends React.Component<Properties> {
+  render() {
+    return (
+      <Modal
+        title='Account Locked'
+        primaryText='Close and Log Out'
+        primaryVariant={Variant.Primary}
+        primaryColor={Color.Red}
+        onPrimary={this.props.onLogout}
+        onClose={this.props.onLogout}
+      >
+        <div>
+          <p>Your account is locked. Please contact support.</p>
+          <p>Closing this modal will redirect you to the login page.</p>
+        </div>
+      </Modal>
+    );
+  }
+}


### PR DESCRIPTION
### What does this do?
- adds account locked dialog (container and component)

### Why are we making this change?
- To display modal dialog indicating to the user their account is locked when the account locked matrix error is thrown on login/initialization

### How do I test this?
- run tests as usual
- this container and component is not yet wired up to the ui (dialog manager), this will come in a follow up PR

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
