### PR TITLE
feat(upload-file): add send and receive pdf file message support

### DIFF
--- a/src/components/message-input/index.test.tsx
+++ b/src/components/message-input/index.test.tsx
@@ -189,7 +189,7 @@ describe('MessageInput', () => {
       'image/*': [],
       // 'text/*': [],
       'video/*': [],
-      // 'application/pdf': [],
+      'application/pdf': [],
       // 'application/zip': [],
       // 'application/msword': [],
     };

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -99,11 +99,8 @@ export class MessageInput extends React.Component<Properties, State> {
   get mimeTypes() {
     return {
       'image/*': [],
-      // 'text/*': [],
       'video/*': [],
-      // 'application/pdf': [],
-      // 'application/zip': [],
-      // 'application/msword': [],
+      'application/pdf': [],
     };
   }
 

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -10,6 +10,7 @@ import { ContentHighlighter } from '../content-highlighter';
 import { ParentMessage } from './parent-message';
 import { IconAlertCircle } from '@zero-tech/zui/icons';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator/Spinner';
+import AttachmentCards from '../../platform-apps/channels/attachment-cards';
 
 describe('message', () => {
   const sender = {
@@ -67,23 +68,37 @@ describe('message', () => {
     expect(wrapper.find('.message__block-image').exists()).toBe(true);
   });
 
-  it('renders placeholder if no media url', () => {
-    const loadAttachmentDetails = jest.fn();
-
-    const wrapper = subject({ loadAttachmentDetails, media: { id: '1', url: null, type: MediaType.Image } });
-
-    expect(wrapper.find('.message__placeholder-container').exists()).toBe(true);
-  });
-
-  it('renders placeholder if matrix media url', () => {
+  it('renders placeholder if no media url and mimetype is not application', () => {
     const loadAttachmentDetails = jest.fn();
 
     const wrapper = subject({
       loadAttachmentDetails,
-      media: { id: '1', url: 'mxc://some-test-matrix-url', type: MediaType.Image },
+      media: { id: '1', url: null, type: MediaType.Image, mimetype: 'image/png' },
     });
 
     expect(wrapper.find('.message__placeholder-container').exists()).toBe(true);
+  });
+
+  it('renders placeholder if matrix media url and mimetype is not application', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    const wrapper = subject({
+      loadAttachmentDetails,
+      media: { id: '1', url: 'mxc://some-test-matrix-url', type: MediaType.Image, mimetype: 'image/png' },
+    });
+
+    expect(wrapper.find('.message__placeholder-container').exists()).toBe(true);
+  });
+
+  it('renders attachment cards if mimetype is application and url is null', () => {
+    const loadAttachmentDetails = jest.fn();
+
+    const wrapper = subject({
+      loadAttachmentDetails,
+      media: { id: '1', url: null, type: MediaType.Image, mimetype: 'application/pdf' },
+    });
+
+    expect(wrapper.find(AttachmentCards).exists()).toBe(true);
   });
 
   it('renders failed alert icon if media download status is failed', () => {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -906,7 +906,7 @@ export class MatrixClient implements IChatClient {
 
     const content: any = {
       body: '',
-      msgtype: media.type.startsWith('image/') ? MsgType.Image : MsgType.Video,
+      msgtype: this.getMsgType(media.type),
       info: {
         mimetype: media.type,
         size: media.size,
@@ -945,6 +945,13 @@ export class MatrixClient implements IChatClient {
       id: messageResult.event_id,
       optimisticId,
     } as unknown as Message;
+  }
+
+  private getMsgType(mimeType: string): string {
+    if (mimeType.startsWith('image/')) return MsgType.Image;
+    if (mimeType.startsWith('video/')) return MsgType.Video;
+    if (mimeType.startsWith('audio/')) return MsgType.Audio;
+    return MsgType.File;
   }
 
   async uploadImageUrl(

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -9,7 +9,7 @@ export async function parseMediaData(matrixMessage) {
 
   let media = null;
   try {
-    if (content?.msgtype === MsgType.Image || content?.msgtype === MsgType.Video) {
+    if (content?.msgtype === MsgType.Image || content?.msgtype === MsgType.Video || content?.msgtype === MsgType.File) {
       media = await buildMediaObject(content);
     }
   } catch (e) {
@@ -24,7 +24,10 @@ export async function parseMediaData(matrixMessage) {
 }
 
 export async function buildMediaObject(content) {
-  const mediaType = content.msgtype === MsgType.Image ? 'image' : 'video';
+  let mediaType;
+  if (content.msgtype === MsgType.Image) mediaType = 'image';
+  else if (content.msgtype === MsgType.Video) mediaType = 'video';
+  else if (content.msgtype === MsgType.File) mediaType = 'file';
 
   if (content.file && content.info) {
     return {

--- a/src/store/messages/uploadable.test.ts
+++ b/src/store/messages/uploadable.test.ts
@@ -2,7 +2,7 @@ import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { uploadImageUrl, uploadFileMessage } from '../../lib/chat';
 
-import { UploadableGiphy, UploadableMedia } from './uploadable';
+import { UploadableAttachment, UploadableGiphy, UploadableMedia } from './uploadable';
 
 describe(UploadableMedia, () => {
   it('uploads the media file', async () => {
@@ -42,6 +42,23 @@ describe(UploadableGiphy, () => {
     const { returnValue } = await expectSaga(() => uploadable.upload(channelId, 'root-id'))
       .provide([
         [matchers.call.fn(uploadImageUrl), { id: 'uploaded-id' }],
+      ])
+      .run();
+
+    expect(returnValue).toEqual({ id: 'uploaded-id' });
+  });
+});
+
+describe(UploadableAttachment, () => {
+  it('uploads the attachment correctly', async () => {
+    const channelId = 'channel-id';
+    const attachment = { name: 'attachment', url: 'http://example.com/attachment', type: 'attachment' };
+    const uploadable = new UploadableAttachment(attachment);
+    uploadable.optimisticMessage = { id: 'optimistic-id' } as any;
+
+    const { returnValue } = await expectSaga(() => uploadable.upload(channelId, 'root-id'))
+      .provide([
+        [matchers.call.fn(uploadFileMessage), { id: 'uploaded-id' }],
       ])
       .run();
 

--- a/src/store/messages/uploadable.ts
+++ b/src/store/messages/uploadable.ts
@@ -58,9 +58,17 @@ export class UploadableGiphy implements Uploadable {
 
 export class UploadableAttachment implements Uploadable {
   public optimisticMessage: Message;
+
   constructor(public file) {}
-  *upload(_channelId, _rootMessageId) {
-    yield;
-    throw new Error('Attachment upload is not supported yet.');
+
+  *upload(channelId, rootMessageId, isPost = false) {
+    return yield call(
+      uploadFileMessage,
+      channelId,
+      this.file.nativeFile,
+      rootMessageId,
+      this.optimisticMessage?.id?.toString(),
+      isPost
+    );
   }
 }

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -18,7 +18,7 @@ export function createOptimisticMessageObject(
   messageText: string,
   user: User,
   parentMessage: ParentMessage = null,
-  file?: { name: string; url: string; mediaType: MediaType; giphy: any },
+  file?: { name: string; url: string; mediaType: MediaType; giphy: any; nativeFile: File },
   rootMessageId?: string
 ): Message {
   const id = uuidv4();
@@ -28,6 +28,7 @@ export function createOptimisticMessageObject(
       type: file.mediaType,
       url: file.giphy ? file.giphy.images.downsized.url : file.url,
       name: file.name,
+      mimetype: file.nativeFile ? file.nativeFile.type : null,
       // Not sure why these are in our types as I don't think we use them at all
       // I'm guessing this is for rendering a loaded message when the image hasn't downloaded yet
       // but we're not doing that yet.


### PR DESCRIPTION
### What does this do?
- send/receive pdf files and display preview

### Why are we making this change?
- to be able to display preview and download pdf files (from messages).

### How do I test this?
- run tests as usual
- run UI and send a pdf file as a message

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
