### PR TITLE
feat(autocomplete-members): add infinite scroll pagination to autocomplete members for add members and create conversation panels

### DIFF
--- a/src/components/messenger/autocomplete-members/index.test.tsx
+++ b/src/components/messenger/autocomplete-members/index.test.tsx
@@ -5,6 +5,7 @@ import { AutocompleteMembers } from './';
 import { when } from 'jest-when';
 
 import { Properties } from './';
+import { Waypoint } from '../../waypoint';
 
 describe('autocomplete-members', () => {
   const subject = (props: Partial<Properties>) => {
@@ -222,6 +223,59 @@ describe('autocomplete-members', () => {
       });
 
     expect(onSearchChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('initially renders only PAGE_SIZE results and shows Waypoint', async () => {
+    const search = jest.fn();
+    const searchResults = Array.from({ length: 30 }, (_, i) => ({
+      name: `Result ${i}`,
+      id: `result-${i}`,
+      image: `image-${i}`,
+    }));
+
+    when(search).calledWith('name').mockResolvedValue(searchResults);
+
+    const wrapper = subject({ search });
+    await searchFor(wrapper, 'name');
+
+    // Should render only the first PAGE_SIZE (20) results
+    expect(wrapper.find('[role="button"]').length).toBe(20);
+    expect(wrapper).toHaveElement(Waypoint);
+  });
+
+  it('shows loading spinner while loading more results', async () => {
+    const search = jest.fn();
+    const searchResults = Array.from({ length: 30 }, (_, i) => ({
+      name: `Result ${i}`,
+      id: `result-${i}`,
+      image: `image-${i}`,
+    }));
+
+    when(search).calledWith('name').mockResolvedValue(searchResults);
+
+    const wrapper = subject({ search });
+    await searchFor(wrapper, 'name');
+
+    wrapper.setState({ isLoadingMore: true });
+
+    expect(wrapper).toHaveElement('Spinner');
+  });
+
+  it('does not show Waypoint when all results are loaded', async () => {
+    const search = jest.fn();
+    const searchResults = Array.from({ length: 10 }, (_, i) => ({
+      name: `Result ${i}`,
+      id: `result-${i}`,
+      image: `image-${i}`,
+    }));
+
+    when(search).calledWith('name').mockResolvedValue(searchResults);
+
+    const wrapper = subject({ search });
+    await searchFor(wrapper, 'name');
+
+    // Should not show Waypoint since all results can be displayed at once
+    expect(wrapper).not.toHaveElement(Waypoint);
   });
 });
 

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -77,6 +77,18 @@
     text-overflow: ellipsis;
     width: 100%;
   }
+
+  &__waypoint-container {
+    height: 1px;
+  }
+
+  &__loading-more {
+    padding: 16px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }
 
 .force-extra-specificity.autocomplete-members__search-wrapper {


### PR DESCRIPTION
### What does this do?
- Adding infinite scroll pagination to the AutocompleteMembers component to load search results in batches of 20 instead of all at once.

### Why are we making this change?
- To improve performance and reduce DOM rendering when searching for users with common patterns that might return many results, providing a consistent user experience with other list components in the application.

### How do I test this?
- run tests as usual
- run UI and navigate to Add Members Panels / Create Conversation Panel > open dev tools Element tab and check only 20 results are in the DOM prior to scrolling and triggering waypoint get more results

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
