### PR TITLE
fix(members-sidekick): fix scroll on secondary sidekick panels

### DIFF
--- a/src/components/sidekick/variants/members-sidekick.module.scss
+++ b/src/components/sidekick/variants/members-sidekick.module.scss
@@ -6,10 +6,13 @@
 }
 
 .Members {
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   max-width: 0;
   overflow: hidden;
   gap: variables.$default-gap;
+  height: 100%;
+  max-height: 100vh;
 
   &.Open {
     transform: translateX(0);
@@ -25,4 +28,15 @@
   }
 
   transition: transform 0.1s ease-out, max-width 0.1s ease-out, padding 0.1s ease-out;
+}
+
+.Content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  height: 100%;
+  max-height: calc(100vh - 120px);
+  margin: 4px 4px 0 0;
+
+  scrollbar-width: none;
 }

--- a/src/components/sidekick/variants/members-sidekick.tsx
+++ b/src/components/sidekick/variants/members-sidekick.tsx
@@ -60,7 +60,7 @@ export class Container extends React.Component<Properties> {
           </Header>
         }
       >
-        {this.renderSecondarySidekickContent()}
+        <div className={styles.Content}>{this.renderSecondarySidekickContent()}</div>
       </SidekickContainer>
     );
   }


### PR DESCRIPTION
### What does this do?
- fixes scroll on secondary sidekick panels

### Why are we making this change?
- bug reported

### How do I test this?
- run tests as usual.
- run ui and test scroll on secondary sidekick panels

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
