### PR TITLE
feat(terminate): run additional index db storage clearance

### DIFF
--- a/src/lib/storage/clear-idb.ts
+++ b/src/lib/storage/clear-idb.ts
@@ -1,0 +1,6 @@
+import { getProvider } from './idb';
+
+export async function clearIndexedDBStorage(): Promise<void> {
+  const provider = await getProvider();
+  await provider.clear();
+}

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -35,6 +35,7 @@ import { throwError } from 'redux-saga-test-plan/providers';
 import { closeUserProfile } from '../user-profile/saga';
 import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
+import { clearIndexedDBStorage } from '../../lib/storage/clear-idb';
 
 describe(nonceOrAuthorize, () => {
   const signedWeb3Token = '0x000000000000000000000000000000000000000A';
@@ -263,6 +264,20 @@ describe(forceLogout, () => {
 
   it('clears the user session', async () => {
     await expectLogoutSaga().call(terminate).run();
+  });
+
+  it('clears IndexedDB storage', async () => {
+    const mockClearIndexedDB = jest.fn();
+
+    await expectSaga(forceLogout)
+      .provide([
+        [call(clearIndexedDBStorage), mockClearIndexedDB()],
+        [call(terminate), null],
+      ])
+      .call(terminate)
+      .run();
+
+    expect(mockClearIndexedDB).toHaveBeenCalled();
   });
 });
 

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -16,6 +16,7 @@ import { completePendingUserProfile } from '../registration/saga';
 import { closeUserProfile } from '../user-profile/saga';
 import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
+import { clearIndexedDBStorage } from '../../lib/storage/clear-idb';
 
 export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
@@ -54,6 +55,12 @@ export function* terminate(isAccountChange = false) {
     yield call(clearSessionApi);
   } catch {
     /* No operation, if user is unauthenticated deleting the cookie fails */
+  }
+
+  try {
+    yield call(clearIndexedDBStorage);
+  } catch (error) {
+    console.error('Error clearing IndexedDB storage:', error);
   }
 
   yield call(clearUserState);


### PR DESCRIPTION
### What does this do?
- run additional index db storage clearance

### Why are we making this change?
- to ensure index db storage is cleared when terminating (log out)

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
