### PR TITLE
fix: only show joining dialog when joining new conversations and conversation is not yet valid

### DIFF
--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -29,14 +29,22 @@ describe(Main, () => {
     return shallow(<Main {...allProps} />);
   };
 
-  it('renders JoiningConversationDialog when isJoiningConversation is true', () => {
-    const wrapper = subject({ context: { isAuthenticated: true }, isJoiningConversation: true });
+  it('renders JoiningConversationDialog when isJoiningConversation is true and isValidConversation is false', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isJoiningConversation: true,
+      isValidConversation: false,
+    });
 
     expect(wrapper).toHaveElement(JoiningConversationDialog);
   });
 
-  it('does not render JoiningConversationDialog when isJoiningConversation is false', () => {
-    const wrapper = subject({ context: { isAuthenticated: true }, isJoiningConversation: false });
+  it('does not render JoiningConversationDialog when isJoiningConversation is false and isValidConversation is true', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isJoiningConversation: false,
+      isValidConversation: true,
+    });
 
     expect(wrapper).not.toHaveElement(JoiningConversationDialog);
   });

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -51,7 +51,7 @@ export class Container extends React.Component<Properties> {
           <>
             <ConversationsSidekick />
             <div className={styles.Split}>
-              {this.props.isJoiningConversation && <JoiningConversationDialog />}
+              {this.props.isJoiningConversation && !this.props.isValidConversation && <JoiningConversationDialog />}
 
               {this.props.isConversationsLoaded &&
                 this.props.isValidConversation &&


### PR DESCRIPTION
### What does this do?
- only shows joining dialog when joining new conversations
- only show joining dialog is active conversation is not valid

### Why are we making this change?
- incorrectly displaying joining dialog

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
