### PR TITLE
feat: Add new functionality to feature flag system

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -2,6 +2,9 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
+  babel: {
+    plugins: [['@babel/plugin-transform-typescript', { allowDeclareFields: true }]],
+  },
   webpack: {
     alias: {
       react: path.resolve('./node_modules/react'),

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -65,6 +65,7 @@ export class FeatureFlags implements FeatureFlagValues {
       const flagKey = key as FeatureFlagKey;
       const defaultValue = this.config[flagKey].defaultValue;
       this._setBoolean(flagKey, defaultValue);
+      localStorage.removeItem(`FEATURE_FLAGS.${flagKey}`);
     });
   }
 }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,208 +1,65 @@
 import window from 'global/window';
+import {
+  getFeatureFlag,
+  setFeatureFlag,
+  FeatureFlagDefinitions,
+  FeatureFlagKey,
+  FeatureFlagValues,
+} from './feature-flags/flags';
+import { developmentFlags } from './feature-flags/development';
+import { productionFlags } from './feature-flags/production';
 
-export class FeatureFlags {
-  _getBoolean(propName: string, defaultValue = false) {
-    const savedValue = window.localStorage.getItem('FEATURE_FLAGS.' + propName);
+export class FeatureFlags implements FeatureFlagValues {
+  private config: FeatureFlagDefinitions;
+  declare channelsApp: boolean;
+  declare enableDevPanel: boolean;
+  declare resetPasswordPage: boolean;
+  declare enableRewards: boolean;
+  declare enableMatrix: boolean;
+  declare allowEmailRegistration: boolean;
+  declare verboseLogging: boolean;
+  declare allowEditPrimaryZID: boolean;
+  declare enableReadReceiptPreferences: boolean;
+  declare enableUserSettings: boolean;
+  declare enableTimerLogs: boolean;
+  declare enableChannels: boolean;
+  declare enableCollapseableMenu: boolean;
+  declare enableMeows: boolean;
+  declare enableTokenGatedChat: boolean;
+  declare enableNotificationsApp: boolean;
+  declare enableNotificationsReadStatus: boolean;
+  declare enableLoadMore: boolean;
+  declare enableComments: boolean;
+  declare enableFeedApp: boolean;
+  declare enableLinkedAccounts: boolean;
+  declare enableZeroWalletSigning: boolean;
+  declare enableFeedChat: boolean;
 
-    switch (savedValue) {
-      case 'true':
-        return true;
-      case 'false':
-        return false;
-      default:
-        return defaultValue;
-    }
+  constructor() {
+    this.config = process.env.NODE_ENV === 'production' ? productionFlags : developmentFlags;
+    this.initializeAccessors();
   }
 
-  _setBoolean(propName: string, value: boolean) {
-    window.localStorage.setItem('FEATURE_FLAGS.' + propName, value.toString());
+  private _getBoolean(propName: FeatureFlagKey, defaultValue = false): boolean {
+    return getFeatureFlag(propName, this.config[propName] ?? { defaultValue });
   }
 
-  get channelsApp() {
-    return this._getBoolean('channelsApp');
+  private _setBoolean(propName: FeatureFlagKey, value: boolean): void {
+    setFeatureFlag(propName, value, this.config[propName]);
   }
 
-  set channelsApp(value: boolean) {
-    this._setBoolean('channelsApp', value);
-  }
-
-  get enableDevPanel() {
-    return this._getBoolean('enableDevPanel');
-  }
-
-  set enableDevPanel(value: boolean) {
-    this._setBoolean('enableDevPanel', value);
-  }
-
-  get resetPasswordPage() {
-    return this._getBoolean('resetPasswordPage');
-  }
-
-  set resetPasswordPage(value: boolean) {
-    this._setBoolean('resetPasswordPage', value);
-  }
-
-  get enableRewards() {
-    return this._getBoolean('enableRewards', true);
-  }
-
-  set enableRewards(value: boolean) {
-    this._setBoolean('enableRewards', value);
-  }
-
-  get enableMatrix() {
-    return this._getBoolean('enableMatrix', true);
-  }
-
-  set enableMatrix(value: boolean) {
-    this._setBoolean('enableMatrix', value);
-  }
-
-  get allowEmailRegistration() {
-    return this._getBoolean('allowEmailRegistration', true);
-  }
-
-  set allowEmailRegistration(value: boolean) {
-    this._setBoolean('allowEmailRegistration', value);
-  }
-
-  get verboseLogging() {
-    return this._getBoolean('verboseLogging', true);
-  }
-
-  set verboseLogging(value: boolean) {
-    this._setBoolean('verboseLogging', value);
-  }
-
-  get allowEditPrimaryZID() {
-    return this._getBoolean('allowEditPrimaryZID', true);
-  }
-
-  set allowEditPrimaryZID(value: boolean) {
-    this._setBoolean('allowEditPrimaryZID', value);
-  }
-
-  get enableReadReceiptPreferences() {
-    return this._getBoolean('enableReadReceiptPreferences', false);
-  }
-
-  set enableReadReceiptPreferences(value: boolean) {
-    this._setBoolean('enableReadReceiptPreferences', value);
-  }
-
-  get enableUserSettings() {
-    return this._getBoolean('enableUserSettings', true);
-  }
-
-  set enableUserSettings(value: boolean) {
-    this._setBoolean('enableUserSettings', value);
-  }
-
-  get enableTimerLogs() {
-    return this._getBoolean('enableTimerLogs', false);
-  }
-
-  set enableTimerLogs(value: boolean) {
-    this._setBoolean('enableTimerLogs', value);
-  }
-
-  get enableChannels() {
-    return this._getBoolean('enableChannels', true);
-  }
-
-  set enableChannels(value: boolean) {
-    this._setBoolean('enableChannels', value);
-  }
-
-  get enableCollapseableMenu() {
-    return this._getBoolean('enableCollapseableMenu', true);
-  }
-
-  set enableCollapseableMenu(value: boolean) {
-    this._setBoolean('enableCollapseableMenu', value);
-  }
-
-  get enableMeows() {
-    return this._getBoolean('enableMeows', true);
-  }
-
-  set enableMeows(value: boolean) {
-    this._setBoolean('enableMeows', value);
-  }
-
-  get enableTokenGatedChat() {
-    return this._getBoolean('enableTokenGatedChat', true);
-  }
-
-  set enableTokenGatedChat(value: boolean) {
-    this._setBoolean('enableTokenGatedChat', value);
-  }
-
-  get enableNotificationsApp() {
-    return this._getBoolean('enableNotificationsApp', true);
-  }
-
-  set enableNotificationsApp(value: boolean) {
-    this._setBoolean('enableNotificationsApp', value);
-  }
-
-  get enableNotificationsReadStatus() {
-    return this._getBoolean('enableNotificationsReadStatus', false);
-  }
-
-  set enableNotificationsReadStatus(value: boolean) {
-    this._setBoolean('enableNotificationsReadStatus', value);
-  }
-
-  get enableLoadMore() {
-    return this._getBoolean('enableLoadMore', true);
-  }
-
-  set enableLoadMore(value: boolean) {
-    this._setBoolean('enableLoadMore', value);
-  }
-
-  get enableComments() {
-    return this._getBoolean('enableComments', true);
-  }
-
-  set enableComments(value: boolean) {
-    this._setBoolean('enableComments', value);
-  }
-
-  get enableFeedApp() {
-    return this._getBoolean('enableFeedApp', true);
-  }
-
-  set enableFeedApp(value: boolean) {
-    this._setBoolean('enableFeedApp', value);
-  }
-
-  get enableLinkedAccounts() {
-    return this._getBoolean('enableLinkedAccounts', true);
-  }
-
-  set enableLinkedAccounts(value: boolean) {
-    this._setBoolean('enableLinkedAccounts', value);
-  }
-
-  get enableZeroWalletSigning() {
-    return this._getBoolean('enableZeroWalletSigning', true);
-  }
-
-  set enableZeroWalletSigning(value: boolean) {
-    this._setBoolean('enableZeroWalletSigning', value);
-  }
-
-  get enableFeedChat() {
-    return this._getBoolean('enableFeedChat', true);
-  }
-
-  set enableFeedChat(value: boolean) {
-    this._setBoolean('enableFeedChat', value);
+  private initializeAccessors() {
+    Object.keys(this.config).forEach((key) => {
+      const flagKey = key as FeatureFlagKey;
+      Object.defineProperty(this, flagKey, {
+        get: () => this._getBoolean(flagKey, this.config[flagKey].defaultValue),
+        set: (value: boolean) => this._setBoolean(flagKey, value),
+        enumerable: true,
+        configurable: true,
+      });
+    });
   }
 }
 
 export const featureFlags = new FeatureFlags();
-
 (window as any).FEATURE_FLAGS = featureFlags;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -59,6 +59,14 @@ export class FeatureFlags implements FeatureFlagValues {
       });
     });
   }
+
+  public reset(): void {
+    Object.keys(this.config).forEach((key) => {
+      const flagKey = key as FeatureFlagKey;
+      const defaultValue = this.config[flagKey].defaultValue;
+      this._setBoolean(flagKey, defaultValue);
+    });
+  }
 }
 
 export const featureFlags = new FeatureFlags();

