### PR TITLE
fix(app-bar): resolve link prop type error by providing hash key instead of undefined for active links

### DIFF
--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -170,7 +170,7 @@ const AppLink = ({ Icon, isActive, to, label, onLinkClick }: AppLinkProps) => {
   };
 
   return (
-    <Link title={label} {...cn('link')} to={!isActive ? to : undefined} onClick={handleClick}>
+    <Link title={label} {...cn('link')} to={!isActive ? to : '#'} onClick={handleClick}>
       <WorldPanelItem Icon={Icon} label={label} isActive={isActive} />
       <span data-active={isActive ? '' : null}>{label}</span>
     </Link>


### PR DESCRIPTION
### What does this do?
- We're modifying the AppLink component to use '#' as the destination for active links instead of undefined, which satisfies React Router's requirement for a valid 'to' prop.

### Why are we making this change?
- To eliminate the console warning about a required prop being undefined while maintaining the current behavior where active links don't navigate to a new page, and, to prevent triggering full page refresh on app bar active app click

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
