### PR TITLE
feat(user-search-results): add infinite scroll pagination to user search results for improved performance

### DIFF
--- a/src/components/messenger/list/user-search-results/index.test.tsx
+++ b/src/components/messenger/list/user-search-results/index.test.tsx
@@ -5,8 +5,11 @@ import { UserSearchResults, Properties } from '.';
 import { Avatar } from '@zero-tech/zui/components';
 
 import { bem } from '../../../../lib/bem';
+import { Waypoint } from '../../../waypoint';
 
 const c = bem('.user-search-results');
+
+const PAGE_SIZE = 20;
 
 describe('UserSearchResults', () => {
   const subject = (props: Partial<Properties>) => {
@@ -85,5 +88,49 @@ describe('UserSearchResults', () => {
     wrapper.find(c('item')).simulate('keydown', { key: 'Enter' });
 
     expect(handleCreate).toHaveBeenCalledWith(userResults[0].value);
+  });
+
+  it('initially renders only PAGE_SIZE results and shows Waypoint', () => {
+    const results = Array.from({ length: 30 }, (_, i) => ({
+      value: `user-${i}`,
+      label: `User ${i}`,
+      image: `image-${i}`,
+      subLabel: `0://user-${i}.test`,
+    }));
+
+    const wrapper = subject({ filter: 'test', results });
+
+    const renderedResults = wrapper.find(c('item'));
+    expect(renderedResults).toHaveLength(PAGE_SIZE);
+    expect(wrapper).toHaveElement(Waypoint);
+  });
+
+  it('shows loading spinner while loading more results', () => {
+    const results = Array.from({ length: 30 }, (_, i) => ({
+      value: `user-${i}`,
+      label: `User ${i}`,
+      image: `image-${i}`,
+      subLabel: `0://user-${i}.test`,
+    }));
+
+    const wrapper = subject({ filter: 'test', results });
+
+    wrapper.setState({ isLoadingMore: true });
+
+    expect(wrapper).toHaveElement('Spinner');
+  });
+
+  it('does not show Waypoint when all results are loaded', () => {
+    const results = Array.from({ length: 10 }, (_, i) => ({
+      value: `user-${i}`,
+      label: `User ${i}`,
+      image: `image-${i}`,
+      subLabel: `0://user-${i}.test`,
+    }));
+
+    const wrapper = subject({ filter: 'test', results });
+
+    // Should not show Waypoint since all results can be displayed at once
+    expect(wrapper).not.toHaveElement(Waypoint);
   });
 });

--- a/src/components/messenger/list/user-search-results/user-search-results.scss
+++ b/src/components/messenger/list/user-search-results/user-search-results.scss
@@ -62,4 +62,17 @@
     text-overflow: ellipsis;
     width: 100%;
   }
+
+  &__waypoint-container {
+    height: 1px;
+    width: 100%;
+  }
+
+  &__loading-more {
+    padding: 16px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
### What does this do?
- Adding infinite scroll pagination to the UserSearchResults component to improve performance by loading search results in batches.

### Why are we making this change?
- To reduce DOM rendering and improve UI responsiveness when searching for users with common patterns that return many results

### How do I test this?
- run tests as usual
- run UI > search results and check elements tab on dev tools to ensure only PAGE_LIMIT amount of search results are in visible in DOM

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
