### PR TITLE
refactor(notifications-app): remove muted tab from notifications app

### DIFF
--- a/src/components/notifications-feed/index.test.tsx
+++ b/src/components/notifications-feed/index.test.tsx
@@ -89,33 +89,6 @@ describe('NotificationsFeed', () => {
     expect(notificationItems.at(0).prop('type')).toBe('highlight');
   });
 
-  it('filters conversations correctly for Muted tab', () => {
-    const conversations = [
-      {
-        id: 'channel-1',
-        unreadCount: { total: 3, highlight: 0 },
-        name: 'Regular Chat',
-        isMuted: false,
-      },
-      {
-        id: 'channel-2',
-        unreadCount: { total: 1, highlight: 1 },
-        name: 'Muted Chat',
-        isMuted: true,
-      },
-    ] as Channel[];
-
-    const wrapper = subject({ conversations, isConversationsLoaded: true });
-    wrapper.setState({ selectedTab: 'muted' });
-
-    const notificationItems = wrapper.find(NotificationItem);
-    expect(notificationItems).toHaveLength(2);
-    expect(notificationItems.at(0).prop('conversation').id).toBe('channel-2');
-    expect(notificationItems.at(0).prop('type')).toBe('total');
-    expect(notificationItems.at(1).prop('conversation').id).toBe('channel-2');
-    expect(notificationItems.at(1).prop('type')).toBe('highlight');
-  });
-
   it('renders notifications when conversations exist', () => {
     const wrapper = subject({
       conversations: mockConversations,

--- a/src/components/notifications-feed/index.tsx
+++ b/src/components/notifications-feed/index.tsx
@@ -15,19 +15,16 @@ import styles from './styles.module.scss';
 enum Tab {
   All = 'all',
   Highlights = 'highlights',
-  Muted = 'muted',
 }
 
 const MESSAGES: Record<Tab, string> = {
   [Tab.All]: 'No new notifications',
   [Tab.Highlights]: 'No new highlights',
-  [Tab.Muted]: 'No notifications in muted conversations',
 };
 
 const TABS: { key: Tab; label: string }[] = [
   { key: Tab.All, label: 'All' },
   { key: Tab.Highlights, label: 'Highlights' },
-  { key: Tab.Muted, label: 'Muted' },
 ];
 
 export interface PublicProperties {}
@@ -81,13 +78,6 @@ export class Container extends React.Component<Properties, State> {
             conversation.unreadCount?.highlight > 0 &&
             !conversation.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
             !conversation.isMuted
-        );
-      case Tab.Muted:
-        return conversations.filter(
-          (conversation) =>
-            conversation.isMuted &&
-            !conversation.labels?.includes(DefaultRoomLabels.ARCHIVED) &&
-            (conversation.unreadCount?.total > 0 || conversation.unreadCount?.highlight > 0)
         );
       case Tab.All:
       default:

--- a/src/components/notifications-feed/index.vitest.tsx
+++ b/src/components/notifications-feed/index.vitest.tsx
@@ -26,7 +26,6 @@ describe('NotificationsFeed', () => {
         options: [
           { key: 'all', label: 'All' },
           { key: 'highlights', label: 'Highlights' },
-          { key: 'muted', label: 'Muted' },
         ],
       })
     );


### PR DESCRIPTION
### What does this do?
- removes muted tab from notifications app

### Why are we making this change?
- muted rooms no longer have tracking for unread notifications so the muted tab is no longer required

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
