### PR TITLE
feat(channel-app): restore last active feed (channel) when returning to channels app

### DIFF
--- a/src/apps/feed/components/sidekick/index.tsx
+++ b/src/apps/feed/components/sidekick/index.tsx
@@ -13,6 +13,7 @@ import {
 
 import classNames from 'classnames';
 import styles from './styles.module.scss';
+import { setLastActiveFeed } from '../../../../lib/last-feed';
 
 export const Sidekick = () => {
   const { isErrorZids, isLoadingZids, selectedZId, zids, search, setSearch, unreadCounts, mutedChannels } =
@@ -40,7 +41,7 @@ export const Sidekick = () => {
               const isMuted = mutedChannels[zid];
               const isUnread = hasUnreadHighlights || hasUnreadTotal;
               return (
-                <FeedItem key={zid} route={`/feed/${zid}`} isSelected={selectedZId === zid}>
+                <FeedItem key={zid} route={`/feed/${zid}`} isSelected={selectedZId === zid} zid={zid}>
                   <div className={classNames(styles.FeedName, { [styles.Unread]: isUnread })}>
                     <span>0://</span>
                     <div>{zid}</div>
@@ -65,10 +66,21 @@ export const Sidekick = () => {
   );
 };
 
-const FeedItem = ({ route, children, isSelected }: { route: string; children: ReactNode; isSelected?: boolean }) => {
+const FeedItem = ({
+  route,
+  children,
+  isSelected,
+  zid,
+}: {
+  route: string;
+  children: ReactNode;
+  isSelected?: boolean;
+  zid: string;
+}) => {
   const history = useHistory();
 
   const handleOnClick = () => {
+    setLastActiveFeed(zid);
     history.push(route);
   };
 

--- a/src/apps/feed/index.tsx
+++ b/src/apps/feed/index.tsx
@@ -9,6 +9,7 @@ import { PostView } from './components/post-view-container';
 import { PanelBody } from '../../components/layout/panel';
 import { IconSlashes } from '@zero-tech/zui/icons';
 import { FeedChat } from './components/feed-chat/container';
+import { getLastActiveFeed } from '../../lib/last-feed';
 
 import styles from './styles.module.scss';
 
@@ -48,6 +49,13 @@ const Loading = () => {
         <IconSlashes /> You are not a member of any channels.
       </PanelBody>
     );
+  }
+
+  const lastActiveFeed = getLastActiveFeed();
+
+  // If we have a last active feed and it's in the list of owned zids, use it
+  if (lastActiveFeed && zids.some((zid) => parseWorldZid(zid) === lastActiveFeed)) {
+    return <Redirect to={`/feed/${lastActiveFeed}`} />;
   }
 
   return <Redirect to={`/feed/${parseWorldZid(zids[0])}`} />;

--- a/src/lib/last-feed.ts
+++ b/src/lib/last-feed.ts
@@ -1,0 +1,15 @@
+const LAST_FEED_KEY = 'last-active-feed';
+
+export const setLastActiveFeed = (feedZid: string): void => {
+  if (feedZid) {
+    localStorage.setItem(LAST_FEED_KEY, feedZid);
+  }
+};
+
+export const getLastActiveFeed = (): string | null => {
+  return localStorage.getItem(LAST_FEED_KEY);
+};
+
+export const clearLastActiveFeed = (): void => {
+  localStorage.removeItem(LAST_FEED_KEY);
+};

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -36,6 +36,7 @@ import { closeUserProfile } from '../user-profile/saga';
 import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
 import { clearIndexedDBStorage } from '../../lib/storage/clear-idb';
+import { clearLastActiveFeed } from '../../lib/last-feed';
 
 describe(nonceOrAuthorize, () => {
   const signedWeb3Token = '0x000000000000000000000000000000000000000A';
@@ -269,6 +270,10 @@ describe(forceLogout, () => {
 
   it('clears the last active tab', async () => {
     await expectLogoutSaga().call(clearLastActiveTab).call(terminate).run();
+  });
+
+  it('clears the last active feed', async () => {
+    await expectLogoutSaga().call(clearLastActiveFeed).call(terminate).run();
   });
 
   it('clears the user session', async () => {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -17,6 +17,7 @@ import { closeUserProfile } from '../user-profile/saga';
 import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
 import { clearRewards } from '../rewards/saga';
+import { clearLastActiveFeed } from '../../lib/last-feed';
 
 export const currentUserSelector = () => (state) => {
   return getDeepProperty(state, 'authentication.user.data', null);
@@ -113,6 +114,7 @@ export function* forceLogout() {
   yield closeLogoutModal();
   yield call(clearLastActiveConversation);
   yield call(clearLastActiveTab);
+  yield call(clearLastActiveFeed);
   yield call(clearRewards);
   yield call(terminate);
 }


### PR DESCRIPTION
### What does this do?
- restores last active feed (channel) when returning to channels app

### Why are we making this change?
- improved ux/desired functionality

### How do I test this?
- run tests as usual
- run the UI, navigate to channels app, select a channel, navigate to another app, return to channels app and check active channel

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
