### PR TITLE
feat(waypoint-wrapper): add waypoint component that wraps react-waypoint with requestAnimationFrame

### DIFF
--- a/src/components/waypoint/index.test.tsx
+++ b/src/components/waypoint/index.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Waypoint } from './index';
+import { Waypoint as ReactWaypoint } from 'react-waypoint';
+
+describe('Waypoint', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const subject = (props = {}) => {
+    const allProps = {
+      onEnter: jest.fn(),
+      ...props,
+    };
+
+    return shallow(<Waypoint {...allProps} />);
+  };
+
+  it('renders ReactWaypoint with correct props', () => {
+    const bottomOffset = '-90%';
+    const wrapper = subject({ bottomOffset });
+
+    expect(wrapper.find(ReactWaypoint).exists()).toBe(true);
+    expect(wrapper.find(ReactWaypoint).prop('bottomOffset')).toBe(bottomOffset);
+  });
+
+  it('calls onEnter when ReactWaypoint onEnter is triggered', () => {
+    const onEnter = jest.fn();
+    const wrapper = subject({ onEnter });
+
+    const onEnterHandler = wrapper.find(ReactWaypoint).prop('onEnter');
+    onEnterHandler({} as any);
+
+    jest.runAllTimers();
+
+    expect(onEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the bottomOffset prop to ReactWaypoint', () => {
+    const bottomOffset = '-50%';
+    const wrapper = subject({ bottomOffset });
+
+    expect(wrapper.find(ReactWaypoint).prop('bottomOffset')).toBe(bottomOffset);
+  });
+
+  it('updates the ReactWaypoint when props change', () => {
+    const onEnter = jest.fn();
+    const wrapper = subject({ onEnter });
+
+    const newOnEnter = jest.fn();
+    wrapper.setProps({ onEnter: newOnEnter });
+
+    const onEnterHandler = wrapper.find(ReactWaypoint).prop('onEnter');
+    onEnterHandler({} as any);
+
+    jest.runAllTimers();
+
+    expect(onEnter).not.toHaveBeenCalled();
+    expect(newOnEnter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/waypoint/index.tsx
+++ b/src/components/waypoint/index.tsx
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+import { Waypoint as ReactWaypoint } from 'react-waypoint';
+
+export const Waypoint = ({ onEnter, bottomOffset }: { onEnter: () => void; bottomOffset?: string }) => {
+  const handleEnter = useCallback(() => {
+    requestAnimationFrame(() => {
+      onEnter();
+    });
+  }, [onEnter]);
+
+  return <ReactWaypoint onEnter={handleEnter} bottomOffset={bottomOffset} />;
+};


### PR DESCRIPTION
### What does this do?
- We're creating a custom Waypoint component that wraps the react-waypoint library to defer callback execution to the next animation frame.

### Why are we making this change?
- To improve scrolling performance by preventing layout thrashing and UI jank when waypoint callbacks trigger state updates or data fetching operations during scroll events.

### How do I test this?
- run tests as usual
- note this is not yet wired up / replacing existing way point imports from react-waypoint

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
