### PR TITLE
refactor(conversation-list-panel): don't reset pagination on filter change

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -94,8 +94,8 @@ export class ConversationListPanel extends React.Component<Properties, State> {
       }
     }
 
-    // Reset pagination when filter or tab changes
-    if (prevState.filter !== this.state.filter || prevState.selectedTab !== this.state.selectedTab) {
+    // Reset pagination when tab changes
+    if (prevState.selectedTab !== this.state.selectedTab) {
       this.setState({ visibleItemCount: PAGE_SIZE });
       this.scrollToTop();
     }


### PR DESCRIPTION
### What does this do?
- prevents pagination reset when filter changes on conversation list panel list items

### Why are we making this change?
- improved ux

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
