### PR TITLE
feat(conversation-list-panel): add infinite scroll pagination to conversation list for improved performance

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
+++ b/src/components/messenger/list/conversation-list-panel/conversation-list-panel.scss
@@ -187,4 +187,17 @@ $side-padding: 16px;
     background-size: cover;
     background-repeat: no-repeat;
   }
+
+  &__waypoint-container {
+    height: 1px;
+    width: 100%;
+  }
+
+  &__loading-more {
+    padding: 16px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/src/components/messenger/list/conversation-list-panel/index.test.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.test.tsx
@@ -5,6 +5,7 @@ import { ConversationListPanel, Properties } from '.';
 import { Channel, DefaultRoomLabels } from '../../../../store/channels';
 import { stubConversation } from '../../../../store/test/store';
 import { IconStar1 } from '@zero-tech/zui/icons';
+import { Waypoint } from '../../../waypoint';
 
 describe('ConversationListPanel', () => {
   const subject = (props: Partial<Properties>) => {
@@ -109,6 +110,36 @@ describe('ConversationListPanel', () => {
 
     selectTab(wrapper, 'Family');
     expect(renderedConversationNames(wrapper)).toStrictEqual(['convo-4']);
+  });
+
+  it('initially renders only PAGE_SIZE conversations and Waypoint', function () {
+    const conversations = Array.from({ length: 30 }, (_, i) =>
+      stubConversation({
+        id: `convo-id-${i}`,
+        name: `convo-${i}`,
+        unreadCount: { total: 0, highlight: 0 },
+      })
+    );
+
+    const wrapper = subject({ conversations: conversations as any });
+
+    expect(wrapper.find('ConversationItem').length).toBe(20);
+
+    expect(wrapper).toHaveElement(Waypoint);
+  });
+
+  it('does not render Waypoint when all conversations are loaded', function () {
+    const conversations = Array.from({ length: 15 }, (_, i) =>
+      stubConversation({
+        id: `convo-id-${i}`,
+        name: `convo-${i}`,
+        unreadCount: { total: 0, highlight: 0 },
+      })
+    );
+
+    const wrapper = subject({ conversations: conversations as any });
+
+    expect(wrapper).not.toHaveElement(Waypoint);
   });
 
   it('renders Favorites tab first', function () {


### PR DESCRIPTION
### What does this do?
- Adding infinite scroll pagination to the conversation list panel to improve performance by loading conversations in batches.

### Why are we making this change?
- To reduce DOM rendering and improve UI performance when dealing with large numbers of conversations.

### How do I test this?
- run tests as usual
- run UI and scroll inside the conversation list panel > check elements tab in the dev tools to confirm 20 conversation list items on initial load & then when loading more

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
