### PR TITLE
fix(matrix-client): push empty rule actions array when muting

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1253,7 +1253,7 @@ export class MatrixClient implements IChatClient {
     await this.waitForConnection();
 
     const rule = {
-      actions: ['dont_notify'],
+      actions: [],
       conditions: [
         {
           kind: 'event_match' as any,
@@ -1270,7 +1270,7 @@ export class MatrixClient implements IChatClient {
       // If the rule already exists, update it
       if (error.errcode === 'M_UNKNOWN') {
         await this.matrix.setPushRuleEnabled('global', PushRuleKind.Override, roomId, true);
-        await this.matrix.setPushRuleActions('global', PushRuleKind.Override, roomId, ['dont_notify'] as any);
+        await this.matrix.setPushRuleActions('global', PushRuleKind.Override, roomId, []);
       } else {
         throw error;
       }
@@ -1639,7 +1639,7 @@ export class MatrixClient implements IChatClient {
         if (roomCondition) {
           const roomId = roomCondition.pattern;
           // A room is muted if the rule is enabled and has "dont_notify" action
-          const isMuted = rule.enabled && rule.actions.some((action) => action === 'dont_notify');
+          const isMuted = rule.enabled && rule.actions.length === 0;
 
           this.events.roomMuteStatusChanged(roomId, isMuted);
         }
@@ -1751,7 +1751,7 @@ export class MatrixClient implements IChatClient {
       );
 
       // A room is muted if there's a matching condition, the rule is enabled, and has "dont_notify" action
-      return roomCondition && rule.enabled && rule.actions.some((action) => action === 'dont_notify');
+      return roomCondition && rule.enabled && rule.actions.length === 0;
     });
 
     return !!muteRule;


### PR DESCRIPTION
### What does this do?
- push empty rule actions array when muting

### Why are we making this change?
- fixes getting correct muted rooms on initial load and real time tracking 

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
