### PR TITLE
Trigger `recordMessageSent` with `type == 'social'` in a social (token gated) channel

### DIFF
--- a/src/apps/feed/components/feed-chat/index.tsx
+++ b/src/apps/feed/components/feed-chat/index.tsx
@@ -115,6 +115,7 @@ export class Container extends React.Component<Properties> {
       mentionedUserIds,
       parentMessage: this.props.channel.reply,
       files: media,
+      isSocialChannel: true,
     };
 
     this.props.sendMessage(payloadSendMessage);

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -62,7 +62,8 @@ export interface IChatClient {
     mentionedUserIds: string[],
     parentMessage?: ParentMessage,
     file?: FileUploadResult,
-    optimisticId?: string
+    optimisticId?: string,
+    isSocialChannel?: boolean
   ) => Promise<MessagesResponse>;
   fetchConversationsWithUsers: (users: User[]) => Promise<Partial<Channel>[]>;
   deleteMessageByRoomId: (roomId: string, messageId: string) => Promise<void>;
@@ -170,9 +171,18 @@ export class Chat {
     mentionedUserIds: string[],
     parentMessage?: ParentMessage,
     file?: FileUploadResult,
-    optimisticId?: string
+    optimisticId?: string,
+    isSocialChannel?: boolean
   ): Promise<any> {
-    return this.client.sendMessagesByChannelId(channelId, message, mentionedUserIds, parentMessage, file, optimisticId);
+    return this.client.sendMessagesByChannelId(
+      channelId,
+      message,
+      mentionedUserIds,
+      parentMessage,
+      file,
+      optimisticId,
+      isSocialChannel || false
+    );
   }
 
   async fetchConversationsWithUsers(users: User[]): Promise<any[]> {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -992,7 +992,7 @@ export class MatrixClient implements IChatClient {
   }
 
   async recordMessageSent(roomId: string, isSocialChannel: boolean = false): Promise<void> {
-    let messageType = isSocialChannel ? ChatMessageType.SOCIAL : ChatMessageType.GENERAL;
+    let messageType = isSocialChannel ? ChatMessageType.CHANNEL : ChatMessageType.GROUP;
     const data = { roomId, sentAt: new Date().valueOf(), type: messageType };
 
     await post<any>('/matrix/message')

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -40,3 +40,8 @@ export enum PowerLevels {
   Moderator = 50, // "Moderator" or ~PL50
   Owner = 100, // "Admin" or PL100
 }
+
+export enum ChatMessageType {
+  GENERAL = 'general',
+  SOCIAL = 'social',
+}

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -42,6 +42,6 @@ export enum PowerLevels {
 }
 
 export enum ChatMessageType {
-  GENERAL = 'general',
-  SOCIAL = 'social',
+  GROUP = 'group', // encrpyted/unencrypted group chats
+  CHANNEL = 'channel', // token gated (social) chats
 }

--- a/src/store/messages/saga.send.test.ts
+++ b/src/store/messages/saga.send.test.ts
@@ -42,7 +42,7 @@ describe(send, () => {
       .next({ optimisticRootMessage: { id: 'optimistic-message-id' } })
       .spawn(createOptimisticPreview, channelId, { id: 'optimistic-message-id' })
       .next()
-      .call(performSend, channelId, message, mentionedUserIds, parentMessage, 'optimistic-message-id')
+      .call(performSend, channelId, message, mentionedUserIds, parentMessage, 'optimistic-message-id', false)
       .next({ id: 'message-id' })
       .next()
       .next()
@@ -250,8 +250,9 @@ describe(performSend, () => {
       'user-id2',
     ];
     const parentMessage = { id: 'parent' };
+    const isSocialChannel = true;
 
-    await expectSaga(performSend, channelId, message, mentionedUserIds, parentMessage, 'optimistic-id')
+    await expectSaga(performSend, channelId, message, mentionedUserIds, parentMessage, 'optimistic-id', isSocialChannel)
       .provide([
         stubResponse(matchers.call.fn(chat.get), chatClient),
         stubResponse(matchers.call.fn(chatClient.sendMessagesByChannelId), {}),
@@ -265,6 +266,7 @@ describe(performSend, () => {
           parentMessage,
           null,
           'optimistic-id',
+          isSocialChannel,
         ],
       })
       .run();

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -70,6 +70,7 @@ export interface SendPayload {
   file?: FileUploadResult;
   optimisticId?: string;
   files?: MediaInfo[];
+  isSocialChannel?: boolean;
 }
 
 interface MediaInfo {
@@ -209,7 +210,7 @@ export function* fetch(action) {
 }
 
 export function* send(action) {
-  const { channelId, message, mentionedUserIds, parentMessage, files = [] } = action.payload;
+  const { channelId, message, mentionedUserIds, parentMessage, files = [], isSocialChannel = false } = action.payload;
 
   const processedFiles: Uploadable[] = files.map(createUploadableFile);
 
@@ -231,7 +232,8 @@ export function* send(action) {
       message,
       mentionedUserIds,
       parentMessage,
-      optimisticRootMessage.id
+      optimisticRootMessage.id,
+      isSocialChannel
     );
 
     if (textMessage) {
@@ -300,7 +302,14 @@ export function* createOptimisticPreview(channelId: string, optimisticMessage) {
   }
 }
 
-export function* performSend(channelId, message, mentionedUserIds, parentMessage, optimisticId) {
+export function* performSend(
+  channelId,
+  message,
+  mentionedUserIds,
+  parentMessage,
+  optimisticId,
+  isSocialChannel: boolean = false
+) {
   const chatClient = yield call(chat.get);
 
   const messageCall = call(
@@ -313,7 +322,8 @@ export function* performSend(channelId, message, mentionedUserIds, parentMessage
     mentionedUserIds,
     parentMessage,
     null,
-    optimisticId
+    optimisticId,
+    isSocialChannel
   );
 
   const result = yield sendMessage(messageCall, channelId, optimisticId);


### PR DESCRIPTION
### What does this do?

Updates the `sendMessage` logic to also include the channel type (if it is a social channel or not). If yes, then we pass on this info to `recordMessageSent` fn, which calls the respective API to record that event.

This is done so that in the rewards calculation, we can filter out the users who have sent messages in social channels. 
