### PR TITLE
refactor(matrix-client): optimize room tags fetching by using in-memory data instead of network requests

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -357,10 +357,6 @@ export async function removeRoomFromLabel(roomId: string, label: string) {
   return await chat.get().matrix.removeRoomFromLabel(roomId, label);
 }
 
-export async function getRoomTags(conversations: Partial<Channel>[]) {
-  return await chat.get().matrix.getRoomTags(conversations);
-}
-
 export async function createUnencryptedConversation(
   users: User[],
   name: string,

--- a/src/lib/chat/matrix-client.test.ts
+++ b/src/lib/chat/matrix-client.test.ts
@@ -73,7 +73,6 @@ const getSdkClient = (sdkClient = {}) => ({
   invite: jest.fn().mockResolvedValue({}),
   setRoomTag: jest.fn().mockResolvedValue({}),
   deleteRoomTag: jest.fn().mockResolvedValue({}),
-  getRoomTags: jest.fn().mockResolvedValue({}),
   ...sdkClient,
 });
 
@@ -1678,40 +1677,6 @@ describe('matrix client', () => {
       await client.removeRoomFromLabel('channel-id', DefaultRoomLabels.WORK);
 
       expect(deleteRoomTag).toHaveBeenCalledWith('channel-id', DefaultRoomLabels.WORK);
-    });
-  });
-
-  describe('getRoomTags', () => {
-    it('returns correct tags for all rooms', async () => {
-      const conversations = [
-        { id: 'room1', labels: [] },
-        { id: 'room2', labels: [] },
-      ];
-
-      const getRoomTags = jest
-        .fn()
-        .mockResolvedValueOnce({ tags: { 'm.favorite': {}, 'm.mute': {}, 'm.work': {}, 'm.family': {} } })
-        .mockResolvedValueOnce({ tags: {} });
-
-      const client = subject({ createClient: jest.fn(() => getSdkClient({ getRoomTags })) });
-
-      await client.connect(null, 'token');
-      await client.getRoomTags(conversations);
-
-      expect(getRoomTags).toHaveBeenCalledWith('room1');
-      expect(getRoomTags).toHaveBeenCalledWith('room2');
-      expect(conversations).toEqual([
-        {
-          id: 'room1',
-          labels: [
-            'm.favorite',
-            'm.mute',
-            'm.work',
-            'm.family',
-          ],
-        },
-        { id: 'room2', labels: [] },
-      ]);
     });
   });
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1227,17 +1227,6 @@ export class MatrixClient implements IChatClient {
     return await Promise.all(matches.map((r) => this.mapConversation(r)));
   }
 
-  async getRoomTags(conversations: Partial<Channel>[]): Promise<void> {
-    const tags = conversations.map(async (conversation) => {
-      featureFlags.enableTimerLogs && console.time(`xxxgetRoomTags${conversation.id}`);
-      const result = await this.matrix.getRoomTags(conversation.id);
-      conversation.labels = Object.keys(result.tags);
-      featureFlags.enableTimerLogs && console.timeEnd(`xxxgetRoomTags${conversation.id}`);
-    });
-
-    await Promise.all(tags);
-  }
-
   async addRoomToLabel(roomId: string, label: string): Promise<void> {
     await this.waitForConnection();
     await this.matrix.setRoomTag(roomId, label);
@@ -1593,6 +1582,7 @@ export class MatrixClient implements IChatClient {
     const avatarUrl = this.getRoomAvatar(room);
     const createdAt = this.getRoomCreatedAt(room);
     const groupType = this.getRoomGroupType(room);
+    const roomTags = Object.keys(room.tags || {});
 
     featureFlags.enableTimerLogs && console.time(`xxxgetUpToLatestUserMessageFromRoom${room.roomId}`);
     const messages = await this.getUpToLatestUserMessageFromRoom(room);
@@ -1620,7 +1610,7 @@ export class MatrixClient implements IChatClient {
       conversationStatus: ConversationStatus.CREATED,
       adminMatrixIds: admins,
       moderatorIds: mods,
-      labels: [],
+      labels: roomTags,
       isSocialChannel,
       // this isn't the best way to get the zid as it relies on the name format, but it's a quick fix
       zid: isSocialChannel ? name?.split('://')[1] : null,

--- a/src/store/channels-list/saga.test.ts
+++ b/src/store/channels-list/saga.test.ts
@@ -1,7 +1,7 @@
 import { testSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 import * as matchers from 'redux-saga-test-plan/matchers';
-import { chat, getRoomTags } from '../../lib/chat';
+import { chat } from '../../lib/chat';
 
 import {
   fetchConversations,
@@ -59,7 +59,6 @@ describe('channels list saga', () => {
         [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
         [matchers.call.fn(mapToZeroUsers), null],
         [matchers.call.fn(getUserReadReceiptPreference), null],
-        [matchers.call.fn(getRoomTags), null],
       ]);
     }
 
@@ -136,7 +135,6 @@ describe('channels list saga', () => {
           [matchers.call.fn(chatClient.getConversations), MOCK_CONVERSATIONS],
           [matchers.call.fn(mapToZeroUsers), null],
           [matchers.call.fn(getUserReadReceiptPreference), null],
-          [matchers.call.fn(getRoomTags), null],
         ])
         .withReducer(rootReducer, { channelsList: { value: [] } } as RootState)
         .fork(loadSecondaryConversationData, [...MOCK_CONVERSATIONS])

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -3,7 +3,7 @@ import getDeepProperty from 'lodash.get';
 import uniqBy from 'lodash.uniqby';
 import { fork, put, call, take, all, select, spawn } from 'redux-saga/effects';
 import { receive, denormalizeConversations, setStatus } from '.';
-import { batchDownloadFiles, chat, downloadFile, getRoomTags } from '../../lib/chat';
+import { batchDownloadFiles, chat, downloadFile } from '../../lib/chat';
 
 import { AsyncListStatus } from '../normalized';
 import { toLocalChannel, mapChannelMembers, mapChannelMessages } from './utils';
@@ -176,13 +176,11 @@ export function* fetchConversations() {
 
 export function* loadSecondaryConversationData(conversations) {
   yield put(setIsSecondaryConversationDataLoaded(false));
-  yield call(getRoomTags, conversations);
   yield call(parseProfileImagesForMembers, conversations);
 
   const receiveCalls = conversations.map((conversation) =>
     call(receiveChannel, {
       id: conversation.id,
-      labels: conversation.labels,
       otherMembers: conversation.otherMembers,
       memberHistory: conversation.memberHistory,
     })


### PR DESCRIPTION
### What does this do?
- We're eliminating network requests for room tags by accessing the data directly from Room objects already in memory.

### Why are we making this change?
- To significantly improve initial load performance by removing unnecessary network requests and making room tags immediately available during conversation loading.

### How do I test this?
- run tests as usual.
- run the UI, monitor initial load of the app

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
