### PR TITLE
feat(search-members): filter telegram bridge bot user from search results

### DIFF
--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -29,6 +29,7 @@ import { denormalizeConversations } from '../../../store/channels-list';
 import { CreateMessengerConversation } from '../../../store/channels-list/types';
 import { createConversation } from '../../../store/create-conversation';
 import { openUserProfile } from '../../../store/user-profile';
+import { config } from '../../../config';
 
 export interface PublicProperties {}
 
@@ -132,9 +133,11 @@ export class Container extends React.Component<Properties> {
     const myUserId = this.props.currentUser.userId;
 
     const users: MemberNetworks[] = await searchMyNetworksByName(search);
+    const isTelegramBotUser = (user) => user.id === config.telegramBotUserId;
 
     const mappedFilteredUsers = users
       ?.filter((user) => user.id !== myUserId)
+      ?.filter((user) => !isTelegramBotUser(user))
       .map((user) => ({
         ...user,
         image: usersFromState[user.id]?.profileImage ?? user.profileImage, // since redux state has local blob url image

--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -14,6 +14,7 @@ import { previewDisplayDate } from '../../../lib/chat/chat-message';
 import { UserHeader } from './user-header';
 import { ErrorDialog } from '../../error-dialog';
 import { bem } from '../../../lib/bem';
+import { config } from '../../../config';
 
 const c = bem('.direct-message-members');
 
@@ -256,6 +257,7 @@ describe('messenger-list', () => {
       { id: 'user-1', name: 'Jack', profileImage: 'image-url-1' },
       { id: myUserId, name: 'Janet', profileImage: 'image-url-2' }, // Current user
       { id: 'user-3', name: 'Jake', profileImage: 'image-url-3' },
+      { id: config.telegramBotUserId, name: 'Telegram Bridge Bot', profileImage: 'image-url-4' },
     ];
 
     const stages = [
@@ -275,6 +277,23 @@ describe('messenger-list', () => {
         const searchResults = await wrapper.find(component).prop(searchProp)('Ja');
 
         expect(searchResults).toEqual(expect.not.arrayContaining([{ id: myUserId }]));
+        expect(searchResults).toEqual([
+          { id: 'user-1', name: 'Jack', image: 'image-url-1', profileImage: 'image-url-1' },
+          { id: 'user-3', name: 'Jake', image: 'image-url-3', profileImage: 'image-url-3' },
+        ]);
+      });
+
+      it(`excludes the telegram bot user from search results in stage: ${stage}`, async () => {
+        when(mockSearchMyNetworksByName).calledWith('Telegram').mockResolvedValue(mockSearchResults);
+
+        const wrapper = subject({
+          stage: Stage.None,
+          myUserId: myUserId,
+        });
+
+        const searchResults = await wrapper.find(ConversationListPanel).prop('search')('Telegram');
+
+        expect(searchResults).toEqual(expect.not.arrayContaining([{ id: config.telegramBotUserId }]));
         expect(searchResults).toEqual([
           { id: 'user-1', name: 'Jack', image: 'image-url-1', profileImage: 'image-url-1' },
           { id: 'user-3', name: 'Jake', image: 'image-url-3', profileImage: 'image-url-3' },

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -39,6 +39,7 @@ import { Button } from '@zero-tech/zui/components/Button';
 import { IconPlus } from '@zero-tech/zui/icons';
 import { GroupTypeDialog } from './group-details-panel/group-type-dialog';
 import { AdminMessageType } from '../../../store/messages';
+import { config } from '../../../config';
 
 import { bemClassName } from '../../../lib/bem';
 import './styles.scss';
@@ -151,9 +152,11 @@ export class Container extends React.Component<Properties, State> {
   usersInMyNetworks = async (search: string) => {
     const { users: usersFromState, myUserId, receiveSearchResults } = this.props;
     const users: MemberNetworks[] = await searchMyNetworksByName(search);
+    const isTelegramBotUser = (user) => user.id === config.telegramBotUserId;
 
     const mappedFilteredUsers = users
       ?.filter((user) => user.id !== myUserId)
+      ?.filter((user) => !isTelegramBotUser(user))
       .map((user) => ({
         ...user,
         // since redux state has local blob url image


### PR DESCRIPTION
### What does this do?
- filters telegram bridge bot user from search results

### Why are we making this change?
- prevent bridge bot being added to group conversations
- prevent bridge bot being searched before initiating in linked accounts

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