--- a/src/lib/feature-flags/development.ts
+++ b/src/lib/feature-flags/development.ts
@@ -1,0 +1,27 @@
+import { FeatureFlagDefinitions } from './flags';
+
+export const developmentFlags: FeatureFlagDefinitions = {
+  channelsApp: { defaultValue: false },
+  enableDevPanel: { defaultValue: false },
+  resetPasswordPage: { defaultValue: false },
+  enableRewards: { defaultValue: true },
+  enableMatrix: { defaultValue: true },
+  allowEmailRegistration: { defaultValue: true },
+  verboseLogging: { defaultValue: false },
+  allowEditPrimaryZID: { defaultValue: true },
+  enableReadReceiptPreferences: { defaultValue: false },
+  enableUserSettings: { defaultValue: true },
+  enableTimerLogs: { defaultValue: false },
+  enableChannels: { defaultValue: true },
+  enableCollapseableMenu: { defaultValue: true },
+  enableMeows: { defaultValue: true },
+  enableTokenGatedChat: { defaultValue: true },
+  enableNotificationsApp: { defaultValue: true },
+  enableNotificationsReadStatus: { defaultValue: false },
+  enableLoadMore: { defaultValue: true },
+  enableComments: { defaultValue: true },
+  enableFeedApp: { defaultValue: true },
+  enableLinkedAccounts: { defaultValue: true },
+  enableZeroWalletSigning: { defaultValue: true },
+  enableFeedChat: { defaultValue: true, locked: true },
+};

