### PR TITLE
refactor(clear-storage): clear remaining user/session specific storage

### DIFF
--- a/src/lib/chat/session-storage.ts
+++ b/src/lib/chat/session-storage.ts
@@ -13,6 +13,10 @@ export class SessionStorage {
     this.storage.removeItem('mxz_device_id');
     this.storage.removeItem(`mxz_access_token_${deviceId}`);
     this.storage.removeItem('mxz_user_id');
+
+    const allKeys = Object.keys(this.storage);
+    const filterKeys = allKeys.filter((key) => key.includes('mxjssdk_memory_filter'));
+    filterKeys.forEach((key) => this.storage.removeItem(key));
   }
 
   set(session: ChatSession) {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -16,7 +16,7 @@ import { completePendingUserProfile } from '../registration/saga';
 import { closeUserProfile } from '../user-profile/saga';
 import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
-import { clearIndexedDBStorage } from '../../lib/storage/clear-idb';
+import { clearRewards } from '../rewards/saga';
 
 export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
@@ -55,12 +55,6 @@ export function* terminate(isAccountChange = false) {
     yield call(clearSessionApi);
   } catch {
     /* No operation, if user is unauthenticated deleting the cookie fails */
-  }
-
-  try {
-    yield call(clearIndexedDBStorage);
-  } catch (error) {
-    console.error('Error clearing IndexedDB storage:', error);
   }
 
   yield call(clearUserState);
@@ -119,6 +113,7 @@ export function* forceLogout() {
   yield closeLogoutModal();
   yield call(clearLastActiveConversation);
   yield call(clearLastActiveTab);
+  yield call(clearRewards);
   yield call(terminate);
 }
 

--- a/src/store/rewards/saga.ts
+++ b/src/store/rewards/saga.ts
@@ -126,6 +126,11 @@ export function* closeRewardsTooltip() {
   }
 }
 
+export const clearRewards = (): void => {
+  localStorage.removeItem(lastDayRewardsKey);
+  localStorage.removeItem(totalRewardsKey);
+};
+
 export function* transferMeow(action) {
   yield put(setTransferError({ error: null }));
 


### PR DESCRIPTION
### What does this do?
- clears remaining user/session specific storage

### Why are we making this change?
- ensures storage is cleared to prevent log out / log in issues between different users on the same device.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
