### PR TITLE
feat: move hover to app bar, not container

### DIFF
--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -38,10 +38,10 @@ $width: 46px;
     backdrop-filter: blur(30px);
     list-style: none;
     transition: width 0.15s ease-in-out;
-  }
 
-  &:hover &__container {
-    width: calc(200px);
+    &:hover {
+      width: calc(200px);
+    }
   }
 
   &__notification-icon-wrapper {


### PR DESCRIPTION
### What does this do?


- Moves hover to app bar, rather than the whole container.
