### PR TITLE
feat(attachment-preview-modal): add attachment preview modal component

### DIFF
--- a/src/components/attachment-preview-modal/index.test.tsx
+++ b/src/components/attachment-preview-modal/index.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { AttachmentPreviewModal } from '.';
+import { Modal } from '../modal';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+
+describe(AttachmentPreviewModal, () => {
+  const defaultProps = {
+    attachment: {
+      name: 'test.pdf',
+      url: 'http://test.com/test.pdf',
+      mimetype: 'application/pdf',
+    },
+    onClose: jest.fn(),
+  };
+
+  const subject = (props = {}) => {
+    return shallow(<AttachmentPreviewModal {...defaultProps} {...props} />);
+  };
+
+  it('renders iframe for PDF files', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find('iframe').exists()).toBe(true);
+    expect(wrapper.find('iframe').prop('src')).toBe('http://test.com/test.pdf');
+  });
+
+  it('shows alert for non-previewable files', () => {
+    const wrapper = subject({
+      attachment: {
+        ...defaultProps.attachment,
+        mimetype: 'application/zip',
+      },
+    });
+
+    expect(wrapper.find('iframe').exists()).toBe(false);
+    expect(wrapper.find(IconAlertCircle).exists()).toBe(true);
+  });
+
+  it('displays correct modal title for previewable files', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find(Modal).prop('title')).toBe('File Preview');
+  });
+
+  it('displays correct modal title for non-previewable files', () => {
+    const wrapper = subject({
+      attachment: {
+        ...defaultProps.attachment,
+        mimetype: 'application/zip',
+      },
+    });
+
+    expect(wrapper.find(Modal).prop('title')).toBe('Download File');
+  });
+
+  it('displays file name', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find('.attachment-preview-modal__info p').text()).toBe('test.pdf');
+  });
+
+  it('calls onClose when modal is closed', () => {
+    const onClose = jest.fn();
+    const wrapper = subject({ onClose });
+
+    wrapper.find(Modal).prop('onClose')();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/attachment-preview-modal/index.tsx
+++ b/src/components/attachment-preview-modal/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Modal } from '../modal';
+import { bemClassName } from '../../lib/bem';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+
+import './styles.scss';
+
+const cn = bemClassName('attachment-preview-modal');
+
+const PREVIEWABLE_TYPES = [
+  'application/pdf',
+  'text/plain',
+  'text/csv',
+  'text/markdown',
+  'application/json',
+];
+
+interface Props {
+  attachment: {
+    name: string;
+    url: string;
+    mimetype?: string;
+  };
+  onClose: () => void;
+}
+
+export const AttachmentPreviewModal: React.FC<Props> = ({ attachment, onClose }) => {
+  const fileType = attachment.mimetype;
+  const canPreview = PREVIEWABLE_TYPES.includes(fileType);
+
+  return (
+    <Modal onClose={onClose} title={canPreview ? 'File Preview' : 'Download File'}>
+      <div {...cn()}>
+        {canPreview ? (
+          <iframe src={attachment.url} {...cn('preview')} title={attachment.name} />
+        ) : (
+          <div {...cn('alert')}>
+            <IconAlertCircle size={24} />
+            <p>Preview not available for this file type</p>
+          </div>
+        )}
+        <div {...cn('info')}>
+          <p>{attachment.name}</p>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/attachment-preview-modal/styles.scss
+++ b/src/components/attachment-preview-modal/styles.scss
@@ -1,0 +1,28 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.attachment-preview-modal {
+  display: flex;
+  flex-direction: column;
+  width: 500px;
+
+  &__preview {
+    width: 100%;
+    height: 60vh;
+    border: none;
+    border-radius: 8px;
+    background: var(--color-background-secondary);
+  }
+
+  &__info {
+    display: flex;
+    justify-content: center;
+    color: theme.$color-greyscale-11;
+  }
+
+  &__alert {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: theme.$color-error-transparency-11;
+  }
+}


### PR DESCRIPTION
### What does this do?
- adds attachment preview modal component

### Why are we making this change?
- to render previews for certain file types

### How do I test this?
- run tests as usual
- this is not yet wired up to the UI but you can see the screenshot below of the component.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

No Preview Available due to type:

<img width="780" alt="Screenshot 2024-12-18 at 15 17 21" src="https://github.com/user-attachments/assets/0237794d-fd26-4461-9978-9fae2ed098ae" />

Preview Available:

<img width="780" alt="Screenshot 2024-12-18 at 15 20 15" src="https://github.com/user-attachments/assets/c7cfb0d8-f6c6-4d73-a8bd-744efc91f1c0" />
