### PR TITLE
fix: correct arweave URL

### DIFF
--- a/src/apps/feed/components/post/actions/arweave/useArweaveAction.ts
+++ b/src/apps/feed/components/post/actions/arweave/useArweaveAction.ts
@@ -1,7 +1,7 @@
 export const useArweaveAction = (arweaveId: string) => {
   const handleOnClick = () => {
     // @note this is temporarily hardcoded, and will not work on devnet
-    window.open(`https://irys.xyz/${arweaveId}`, '_blank');
+    window.open(`https://arweave.net/${arweaveId}`, '_blank');
   };
 
   return {


### PR DESCRIPTION
# What does this do?

- Uses correct Arweave URL for on-chain data.
