### PR TITLE
refactor(chat-saga): add debounce to feed chat validation to prevent duplicate API calls

### DIFF
--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -1,4 +1,4 @@
-import { put, select, call, take, takeEvery, spawn, race, takeLatest } from 'redux-saga/effects';
+import { put, select, call, take, takeEvery, spawn, race, takeLatest, debounce } from 'redux-saga/effects';
 import { takeEveryFromBus } from '../../lib/saga';
 
 import {
@@ -234,7 +234,8 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.setActiveConversationId, ({ payload }: any) =>
     validateActiveConversation(payload.id)
   );
-  yield takeLatest(SagaActionTypes.ValidateFeedChat, ({ payload }: any) => validateActiveConversation(payload.id));
+
+  yield debounce(300, SagaActionTypes.ValidateFeedChat, ({ payload }: any) => validateActiveConversation(payload.id));
 
   const authBus = yield call(getAuthChannel);
   yield takeEveryFromBus(authBus, AuthEvents.UserLogout, clearOnLogout);


### PR DESCRIPTION
### What does this do?
- We're adding a debounce effect to the ValidateFeedChat action to prevent multiple validation calls when navigating to the feed app.

### Why are we making this change?
- To improve performance by preventing unnecessary duplicate API calls that occur when components mount or update in quick succession.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
