### PR TITLE
refactor: optimize DOM operations with requestAnimationFrame for smoother UI performance

### DIFF
--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -89,9 +89,13 @@ export class PostInput extends React.Component<Properties, State> {
 
   adjustTextareaHeight = () => {
     if (this.textareaRef.current) {
-      const textarea = this.textareaRef.current;
-      textarea.style.height = 'auto';
-      textarea.style.height = `${textarea.scrollHeight}px`;
+      requestAnimationFrame(() => {
+        const textarea = this.textareaRef.current;
+        if (textarea) {
+          textarea.style.height = 'auto';
+          textarea.style.height = `${textarea.scrollHeight}px`;
+        }
+      });
     }
   };
 

--- a/src/components/autocomplete-dropdown/index.tsx
+++ b/src/components/autocomplete-dropdown/index.tsx
@@ -76,8 +76,12 @@ export class AutocompleteDropdown extends React.Component<Properties, State> {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.itemsElement.current && prevState.matches?.length !== this.state.matches?.length) {
-      this.setState({
-        dropdownHeight: this.itemsElement.current.getBoundingClientRect().height,
+      requestAnimationFrame(() => {
+        if (this._isMounted && this.itemsElement.current) {
+          this.setState({
+            dropdownHeight: this.itemsElement.current.getBoundingClientRect().height,
+          });
+        }
       });
     }
   }

--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -2,8 +2,7 @@ import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import './styles.scss';
 import { bemClassName } from '../../lib/bem';
-import { Waypoint } from 'react-waypoint';
-
+import { Waypoint } from '../waypoint';
 const cn = bemClassName('inverted-scroll');
 
 export interface Properties {
@@ -22,7 +21,11 @@ export class InvertedScroll extends React.Component<Properties, State> {
 
   scrollToBottom() {
     this.pinBottom();
-    this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
+    requestAnimationFrame(() => {
+      if (this.scrollWrapper) {
+        this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
+      }
+    });
   }
 
   setScrollWrapper = (element: HTMLElement) => {

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -197,15 +197,19 @@ export class Message extends React.Component<Properties, State> {
   };
 
   scrollToMessage = (messageId: string) => {
-    const messageElement = document.querySelector(`[data-message-id="${messageId}"]`);
-    const messageBlock = messageElement?.querySelector('.message__block');
-    if (messageBlock) {
-      messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      messageBlock.classList.add('message__block--parent-message-highlight');
-      setTimeout(() => {
-        messageBlock.classList.remove('message__block--parent-message-highlight');
-      }, 3000);
-    }
+    requestAnimationFrame(() => {
+      const messageElement = document.querySelector(`[data-message-id="${messageId}"]`);
+      const messageBlock = messageElement?.querySelector('.message__block');
+      if (messageBlock) {
+        messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        messageBlock.classList.add('message__block--parent-message-highlight');
+        setTimeout(() => {
+          requestAnimationFrame(() => {
+            messageBlock.classList.remove('message__block--parent-message-highlight');
+          });
+        }, 3000);
+      }
+    });
   };
 
   onParentMessageClick = (messageId: string) => {
@@ -232,14 +236,18 @@ export class Message extends React.Component<Properties, State> {
   };
 
   handleMediaAspectRatio = (width: number, height: number) => {
-    const aspectRatio = width / height;
-    this.setState({ isFullWidth: height > 640 && aspectRatio <= 5 / 4 });
+    requestAnimationFrame(() => {
+      const aspectRatio = width / height;
+      this.setState({ isFullWidth: height > 640 && aspectRatio <= 5 / 4 });
+    });
   };
 
   handleImageLoad = (event) => {
-    const { naturalWidth: width, naturalHeight: height } = event.target;
-    this.handleMediaAspectRatio(width, height);
-    this.setState({ isImageLoaded: true });
+    requestAnimationFrame(() => {
+      const { naturalWidth: width, naturalHeight: height } = event.target;
+      this.handleMediaAspectRatio(width, height);
+      this.setState({ isImageLoaded: true });
+    });
   };
 
   handlePlaceholderAspectRatio = (width: number, height: number, maxWidth: number, maxHeight: number) => {


### PR DESCRIPTION
### What does this do?
- We're wrapping DOM manipulation operations in requestAnimationFrame calls to defer them to the browser's next paint cycle.

### Why are we making this change?
- To improve UI responsiveness and scrolling performance by preventing layout thrashing and ensuring DOM operations happen at optimal times in the rendering pipeline.

### How do I test this?
- run tests as usual
- run ui as usual and interact

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
