### PR TITLE
refactor: add on leave prop to waypoint wrapper

### DIFF
--- a/src/components/waypoint/index.test.tsx
+++ b/src/components/waypoint/index.test.tsx
@@ -19,6 +19,7 @@ describe('Waypoint', () => {
   const subject = (props = {}) => {
     const allProps = {
       onEnter: jest.fn(),
+      onLeave: jest.fn(),
       ...props,
     };
 
@@ -66,5 +67,15 @@ describe('Waypoint', () => {
 
     expect(onEnter).not.toHaveBeenCalled();
     expect(newOnEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onLeave when ReactWaypoint onLeave is triggered', () => {
+    const onLeave = jest.fn();
+    const wrapper = subject({ onLeave });
+
+    const onLeaveHandler = wrapper.find(ReactWaypoint).prop('onLeave');
+    onLeaveHandler({} as any);
+
+    expect(onLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/waypoint/index.tsx
+++ b/src/components/waypoint/index.tsx
@@ -1,12 +1,20 @@
 import { useCallback } from 'react';
 import { Waypoint as ReactWaypoint } from 'react-waypoint';
 
-export const Waypoint = ({ onEnter, bottomOffset }: { onEnter: () => void; bottomOffset?: string }) => {
+export const Waypoint = ({
+  onEnter,
+  onLeave,
+  bottomOffset,
+}: {
+  onEnter: () => void;
+  onLeave?: () => void;
+  bottomOffset?: string;
+}) => {
   const handleEnter = useCallback(() => {
     requestAnimationFrame(() => {
       onEnter();
     });
   }, [onEnter]);
 
-  return <ReactWaypoint onEnter={handleEnter} bottomOffset={bottomOffset} />;
+  return <ReactWaypoint onEnter={handleEnter} onLeave={onLeave} bottomOffset={bottomOffset} />;
 };


### PR DESCRIPTION
### What does this do?
- adds on leave prop to waypoint wrapper

### Why are we making this change?
- additional prop for custom waypoint wrapper to replace existing waypoint imports

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
