### PR TITLE
fix(app-bar): messenger link to handle missing conversation id

### DIFF
--- a/src/components/app-bar/container.tsx
+++ b/src/components/app-bar/container.tsx
@@ -4,15 +4,17 @@ import { denormalizeConversations } from '../../store/channels-list';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import { DefaultRoomLabels } from '../../store/channels';
+import { getLastActiveConversation } from '../../lib/last-conversation';
 
 export const AppBar = () => {
-  const { activeApp, hasUnreadNotifications, hasUnreadHighlights } = useAppBar();
+  const { activeApp, hasUnreadNotifications, hasUnreadHighlights, lastActiveMessengerConversationId } = useAppBar();
 
   return (
     <AppBarComponent
       activeApp={activeApp}
       hasUnreadNotifications={hasUnreadNotifications}
       hasUnreadHighlights={hasUnreadHighlights}
+      lastActiveMessengerConversationId={lastActiveMessengerConversationId}
     />
   );
 };
@@ -40,9 +42,12 @@ const useAppBar = () => {
     );
   });
 
+  const lastActiveMessengerConversationId = getLastActiveConversation();
+
   return {
     activeApp: match?.params?.app ?? '',
     hasUnreadNotifications,
     hasUnreadHighlights,
+    lastActiveMessengerConversationId,
   };
 };

--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { IconProps } from '@zero-tech/zui/components/Icons/Icons.types';
 import { featureFlags } from '../../lib/feature-flags';
 import { LegacyPanel } from '../layout/panel';
+import { getLastActiveConversation } from '../../lib/last-conversation';
 
 import { bemClassName } from '../../lib/bem';
 
@@ -93,9 +94,15 @@ export class AppBar extends React.Component<Properties, State> {
     );
   };
 
+  getLastConversationId = () => {
+    return getLastActiveConversation();
+  };
+
   render() {
     const { activeApp } = this.props;
     const isActive = checkActive(activeApp);
+    const lastConversationId = this.getLastConversationId();
+    const messengerPath = lastConversationId ? `/conversation/${lastConversationId}` : '/';
 
     return (
       <>
@@ -121,7 +128,7 @@ export class AppBar extends React.Component<Properties, State> {
               Icon={IconMessageSquare2}
               isActive={isActive('conversation')}
               label='Chat'
-              to='/conversation'
+              to={messengerPath}
               onLinkClick={this.unhoverContainer}
             />
             <AppLink

--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -19,6 +19,7 @@ export interface Properties {
   activeApp: string | undefined;
   hasUnreadNotifications: boolean;
   hasUnreadHighlights: boolean;
+  lastActiveMessengerConversationId?: string | undefined;
 }
 
 interface State {
@@ -101,8 +102,9 @@ export class AppBar extends React.Component<Properties, State> {
   render() {
     const { activeApp } = this.props;
     const isActive = checkActive(activeApp);
-    const lastConversationId = this.getLastConversationId();
-    const messengerPath = lastConversationId ? `/conversation/${lastConversationId}` : '/';
+    const messengerPath = this.props.lastActiveMessengerConversationId
+      ? `/conversation/${this.props.lastActiveMessengerConversationId}`
+      : '/';
 
     return (
       <>

--- a/src/components/app-bar/index.vitest.tsx
+++ b/src/components/app-bar/index.vitest.tsx
@@ -41,6 +41,7 @@ const DEFAULT_PROPS: Properties = {
   activeApp: undefined,
   hasUnreadNotifications: false,
   hasUnreadHighlights: false,
+  lastActiveMessengerConversationId: undefined,
 };
 
 const renderComponent = (props: Partial<Properties>) => {

--- a/src/lib/last-conversation.ts
+++ b/src/lib/last-conversation.ts
@@ -7,7 +7,6 @@ export const setLastActiveConversation = (conversationId: string): void => {
 };
 
 export const getLastActiveConversation = (): string | null => {
-  console.log('xxxx getLastActiveConversation called');
   return localStorage.getItem(LAST_CONVERSATION_KEY);
 };
 

--- a/src/lib/last-conversation.ts
+++ b/src/lib/last-conversation.ts
@@ -7,6 +7,7 @@ export const setLastActiveConversation = (conversationId: string): void => {
 };
 
 export const getLastActiveConversation = (): string | null => {
+  console.log('xxxx getLastActiveConversation called');
   return localStorage.getItem(LAST_CONVERSATION_KEY);
 };
 


### PR DESCRIPTION
### What does this do?
- We're updating the AppBar component to handle cases where no last active conversation ID is available by redirecting to the root path instead of an invalid URL.

### Why are we making this change?
- To prevent users from being directed to an invalid URL like /conversation/null when no last conversation exists, ensuring a better user experience by leveraging the app's existing fallback logic.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
