### PR TITLE
refactor(chat-view): optimize message rendering by pre-computing ownership checks

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -138,17 +138,19 @@ export class ChatView extends React.Component<Properties, State> {
       if (message.isAdmin) {
         return <AdminMessageContainer key={message.optimisticId || message.id} message={message} />;
       } else {
+        const isUserOwner = this.isUserOwnerOfMessage(message);
+        const isUserOwnerOfParentMessage = this.isUserOwnerOfMessage(message.parentMessage);
         const messageRenderProps = getMessageRenderProps(
           index,
           groupMessages.length,
           this.props.isOneOnOne,
-          this.isUserOwnerOfMessage(message)
+          isUserOwner
         );
         return (
           <div
             key={message.optimisticId || message.id}
             className={classNames('messages__message-row', {
-              'messages__message-row--owner': this.isUserOwnerOfMessage(message),
+              'messages__message-row--owner': isUserOwner,
             })}
           >
             <div {...cn('group-message', messageRenderProps.position)}>
@@ -159,7 +161,7 @@ export class ChatView extends React.Component<Properties, State> {
                 onImageClick={this.openLightbox}
                 messageId={message.id}
                 updatedAt={message.updatedAt}
-                isOwner={this.isUserOwnerOfMessage(message)}
+                isOwner={isUserOwner}
                 isHidden={message.isHidden}
                 onDelete={this.props.deleteMessage}
                 onEdit={this.props.editMessage}
@@ -167,7 +169,7 @@ export class ChatView extends React.Component<Properties, State> {
                 onReportUser={this.props.onReportUser}
                 onInfo={this.openMessageInfo}
                 parentMessageText={message.parentMessageText}
-                parentSenderIsCurrentUser={this.isUserOwnerOfMessage(message.parentMessage)}
+                parentSenderIsCurrentUser={isUserOwnerOfParentMessage}
                 parentSenderFirstName={message.parentMessage?.sender?.firstName}
                 parentSenderLastName={message.parentMessage?.sender?.lastName}
                 parentMessageMediaUrl={message?.parentMessageMedia?.url}


### PR DESCRIPTION
### What does this do?
- Pre-computing message ownership checks in the renderMessageGroup method to avoid redundant calculations during render.

### Why are we making this change?
- To improve rendering performance by reducing redundant function calls when displaying messages, especially in conversations with many messages.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
