### PR TITLE
refactor: increase reaction menu emoji picker z-index and anchor component relative to menu item

### DIFF
--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -183,6 +183,7 @@
     display: flex;
     align-self: center;
     opacity: 0;
+    position: relative;
     // Sometimes we render an empty menu. This ensures consistency of width of the message bubble.
     min-width: 64px;
   }

--- a/src/components/reaction-menu/styles.scss
+++ b/src/components/reaction-menu/styles.scss
@@ -10,7 +10,7 @@
   position: absolute;
   bottom: 75px;
   left: 390px;
-  z-index: 1010;
+  z-index: 2000;
   color: var(--color-greyscale-11);
 }
 


### PR DESCRIPTION
### What does this do?
- increases reaction menu emoji picker z-index
- anchor component relative to menu item

### Why are we making this change?
- fix issue where users are reporting emojis can't be selected

### How do I test this?
- run ui as usual and test reactions

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
