### PR TITLE
feat(user-profile): add linked accounts panel and telegram bridge setup

### DIFF
--- a/src/components/messenger/user-profile/container.tsx
+++ b/src/components/messenger/user-profile/container.tsx
@@ -15,6 +15,7 @@ import {
   openSettings,
   openDownloads,
   openAccountManagement,
+  openLinkedAccounts,
 } from '../../../store/user-profile';
 import { logout } from '../../../store/authentication';
 import { openBackupDialog } from '../../../store/matrix';
@@ -35,6 +36,7 @@ export interface Properties extends PublicProperties {
   openSettings: () => void;
   openDownloads: () => void;
   openAccountManagement: () => void;
+  openLinkedAccounts: () => void;
 }
 
 export class Container extends React.Component<Properties> {
@@ -63,6 +65,7 @@ export class Container extends React.Component<Properties> {
       openSettings,
       openDownloads,
       openAccountManagement,
+      openLinkedAccounts,
     };
   }
 
@@ -82,6 +85,7 @@ export class Container extends React.Component<Properties> {
         onSettings={this.props.openSettings}
         onDownloads={this.props.openDownloads}
         onManageAccounts={this.props.openAccountManagement}
+        onOpenLinkedAccounts={this.props.openLinkedAccounts}
       />
     );
   }

--- a/src/components/messenger/user-profile/index.test.tsx
+++ b/src/components/messenger/user-profile/index.test.tsx
@@ -7,7 +7,7 @@ import { EditProfileContainer } from '../../edit-profile/container';
 import { SettingsPanelContainer } from './settings-panel/container';
 import { AccountManagementContainer } from './account-management-panel/container';
 import { DownloadsPanel } from './downloads-panel';
