### PR TITLE
fix(chat-message): clear message content for audio messages to prevent filename display

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -62,9 +62,14 @@ export async function mapMatrixMessage(matrixMessage, sdkMatrixClient: SDKMatrix
     messageContent = parsePlainBody(content.body);
   }
 
+  const message =
+    content.msgtype === MsgType.Image || content.msgtype === MsgType.Video || content.msgtype === MsgType.Audio
+      ? ''
+      : messageContent;
+
   return {
     id: event_id,
-    message: content.msgtype === MsgType.Image || content.msgtype === MsgType.Video ? '' : messageContent,
+    message,
     createdAt: origin_server_ts,
     updatedAt: updatedAt,
     sender: {


### PR DESCRIPTION
clears message content for audio messages to prevent filename display