### PR TITLE
Disable redux dev tools in production

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,6 +17,7 @@ export function setupStore(preloadedState?: Partial<RootState>) {
     reducer: rootReducer,
     middleware: (defaults) => defaults({ thunk: false }).concat(sagaMiddleware),
     preloadedState,
+    devTools: process.env.NODE_ENV !== 'production',
   });
 }
 


### PR DESCRIPTION
### What does this do?

Disabling devtools in production. Shouldn't have a large impact, but every bit helps.
Also, if someone does have the extension it could make a difference as we use it redux quite heavily
