### PR TITLE
feat(external-app): add support for iframe fullscreen feature in external apps

### DIFF
--- a/src/apps/external-app/index.tsx
+++ b/src/apps/external-app/index.tsx
@@ -115,8 +115,19 @@ class ExternalAppComponent extends Component<Properties, State> {
     }, '');
   };
 
+  getFullscreenFeature = () => {
+    return this.props.manifest.features.find((feature) => feature.type === 'fullscreen');
+  };
+
   render() {
-    return <IFrame src={this.state.loadedUrl} title={this.props.manifest.title} allow={this.getAllowAttribute()} />;
+    return (
+      <IFrame
+        src={this.state.loadedUrl}
+        title={this.props.manifest.title}
+        allow={this.getAllowAttribute()}
+        isFullscreen={!!this.getFullscreenFeature()}
+      />
+    );
   }
 }
 

--- a/src/apps/external-app/index.vitest.tsx
+++ b/src/apps/external-app/index.vitest.tsx
@@ -154,4 +154,36 @@ describe(ExternalApp, () => {
       expect(history.location.pathname).toBe('/foo');
     });
   });
+
+  describe('fullscreen feature', () => {
+    it('should pass isFullscreen=false when no fullscreen feature exists', () => {
+      renderComponent({
+        manifest: {
+          ...DEFAULT_PROPS.manifest,
+          features: [],
+        },
+      });
+      expect(mockIFrame).toHaveBeenCalledWith(expect.objectContaining({ isFullscreen: false }));
+    });
+
+    it('should pass isFullscreen=true when fullscreen feature exists', () => {
+      renderComponent({
+        manifest: {
+          ...DEFAULT_PROPS.manifest,
+          features: [{ type: 'fullscreen' }],
+        },
+      });
+      expect(mockIFrame).toHaveBeenCalledWith(expect.objectContaining({ isFullscreen: true }));
+    });
+
+    it('should pass isFullscreen=false when other features exist but not fullscreen', () => {
+      renderComponent({
+        manifest: {
+          ...DEFAULT_PROPS.manifest,
+          features: [{ type: 'microphone' }],
+        },
+      });
+      expect(mockIFrame).toHaveBeenCalledWith(expect.objectContaining({ isFullscreen: false }));
+    });
+  });
 });


### PR DESCRIPTION
### What does this do?
- We're adding support for the fullscreen feature in external apps by passing the isFullscreen prop to the IFrame component based on the app's manifest.

### Why are we making this change?
- To allow external apps to specify a fullscreen mode that changes the layout and appearance of the app within zOS, providing a better user experience for apps that need more screen real estate.

### How do I test this?
- run tests as usual
- run UI and check fullscreen styles are applied to fullscreen zapps using iframe

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
