### PR TITLE
feat(iframe): implement responsive fullscreen iframe styling for large displays

### DIFF
--- a/src/apps/iframe/index.tsx
+++ b/src/apps/iframe/index.tsx
@@ -8,8 +8,11 @@ export interface IFrameProps {
   src: string;
   title: string;
   allow?: string;
+  isFullscreen?: boolean;
 }
 
-export const IFrame = ({ src, title, allow }: IFrameProps) => {
-  return <iframe data-testid='iframe' {...cn('')} src={src} title={title} allow={allow} />;
+export const IFrame = ({ src, title, allow, isFullscreen = false }: IFrameProps) => {
+  return (
+    <iframe {...cn('', isFullscreen && 'is-fullscreen')} data-testid='iframe' src={src} title={title} allow={allow} />
+  );
 };

--- a/src/apps/iframe/index.vitest.tsx
+++ b/src/apps/iframe/index.vitest.tsx
@@ -1,3 +1,4 @@
+// src/apps/iframe/index.vitest.tsx
 import { render, screen } from '@testing-library/react';
 
 import { IFrame, IFrameProps } from '.';
@@ -7,21 +8,38 @@ const DEFAULT_PROPS: IFrameProps = {
   src: 'https://foo.bar',
 };
 
-var iFrame: HTMLIFrameElement;
-
 describe(IFrame, () => {
-  beforeEach(() => {
-    render(<IFrame {...DEFAULT_PROPS} />);
-    iFrame = screen.getByTestId('iframe') as HTMLIFrameElement;
-  });
+  describe('by default', () => {
+    let iFrame: HTMLIFrameElement;
 
-  describe('iframe', () => {
+    beforeEach(() => {
+      render(<IFrame {...DEFAULT_PROPS} />);
+      iFrame = screen.getByTestId('iframe') as HTMLIFrameElement;
+    });
+
     it('should have correct title', () => {
       expect(iFrame.title).toBe('Bar');
     });
 
     it('should have correct src', () => {
       expect(iFrame.src).toBe('https://foo.bar/');
+    });
+
+    it('should not have is-fullscreen class', () => {
+      expect(iFrame.classList.contains('iframe--is-fullscreen')).toBe(false);
+    });
+  });
+
+  describe('when isFullscreen is true', () => {
+    let iFrame: HTMLIFrameElement;
+
+    beforeEach(() => {
+      render(<IFrame {...DEFAULT_PROPS} isFullscreen={true} />);
+      iFrame = screen.getByTestId('iframe') as HTMLIFrameElement;
+    });
+
+    it('should have is-fullscreen class', () => {
+      expect(iFrame.classList.contains('iframe--is-fullscreen')).toBe(true);
     });
   });
 });

--- a/src/apps/iframe/styles.scss
+++ b/src/apps/iframe/styles.scss
@@ -3,4 +3,16 @@
   height: 100%;
   border: none;
   pointer-events: auto;
+
+  &--is-fullscreen {
+    @media (min-width: 2561px) {
+      display: flex;
+      align-self: center;
+      height: 70vh;
+      margin: 0 auto;
+      border-radius: 24px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+      width: 100%;
+    }
+  }
 }


### PR DESCRIPTION
### What does this do?
- We're adding responsive styling for fullscreen iframes that displays them in a contained, centered view on large screens (2561px+) while maintaining full-screen behavior on smaller displays.

### Why are we making this change?
- To improve the user experience on large displays by presenting fullscreen ZApps in a more visually appealing, contained format rather than stretching them across the entire screen.

### How do I test this?
- run tests as usual
- Note :: not yet wired up to fullscreen zapps - check commit history for follow ups

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
