### PR TITLE
fix(chat-saga/chat-state): handle race condition in conversation validation by cancelling previous tasks

### DIFF
--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -20,7 +20,6 @@ import { ERROR_DIALOG_CONTENT, JoinRoomApiErrorCode, translateJoinRoomApiError }
 import { getRoomIdForAlias, isRoomMember } from '../../lib/chat';
 import { joinRoom as apiJoinRoom } from './api';
 import { call } from 'redux-saga/effects';
-import { openSidekickForSocialChannel } from '../group-management/saga';
 import { getHistory } from '../../lib/browser';
 
 describe(performValidateActiveConversation, () => {
@@ -310,9 +309,7 @@ describe(validateActiveConversation, () => {
       .next()
       .call(waitForChatConnectionCompletion)
       .next(true)
-      .call(performValidateActiveConversation, 'convo-1')
-      .next()
-      .spawn(openSidekickForSocialChannel, 'convo-1')
+      .fork(performValidateActiveConversation, 'convo-1')
       .next()
       .put(setIsJoiningConversation(false))
       .next()

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -1,4 +1,4 @@
-import { put, select, call, take, takeEvery, spawn, race, takeLatest } from 'redux-saga/effects';
+import { put, select, call, take, takeEvery, spawn, race, takeLatest, cancel, fork } from 'redux-saga/effects';
 import { takeEveryFromBus } from '../../lib/saga';
 
 import {
@@ -23,7 +23,6 @@ import { markConversationAsRead, openFirstConversation, rawChannelSelector } fro
 import { translateJoinRoomApiError, parseAlias, isAlias, extractDomainFromAlias } from './utils';
 import { joinRoom as apiJoinRoom } from './api';
 import { rawConversationsList } from '../channels-list/selectors';
-import { openSidekickForSocialChannel } from '../group-management/saga';
 
 function* initChat(userId, token) {
   const { chatConnection, connectionPromise, activate } = createChatConnection(userId, token, chat.get());
@@ -112,16 +111,24 @@ export function* setActiveConversation(id: string) {
   history.push({ pathname: `/conversation/${id}` });
 }
 
+let activeValidationTask = null;
 export function* validateActiveConversation(conversationId: string) {
   try {
     yield put(clearJoinRoomErrorContent());
     yield put(setIsJoiningConversation(true));
 
     const isLoaded = yield call(waitForChatConnectionCompletion);
-    if (isLoaded) {
-      yield call(performValidateActiveConversation, conversationId);
-      yield spawn(openSidekickForSocialChannel, conversationId);
+
+    if (!isLoaded) {
+      return;
     }
+
+    // Cancel any in-progress validation task to prevent race conditions
+    if (activeValidationTask) {
+      yield cancel(activeValidationTask);
+    }
+
+    activeValidationTask = yield fork(performValidateActiveConversation, conversationId);
   } finally {
     yield put(setIsJoiningConversation(false));
   }
@@ -182,38 +189,44 @@ export function* setWhenUserJoinedRoom(conversationId: string) {
 }
 
 export function* performValidateActiveConversation(activeConversationId: string) {
-  const history = yield call(getHistory);
-  const currentPath = history.location.pathname;
-  const isMessengerApp = currentPath.startsWith('/conversation');
+  try {
+    const history = yield call(getHistory);
+    const currentPath = history.location.pathname;
+    const isMessengerApp = currentPath.startsWith('/conversation');
 
-  if (!activeConversationId) {
-    yield put(clearJoinRoomErrorContent());
-    yield call(openFirstConversation);
-    return;
+    if (!activeConversationId) {
+      yield put(clearJoinRoomErrorContent());
+      yield call(openFirstConversation);
+      return;
+    }
+
+    let conversationId = activeConversationId;
+    if (isAlias(activeConversationId)) {
+      activeConversationId = parseAlias(activeConversationId);
+      conversationId = yield call(getRoomIdForAlias, activeConversationId);
+    }
+
+    const conversation = yield select(rawChannelSelector(conversationId));
+    if (conversation?.isSocialChannel && isMessengerApp) {
+      // If it's a social channel and accessed from messenger app, open the last active conversation instead
+      yield call(openFirstConversation);
+      return;
+    }
+
+    if (!conversationId || !(yield call(isMemberOfActiveConversation, conversationId))) {
+      yield call(joinRoom, activeConversationId);
+      return;
+    }
+
+    yield put(rawSetActiveConversationId(conversationId));
+
+    // Mark conversation as read, now that it has been set as active
+    yield call(markConversationAsRead, conversationId);
+  } catch (error) {
+    console.error('Error validating active conversation', error);
+  } finally {
+    activeValidationTask = null;
   }
-
-  let conversationId = activeConversationId;
-  if (isAlias(activeConversationId)) {
-    activeConversationId = parseAlias(activeConversationId);
-    conversationId = yield call(getRoomIdForAlias, activeConversationId);
-  }
-
-  const conversation = yield select(rawChannelSelector(conversationId));
-  if (conversation?.isSocialChannel && isMessengerApp) {
-    // If it's a social channel and accessed from messenger app, open the last active conversation instead
-    yield call(openFirstConversation);
-    return;
-  }
-
-  if (!conversationId || !(yield call(isMemberOfActiveConversation, conversationId))) {
-    yield call(joinRoom, activeConversationId);
-    return;
-  }
-
-  yield put(rawSetActiveConversationId(conversationId));
-
-  // Mark conversation as read, now that it has been set as active
-  yield call(markConversationAsRead, conversationId);
 }
 
 export function* closeErrorDialog() {
@@ -223,6 +236,7 @@ export function* closeErrorDialog() {
 
 export function* saga() {
   yield spawn(connectOnLogin);
+
   yield takeLatest(SagaActionTypes.setActiveConversationId, ({ payload }: any) =>
     validateActiveConversation(payload.id)
   );


### PR DESCRIPTION
### What does this do?
- Implements a task cancellation mechanism in the conversation validation process to prevent race conditions when users navigate between conversations quickly.

### Why are we making this change?
- To fix a bug where the active conversation ID could be incorrectly set when a user navigates away from a conversation before validation completes, causing UI inconsistencies between the URL and displayed conversation.

### How do I test this?
- run tests as usual
- run UI and navigate between channels and messenger app to test correct room content is rendered

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
