### PR TITLE
chore: create `enableFeedApp` feature flag

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -169,6 +169,14 @@ export class FeatureFlags {
   set enableComments(value: boolean) {
     this._setBoolean('enableComments', value);
   }
+
+  get enableFeedApp() {
+    return this._getBoolean('enableFeedApp', true);
+  }
+
+  set enableFeedApp(value: boolean) {
+    this._setBoolean('enableFeedApp', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();


### PR DESCRIPTION
### What does this do?

Adds a feature flag for the Feed app.