### PR TITLE
Add caching to images

### DIFF
--- a/src/lib/storage/clear-idb.ts
+++ b/src/lib/storage/clear-idb.ts
@@ -1,4 +1,4 @@
-import { getProvider } from './idb';
+import { getProvider } from './media-cache/idb';
 
 export async function clearIndexedDBStorage(): Promise<void> {
   const provider = await getProvider();

--- a/src/lib/storage/media-cache/browser-cache.ts
+++ b/src/lib/storage/media-cache/browser-cache.ts
@@ -61,10 +61,7 @@ export class BrowserMediaCache {
 
   async clear() {
     try {
-      console.log('xxx Clearing browser cache .. ');
       await caches.delete(this.cacheName);
-
-      console.log('xxx Browser cache after clearing .. ', await caches.keys());
     } catch (err) {
       console.error('Failed to clear browser cache:', err);
     }
@@ -86,19 +83,6 @@ export class BrowserMediaCache {
 
         const timestamp = new Date(dateHeader).getTime();
         if (now - timestamp > this.maxAgeMs) {
-          console.log(
-            'xxx Removing from browser cache:',
-            '\n  URL:',
-            request.url,
-            '\n  Last accessed:',
-            new Date(timestamp).toISOString(),
-            '\n  Current time:',
-            new Date(now).toISOString(),
-            '\n  Age (ms):',
-            now - timestamp,
-            '\n  Max age (ms):',
-            this.maxAgeMs
-          );
           await cache.delete(request);
           removedCount++;
         }

--- a/src/lib/storage/media-cache/browser-cache.ts
+++ b/src/lib/storage/media-cache/browser-cache.ts
@@ -1,0 +1,122 @@
+import { MAX_CACHE_AGE_MS } from './index';
+
+export class BrowserMediaCache {
+  private cacheName: string;
+  private maxAgeMs: number; // Changed to milliseconds
+  private cachePromise: Promise<Cache>;
+
+  constructor(cacheName = 'image-store') {
+    this.cacheName = cacheName;
+    this.maxAgeMs = MAX_CACHE_AGE_MS;
+    this.cachePromise = this.initCache();
+  }
+
+  private async initCache() {
+    return await caches.open(this.cacheName);
+  }
+
+  private getCacheKey(url: string): Request {
+    // Create a normalized cache key - critical for mxc:// URLs
+    return new Request(`https://cache-key/${encodeURIComponent(url)}`);
+  }
+
+  async storeImage(url: string, blob: Blob): Promise<void> {
+    try {
+      const cache = await this.cachePromise;
+      const cacheKey = this.getCacheKey(url);
+      const response = new Response(blob, {
+        headers: { date: new Date().toISOString() },
+      });
+
+      await cache.put(cacheKey, response);
+    } catch (err) {
+      console.error('Failed to store in browser cache:', err);
+    }
+  }
+
+  async getImage(url: string): Promise<string | null> {
+    try {
+      const cache = await this.cachePromise;
+      const cacheKey = this.getCacheKey(url);
+      const response = await cache.match(cacheKey);
+
+      if (!response) return null;
+
+      // Create a new blob from the response
+      // Refresh the timestamp on access (like IndexedDB does)
+      const blob = await response.blob();
+      const updatedResponse = new Response(blob, {
+        headers: { date: new Date().toISOString() },
+      });
+
+      // Update the cache with fresh timestamp
+      cache.put(cacheKey, updatedResponse);
+
+      return URL.createObjectURL(blob);
+    } catch (err) {
+      console.error('Failed to get from browser cache:', err);
+      return null;
+    }
+  }
+
+  async clear() {
+    try {
+      console.log('xxx Clearing browser cache .. ');
+      await caches.delete(this.cacheName);
+
+      console.log('xxx Browser cache after clearing .. ', await caches.keys());
+    } catch (err) {
+      console.error('Failed to clear browser cache:', err);
+    }
+  }
+
+  async cleanup() {
+    try {
+      const cache = await this.cachePromise;
+      const keys = await cache.keys();
+      const now = Date.now();
+      let removedCount = 0;
+
+      for (const request of keys) {
+        const response = await cache.match(request);
+        if (!response) continue;
+
+        const dateHeader = response.headers.get('date');
+        if (!dateHeader) continue;
+
+        const timestamp = new Date(dateHeader).getTime();
+        if (now - timestamp > this.maxAgeMs) {
+          console.log(
+            'xxx Removing from browser cache:',
+            '\n  URL:',
+            request.url,
+            '\n  Last accessed:',
+            new Date(timestamp).toISOString(),
+            '\n  Current time:',
+            new Date(now).toISOString(),
+            '\n  Age (ms):',
+            now - timestamp,
+            '\n  Max age (ms):',
+            this.maxAgeMs
+          );
+          await cache.delete(request);
+          removedCount++;
+        }
+      }
+
+      return removedCount;
+    } catch (err) {
+      console.error('Failed to cleanup browser cache:', err);
+      return 0;
+    }
+  }
+}
+
+let browserCacheInstance: BrowserMediaCache | null = null;
+
+export function getBrowserCache(): BrowserMediaCache {
+  if (!browserCacheInstance) {
+    browserCacheInstance = new BrowserMediaCache();
+  }
+  return browserCacheInstance;
+}

--- a/src/lib/storage/media-cache/idb.ts
+++ b/src/lib/storage/media-cache/idb.ts
@@ -1,13 +1,16 @@
 import { openDB } from 'idb';
+import { MAX_CACHE_AGE_MS } from '.';
 
 export class IndexedDBHelper {
   private dbName: string;
   private storeName: string;
   private dbPromise: Promise<any>;
+  private maxAgeMs: number; // Default cache expiry time
 
-  constructor(dbName, storeName) {
+  constructor(dbName, storeName, maxAgeMs = MAX_CACHE_AGE_MS) {
     this.dbName = dbName; // Name of the database
     this.storeName = storeName; // Name of the object store
+    this.maxAgeMs = maxAgeMs;
 
     // Initialize the database
     this.dbPromise = this.initDB();
@@ -26,16 +29,31 @@ export class IndexedDBHelper {
   }
 
   // Method to add or update a record
-  async put(id, value) {
+  async put(id, value, timestamp = Date.now()) {
     const db = await this.dbPromise;
-    return await db.put(this.storeName, { id, value });
+    return await db.put(this.storeName, { id, value, timestamp });
   }
 
   // Method to retrieve a record by id
   async get(id) {
     const db = await this.dbPromise;
     const record = await db.get(this.storeName, id);
-    return record ? record.value : null;
+
+    if (!record) {
+      return null;
+    }
+
+    // Update timestamp to keep recently accessed files fresh
+    this.refreshTimestamp(record);
+
+    return record.value;
+  }
+
+  // Method to refresh record timestamp
+  async refreshTimestamp(record) {
+    record.timestamp = Date.now();
+    const db = await this.dbPromise;
+    await db.put(this.storeName, record);
   }
 
   // Method to delete a record by id
@@ -48,22 +66,43 @@ export class IndexedDBHelper {
   async getAll() {
     const db = await this.dbPromise;
     const records = await db.getAll(this.storeName);
-    return records.map((record) => record.value);
+    return records;
   }
 
   // Method to clear the object store
   async clear() {
+    console.log('xxx Clearing IndexedDB .. ');
+
     const db = await this.dbPromise;
     return db.clear(this.storeName);
   }
+
+  // Method to clean up expired entries
+  async cleanupExpired() {
+    if (!this.maxAgeMs) {
+      return 0;
+    }
+
+    const records = await this.getAll();
+    const now = Date.now();
+    let removedCount = 0;
+
+    for (const record of records) {
+      if (now - record.timestamp > this.maxAgeMs) {
+        await this.delete(record.id);
+        removedCount++;
+      }
+    }
+
+    return removedCount;
+  }
 }
 
-function createProvider() {
-  return new IndexedDBHelper('zos-db', 'image-store');
-}
+let indexedDBInstance: IndexedDBHelper | null = null;
 
-let provider;
 export function getProvider(): IndexedDBHelper {
-  provider = provider ?? createProvider();
-  return provider;
+  if (!indexedDBInstance) {
+    indexedDBInstance = new IndexedDBHelper('zos-db', 'image-store');
+  }
+  return indexedDBInstance;
 }

--- a/src/lib/storage/media-cache/idb.ts
+++ b/src/lib/storage/media-cache/idb.ts
@@ -71,8 +71,6 @@ export class IndexedDBHelper {
 
   // Method to clear the object store
   async clear() {
-    console.log('xxx Clearing IndexedDB .. ');
-
     const db = await this.dbPromise;
     return db.clear(this.storeName);
   }

--- a/src/lib/storage/media-cache/index.ts
+++ b/src/lib/storage/media-cache/index.ts
@@ -1,0 +1,47 @@
+import { getProvider } from './idb';
+import { getBrowserCache } from './browser-cache';
+
+export const MAX_CACHE_AGE_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+// FileUrl is the mxc://.. url of the file
+export async function getFileFromCache(fileUrl: string): Promise<string | null> {
+  // Try browser cache first (faster, memory efficient)
+  const browserCache = getBrowserCache();
+  const cachedUrl = await browserCache.getImage(fileUrl);
+  if (cachedUrl) {
+    return cachedUrl;
+  }
+
+  // Try IndexedDB if not in browser cache
+  const indexedDB = getProvider();
+  const blob = await indexedDB.get(fileUrl);
+  if (blob) {
+    // Store in browser cache for future requests
+    browserCache.storeImage(fileUrl, blob);
+    return URL.createObjectURL(blob);
+  }
+
+  return null;
+}
+
+// Store file in all caches
+export async function putFileToCache(fileUrl: string, blob: Blob): Promise<void> {
+  const indexedDB = getProvider();
+  const browserCache = getBrowserCache();
+
+  // Store in IndexedDB for persistence & browser cache for memory efficiency
+  await Promise.all([indexedDB.put(fileUrl, blob), browserCache.storeImage(fileUrl, blob)]);
+}
+
+export async function performCacheMaintenance(): Promise<void> {
+  const [idbRemoved, browserRemoved] = await Promise.all([getProvider().cleanupExpired(), getBrowserCache().cleanup()]);
+
+  console.log(
+    `Cache maintenance completed: removed ${idbRemoved} items from IndexedDB and ${browserRemoved} from browser cache`
+  );
+}
+
+export async function clearCache(): Promise<void> {
+  await getProvider().clear();
+  await getBrowserCache().clear();
+}

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -38,6 +38,12 @@ import { clearLastActiveTab } from '../../lib/last-tab';
 import { clearIndexedDBStorage } from '../../lib/storage/clear-idb';
 import { clearLastActiveFeed } from '../../lib/last-feed';
 
+// Mock the media-cache module
+jest.mock('../../lib/storage/media-cache', () => ({
+  clearCache: jest.fn(),
+  performCacheMaintenance: jest.fn(),
+}));
+
 describe(nonceOrAuthorize, () => {
   const signedWeb3Token = '0x000000000000000000000000000000000000000A';
   const authorizationResponse = {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -660,9 +660,7 @@ export function* loadAttachmentDetails(action) {
     // Set status to 'LOADING'
     yield put(updateMediaStatus(messageId, media, MediaDownloadStatus.Loading));
 
-    const blob = yield call(decryptFile, media.file || { url: media.url }, media.mimetype);
-    const url = URL.createObjectURL(blob);
-
+    const url = yield call(decryptFile, media.file || { url: media.url }, media.mimetype);
     if (!url) {
       yield put(updateMediaStatus(messageId, media, MediaDownloadStatus.Failed));
       return;

--- a/src/store/registration/saga.ts
+++ b/src/store/registration/saga.ts
@@ -30,7 +30,7 @@ import { getHistory } from '../../lib/browser';
 import { setIsComplete as setPageLoadComplete } from '../page-load';
 import { createConversation } from '../channels-list/saga';
 import { getZEROUsers as getZEROUsersAPI } from '../channels-list/api';
-import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
+import { getProvider as getIndexedDbProvider } from '../../lib/storage/media-cache/idb';
 import { receive as receiveUser } from '../users';
 
 export function* validateInvite(action) {

--- a/src/store/users/saga.test.ts
+++ b/src/store/users/saga.test.ts
@@ -22,7 +22,7 @@ const mockIdb = {
   },
 };
 
-jest.mock('../../lib/storage/idb', () => ({
+jest.mock('../../lib/storage/media-cache/idb', () => ({
   getProvider: () => mockIdb,
 }));
 

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -13,7 +13,7 @@ import {
   getProfileInfo as matrixGetProfileInfo,
 } from '../../lib/chat';
 import cloneDeep from 'lodash/cloneDeep';
-import { getProvider as getIndexedDbProvider } from '../../lib/storage/idb';
+import { getProvider as getIndexedDbProvider } from '../../lib/storage/media-cache/idb';
 import { editUserProfile as apiEditUserProfile } from '../edit-profile/api';
 import { User } from '../authentication/types';
 


### PR DESCRIPTION
### What does this do?

- Puts the downloaded images to a cache (browser cache API + indexedDB), for faster retrieval later.
- When the user reloads, it will fetch it from cache first, and if found, it will be returned. This should help in better reload times.
- Also added a `cleanUp` function to run a clearance script every 2 hours, this will refresh the cache i.e get rid of older entries which haven't been accessed since the last "2 days".