### PR TITLE
Add error page and and re-direct user fetch errors

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import '@zer0-os/zos-component-library/dist/index.css';
 import './index.scss';
 import { Invite } from './invite';
 import { ResetPassword } from './reset-password';
-import { LoginPage } from './pages';
+import { LoginPage, ErrorPage } from './pages';
 import { getHistory } from './lib/browser';
 import { ElectronTitlebar } from './components/electron-titlebar';
 import { desktopInit } from './lib/desktop';
@@ -50,6 +50,7 @@ root.render(
                   <Route path='/get-access' exact component={Invite} />
                   <Route path='/login' exact component={LoginPage} />
                   <Route path='/reset-password' exact component={ResetPassword} />
+                  <Route path='/error' exact component={ErrorPage} />
                   <Route component={App} />
                 </Switch>
               </RainbowKitConnect>

--- a/src/pages/error/error-component.tsx
+++ b/src/pages/error/error-component.tsx
@@ -10,10 +10,11 @@ import './error.scss';
 const cn = bemClassName('error-page');
 
 interface ErrorComponentProperties {
+  error: string;
   onRetry: () => void;
 }
 
-export const ErrorComponent = ({ onRetry }: ErrorComponentProperties) => {
+export const ErrorComponent = ({ error, onRetry }: ErrorComponentProperties) => {
   return (
     <>
       <ThemeEngine theme={Themes.Dark} />
@@ -23,7 +24,7 @@ export const ErrorComponent = ({ onRetry }: ErrorComponentProperties) => {
             <ZeroLogo />
           </div>
           <div {...cn('message-container')}>
-            <h3 {...cn('message')}>There was an error loading ZERO, please try again.</h3>
+            <h3 {...cn('message')}>{error}</h3>
             <Button onPress={onRetry}>Try Again</Button>
           </div>
         </main>

--- a/src/pages/error/error-component.tsx
+++ b/src/pages/error/error-component.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { ThemeEngine, Themes } from '@zero-tech/zui/components/ThemeEngine';
+import { Button } from '@zero-tech/zui/components';
+import ZeroLogo from '../../zero-logo.svg?react';
+
+import { bemClassName } from '../../lib/bem';
+import './error.scss';
+
+const cn = bemClassName('error-page');
+
+interface ErrorComponentProperties {
+  onRetry: () => void;
+}
+
+export const ErrorComponent = ({ onRetry }: ErrorComponentProperties) => {
+  return (
+    <>
+      <ThemeEngine theme={Themes.Dark} />
+      <div {...cn('')}>
+        <main {...cn('content')}>
+          <div {...cn('logo-container')}>
+            <ZeroLogo />
+          </div>
+          <div {...cn('message-container')}>
+            <h3 {...cn('message')}>There was an error loading ZERO, please try again.</h3>
+            <Button onPress={onRetry}>Try Again</Button>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+};

--- a/src/pages/error/error-container.tsx
+++ b/src/pages/error/error-container.tsx
@@ -1,0 +1,11 @@
+import { ErrorComponent } from './error-component';
+
+export const ErrorPage = () => {
+  const handleRetry = () => {
+    window.location.href = '/';
+  };
+
+  const error = 'There was an error loading ZERO, please try again.';
+
+  return <ErrorComponent onRetry={handleRetry} error={error} />;
+};

--- a/src/pages/error/error.scss
+++ b/src/pages/error/error.scss
@@ -1,0 +1,54 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+@import '../../background';
+@import '../../glass';
+
+.error-page {
+  @include root-background;
+
+  position: absolute;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  z-index: 10;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 24px 0;
+    box-sizing: border-box;
+  }
+
+  &__logo-container {
+    padding-left: 8px;
+    margin-bottom: 76px;
+    mix-blend-mode: screen;
+  }
+
+  &__message-container {
+    @include glass-shadow-and-blur;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    padding: 32px;
+    background: rgba(11, 7, 7, 0.75);
+    border-radius: 8px;
+  }
+
+  &__message {
+    @include glass-text-primary-color;
+    text-align: center;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 22px;
+    margin: 0;
+  }
+}

--- a/src/pages/error/index.ts
+++ b/src/pages/error/index.ts
@@ -1,0 +1,1 @@
+export { ErrorPage } from './error-container';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export * from './login';
+export * from './error';

--- a/src/store/authentication/api.ts
+++ b/src/store/authentication/api.ts
@@ -23,11 +23,12 @@ export async function fetchCurrentUser(): Promise<User> {
   try {
     const response = await get('/api/users/current');
     return response.body;
-  } catch (error) {
-    console.log(error);
+  } catch (error: any) {
+    if (error?.response?.status === 401) {
+      return null;
+    }
+    throw error;
   }
-
-  return null;
 }
 
 export async function clearSession(): Promise<AuthorizationResponse> {

--- a/src/store/authentication/api.ts
+++ b/src/store/authentication/api.ts
@@ -1,5 +1,6 @@
 import { AuthorizationResponse, User } from './types';
 import { del, get, post } from '../../lib/api/rest';
+import * as Sentry from '@sentry/react';
 
 export async function nonceOrAuthorize(signedWeb3Token: string): Promise<AuthorizationResponse> {
   const response = await post('/authentication/nonceOrAuthorize').set('Authorization', `Web3 ${signedWeb3Token}`);
@@ -27,6 +28,7 @@ export async function fetchCurrentUser(): Promise<User> {
     if (error?.response?.status === 401) {
       return null;
     }
+    Sentry.captureException(error);
     throw error;
   }
 }

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -66,13 +66,13 @@ export function* getCurrentUser() {
   try {
     const user = yield call(fetchCurrentUser);
     if (!user) {
-      return false;
+      return { success: false, error: 'unauthenticated' };
     }
 
     yield completeUserLogin(user);
-    return true;
+    return { success: true };
   } catch (e) {
-    return false;
+    return { success: false, error: 'critical' };
   }
 }
 

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -21,12 +21,14 @@ export function* saga() {
     return;
   }
 
-  const success = yield call(getCurrentUser);
-  if (success) {
+  const result = yield call(getCurrentUser);
+  if (result.success) {
     yield handleAuthenticatedUser(history);
-  } else {
+  } else if (result.error === 'unauthenticated') {
     yield handleUnauthenticatedUser(history);
     yield call(setMobileAppDownloadVisibility, history);
+  } else {
+    yield handleCriticalError(history);
   }
 
   yield put(setIsComplete(true));
@@ -50,6 +52,10 @@ function* handleUnauthenticatedUser(history) {
   yield put(setEntryPath(history.location.pathname));
   yield spawn(redirectOnUserLogin);
   yield history.replace({ pathname: '/login' });
+}
+
+function* handleCriticalError(history) {
+  yield history.replace({ pathname: '/error' });
 }
 
 const MOBILE_APP_DOWNLOAD_PATHS = [


### PR DESCRIPTION
### What does this do?
Adds error page.
Sends the user to the error page if there is a failure getting the current user that isn't a 401

<img width="1437" alt="Screenshot 2025-03-10 at 9 10 41 AM" src="https://github.com/user-attachments/assets/70aed78e-61a5-4f55-a8f2-7f2da3982ffd" />

### Why are we making this change?

Currently if there is an error fetching the user, we show the user as logged out. There are times where this can be inaccurate and cause users to log back in when they just need to retry.

### How do I test this?
Go to the site incognito and make sure you end up on the login page (401 for getting current user)
Block current user request in network tab then refresh, you should end up on error page.
