### PR TITLE
feat(feed-chat): only render FeedChat for ZIDs owned by the user

### DIFF
--- a/src/apps/feed/components/feed-chat/container.tsx
+++ b/src/apps/feed/components/feed-chat/container.tsx
@@ -1,9 +1,20 @@
+import { useOwnedZids } from '../../../../lib/hooks/useOwnedZids';
+import { parseWorldZid } from '../../../../lib/zid';
 import { FeedChatContainer } from './index';
 import { useRouteMatch } from 'react-router-dom';
 
 export const FeedChat = () => {
   const route = useRouteMatch<{ zid: string }>('/feed/:zid');
   const zid = route?.params?.zid;
+  const { zids } = useOwnedZids();
+
+  // Check if the current ZID is owned by the user
+  const isOwnedZid = zid && zids?.some((userZid) => parseWorldZid(userZid) === zid);
+
+  // Only render if the user owns this ZID
+  if (!isOwnedZid) {
+    return null;
+  }
 
   return <FeedChatContainer zid={zid} />;
 };


### PR DESCRIPTION
### What does this do?
- We're making this change to ensure users can only access chat functionality for ZIDs they own, improving security and preventing unauthorized access to chat features.

### Why are we making this change?
- We're adding a conditional check in the FeedChat component that verifies if the current ZID is in the user's list of owned ZIDs before rendering the chat interface.

### How do I test this?
- run tests as usual
- run ui and test scenario

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
