### PR TITLE
Fix issue with mentions where hash is being displayed on UI

### DIFF
--- a/src/components/content-highlighter/content-highlight.test.tsx
+++ b/src/components/content-highlighter/content-highlight.test.tsx
@@ -32,9 +32,16 @@ describe('ContentHighlighter', () => {
     expect(wrapper.text()).toContain('Hello, world! 🙂');
   });
 
-  it('renders content with a user mention', () => {
+  it('renders content with a user mention (ZERO user ID)', () => {
     const wrapper = render({
       message: 'Hello, @[John Doe](user:123)!',
+    });
+    expect(wrapper.find('.content-highlighter__user-mention').text()).toEqual('John Doe');
+  });
+
+  it('renders content with a user mention (matrix user ID)', () => {
+    const wrapper = render({
+      message: 'Hello, @[John Doe](user:@123:zos.zer0.io)!',
     });
     expect(wrapper.find('.content-highlighter__user-mention').text()).toEqual('John Doe');
   });

--- a/src/components/content-highlighter/index.tsx
+++ b/src/components/content-highlighter/index.tsx
@@ -20,9 +20,9 @@ const cn = bemClassName('content-highlighter');
 
 export class ContentHighlighter extends React.Component<Properties> {
   renderContent(message) {
-    const parts = message.split(/(@\[.*?\]\([a-z]+:[A-Za-z0-9_-]+\))/gi);
+    const parts = message.split(/(@\[.*?\]\([a-z]+:[A-Za-z0-9_@:.-]+\))/gi);
     return parts.map((part, index) => {
-      const match = part.match(/@\[(.*?)\]\(([a-z]+):([A-Za-z0-9_-]+)\)/i);
+      const match = part.match(/@\[(.*?)\]\(([a-z]+):([A-Za-z0-9_@:.-]+)\)/i);
 
       if (!match) {
         return textToPlainEmojis(part);
@@ -41,7 +41,6 @@ export class ContentHighlighter extends React.Component<Properties> {
           </span>
         );
       }
-
       return part;
     });
   }


### PR DESCRIPTION
### What does this do?

Issue:
![image](https://github.com/user-attachments/assets/c392814f-0311-49a1-8272-94154d263398)

Reason: Sometimes, instead of the `userId`, the `matrixId` is being returned in the `suggestDisplayNamesForMentions` function (**particularly on desktop**). The current regex for highlighting user mentions wasn't able to parse the matrixId (just the user id).

This PR fixes that.
