### PR TITLE
chore: bump minor (`1.262.0` -> `1.263.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ZERO",
-  "version": "1.262.0",
+  "version": "1.263.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ZERO",
-      "version": "1.262.0",
+      "version": "1.263.0",
       "dependencies": {
         "@craco/craco": "^7.1.0",
         "@emotion/react": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ZERO",
-  "version": "1.262.0",
+  "version": "1.263.0",
   "private": true,
   "main": "./public/electron.js",
   "engines": {


### PR DESCRIPTION
# What does this do?

- Increments version.