--- a/src/lib/feature-flags/development.ts
+++ b/src/lib/feature-flags/development.ts
@@ -23,5 +23,5 @@ export const developmentFlags: FeatureFlagDefinitions = {
   enableFeedApp: { defaultValue: true },
   enableLinkedAccounts: { defaultValue: true },
   enableZeroWalletSigning: { defaultValue: true },
-  enableFeedChat: { defaultValue: true, locked: true },
+  enableFeedChat: { defaultValue: true },
 };

--- a/src/lib/feature-flags/flags.ts
+++ b/src/lib/feature-flags/flags.ts
@@ -1,0 +1,75 @@
+import { store } from '../../store';
+import { currentUserSelector } from '../../store/authentication/saga';
+
+export type FeatureFlagKey =
+  | 'channelsApp'
+  | 'enableDevPanel'
+  | 'resetPasswordPage'
+  | 'enableRewards'
+  | 'enableMatrix'
+  | 'allowEmailRegistration'
+  | 'verboseLogging'
+  | 'allowEditPrimaryZID'
+  | 'enableReadReceiptPreferences'
+  | 'enableUserSettings'
+  | 'enableTimerLogs'
+  | 'enableChannels'
+  | 'enableCollapseableMenu'
+  | 'enableMeows'
+  | 'enableTokenGatedChat'
+  | 'enableNotificationsApp'
+  | 'enableNotificationsReadStatus'
+  | 'enableLoadMore'
+  | 'enableComments'
+  | 'enableFeedApp'
+  | 'enableLinkedAccounts'
+  | 'enableZeroWalletSigning'
+  | 'enableFeedChat';
+
+export interface FeatureFlagConfig {
+  defaultValue: boolean;
+  locked?: boolean;
+  allowedUserIds?: string[];
+}
+
+export type FeatureFlagDefinitions = Record<FeatureFlagKey, FeatureFlagConfig>;
+
+export type FeatureFlagValues = Record<FeatureFlagKey, boolean>;
+
+export const getFeatureFlag = (propName: FeatureFlagKey, config?: FeatureFlagConfig): boolean => {
+  const savedValue = window.localStorage.getItem('FEATURE_FLAGS.' + propName);
+
+  // If the config has allowedUserIds, treat it as a locked feature that's only enabled for specific users
+  if (config?.allowedUserIds) {
+    const state = store.getState();
+    const userId = currentUserSelector()(state)?.id;
+    if (userId && config.allowedUserIds.includes(userId)) {
+      return true;
+    }
+    return false;
+  }
+
+  // If the value exists in localStorage, use it unless the flag is locked
+  if (savedValue !== null) {
+    const boolValue = savedValue === 'true';
+    // If config exists and is locked, ensure we're using the default value
+    if (config?.locked) {
+      return config.defaultValue;
+    }
+    return boolValue;
+  }
+
+  // If no saved value, return the default value from config or false
+  return config?.defaultValue ?? false;
+};
+
+export const setFeatureFlag = (propName: FeatureFlagKey, value: boolean, config?: FeatureFlagConfig): boolean => {
+  // If the flag is locked or has allowedUserIds, prevent modification
+  if (config?.locked || config?.allowedUserIds) {
+    console.warn('Feature flag is locked');
+    return false;
+  }
+
+  window.localStorage.setItem('FEATURE_FLAGS.' + propName, value.toString());
+  return true;
+};

