### PR TITLE
refactor: prevent name editing for social channels instead of 0:// prefix check

### DIFF
--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -50,6 +50,7 @@ export interface Properties extends PublicProperties {
   conversationModeratorIds: string[];
   isOneOnOne: boolean;
   existingConversations: Channel[];
+  isSocialChannel: boolean;
   users: { [id: string]: User };
 
   back: () => void;
@@ -87,6 +88,7 @@ export class Container extends React.Component<Properties> {
       addMemberError: groupManagement.addMemberError,
       errors: groupManagement.errors,
       name: conversation?.name || '',
+      isSocialChannel: conversation?.isSocialChannel || false,
       conversationIcon: conversation?.icon || '',
       currentUser: {
         userId: currentUser?.id,
@@ -198,6 +200,7 @@ export class Container extends React.Component<Properties> {
           setLeaveGroupStatus={this.props.setLeaveGroupStatus}
           onMemberClick={this.processMemberConversation}
           openUserProfile={this.props.openUserProfile}
+          isSocialChannel={this.props.isSocialChannel}
         />
         <MemberManagementDialogContainer />
       </>

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -21,6 +21,7 @@ describe(EditConversationPanel, () => {
       icon: '',
       conversationAdminIds: [],
       conversationModeratorIds: [],
+      isSocialChannel: false,
       ...props,
     };
 
@@ -113,6 +114,17 @@ describe(EditConversationPanel, () => {
       const wrapper = subject({ state: EditConversationState.NONE });
 
       expect(wrapper.find(Alert).exists()).toBe(false);
+    });
+
+    it('disables edit input when isSocialChannel is true', () => {
+      const wrapper = subject({
+        name: 'Display Name',
+        icon: 'icon-url',
+        conversationAdminIds: ['matrix-id'],
+        isSocialChannel: true,
+      });
+
+      expect(wrapper.find('Input[name="name"]').prop('isDisabled')).toBe(true);
     });
   });
 

--- a/src/components/messenger/group-management/edit-conversation-panel/index.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.tsx
@@ -25,6 +25,7 @@ export interface Properties {
   state: EditConversationState;
   conversationAdminIds: string[];
   conversationModeratorIds: string[];
+  isSocialChannel: boolean;
 
   onBack: () => void;
   onEdit: (name: string, image: File | null) => void;
@@ -70,7 +71,7 @@ export class EditConversationPanel extends React.Component<Properties, State> {
   }
 
   get canEditGroupName() {
-    return !this.props.name.includes('0://');
+    return !this.props.isSocialChannel;
   }
 
   get isCurrentUserAdmin() {

--- a/src/components/messenger/group-management/index.test.tsx
+++ b/src/components/messenger/group-management/index.test.tsx
@@ -18,6 +18,7 @@ describe(GroupManagement, () => {
       name: '',
       icon: '',
       isOneOnOne: false,
+      isSocialChannel: false,
       errors: {},
       editConversationState: EditConversationState.NONE,
       conversationAdminIds: [],

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -20,6 +20,7 @@ export interface Properties {
   currentUser: User;
   otherMembers: User[];
   editConversationState: EditConversationState;
+  isSocialChannel: boolean;
   canAddMembers: boolean;
   canEditGroup: boolean;
   canLeaveGroup: boolean;
@@ -62,6 +63,7 @@ export class GroupManagement extends React.PureComponent<Properties> {
             onBack={this.props.onBack}
             onEdit={this.props.onEditConversation}
             state={this.props.editConversationState}
+            isSocialChannel={this.props.isSocialChannel}
           />
         )}
         {this.props.stage === Stage.ViewGroupInformation && (


### PR DESCRIPTION
- prevent name editing for social channels instead of 0:// prefix check
