### PR TITLE
fix: `thirdweb` SDK chain select env

### DIFF
--- a/src/lib/web3/thirdweb/client.ts
+++ b/src/lib/web3/thirdweb/client.ts
@@ -15,5 +15,5 @@ function createClient(): ThirdwebClient {
 }
 
 export function getChain() {
-  return process.env.NODE_ENV === 'development' ? sepolia : mainnet;
+  return config.supportedChainId === '1' ? mainnet : sepolia;
 }


### PR DESCRIPTION
### What does this do?

- We were using `NODE_ENV` previously. Since we're selecting based on which chain the app is programmed to, we should use `REACT_APP_ETH_CHAIN`. This will make it easier to sync with the zOS API, e.g. we can set both environment variables to `sepolia` rather than have to match `NODE_ENV`.
