### PR TITLE
feat(matrix-client): add room id to alias (zid) conversion using matrix get room local aliases

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -424,3 +424,7 @@ export function getProfileInfo(userId: string): Promise<{
 }> {
   return chat.get().matrix.getProfileInfo(userId);
 }
+
+export async function getAliasForRoomId(roomId: string) {
+  return chat.get().matrix.getAliasForRoomId(roomId);
+}

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -1571,6 +1571,58 @@ describe('matrix client', () => {
     });
   });
 
+  describe('getAliasForRoomId', () => {
+    it('returns alias for room ID', async () => {
+      const aliases = { aliases: ['#test-room:zos-dev.zero.io'] };
+      const getLocalAliases = jest.fn().mockResolvedValue(aliases);
+
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getLocalAliases })),
+      });
+
+      await client.connect(null, 'token');
+      const result = await client.getAliasForRoomId('!heExvpcoNDAMAPMsRd:zos-dev.zero.io');
+
+      expect(result).toEqual('test-room');
+    });
+
+    it('returns undefined if room has no aliases', async () => {
+      const getLocalAliases = jest.fn().mockResolvedValue({ aliases: [] });
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getLocalAliases })),
+      });
+
+      await client.connect(null, 'token');
+      const result = await client.getAliasForRoomId('!heExvpcoNDAMAPMsRd:zos-dev.zero.io');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if forbidden to access room (M_FORBIDDEN)', async () => {
+      const getLocalAliases = jest.fn().mockRejectedValue({ errcode: 'M_FORBIDDEN' });
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getLocalAliases })),
+      });
+
+      await client.connect(null, 'token');
+      const result = await client.getAliasForRoomId('!heExvpcoNDAMAPMsRd:zos-dev.zero.io');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if room is unknown (M_UNKNOWN)', async () => {
+      const getLocalAliases = jest.fn().mockRejectedValue({ errcode: 'M_UNKNOWN' });
+      const client = subject({
+        createClient: jest.fn(() => getSdkClient({ getLocalAliases })),
+      });
+
+      await client.connect(null, 'token');
+      const result = await client.getAliasForRoomId('!heExvpcoNDAMAPMsRd:zos-dev.zero.io');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('getRoomIdForAlias', () => {
     it('returns room ID for alias', async () => {
       const roomId = '!heExvpcoNDAMAPMsRd:zos-dev.zero.io';

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1178,6 +1178,24 @@ export class MatrixClient implements IChatClient {
     await this.matrix.redactEvent(roomId, messageId);
   }
 
+  async getAliasForRoomId(roomId: string): Promise<string | undefined> {
+    await this.waitForConnection();
+    return await this.matrix
+      .getLocalAliases(roomId)
+      .catch((err) => {
+        if (err.errcode === 'M_FORBIDDEN' || err.errcode === 'M_UNKNOWN') {
+          return Promise.resolve(undefined);
+        }
+      })
+      .then((response) => {
+        const alias = response?.aliases?.[0];
+        if (!alias) return undefined;
+
+        const match = alias.match(/#(.+?):/);
+        return match?.[1];
+      });
+  }
+
   async getRoomIdForAlias(alias: string): Promise<string | undefined> {
     await this.waitForConnection();
     return await this.matrix


### PR DESCRIPTION
### What does this do?
- adds room id to alias (zid) conversion using matrix get room local aliases

### Why are we making this change?
- to be able to get the alias (zid) of the room from id 

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
