### PR TITLE
fix: dot grid background browser compatibility

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -77,7 +77,7 @@ $border-color-hover: theme-zui.$color-primary-7;
       --dot-space: 48px;
 
       background-color: rgba(0, 0, 0, 1);
-      background-image: radial-gradient(circle, rgba(255, 255, 255, 0.3) var(--dot-size), transparent 0);
+      background-image: radial-gradient(circle, rgba(255, 255, 255, 0.2) var(--dot-size), transparent 0);
       background-size: var(--dot-space) var(--dot-space);
       background-repeat: repeat;
       background-attachment: fixed;


### PR DESCRIPTION
### What does this do?

- Some browsers can't render sub-pixel dots. So, I made them `1px`, and took visual weight away from them via opacity.
