### PR TITLE
chore: remove unnecessary `console.log`

### DIFF
--- a/src/apps/feed/lib/useSubmitPost.ts
+++ b/src/apps/feed/lib/useSubmitPost.ts
@@ -47,8 +47,6 @@ export const useSubmitPost = () => {
         throw new Error('Post is empty');
       }
 
-      console.log('BOSH');
-
       if (!userWallets.find((w) => w.publicAddress.toLowerCase() === connectedAddress.toLowerCase())) {
         throw new Error('Wallet is not linked to your account');
       }


### PR DESCRIPTION
# What does this do?

- Removes a `console.log` which was missed in a previous PR.