--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -1,0 +1,27 @@
+import { FeatureFlagDefinitions } from './flags';
+
+export const productionFlags: FeatureFlagDefinitions = {
+  channelsApp: { defaultValue: false },
+  enableDevPanel: { defaultValue: false },
+  resetPasswordPage: { defaultValue: false },
+  enableRewards: { defaultValue: true },
+  enableMatrix: { defaultValue: true },
+  allowEmailRegistration: { defaultValue: true },
+  verboseLogging: { defaultValue: false },
+  allowEditPrimaryZID: { defaultValue: true },
+  enableReadReceiptPreferences: { defaultValue: false },
+  enableUserSettings: { defaultValue: true },
+  enableTimerLogs: { defaultValue: false },
+  enableChannels: { defaultValue: true },
+  enableCollapseableMenu: { defaultValue: true },
+  enableMeows: { defaultValue: true },
+  enableTokenGatedChat: { defaultValue: true },
+  enableNotificationsApp: { defaultValue: true },
+  enableNotificationsReadStatus: { defaultValue: false },
+  enableLoadMore: { defaultValue: true },
+  enableComments: { defaultValue: true },
+  enableFeedApp: { defaultValue: true },
+  enableLinkedAccounts: { defaultValue: true },
+  enableZeroWalletSigning: { defaultValue: true },
+  enableFeedChat: { defaultValue: true },
+};


### PR DESCRIPTION
### What does this do?

This adds a few new features to the feature flag system and makes it a bit easier to maintain.
- Flags can now be controlled separately in development vs production
- Flags can be locked, preventing tampering in the console
- Flags can be restricted to individual users
  - Flags with this restriction are considered locked
- Flags can be reset to their defaults with `FEATURES_FLAGS.reset()`

### Why are we making this change?

This should allow us more control over rolling out new features.
For instance, we can enable something that only the team can test out internally for a while before going to staging, and then production.

Locking flag
```
{ enableFeedChat: { defaultValue: true, locked: true } }
```
![Screenshot 2025-03-13 at 3 44 08 PM](https://github.com/user-attachments/assets/df558780-e6fb-4414-bc60-dac275e08b54)


Enabled for specific users
```
{ enableFeedChat: { defaultValue: true, allowedUserIds: ['12345'] } }
```
### How do I test this?

I kept all of the flags with their current value so everything should work the same.
