### PR TITLE
feat(group-management): debounce user search in group management to reduce api calls

### DIFF
--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { debounce } from 'lodash';
 import { connectContainer } from '../../../store/redux-container';
 
 import {
@@ -67,6 +68,9 @@ export interface Properties extends PublicProperties {
 }
 
 export class Container extends React.Component<Properties> {
+  private debouncedSearch: any;
+  private currentSearchResolve: ((value: any) => void) | null = null;
+
   static mapState(state: RootState): Partial<Properties> {
     const {
       groupManagement,
@@ -131,7 +135,28 @@ export class Container extends React.Component<Properties> {
     };
   }
 
-  usersInMyNetworks = async (search: string) => {
+  constructor(props: Properties) {
+    super(props);
+
+    // Create a debounced version of the search function
+    this.debouncedSearch = debounce(this.performSearch, 300);
+  }
+
+  componentWillUnmount() {
+    // Cancel any pending debounced searches
+    if (this.debouncedSearch && this.debouncedSearch.cancel) {
+      this.debouncedSearch.cancel();
+    }
+  }
+
+  usersInMyNetworks = (search: string) => {
+    return new Promise((resolve) => {
+      this.currentSearchResolve = resolve;
+      this.debouncedSearch(search);
+    });
+  };
+
+  performSearch = async (search: string) => {
     const { users: usersFromState, receiveSearchResults } = this.props;
     const myUserId = this.props.currentUser.userId;
 
@@ -141,14 +166,18 @@ export class Container extends React.Component<Properties> {
       ?.filter((user) => user.id !== myUserId)
       .map((user) => ({
         ...user,
-        image: usersFromState[user.id]?.profileImage ?? user.profileImage, // since redux state has local blob url image
+        // since redux state has local blob url image
+        image: usersFromState[user.id]?.profileImage ?? user.profileImage,
         profileImage: usersFromState[user.id]?.profileImage ?? user.profileImage,
       }));
 
     // Send the filtered results to the state handler
     receiveSearchResults(mappedFilteredUsers);
 
-    return mappedFilteredUsers;
+    if (this.currentSearchResolve) {
+      this.currentSearchResolve(mappedFilteredUsers);
+      this.currentSearchResolve = null;
+    }
   };
 
   onAddMembers = async (selectedOptions: Option[]) => {


### PR DESCRIPTION
### What does this do?
- Adding debounce to the user search functionality in the group management component to prevent multiple API calls when typing search terms.

### Why are we making this change?
- To improve performance by reducing unnecessary network requests when users are typing search queries in the group management interface.

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
