### PR TITLE
fix: notification dot relative to icon

### DIFF
--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -46,6 +46,8 @@ $width: 46px;
 
   &__notification-icon-wrapper {
     position: relative;
+    width: 22px;
+    height: 22px;
   }
 
   &__notification-icon {


### PR DESCRIPTION
### What does this do?

- Positions new notification dot relative to icon, rather than container.
