### PR TITLE
feat(channel-zid-list): display unread count on muted zids in the channel zid list

### DIFF
--- a/src/apps/feed/components/sidekick/index.tsx
+++ b/src/apps/feed/components/sidekick/index.tsx
@@ -12,6 +12,7 @@ import { LoadingIndicator } from '@zero-tech/zui/components/LoadingIndicator';
 import { IconBellOff1, IconSearchMd } from '@zero-tech/zui/icons';
 import { Panel, PanelBody } from '../../../../components/layout/panel';
 
+import classNames from 'classnames';
 import styles from './styles.module.scss';
 
 export const Sidekick = () => {
@@ -56,20 +57,23 @@ export const Sidekick = () => {
                       const hasUnreadHighlights = unreadCounts[zid]?.highlight > 0;
                       const hasUnreadTotal = unreadCounts[zid]?.total > 0;
                       const isMuted = mutedChannels[zid];
-
+                      const isUnread = hasUnreadHighlights || hasUnreadTotal;
                       return (
                         <FeedItem key={zid} route={`/feed/${zid}`} isSelected={selectedZId === zid}>
-                          <div className={styles.FeedName}>
+                          <div className={classNames(styles.FeedName, { [styles.Unread]: isUnread })}>
                             <span>0://</span>
                             <div>{zid}</div>
                           </div>
-                          {isMuted && <IconBellOff1 className={styles.MutedIcon} size={16} />}
-                          {!hasUnreadHighlights && hasUnreadTotal && (
-                            <div className={styles.UnreadCount}>{unreadCounts[zid]?.total}</div>
-                          )}
-                          {hasUnreadHighlights && (
-                            <div className={styles.UnreadHighlight}>{unreadCounts[zid]?.highlight}</div>
-                          )}
+
+                          <div className={styles.ItemIcons}>
+                            {isMuted && <IconBellOff1 className={styles.MutedIcon} size={16} />}
+                            {!hasUnreadHighlights && hasUnreadTotal && (
+                              <div className={styles.UnreadCount}>{unreadCounts[zid]?.total}</div>
+                            )}
+                            {hasUnreadHighlights && (
+                              <div className={styles.UnreadHighlight}>{unreadCounts[zid]?.highlight}</div>
+                            )}
+                          </div>
                         </FeedItem>
                       );
                     })}

--- a/src/apps/feed/components/sidekick/styles.module.scss
+++ b/src/apps/feed/components/sidekick/styles.module.scss
@@ -150,3 +150,13 @@
 
   align-self: center;
 }
+
+.ItemIcons {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.Unread {
+  font-weight: 600;
+}


### PR DESCRIPTION
### What does this do?
- display unread count on muted zids in the channel zid list

### Why are we making this change?
- display unread count and mute icon on unread channel zid list 

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
