### PR TITLE
fix: unable to mark channel chat notifications as read

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,18 +9,9 @@ import { getMainBackgroundClass, getMainBackgroundVideoSrc } from './utils';
 import { AppBar } from './components/app-bar/container';
 import { DialogManager } from './components/dialog-manager/container';
 import { ThemeEngine } from './components/theme-engine';
-import { denormalizeConversations } from './store/channels-list';
-import { DefaultRoomLabels } from './store/channels';
 
 export const App = () => {
-  const {
-    isAuthenticated,
-    mainClassName,
-    videoBackgroundSrc,
-    wrapperClassName,
-    hasUnreadNotifications,
-    hasUnreadHighlights,
-  } = useAppMain();
+  const { isAuthenticated, mainClassName, videoBackgroundSrc, wrapperClassName } = useAppMain();
 
   return (
     // See: ZOS-115
@@ -32,7 +23,7 @@ export const App = () => {
             {videoBackgroundSrc && <VideoBackground src={videoBackgroundSrc} />}
             <div className={wrapperClassName}>
               <DialogManager />
-              <AppBar hasUnreadNotifications={hasUnreadNotifications} hasUnreadHighlights={hasUnreadHighlights} />
+              <AppBar />
               <AppRouter />
             </div>
           </>
@@ -47,26 +38,6 @@ const useAppMain = () => {
   const isAuthenticated = useSelector((state: RootState) => !!state.authentication.user?.data);
   const background = useSelector((state: RootState) => state.background.selectedMainBackground);
 
-  const hasUnreadNotifications = useSelector((state: RootState) => {
-    const conversations = denormalizeConversations(state);
-    return conversations.some(
-      (channel) =>
-        channel.unreadCount?.total > 0 &&
-        !channel.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
-        !channel.labels?.includes(DefaultRoomLabels.MUTE)
-    );
-  });
-
-  const hasUnreadHighlights = useSelector((state: RootState) => {
-    const conversations = denormalizeConversations(state);
-    return conversations.some(
-      (channel) =>
-        channel.unreadCount?.highlight > 0 &&
-        !channel.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
-        !channel.labels?.includes(DefaultRoomLabels.MUTE)
-    );
-  });
-
   const videoBackgroundSrc = getMainBackgroundVideoSrc(background);
   const mainClassName = classNames('main', 'messenger-full-screen', getMainBackgroundClass(background), {
     'sidekick-panel-open': isAuthenticated,
@@ -80,8 +51,6 @@ const useAppMain = () => {
     mainClassName,
     videoBackgroundSrc,
     wrapperClassName,
-    hasUnreadNotifications,
-    hasUnreadHighlights,
   };
 };
 

--- a/src/apps/feed/components/feed-chat/index.tsx
+++ b/src/apps/feed/components/feed-chat/index.tsx
@@ -23,8 +23,11 @@ import { MembersSidekick } from '../../../../components/sidekick/variants/member
 import classNames from 'classnames';
 import styles from './styles.module.scss';
 
-interface Properties {
+export interface PublicProperties {
   zid?: string;
+}
+
+export interface Properties extends PublicProperties {
   channel: Channel;
   activeConversationId: string;
   isJoiningConversation: boolean;
@@ -214,4 +217,4 @@ export class Container extends React.Component<Properties> {
   }
 }
 
-export const FeedChatContainer = connectContainer<{ zid?: string }>(Container);
+export const FeedChatContainer = connectContainer<PublicProperties>(Container);

--- a/src/components/app-bar/container.tsx
+++ b/src/components/app-bar/container.tsx
@@ -1,20 +1,48 @@
 import { useRouteMatch } from 'react-router-dom';
 import { AppBar as AppBarComponent } from './';
+import { denormalizeConversations } from '../../store/channels-list';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store';
+import { DefaultRoomLabels } from '../../store/channels';
 
-export const AppBar = ({
-  hasUnreadNotifications,
-  hasUnreadHighlights,
-}: {
-  hasUnreadNotifications: boolean;
-  hasUnreadHighlights: boolean;
-}) => {
-  const match = useRouteMatch('/:app');
+export const AppBar = () => {
+  const { activeApp, hasUnreadNotifications, hasUnreadHighlights } = useAppBar();
 
   return (
     <AppBarComponent
-      activeApp={match?.params?.app ?? ''}
+      activeApp={activeApp}
       hasUnreadNotifications={hasUnreadNotifications}
       hasUnreadHighlights={hasUnreadHighlights}
     />
   );
+};
+
+const useAppBar = () => {
+  const match = useRouteMatch('/:app');
+
+  const hasUnreadNotifications = useSelector((state: RootState) => {
+    const conversations = denormalizeConversations(state);
+    return conversations.some(
+      (channel) =>
+        channel.unreadCount?.total > 0 &&
+        !channel.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
+        !channel.labels?.includes(DefaultRoomLabels.MUTE)
+    );
+  });
+
+  const hasUnreadHighlights = useSelector((state: RootState) => {
+    const conversations = denormalizeConversations(state);
+    return conversations.some(
+      (channel) =>
+        channel.unreadCount?.highlight > 0 &&
+        !channel.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
+        !channel.labels?.includes(DefaultRoomLabels.MUTE)
+    );
+  });
+
+  return {
+    activeApp: match?.params?.app ?? '',
+    hasUnreadNotifications,
+    hasUnreadHighlights,
+  };
 };

--- a/src/components/app-bar/container.vitest.tsx
+++ b/src/components/app-bar/container.vitest.tsx
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { AppBar } from './container';
+import { renderWithProviders } from '../../test-utils';
 
 const mockAppBar = vi.fn();
 
@@ -13,9 +13,9 @@ vi.mock('./', () => ({
 }));
 
 const renderComponent = (route: string | undefined = '/') => {
-  render(
+  renderWithProviders(
     <MemoryRouter initialEntries={[route]}>
-      <AppBar hasUnreadNotifications={false} hasUnreadHighlights={false} />
+      <AppBar />
     </MemoryRouter>
   );
 };

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -213,7 +213,6 @@ export function* publishUserStoppedTypingEvent(roomId) {
 
 // publishes a user stopped typing event when a message is sent
 function* listenForMessageSent() {
-  console.log('message sent');
   const chatBus = yield call(getChatMessageBus);
   while (true) {
     const { channelId } = yield take(chatBus, ChatMessageEvents.Sent);

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -46,13 +46,14 @@ export function* markConversationAsRead(conversationId) {
   const currentUser = yield select(currentUserSelector());
   const conversationInfo = yield select(rawChannelSelector(conversationId));
 
-  // We should only mark as read if the user is in the messenger app and not in the notifications feed
+  // We should only mark as read if the user is in the Messenger or Feed app and not in the notifications feed
   const history = yield call(getHistory);
   const isMessengerAppActive = history.location?.pathname?.startsWith('/conversation/');
+  const isFeedAppActive = history.location?.pathname?.startsWith('/feed/');
 
   if (
     (conversationInfo?.unreadCount?.total > 0 || conversationInfo?.unreadCount?.highlight > 0) &&
-    isMessengerAppActive
+    (isMessengerAppActive || isFeedAppActive)
   ) {
     yield call(markAllMessagesAsRead, conversationId, currentUser.id);
   }
@@ -212,6 +213,7 @@ export function* publishUserStoppedTypingEvent(roomId) {
 
 // publishes a user stopped typing event when a message is sent
 function* listenForMessageSent() {
+  console.log('message sent');
   const chatBus = yield call(getChatMessageBus);
   while (true) {
     const { channelId } = yield take(chatBus, ChatMessageEvents.Sent);

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -19,7 +19,7 @@ import { receive } from '../users';
 import { chat, getRoomIdForAlias, isRoomMember } from '../../lib/chat';
 import { ConversationEvents, getConversationsBus } from '../channels-list/channels';
 import { getHistory } from '../../lib/browser';
-import { openFirstConversation } from '../channels/saga';
+import { markConversationAsRead, openFirstConversation } from '../channels/saga';
 import { translateJoinRoomApiError, parseAlias, isAlias, extractDomainFromAlias } from './utils';
 import { joinRoom as apiJoinRoom } from './api';
 import { rawConversationsList } from '../channels-list/selectors';
@@ -198,6 +198,9 @@ export function* performValidateActiveConversation(activeConversationId: string)
   }
 
   yield put(rawSetActiveConversationId(conversationId));
+
+  // Mark conversation as read, now that it has been set as active
+  yield call(markConversationAsRead, conversationId);
 }
 
 export function* closeErrorDialog() {


### PR DESCRIPTION
### What does this do?

- Moves App Bar notification count state to App Bar (prevents re-rendering the whole app).
- Adds `isFeedApp` to "mark as read" conditional in Matrix client.
- Calls "mark as read" whenever a chat is validated (i.e. when it's opened).