### PR TITLE
Fix: Incorrect user id for feature flag

### DIFF
--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -28,7 +28,7 @@ export const productionFlags: FeatureFlagDefinitions = {
     defaultValue: false,
     allowedUserIds: [
       'dca9d449-548b-4fc9-8411-aab7b48bffc0',
-      '020705c6-0740-4d4d-8185-0ba7542b9725',
+      'f977959f-08db-4e09-b730-b5d7a6577481',
       'bcdcdf9b-e278-43c5-ac34-07a21689ab01',
       'a8df265e-5e4c-46e9-a6e5-9da8684f96ac',
     ],


### PR DESCRIPTION
### What does this do?
Fix an incorrect user id for aura flag