### PR TITLE
fix: handle `undefined` `firstName`

### DIFF
--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -28,6 +28,27 @@ describe('sortMembers', () => {
 
     expect(sortedMembers).toStrictEqual(expectedOrder);
   });
+
+  it('sorts alphabetically by firstName', () => {
+    const members = [
+      { firstName: 'Zeb' },
+      { firstName: '' },
+      { firstName: 'Charlie' },
+      { firstName: null },
+      { firstName: 'Adam' },
+    ] as any;
+
+    const sortedMembers = sortMembers(members, [], []);
+    const expectedOrder = [
+      { firstName: '' },
+      { firstName: null },
+      { firstName: 'Adam' },
+      { firstName: 'Charlie' },
+      { firstName: 'Zeb' },
+    ];
+
+    expect(sortedMembers).toStrictEqual(expectedOrder);
+  });
 });
 
 describe('isUserAdmin', () => {

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -42,7 +42,7 @@ export function sortMembers(members: User[], adminIds: string[], conversationMod
     if (!a.isOnline && b.isOnline) return 1;
 
     // Finally sort alphabetically by firstName
-    return a.firstName!.localeCompare(b.firstName);
+    return (a.firstName || '').localeCompare(b.firstName || '');
   });
 }
 


### PR DESCRIPTION
### What does this do?

- Adds handling for `undefined` `firstName` in `sortMembers`.
- Members with `undefined` `firstName` are sorted to the top of the list.
- Adds tests for the above case.

Note: I'm not sure why `firstName` could ever be `undefined`.