### PR TITLE
feat(edit-conversation-panel): add infinite scroll pagination to edit conversation panel for improved performance

### DIFF
--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -7,6 +7,7 @@ import { Alert } from '@zero-tech/zui/components';
 import { CitizenListItem } from '../../../citizen-list-item';
 import { User } from '../../../../store/channels';
 import { EditConversationState } from '../../../../store/group-management/types';
+import { Waypoint } from '../../../waypoint';
 
 describe(EditConversationPanel, () => {
   const subject = (props: Partial<Properties>) => {
@@ -242,6 +243,48 @@ describe(EditConversationPanel, () => {
       const item = wrapper.find(CitizenListItem).findWhere((c) => c.prop('user').userId === 'otherMember1');
 
       expect(item.prop('onRemove')).toBeFalsy();
+    });
+  });
+
+  describe('Infinite Scroll', () => {
+    it('initially renders only PAGE_SIZE members and shows Waypoint', () => {
+      const otherMembers = Array.from({ length: 30 }, (_, i) => ({
+        userId: `user-${i}`,
+        matrixId: `matrix-id-${i}`,
+        firstName: `User ${i}`,
+      })) as User[];
+
+      const wrapper = subject({ otherMembers });
+
+      expect(wrapper.find(CitizenListItem).length).toBe(21); // 1 current user + 20 other members
+      expect(wrapper).toHaveElement(Waypoint);
+    });
+
+    it('shows loading spinner while loading more members', () => {
+      const otherMembers = Array.from({ length: 30 }, (_, i) => ({
+        userId: `user-${i}`,
+        matrixId: `matrix-id-${i}`,
+        firstName: `User ${i}`,
+      })) as User[];
+
+      const wrapper = subject({ otherMembers });
+
+      wrapper.setState({ isLoadingMore: true });
+
+      expect(wrapper).toHaveElement('Spinner');
+    });
+
+    it('does not show Waypoint when all members are loaded', () => {
+      const otherMembers = Array.from({ length: 10 }, (_, i) => ({
+        userId: `user-${i}`,
+        matrixId: `matrix-id-${i}`,
+        firstName: `User ${i}`,
+      })) as User[];
+
+      const wrapper = subject({ otherMembers });
+
+      // Should not show Waypoint since all members can be displayed at once
+      expect(wrapper).not.toHaveElement(Waypoint);
     });
   });
 });

--- a/src/components/messenger/group-management/edit-conversation-panel/styles.scss
+++ b/src/components/messenger/group-management/edit-conversation-panel/styles.scss
@@ -53,4 +53,17 @@
     padding-top: 8px;
     flex-grow: 1;
   }
+
+  &__waypoint-container {
+    height: 1px;
+    width: 100%;
+  }
+
+  &__loading-more {
+    padding: 16px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
### What does this do?
- Adding infinite scroll pagination to the EditConversationPanel to improve performance by loading members in batches.

### Why are we making this change?
- To reduce DOM rendering and improve UI performance when editing groups with many members.

### How do I test this?
- run tests as usual
- run UI > navigate to the edit conversation panel and check elements tab for number of members and scroll to check waypoint on enter is triggered to load more members

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
