### PR TITLE
fix: unable to MEOW posts before loading individual post

### DIFF
--- a/src/apps/feed/lib/useMeowPost.ts
+++ b/src/apps/feed/lib/useMeowPost.ts
@@ -10,7 +10,6 @@ export const useMeowPost = () => {
 
   const { mutate } = useMutation({
     mutationFn: async ({ postId, meowAmount }: { postId: string; meowAmount: string }) => {
-      console.log('triggered: mutationFn');
       const meowAmountWei = ethers.utils.parseEther(meowAmount.toString());
       const res = await meowPostApi(postId, meowAmountWei.toString());
 


### PR DESCRIPTION
# What does this do?

- Fixes issue where users were unable to MEOW posts before loading them individually.
- Was running `updatePostReactions` with `undefined` query data, so it was crashing silently.