### PR TITLE
feat(view-members-panel): add infinite scroll pagination to member list for improved performance

### DIFF
--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { ViewMembersPanel, Properties } from '.';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { User } from '../../../../store/channels';
+import { Waypoint } from '../../../waypoint';
 
 import { bem } from '../../../../lib/bem';
 
@@ -26,6 +27,46 @@ describe(ViewMembersPanel, () => {
 
     return shallow(<ViewMembersPanel {...allProps} />);
   };
+
+  it('initially renders only PAGE_SIZE members and shows Waypoint', () => {
+    const otherMembers = Array.from({ length: 30 }, (_, i) => ({
+      userId: `user-${i}`,
+      matrixId: `matrix-id-${i}`,
+      firstName: `User ${i}`,
+    })) as User[];
+
+    const wrapper = subject({ otherMembers });
+
+    expect(wrapper.find(CitizenListItem).length).toBe(21); // 1 current user + 20 other members
+
+    expect(wrapper).toHaveElement(Waypoint);
+  });
+
+  it('shows loading spinner while loading more members', () => {
+    const otherMembers = Array.from({ length: 30 }, (_, i) => ({
+      userId: `user-${i}`,
+      matrixId: `matrix-id-${i}`,
+      firstName: `User ${i}`,
+    })) as User[];
+
+    const wrapper = subject({ otherMembers });
+
+    wrapper.setState({ isLoadingMore: true });
+
+    expect(wrapper).toHaveElement('Spinner');
+  });
+
+  it('does not show Waypoint when all members are loaded', () => {
+    const otherMembers = Array.from({ length: 10 }, (_, i) => ({
+      userId: `user-${i}`,
+      matrixId: `matrix-id-${i}`,
+      firstName: `User ${i}`,
+    })) as User[];
+
+    const wrapper = subject({ otherMembers });
+
+    expect(wrapper).not.toHaveElement(Waypoint);
+  });
 
   it('publishes onAdd event', () => {
     const onAdd = jest.fn();

--- a/src/components/messenger/group-management/view-members-panel/styles.scss
+++ b/src/components/messenger/group-management/view-members-panel/styles.scss
@@ -43,4 +43,17 @@
     padding-top: 8px;
     flex-grow: 1;
   }
+
+  &__waypoint-container {
+    height: 1px;
+    width: 100%;
+  }
+
+  &__loading-more {
+    padding: 16px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
### What does this do?
- Adding infinite scroll pagination to the ViewMembersPanel to improve performance by loading members in batches.

### Why are we making this change?
- To reduce DOM rendering and improve UI performance when dealing with large groups that have many members.

### How do I test this?
- run tests as usual
- run UI and open members panel > you can check the element tab in dev tools to see that up to 20 members are initially rendered in DOM before scrolling and entering waypoint

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
