### PR TITLE
feat(messenger/conversation-actions): disable group management actions for social channels

### DIFF
--- a/src/components/messenger/conversation-actions/container.test.tsx
+++ b/src/components/messenger/conversation-actions/container.test.tsx
@@ -47,6 +47,22 @@ describe('ConversationActionsContainer', () => {
         );
       });
 
+      it('is false when the conversation is social channel', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({
+              otherMembers: [stubUser(), stubUser()],
+              adminMatrixIds: ['other-user-matrix-id'],
+              isSocialChannel: true,
+            })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationActionsContainer.mapState(state.build())).toEqual(
+          expect.objectContaining({ canLeaveRoom: false })
+        );
+      });
+
       it('is true when user is not admin and more than one other member', () => {
         const state = new StoreBuilder()
           .withActiveConversation(
@@ -59,9 +75,9 @@ describe('ConversationActionsContainer', () => {
         );
       });
 
-      it('is true when the conversation is a social channel and has multiple members', () => {
+      it('is true when the conversation has multiple members', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ otherMembers: [stubUser(), stubUser()], isSocialChannel: true }))
+          .withActiveConversation(stubConversation({ otherMembers: [stubUser(), stubUser()] }))
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(ConversationActionsContainer.mapState(state.build())).toEqual(
@@ -127,19 +143,25 @@ describe('ConversationActionsContainer', () => {
         );
       });
 
-      it('is true when the conversation is a social channel and user is an admin', () => {
+      it('is true when the user is an admin', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(
-            stubConversation({
-              isOneOnOne: true,
-              adminMatrixIds: ['current-user-matrix-id'],
-              isSocialChannel: true,
-            })
-          )
+          .withActiveConversation(stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'] }))
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(ConversationActionsContainer.mapState(state.build())).toEqual(
           expect.objectContaining({ canEdit: true })
+        );
+      });
+
+      it('is false when the conversation is a social channel and current user is admin', () => {
+        const state = new StoreBuilder()
+          .withActiveConversation(
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: true })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
+
+        expect(ConversationActionsContainer.mapState(state.build())).toEqual(
+          expect.objectContaining({ canEdit: false })
         );
       });
 
@@ -191,19 +213,15 @@ describe('ConversationActionsContainer', () => {
         );
       });
 
-      it('is true when the conversation is a social channel and user is an admin', () => {
+      it('is false when the conversation is a social channel', () => {
         const state = new StoreBuilder()
           .withActiveConversation(
-            stubConversation({
-              isOneOnOne: true,
-              adminMatrixIds: ['current-user-matrix-id'],
-              isSocialChannel: true,
-            })
+            stubConversation({ isOneOnOne: false, adminMatrixIds: ['current-user-matrix-id'], isSocialChannel: true })
           )
           .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(ConversationActionsContainer.mapState(state.build())).toEqual(
-          expect.objectContaining({ canAddMembers: true })
+          expect.objectContaining({ canAddMembers: false })
         );
       });
 

--- a/src/components/messenger/conversation-actions/container.tsx
+++ b/src/components/messenger/conversation-actions/container.tsx
@@ -55,10 +55,10 @@ export class Container extends React.Component<Properties> {
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
     const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.id) ?? false;
 
-    const canLeaveRoom = !isCurrentUserRoomAdmin && hasMultipleMembers;
+    const canLeaveRoom = !isSocialChannel && !isCurrentUserRoomAdmin && hasMultipleMembers;
     const canEdit =
-      (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && (!directMessage?.isOneOnOne || isSocialChannel);
-    const canAddMembers = isCurrentUserRoomAdmin && (!directMessage?.isOneOnOne || isSocialChannel);
+      !isSocialChannel && (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !directMessage?.isOneOnOne;
+    const canAddMembers = !isSocialChannel && isCurrentUserRoomAdmin && !directMessage?.isOneOnOne;
     const canViewDetails = !directMessage?.isOneOnOne || isSocialChannel;
     const canReportUser = directMessage?.isOneOnOne && !isSocialChannel;
 


### PR DESCRIPTION
### What does this do?
- disables group management actions for social channels

### Why are we making this change?
- prevent users being added, leaving or edited on social channels (if the user was somehow able to render the conversation in messenger app, which in a follow up should not be possible).

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
