### PR TITLE
chore: bump patch (`1.255.0` -> `1.255.1`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ZERO",
-  "version": "1.255.0",
+  "version": "1.255.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ZERO",
-      "version": "1.255.0",
+      "version": "1.255.1",
       "dependencies": {
         "@craco/craco": "^7.1.0",
         "@emotion/react": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ZERO",
-  "version": "1.255.0",
+  "version": "1.255.1",
   "private": true,
   "main": "./public/electron.js",
   "engines": {


### PR DESCRIPTION
# What does this do?

- Bumps patch version.