### PR TITLE
refactor(messenger-main): reduce unnecessary DOM elements by conditionally rendering MembersSidekick to improve performance

### DIFF
--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -5,6 +5,7 @@ import { Container as Main, Properties } from './Main';
 import { MessengerChat } from '../../components/messenger/chat';
 import { MessengerFeed } from '../../components/messenger/feed';
 import { JoiningConversationDialog } from '../../components/joining-conversation-dialog';
+import { MembersSidekick } from '../../components/sidekick/variants/members-sidekick';
 
 jest.mock('../../lib/web3/thirdweb/client', () => ({
   getThirdWebClient: jest.fn(),
@@ -23,6 +24,7 @@ describe(Main, () => {
       isSocialChannel: false,
       isJoiningConversation: false,
       isConversationsLoaded: true,
+      isSecondarySidekickOpen: false,
       ...props,
     };
 
@@ -104,5 +106,15 @@ describe(Main, () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isSocialChannel: true, isValidConversation: false });
 
     expect(wrapper).not.toHaveElement(MessengerFeed);
+  });
+
+  it('should render members sidekick when is secondary sidekick open', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isSecondarySidekickOpen: true,
+      isConversationsLoaded: true,
+    });
+
+    expect(wrapper).toHaveElement(MembersSidekick);
   });
 });

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -22,12 +22,14 @@ export interface Properties {
   isSocialChannel: boolean;
   isJoiningConversation: boolean;
   isConversationsLoaded: boolean;
+  isSecondarySidekickOpen: boolean;
 }
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
     const {
       chat: { activeConversationId, isJoiningConversation, isConversationsLoaded },
+      groupManagement: { isSecondarySidekickOpen },
     } = state;
 
     const currentChannel = denormalize(activeConversationId, state) || null;
@@ -37,6 +39,7 @@ export class Container extends React.Component<Properties> {
       isSocialChannel: currentChannel?.isSocialChannel,
       isJoiningConversation,
       isConversationsLoaded,
+      isSecondarySidekickOpen,
     };
   }
 
@@ -57,7 +60,7 @@ export class Container extends React.Component<Properties> {
                 this.props.isValidConversation &&
                 (this.props.isSocialChannel ? <MessengerFeed /> : <MessengerChat />)}
             </div>
-            {this.props.isConversationsLoaded && <MembersSidekick />}
+            {this.props.isConversationsLoaded && this.props.isSecondarySidekickOpen && <MembersSidekick />}
 
             <FeatureFlag featureFlag='enableDevPanel'>
               <DevPanelContainer />


### PR DESCRIPTION
### What does this do?
We are modifying the rendering logic of the MembersSidekick component to ensure it is only rendered when the isSecondarySidekickOpen flag is true.

### Why are we making this change?
This change is being made to improve the application's performance by reducing unnecessary DOM elements and memory usage when the MembersSidekick is not visible.

### How do I test this?
- run tests as usual
- run ui and check element tab in dev tools doesn't show the secondary sidekick container

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?



