### PR TITLE
Reduce matrix `/sync` timeout from `30s` to `25s`

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -1450,7 +1450,9 @@ export class MatrixClient implements IChatClient {
       // this.matrix.getCrypto().globalBlacklistUnverifiedDevices = false;
       this.matrix.setGlobalErrorOnUnknownDevices(false);
 
-      await this.matrix.startClient();
+      await this.matrix.startClient({
+        pollTimeout: 25000,
+      });
 
       featureFlags.enableTimerLogs && console.time('xxxWaitForSync');
       await this.waitForSync();


### PR DESCRIPTION
### What does this do?

One of the reasons we're getting lots of 503's could be due to sync timing out on the homeserver (attached sc)

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/8e78bd05-04ee-4018-8919-31c49cc90c00" />

Heroku by default has a 30s timeout which returns as 503. This is the same as our sync timeout. Basically, before the sync times out, i think heroku is timing out the request (`code=H12` on logs) and returning 503.

This PR reduces our matrix timeout from 30s to 25s to avoid this.
