### PR TITLE
feat: flip `enableFeedApp` feature flag

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -171,7 +171,7 @@ export class FeatureFlags {
   }
 
   get enableFeedApp() {
-    return this._getBoolean('enableFeedApp', true);
+    return this._getBoolean('enableFeedApp', false);
   }
 
   set enableFeedApp(value: boolean) {


### PR DESCRIPTION
# What does this do?

- `enableFeedApp` was accidentally set to `true`. This PR sets it to `false`