### PR TITLE
Fix background image deprecated method

### DIFF
--- a/src/components/background-image/index.tsx
+++ b/src/components/background-image/index.tsx
@@ -47,7 +47,7 @@ export class BackgroundImage extends React.Component<Properties> {
     this.initialLoad();
   }
 
-  componentWillReceiveProps(nextProps: Properties) {
+  componentDidUpdate(nextProps: Properties) {
     if (this.props.provider.getSourceUrl(this.props.source) !== this.props.provider.getSourceUrl(nextProps.source)) {
       this.transitionToNewImage(nextProps);
     }


### PR DESCRIPTION
### What does this do?

Fix react warning calling out that this method was renamed in React v17