### PR TITLE
feat(app-bar): add responsive app bar positioning for fullscreen zapps on large displays

### DIFF
--- a/src/components/app-bar/styles.scss
+++ b/src/components/app-bar/styles.scss
@@ -27,6 +27,13 @@ $width: 36px;
     left: 0;
     height: 100vh;
     box-sizing: border-box;
+
+    @media (min-width: 2561px) {
+      // Reset to default positioning for large screens
+      position: relative;
+      height: auto;
+      box-sizing: unset;
+    }
   }
 
   &__container {


### PR DESCRIPTION
### What does this do?
- We're adding a media query to reset the app bar positioning to default on large screens (2561px and wider) when in fullscreen mode.

### Why are we making this change?
- To provide a more consistent user experience on large displays by preventing UI layout shifts and maintaining visual harmony between fullscreen and non-fullscreen apps.

### How do I test this?
- run tests as usual
- run UI > navigate to fullscreen zapp(aura) > check app bar is consistent re position to other apps on large screensize

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
