### PR TITLE
fix: redirect to world ZID

### DIFF
--- a/src/apps/feed/index.tsx
+++ b/src/apps/feed/index.tsx
@@ -1,6 +1,7 @@
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 import { useOwnedZids } from '../../lib/hooks/useOwnedZids';
+import { parseWorldZid } from '../../lib/zid';
 
 import { Feed } from './components/feed';
 import { Sidekick } from './components/sidekick';
@@ -45,5 +46,5 @@ const Loading = () => {
     );
   }
 
-  return <Redirect to={`/feed/${zids?.[0]?.split('.')[0]}`} />;
+  return <Redirect to={`/feed/${parseWorldZid(zids[0])}`} />;
 };

--- a/src/lib/zid.ts
+++ b/src/lib/zid.ts
@@ -1,0 +1,7 @@
+export const parseWorldZid = (zid: string) => {
+  const worldZid = zid?.split('.')[0];
+
+  if (worldZid?.length) {
+    return worldZid;
+  }
+};

--- a/src/lib/zid.vitest.ts
+++ b/src/lib/zid.vitest.ts
@@ -1,0 +1,23 @@
+import { parseWorldZid } from './zid';
+
+describe('getWorldZid', () => {
+  it('should return the world zid', () => {
+    expect(parseWorldZid('foo')).toBe('foo');
+    expect(parseWorldZid('foo.bar')).toBe('foo');
+    expect(parseWorldZid('foo.bar.baz')).toBe('foo');
+  });
+
+  it('should handle undefined', () => {
+    expect(parseWorldZid(undefined)).toBe(undefined);
+  });
+
+  it('should handle empty string', () => {
+    expect(parseWorldZid('')).toBe(undefined);
+  });
+
+  it('should handle ZIDs with 0:// prefix', () => {
+    expect(parseWorldZid('0://foo')).toBe('0://foo');
+    expect(parseWorldZid('0://foo.bar')).toBe('0://foo');
+    expect(parseWorldZid('0://foo.bar.baz')).toBe('0://foo');
+  });
+});


### PR DESCRIPTION
### What does this do?

- Redirect to world ZID, rather than ZID (i.e. `foo` instead of `foo.bar`).