### PR TITLE
refactor(waypoints): replace existing waypoint imports with custom waypoint wrapper imports that use requestAnimationFrame

### DIFF
--- a/src/apps/feed/components/feed-view-container/feed-view.test.tsx
+++ b/src/apps/feed/components/feed-view-container/feed-view.test.tsx
@@ -4,7 +4,7 @@ import { FeedView, Message, Properties } from './feed-view';
 import { Posts } from '../posts';
 import { MessagesFetchState } from '../../../../store/channels';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
-import { Waypoint } from 'react-waypoint';
+import { Waypoint } from '../../../../components/waypoint';
 
 describe('FeedView', () => {
   const POST_MESSAGES_TEST = [

--- a/src/apps/feed/components/feed-view-container/feed-view.tsx
+++ b/src/apps/feed/components/feed-view-container/feed-view.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import { Waypoint } from 'react-waypoint';
 
 import { Posts } from '../posts';
 import { MessagesFetchState } from '../../../../store/channels';
@@ -7,6 +6,7 @@ import { Media, Message as MessageModel } from '../../../../store/messages';
 import { Payload as PayloadFetchPosts } from '../../../../store/posts/saga';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { LoadMoreButton } from '../load-more';
+import { Waypoint } from '../../../../components/waypoint';
 
 import { bemClassName } from '../../../../lib/bem';
 import './styles.scss';

--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -3,7 +3,7 @@ import { useFeed } from './lib/useFeed';
 import { Message } from '../message';
 import { Post } from '../post';
 import { PostInput } from '../post-input-hook';
-import { Waypoint } from 'react-waypoint';
+import { Waypoint } from '../../../../components/waypoint';
 import { Panel, PanelBody, PanelHeader, PanelTitle } from '../../../../components/layout/panel';
 
 import styles from './styles.module.scss';

--- a/src/apps/feed/components/post-view-container/reply-list/index.tsx
+++ b/src/apps/feed/components/post-view-container/reply-list/index.tsx
@@ -1,8 +1,7 @@
 import { useReplyList } from './useReplyList';
 
 import { Post } from '../../post';
-import { Waypoint } from 'react-waypoint';
-
+import { Waypoint } from '../../../../../components/waypoint';
 import styles from './styles.module.scss';
 
 export interface RepliesProps {

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Waypoint } from 'react-waypoint';
 import { shallow } from 'enzyme';
 import { ChatView, Properties } from './chat-view';
+import { Waypoint } from '../waypoint';
 
 import { Message as MessageModel } from '../../store/messages';
 import InvertedScroll from '../inverted-scroll';

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Waypoint } from 'react-waypoint';
+import { Waypoint } from '../waypoint';
 import classNames from 'classnames';
 import moment from 'moment';
 import { Message as MessageModel, MediaType, EditMessageOptions, Media } from '../../store/messages';


### PR DESCRIPTION
### What does this do?
- replaces existing react waypoint imports for the custom waypoint wrapper imports

### Why are we making this change?
- to use the new custom waypoint wrapper with requestAnimationFrame

### How do I test this?
- run tests as usual
- run ui and test scroll / waypoints

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
