### PR TITLE
feat(view-group-information-panel): add infinite scroll pagination to group information panel for improved performance

### DIFF
--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -8,6 +8,7 @@ import { Button } from '@zero-tech/zui/components/Button';
 
 import { IconUsers1 } from '@zero-tech/zui/icons';
 import { bem } from '../../../../lib/bem';
+import { Waypoint } from '../../../waypoint';
 
 const c = bem('.view-group-information-panel');
 
@@ -216,5 +217,45 @@ describe(ViewGroupInformationPanel, () => {
     expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null); // current user is displayed at top
     expect(wrapper.find(CitizenListItem).at(1)).toHaveProp('tag', 'Mod');
     expect(wrapper.find(CitizenListItem).at(2)).toHaveProp('tag', null);
+  });
+
+  it('initially renders only PAGE_SIZE members and shows Waypoint', () => {
+    const otherMembers = Array.from({ length: 30 }, (_, i) => ({
+      userId: `user-${i}`,
+      matrixId: `matrix-id-${i}`,
+      firstName: `User ${i}`,
+    })) as User[];
+
+    const wrapper = subject({ otherMembers });
+
+    expect(wrapper.find(CitizenListItem).length).toBe(21); // 1 current user + 20 other members
+    expect(wrapper).toHaveElement(Waypoint);
+  });
+
+  it('shows loading spinner while loading more members', () => {
+    const otherMembers = Array.from({ length: 30 }, (_, i) => ({
+      userId: `user-${i}`,
+      matrixId: `matrix-id-${i}`,
+      firstName: `User ${i}`,
+    })) as User[];
+
+    const wrapper = subject({ otherMembers });
+
+    wrapper.setState({ isLoadingMore: true });
+
+    expect(wrapper).toHaveElement('Spinner');
+  });
+
+  it('does not show Waypoint when all members are loaded', () => {
+    const otherMembers = Array.from({ length: 10 }, (_, i) => ({
+      userId: `user-${i}`,
+      matrixId: `matrix-id-${i}`,
+      firstName: `User ${i}`,
+    })) as User[];
+
+    const wrapper = subject({ otherMembers });
+
+    // Should not show Waypoint since all members can be displayed at once
+    expect(wrapper).not.toHaveElement(Waypoint);
   });
 });

--- a/src/components/messenger/group-management/view-group-information-panel/index.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.tsx
@@ -10,10 +10,14 @@ import { CitizenListItem } from '../../../citizen-list-item';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { LeaveGroupDialogStatus } from '../../../../store/group-management';
 import { getTagForUser, sortMembers } from '../../list/utils/utils';
+import { Waypoint } from '../../../waypoint';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 
 import './styles.scss';
 
 const cn = bemClassName('view-group-information-panel');
+
+const PAGE_SIZE = 20;
 
 export interface Properties {
   name: string;
@@ -34,7 +38,17 @@ export interface Properties {
   openUserProfile: () => void;
 }
 
-export class ViewGroupInformationPanel extends React.Component<Properties> {
+interface State {
+  visibleMemberCount: number;
+  isLoadingMore: boolean;
+}
+
+export class ViewGroupInformationPanel extends React.Component<Properties, State> {
+  state: State = {
+    visibleMemberCount: PAGE_SIZE,
+    isLoadingMore: false,
+  };
+
   getTag(user: User) {
     return getTagForUser(user, this.props.conversationAdminIds, this.props.conversationModeratorIds);
   }
@@ -63,6 +77,24 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
     this.props.openUserProfile();
   };
 
+  loadMoreMembers = () => {
+    const { visibleMemberCount } = this.state;
+    const { otherMembers } = this.props;
+    const totalMembers = otherMembers.length;
+
+    // Don't load more if we've already loaded all members or if we're already loading
+    if (visibleMemberCount >= totalMembers || this.state.isLoadingMore) return;
+
+    this.setState({ isLoadingMore: true }, () => {
+      requestAnimationFrame(() => {
+        this.setState({
+          visibleMemberCount: Math.min(visibleMemberCount + PAGE_SIZE, totalMembers),
+          isLoadingMore: false,
+        });
+      });
+    });
+  };
+
   renderDetails = () => {
     return (
       <div {...cn('details')}>
@@ -89,7 +121,10 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
 
   renderMembers = () => {
     const { otherMembers, conversationAdminIds, conversationModeratorIds } = this.props;
+    const { visibleMemberCount, isLoadingMore } = this.state;
     const sortedOtherMembers = sortMembers(otherMembers, conversationAdminIds, conversationModeratorIds);
+    const visibleMembers = sortedOtherMembers.slice(0, visibleMemberCount);
+    const hasMoreMembers = visibleMembers.length < sortedOtherMembers.length;
 
     return (
       <div {...cn('members')}>
@@ -109,7 +144,7 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
               tag={this.getTag(this.props.currentUser)}
               onSelected={this.openProfile}
             ></CitizenListItem>
-            {sortedOtherMembers.map((u) => (
+            {visibleMembers.map((u) => (
               <CitizenListItem
                 key={u.userId}
                 user={u}
@@ -118,6 +153,18 @@ export class ViewGroupInformationPanel extends React.Component<Properties> {
               ></CitizenListItem>
             ))}
           </ScrollbarContainer>
+
+          {hasMoreMembers && (
+            <div {...cn('waypoint-container')}>
+              <Waypoint onEnter={this.loadMoreMembers} />
+            </div>
+          )}
+
+          {isLoadingMore && (
+            <div {...cn('loading-more')}>
+              <Spinner />
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/components/messenger/group-management/view-group-information-panel/styles.scss
+++ b/src/components/messenger/group-management/view-group-information-panel/styles.scss
@@ -99,4 +99,17 @@
     padding-top: 8px;
     flex-grow: 1;
   }
+
+  &__waypoint-container {
+    height: 1px;
+    width: 100%;
+  }
+
+  &__loading-more {
+    padding: 16px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
### What does this do?
- Adding infinite scroll pagination to the ViewGroupInformationPanel to improve performance by loading members in batches.

### Why are we making this change?
- To reduce DOM rendering and improve UI performance when viewing group information with many members.

### How do I test this?
- run tests as usual
- run UI > navigate to view group info panel and check element tab on dev tools for number of members before and after scrolling & triggering load more members via waypoint component

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