-
+import { LinkedAccountsPanelContainer } from './linked-accounts-panel/container';
 describe(UserProfile, () => {
   const subject = (props: Partial<Properties> = {}) => {
     const allProps: Properties = {
@@ -25,6 +25,7 @@ describe(UserProfile, () => {
       onSettings: () => {},
       onDownloads: () => {},
       onManageAccounts: () => {},
+      onOpenLinkedAccounts: () => {},
       ...props,
     };
 
@@ -59,6 +60,12 @@ describe(UserProfile, () => {
     const wrapper = subject({ stage: Stage.AccountManagement });
 
     expect(wrapper).toHaveElement(AccountManagementContainer);
+  });
+
+  it('renders Linked Accounts Panel Container when stage is Linked Accounts', () => {
+    const wrapper = subject({ stage: Stage.LinkedAccounts });
+
+    expect(wrapper).toHaveElement(LinkedAccountsPanelContainer);
   });
 
   it('renders nothing when stage None', () => {

--- a/src/components/messenger/user-profile/index.tsx
+++ b/src/components/messenger/user-profile/index.tsx
@@ -6,6 +6,7 @@ import { EditProfileContainer } from '../../edit-profile/container';
 import { SettingsPanelContainer } from './settings-panel/container';
 import { AccountManagementContainer } from './account-management-panel/container';
 import { DownloadsPanel } from './downloads-panel';
+import { LinkedAccountsPanelContainer } from './linked-accounts-panel/container';
 
 export interface Properties {
   stage: Stage;
@@ -22,6 +23,7 @@ export interface Properties {
   onSettings: () => void;
   onDownloads: () => void;
   onManageAccounts: () => void;
+  onOpenLinkedAccounts: () => void;
 }
 
 export class UserProfile extends React.Component<Properties> {
@@ -41,6 +43,7 @@ export class UserProfile extends React.Component<Properties> {
             onOpenSettings={this.props.onSettings}
             onOpenDownloads={this.props.onDownloads}
             onManageAccounts={this.props.onManageAccounts}
+            onOpenLinkedAccounts={this.props.onOpenLinkedAccounts}
           />
         )}
 
@@ -49,6 +52,9 @@ export class UserProfile extends React.Component<Properties> {
         {this.props.stage === Stage.Downloads && <DownloadsPanel onClose={this.props.onBackToOverview} />}
         {this.props.stage === Stage.AccountManagement && (
           <AccountManagementContainer onClose={this.props.onBackToOverview} />
+        )}
+        {this.props.stage === Stage.LinkedAccounts && (
+          <LinkedAccountsPanelContainer onClose={this.props.onBackToOverview} />
         )}
       </>
     );

--- a/src/components/messenger/user-profile/linked-accounts-panel/container.test.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/container.test.tsx
@@ -1,0 +1,51 @@
+import { Container } from './container';
+import { Channel } from '../../../../store/channels';
+import { config } from '../../../../config';
+
+describe('Container', () => {
+  describe('onTelegramBot', () => {
+    it('opens existing conversation when one exists', () => {
+      const openConversation = jest.fn();
+      const createConversation = jest.fn();
+
+      const container = new Container({
+        existingConversations: [
+          {
+            id: 'existing-convo',
+            isOneOnOne: true,
+            otherMembers: [{ userId: config.telegramBotUserId }],
+          } as Channel,
+        ],
+        telegramBotUserId: config.telegramBotUserId,
+        openConversation,
+        createConversation,
+        onClose: () => {},
+      });
+
+      container.onTelegramBot();
+
+      expect(openConversation).toHaveBeenCalledWith({ conversationId: 'existing-convo' });
+      expect(createConversation).not.toHaveBeenCalled();
+    });
+
+    it('creates new conversation when none exists', () => {
+      const openConversation = jest.fn();
+      const createConversation = jest.fn();
+
+      const container = new Container({
+        existingConversations: [],
+        telegramBotUserId: config.telegramBotUserId,
+        openConversation,
+        createConversation,
+        onClose: () => {},
+      });
+
+      container.onTelegramBot();
+
+      expect(createConversation).toHaveBeenCalledWith({
+        userIds: [config.telegramBotUserId],
+      });
+      expect(openConversation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/messenger/user-profile/linked-accounts-panel/container.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/container.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import { RootState } from '../../../../store/reducer';
+import { connectContainer } from '../../../../store/redux-container';
+import { openConversation } from '../../../../store/channels';
+import { createConversation } from '../../../../store/create-conversation';
+import { denormalizeConversations } from '../../../../store/channels-list';
+import { Channel } from '../../../../store/channels';
+import { config } from '../../../../config';
+import { LinkedAccountsPanel } from '.';
+
+export interface PublicProperties {
+  onClose?: () => void;
+}
+
+export interface Properties extends PublicProperties {
+  telegramBotUserId: string;
+  existingConversations: Channel[];
+
+  createConversation: (payload: { userIds: string[] }) => void;
+  openConversation: (payload: { conversationId: string }) => void;
+}
+
+export class Container extends React.Component<Properties> {
+  static mapState(state: RootState) {
+    const telegramBotUserId = config.telegramBotUserId;
+    const existingConversations = denormalizeConversations(state);
+
+    return { telegramBotUserId, existingConversations };
+  }
+
+  static mapActions(_props: Properties): Partial<Properties> {
+    return { createConversation, openConversation };
+  }
+
+  onTelegramBot = () => {
+    const { existingConversations, telegramBotUserId, createConversation, openConversation } = this.props;
+
+    const existingConversation = existingConversations?.find(
+      (conversation) =>
+        conversation.isOneOnOne &&
+        conversation.otherMembers?.length === 1 &&
+        conversation.otherMembers[0]?.userId === telegramBotUserId
+    );
+
+    if (existingConversation) {
+      openConversation({ conversationId: existingConversation.id });
+    } else {
+      createConversation({ userIds: [telegramBotUserId] });
+    }
+  };
+
+  render() {
+    return <LinkedAccountsPanel onTelegramLink={this.onTelegramBot} onBack={this.props.onClose} />;
+  }
+}
+
+export const LinkedAccountsPanelContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/messenger/user-profile/linked-accounts-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/index.test.tsx
@@ -2,6 +2,9 @@ import { shallow } from 'enzyme';
 
 import { LinkedAccountsPanel, Properties } from '.';
 import { PanelHeader } from '../../list/panel-header';
+import { bemClassName } from '../../../../lib/bem';
+
+const cn = bemClassName('linked-accounts-panel');
 
 describe(LinkedAccountsPanel, () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -28,7 +31,7 @@ describe(LinkedAccountsPanel, () => {
     const onTelegramLink = jest.fn();
     const wrapper = subject({ onTelegramLink });
 
-    wrapper.find(PanelHeader).simulate('back');
+    wrapper.find(cn('section-header')).simulate('click');
 
     expect(onTelegramLink).toHaveBeenCalled();
   });

--- a/src/components/messenger/user-profile/linked-accounts-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/index.test.tsx
@@ -1,0 +1,35 @@
+import { shallow } from 'enzyme';
+
+import { LinkedAccountsPanel, Properties } from '.';
+import { PanelHeader } from '../../list/panel-header';
+
+describe(LinkedAccountsPanel, () => {
+  const subject = (props: Partial<Properties> = {}) => {
+    const allProps: Properties = {
+      onBack: () => {},
+      onTelegramLink: () => {},
+
+      ...props,
+    };
+
+    return shallow(<LinkedAccountsPanel {...allProps} />);
+  };
+
+  it('publishes onBack event', () => {
+    const onBack = jest.fn();
+    const wrapper = subject({ onBack });
+
+    wrapper.find(PanelHeader).simulate('back');
+
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('publishes onTelegramLink event', () => {
+    const onTelegramLink = jest.fn();
+    const wrapper = subject({ onTelegramLink });
+
+    wrapper.find(PanelHeader).simulate('back');
+
+    expect(onTelegramLink).toHaveBeenCalled();
+  });
+});

--- a/src/components/messenger/user-profile/linked-accounts-panel/index.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/index.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import { bemClassName } from '../../../../lib/bem';
+
+import { PanelHeader } from '../../list/panel-header';
+import { IconLink1 } from '@zero-tech/zui/icons';
+import { ScrollbarContainer } from '../../../scrollbar-container';
+
+import './styles.scss';
+
+const cn = bemClassName('linked-accounts-panel');
+
+export interface Properties {
+  onBack: () => void;
+  onTelegramLink: () => void;
+}
+
+export class LinkedAccountsPanel extends React.Component<Properties> {
+  back = () => {
+    this.props.onBack();
+  };
+
+  telegramLink = () => {
+    this.props.onTelegramLink();
+  };
+
+  render() {
+    return (
+      <div {...cn()}>
+        <div {...cn('header-container')}>
+          <PanelHeader title={'Linked Accounts'} onBack={this.back} />
+        </div>
+
+        <ScrollbarContainer variant='on-hover'>
+          <div {...cn('body')}>
+            <div>
+              <div {...cn('section-header')} onClick={this.telegramLink}>
+                <IconLink1 {...cn('section-icon')} size={24} />
+                <h4 {...cn('section-title')}>Telegram</h4>
+              </div>
+            </div>
+          </div>
+        </ScrollbarContainer>
+      </div>
+    );
+  }
+}

--- a/src/components/messenger/user-profile/linked-accounts-panel/styles.scss
+++ b/src/components/messenger/user-profile/linked-accounts-panel/styles.scss
@@ -1,0 +1,63 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../glass';
+
+.linked-accounts-panel {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+  width: 300px;
+  max-width: 100%;
+  box-sizing: border-box;
+
+  &__header-container {
+    display: flex;
+    width: 235px;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 24px;
+    margin: 0 16px 16px 16px;
+
+    // Forcing a height here allows the flex-grow to fill the size without growing too big
+    height: 1px;
+  }
+
+  &__section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+  }
+
+  &__section-icon {
+    color: theme.$color-secondary-11;
+  }
+
+  &__section-title {
+    color: theme.$color-secondary-11;
+  }
+
+  &__status-dot {
+    &.unlinked-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: #ff3131;
+      flex-shrink: 0;
+      display: block;
+    }
+
+    &.linked-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: theme.$color-secondary-11;
+      flex-shrink: 0;
+      display: block;
+    }
+  }
+}

--- a/src/components/messenger/user-profile/overview-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.test.tsx
@@ -11,7 +11,7 @@ import { bem } from '../../../../lib/bem';
 
 const c = bem('.overview-panel');
 
-const featureFlags = { enableRewards: false, enableUserSettings: false };
+const featureFlags = { enableRewards: false, enableUserSettings: false, enableLinkedAccounts: false };
 
 jest.mock('../../../../lib/feature-flags', () => ({
   featureFlags: featureFlags,
@@ -32,6 +32,7 @@ describe(OverviewPanel, () => {
       onOpenSettings: () => {},
       onOpenDownloads: () => {},
       onManageAccounts: () => {},
+      onOpenLinkedAccounts: () => {},
 
       ...props,
     };
@@ -115,6 +116,17 @@ describe(OverviewPanel, () => {
     wrapper.find(Button).at(2).simulate('press');
 
     expect(onOpenAccountManagement).toHaveBeenCalled();
+  });
+
+  it('publishes onOpenLinkedAccounts event', () => {
+    featureFlags.enableLinkedAccounts = true;
+
+    const onOpenLinkedAccounts = jest.fn();
+    const wrapper = subject({ onOpenLinkedAccounts });
+
+    wrapper.find(Button).at(6).simulate('press');
+
+    expect(onOpenLinkedAccounts).toHaveBeenCalled();
   });
 
   it('opens the invite dialog', () => {

--- a/src/components/messenger/user-profile/overview-panel/index.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.tsx
@@ -7,6 +7,7 @@ import { Image, Modal } from '@zero-tech/zui/components';
 import { Button, Variant as ButtonVariant, Color as ButtonColor } from '@zero-tech/zui/components/Button';
 import {
   IconCurrencyEthereum,
+  IconLink1,
   IconDownload2,
   IconLock1,
   IconLogOut3,
@@ -37,6 +38,7 @@ export interface Properties {
   onOpenSettings: () => void;
   onOpenDownloads: () => void;
   onManageAccounts: () => void;
+  onOpenLinkedAccounts: () => void;
 }
 
 interface State {
@@ -94,6 +96,10 @@ export class OverviewPanel extends React.Component<Properties, State> {
 
   onManageAccounts = () => {
     this.props.onManageAccounts();
+  };
+
+  openLinkedAccounts = () => {
+    this.props.onOpenLinkedAccounts();
   };
 
   renderDetails = () => {
@@ -180,6 +186,18 @@ export class OverviewPanel extends React.Component<Properties, State> {
         >
           Download
         </Button>
+
+        {featureFlags.enableLinkedAccounts && (
+          <Button
+            {...cn('action-button')}
+            variant={ButtonVariant.Secondary}
+            onPress={this.openLinkedAccounts}
+            startEnhancer={<IconLink1 size={20} />}
+            color={ButtonColor.Greyscale}
+          >
+            Linked Accounts
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,4 +26,5 @@ export const config = {
   appleAppStorePath: process.env.REACT_APP_APPLE_APP_STORE_PATH,
   googlePlayStorePath: process.env.REACT_APP_GOOGLE_PLAY_STORE_PATH,
   webAppDownloadPath: process.env.REACT_APP_WEB_APP_DOWNLOAD_PATH,
+  telegramBotUserId: process.env.REACT_APP_TELEGRAM_BOT_USER_ID,
 };

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -177,6 +177,14 @@ export class FeatureFlags {
   set enableFeedApp(value: boolean) {
     this._setBoolean('enableFeedApp', value);
   }
+
+  get enableLinkedAccounts() {
+    return this._getBoolean('enableLinkedAccounts', false);
+  }
+
+  set enableLinkedAccounts(value: boolean) {
+    this._setBoolean('enableLinkedAccounts', value);
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/store/user-profile/index.ts
+++ b/src/store/user-profile/index.ts
@@ -7,6 +7,7 @@ export enum SagaActionTypes {
   OpenSettings = 'user-profile/openSettings',
   OpenDownloads = 'user-profile/openDownloads',
   OpenAccountManagement = 'user-profile/openAccountManagement',
+  OpenLinkedAccounts = 'user-profile/openLinkedAccounts',
   PrivateReadReceipts = 'user-profile/privateReadReceipts',
   PublicReadReceipts = 'user-profile/publicReadReceipts',
 }
@@ -18,6 +19,7 @@ export enum Stage {
   Settings = 'settings',
   AccountManagement = 'account_management',
   Downloads = 'downloads',
+  LinkedAccounts = 'linked_accounts',
 }
 
 export type UserProfileState = {
@@ -36,6 +38,7 @@ export const openEditProfile = createAction(SagaActionTypes.OpenEditProfile);
 export const openSettings = createAction(SagaActionTypes.OpenSettings);
 export const openDownloads = createAction(SagaActionTypes.OpenDownloads);
 export const openAccountManagement = createAction(SagaActionTypes.OpenAccountManagement);
+export const openLinkedAccounts = createAction(SagaActionTypes.OpenLinkedAccounts);
 export const privateReadReceipts = createAction(SagaActionTypes.PrivateReadReceipts);
 export const publicReadReceipts = createAction(SagaActionTypes.PublicReadReceipts);
 

--- a/src/store/user-profile/saga.test.ts
+++ b/src/store/user-profile/saga.test.ts
@@ -10,6 +10,7 @@ import {
   getUserReadReceiptPreference,
   openAccountManagement,
   openDownloads,
+  openLinkedAccounts,
 } from './saga';
 import { UserProfileState, initialState as initialUserProfileState, Stage, setStage, setPublicReadReceipts } from '.';
 import { rootReducer } from '../reducer';
@@ -37,6 +38,17 @@ describe('openAccountManagement', () => {
       .run();
 
     expect(storeState.userProfile.stage).toEqual(Stage.AccountManagement);
+  });
+});
+
+describe('openLinkedAccounts', () => {
+  it('should set stage to LinkedAccounts', async () => {
+    const { storeState } = await expectSaga(openLinkedAccounts)
+      .withReducer(rootReducer, initialState())
+      .put(setStage(Stage.LinkedAccounts))
+      .run();
+
+    expect(storeState.userProfile.stage).toEqual(Stage.LinkedAccounts);
   });
 });
 

--- a/src/store/user-profile/saga.ts
+++ b/src/store/user-profile/saga.ts
@@ -28,6 +28,10 @@ export function* openAccountManagement() {
   yield put(setStage(Stage.AccountManagement));
 }
 
+export function* openLinkedAccounts() {
+  yield put(setStage(Stage.LinkedAccounts));
+}
+
 export function* onPrivateReadReceipts() {
   try {
     yield call(setReadReceiptPreference, 'private');
@@ -63,7 +67,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.OpenSettings, openSettings);
   yield takeLatest(SagaActionTypes.OpenDownloads, openDownloads);
   yield takeLatest(SagaActionTypes.OpenAccountManagement, openAccountManagement);
-
+  yield takeLatest(SagaActionTypes.OpenLinkedAccounts, openLinkedAccounts);
   yield takeLatest(SagaActionTypes.PrivateReadReceipts, onPrivateReadReceipts);
   yield takeLatest(SagaActionTypes.PublicReadReceipts, onPublicReadReceipts);
 }


### PR DESCRIPTION
### What does this do?
- adds linked accounts panel 
- adds telegram bridge setup (create conversation with telegram bot user)

### Why are we making this change?
- to be able to link telegram accounts (bridging)

### How do I test this?
- run tests as usual
- this is currently under featureFlag - enableLinkedAccounts

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
