### PR TITLE
Fix: Fixes the sidekick breaking if it is unmounted.

### DIFF
--- a/src/apps/app-router.module.css
+++ b/src/apps/app-router.module.css
@@ -1,0 +1,3 @@
+.sidekickHidden {
+  display: none;
+}

--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../store/reducer';
 import { Provider as AuthenticationContextProvider } from '../components/authentication/context';
 import { AuraApp } from './aura';
+import styles from './app-router.module.css';
 
 import { Container as SidekickContainer } from '../components/sidekick/components/container';
 import { Header as SidekickHeader } from '../components/sidekick/components/header';
@@ -31,13 +32,11 @@ export const AppRouter = () => {
 
   return (
     <AuthenticationContextProvider value={{ isAuthenticated }}>
-      {renderSidekick && (
-        <SidekickContainer>
-          <SidekickHeader>
-            <CurrentUserDetails />
-          </SidekickHeader>
-        </SidekickContainer>
-      )}
+      <SidekickContainer className={!renderSidekick ? styles.sidekickHidden : ''}>
+        <SidekickHeader>
+          <CurrentUserDetails />
+        </SidekickHeader>
+      </SidekickContainer>
       <Switch>
         <Route path='/conversation/:conversationId' component={MessengerApp} />
         <Route path='/' exact component={MessengerApp} />


### PR DESCRIPTION
### What does this do?

The sidekick breaks if it's unmounted due to how the content portal works.
We'll now hide it instead of unmount it when it's not relevant.

A more permanent fix could be to use a ref instead of a query selector, but that'd be a minor refactor

### Why are we making this change?

Currently broken when switching to zApp and back to an app that has the sidekick

### How do I test this?
Go to explorer, then back to chat. Sidekick should render properly