### PR TITLE
refactor(reaction-menu): rebuild message reaction menu and selection

### DIFF
--- a/src/components/message/reaction-picker/reaction-picker.test.tsx
+++ b/src/components/message/reaction-picker/reaction-picker.test.tsx
@@ -1,0 +1,71 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { ViewModes } from '../../../shared-components/theme-engine';
+import { ReactionPicker, Properties } from './reaction-picker';
+import { Picker } from 'emoji-mart';
+
+describe('ReactionPicker', () => {
+  const subject = (props: Partial<Properties>) => {
+    const allProps: Properties = {
+      isOpen: true,
+      onOpen: jest.fn(),
+      onClose: jest.fn(),
+      onSelect: jest.fn(),
+      ...props,
+    };
+
+    return shallow(<ReactionPicker {...allProps} />);
+  };
+
+  const initialDocument = global.document;
+
+  beforeEach(() => {
+    // @ts-ignore
+    global.document = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    global.document = initialDocument;
+  });
+
+  it('renders Picker', () => {
+    const wrapper = subject({});
+
+    expect(wrapper.find(Picker).exists()).toBeTrue();
+  });
+
+  it('attach mousedown listener to document', () => {
+    subject({});
+
+    expect(global.document.addEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+  });
+
+  it('removeEventListener mousedown listener to document', () => {
+    const wrapper = subject({});
+
+    (wrapper.instance() as any).componentWillUnmount();
+
+    expect(global.document.removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+  });
+
+  it('does not render', () => {
+    const wrapper = subject({ isOpen: false });
+
+    expect(wrapper.find(Picker).exists()).toBeFalsy();
+  });
+
+  it('passes props', () => {
+    const wrapper = subject({});
+
+    expect(wrapper.find(Picker).props()).toEqual(
+      expect.objectContaining({
+        theme: ViewModes.Dark,
+        emoji: 'mechanical_arm',
+        title: 'ZOS',
+      })
+    );
+  });
+});

--- a/src/components/message/reaction-picker/reaction-picker.tsx
+++ b/src/components/message/reaction-picker/reaction-picker.tsx
@@ -1,0 +1,55 @@
+import React, { RefObject } from 'react';
+import { Picker } from 'emoji-mart';
+import { ViewModes } from '../../../shared-components/theme-engine';
+import { bemClassName } from '../../../lib/bem';
+
+import './styles.scss';
+
+const cn = bemClassName('reaction-picker');
+
+export interface Properties {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onSelect: (value: string) => void;
+}
+
+export class ReactionPicker extends React.Component<Properties> {
+  pickerRef: RefObject<HTMLDivElement> = React.createRef();
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.clickOutsideEmojiCheck);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.clickOutsideEmojiCheck);
+  }
+
+  clickOutsideEmojiCheck = (event: MouseEvent) => {
+    if (!this.props.isOpen || !this.pickerRef.current) {
+      return;
+    }
+    if (!this.pickerRef.current.contains(event.target as Node)) {
+      this.props.onClose();
+    }
+  };
+
+  insertEmoji = (emoji: any) => {
+    const emojiToInsert = emoji.native;
+    this.props.onSelect(emojiToInsert);
+  };
+
+  render() {
+    if (!this.props.isOpen) {
+      return null;
+    }
+
+    return (
+      <div {...cn('border-outer')}>
+        <div {...cn('border-inner')} ref={this.pickerRef}>
+          <Picker theme={ViewModes.Dark} emoji='mechanical_arm' title='ZOS' onSelect={this.insertEmoji} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/message/reaction-picker/styles.scss
+++ b/src/components/message/reaction-picker/styles.scss
@@ -1,0 +1,14 @@
+@import '../../../glass';
+
+.reaction-picker {
+  &__border-outer {
+    @include glass-outer;
+  }
+
+  &__border-inner {
+    @include glass-inner;
+
+    opacity: 0;
+    animation: fadeIn 0.3s forwards;
+  }
+}

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -56,6 +56,13 @@
     }
   }
 
+  &__reaction-picker-container {
+    position: absolute;
+    bottom: 75px;
+    z-index: 12;
+    color: theme.$color-greyscale-11;
+  }
+
   &__block {
     position: relative;
     padding: 0px;
@@ -223,10 +230,6 @@
     .message__author-avatar {
       visibility: visible;
     }
-  }
-
-  .emoji-mart-emoji {
-    height: 19px;
   }
 
   &__user-mention {


### PR DESCRIPTION
### What does this do?
- rebuilds message reaction menu and selection

### Why are we making this change?
- reports of reactions not being selected. I think this was due to how we were previously creating a portal in nested components.

### How do I test this?
- run tests as usual
- run ui and test reactions on messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
