### PR TITLE
feat: restore last active conversation when returning to messenger

### DIFF
--- a/src/lib/last-conversation.ts
+++ b/src/lib/last-conversation.ts
@@ -1,0 +1,15 @@
+const LAST_CONVERSATION_KEY = 'last-active-conversation';
+
+export const setLastActiveConversation = (conversationId: string): void => {
+  if (conversationId) {
+    localStorage.setItem(LAST_CONVERSATION_KEY, conversationId);
+  }
+};
+
+export const getLastActiveConversation = (): string | null => {
+  return localStorage.getItem(LAST_CONVERSATION_KEY);
+};
+
+export const clearLastActiveConversation = (): void => {
+  localStorage.removeItem(LAST_CONVERSATION_KEY);
+};

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -33,6 +33,7 @@ import { completePendingUserProfile } from '../registration/saga';
 import { StoreBuilder } from '../test/store';
 import { throwError } from 'redux-saga-test-plan/providers';
 import { closeUserProfile } from '../user-profile/saga';
+import { clearLastActiveConversation } from '../../lib/last-conversation';
 
 describe(nonceOrAuthorize, () => {
   const signedWeb3Token = '0x000000000000000000000000000000000000000A';
@@ -249,6 +250,10 @@ describe(forceLogout, () => {
     const { storeState } = await expectLogoutSaga().withReducer(rootReducer, state.build()).run();
 
     expect(storeState.authentication.displayLogoutModal).toEqual(false);
+  });
+
+  it('clears the last active conversation', async () => {
+    await expectLogoutSaga().call(clearLastActiveConversation).call(terminate).run();
   });
 
   it('clears the user session', async () => {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -14,6 +14,7 @@ import { Events, getAuthChannel } from './channels';
 import { getHistory } from '../../lib/browser';
 import { completePendingUserProfile } from '../registration/saga';
 import { closeUserProfile } from '../user-profile/saga';
+import { clearLastActiveConversation } from '../../lib/last-conversation';
 
 export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
@@ -108,6 +109,7 @@ export function* closeLogoutModal() {
 
 export function* forceLogout() {
   yield closeLogoutModal();
+  yield call(clearLastActiveConversation);
   yield call(terminate);
 }
 

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -26,6 +26,7 @@ import { getUserReadReceiptPreference } from '../user-profile/saga';
 import { featureFlags } from '../../lib/feature-flags';
 import { createUnencryptedConversation as createUnencryptedMatrixConversation } from '../../lib/chat';
 import { isFileUploadedToMatrix } from '../../lib/chat/matrix/media';
+import { clearLastActiveConversation } from '../../lib/last-conversation';
 
 export function* parseProfileImagesForMembers(channels: any[]) {
   // Create a map of users that need profile image downloads
@@ -384,6 +385,7 @@ function* currentUserLeftChannel(channelId) {
 
   const activeConversationId = yield select((state) => getDeepProperty(state, 'chat.activeConversationId', ''));
   if (activeConversationId === channelId) {
+    yield call(clearLastActiveConversation);
     yield call(openFirstConversation);
   }
 }


### PR DESCRIPTION
### What does this do?
The implementation adds localStorage persistence to remember and restore the last active conversation when navigating between apps, while maintaining existing conversation management behaviors for user actions like leaving rooms or logging out.

### Why are we making this change?
Improve UX

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
