### PR TITLE
fix(inverted-scroll): remove requestAnimationFrame in scrollToBottom for immediate scroll execution

### DIFF
--- a/src/components/inverted-scroll/index.tsx
+++ b/src/components/inverted-scroll/index.tsx
@@ -21,11 +21,7 @@ export class InvertedScroll extends React.Component<Properties, State> {
 
   scrollToBottom() {
     this.pinBottom();
-    requestAnimationFrame(() => {
-      if (this.scrollWrapper) {
-        this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
-      }
-    });
+    this.scrollWrapper.scrollTop = this.scrollWrapper.scrollHeight;
   }
 
   setScrollWrapper = (element: HTMLElement) => {
@@ -40,9 +36,11 @@ export class InvertedScroll extends React.Component<Properties, State> {
   preventHigherScroll = () => {
     // If we get fully scrolled to the top, scroll down a bit to prevent
     // the browser from pinning our position to the top of the scroll view.
-    if (this.scrollWrapper) {
-      this.scrollWrapper.scroll(0, 1);
-    }
+    requestAnimationFrame(() => {
+      if (this.scrollWrapper) {
+        this.scrollWrapper.scroll(0, 1);
+      }
+    });
   };
 
   pinBottom = () => this.setState({ pinnedBottom: true });


### PR DESCRIPTION
### What does this do?
- We're removing the requestAnimationFrame wrapper from the scrollToBottom method in the InvertedScroll component, restoring the direct approach to setting the scroll position.

### Why are we making this change?
- The requestAnimationFrame was causing unreliable scrolling behavior when switching between conversations. Since it defers the scroll operation to the next animation frame, it sometimes executed before all content was fully rendered, resulting in chat history not properly scrolling to the bottom when users returned to a conversation with new messages.

### How do I test this?
- run tests as usual
- run ui and switch between unread conversations & check scroll to bottom is working as expected

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
