### PR TITLE
Refactor and optimize message component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@testing-library/dom": "^10.2.0",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/react-hooks": "^8.0.1",
         "@types/enzyme": "^3.10.10",
         "@types/jest-when": "^3.5.2",
         "@types/react-portal": "^4.0.4",
@@ -10405,6 +10406,37 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
           "optional": true
         }
       }
@@ -35188,6 +35220,23 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -50674,6 +50723,16 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@todesktop/client-core": {
@@ -68370,6 +68429,15 @@
         "attr-accept": "^2.2.2",
         "file-selector": "^0.6.0",
         "prop-types": "^15.8.1"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@cfaester/enzyme-adapter-react-18": "^0.8.0",
     "@testing-library/dom": "^10.2.0",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/enzyme": "^3.10.10",
     "@types/jest-when": "^3.5.2",
     "@types/react-portal": "^4.0.4",

--- a/setupVitest.ts
+++ b/setupVitest.ts
@@ -2,6 +2,15 @@ import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
+// Mock ResizeObserver since it's not available in jsdom
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserver;
+
 afterEach(() => {
   cleanup();
 });

--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -38,9 +38,9 @@ export interface Properties extends PublicProperties {
     isAuthenticated: boolean;
   };
   isSecondarySidekickOpen: boolean;
-  openDeleteMessage: (messageId: number) => void;
+  openDeleteMessage: (messageId: string) => void;
   toggleSecondarySidekick: () => void;
-  openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  openMessageInfo: (payload: { roomId: string; messageId: string }) => void;
   loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
   sendEmojiReaction: (payload: { roomId: string; messageId: string; key: string }) => void;
   openReportUserModal: (payload: { reportedUserId: string }) => void;
@@ -140,7 +140,7 @@ export class Container extends React.Component<Properties> {
     }
   };
 
-  handleDeleteMessage = (messageId: number): void => {
+  handleDeleteMessage = (messageId: string): void => {
     const { channelId } = this.props;
     if (channelId && messageId) {
       this.props.openDeleteMessage(messageId);
@@ -148,7 +148,7 @@ export class Container extends React.Component<Properties> {
   };
 
   handleEditMessage = (
-    messageId: number,
+    messageId: string,
     message: string,
     mentionedUserIds: string[],
     data?: Partial<EditMessageOptions>
@@ -159,7 +159,7 @@ export class Container extends React.Component<Properties> {
     }
   };
 
-  sendEmojiReaction = async (messageId, key) => {
+  sendEmojiReaction = async (messageId: string, key: string) => {
     try {
       await this.props.sendEmojiReaction({ roomId: this.props.channelId, messageId, key });
     } catch (error) {

--- a/src/components/chat-view-container/chat-view.test.tsx
+++ b/src/components/chat-view-container/chat-view.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { shallow } from 'enzyme';
 import { ChatView, Properties } from './chat-view';
 import { Waypoint } from '../waypoint';
@@ -17,10 +16,10 @@ const c = bem('.chat-view');
 
 describe('ChatView', () => {
   const MESSAGES_TEST = [
-    { id: 1111, message: 'what', sender: { userId: '1' }, createdAt: 1658776625730 },
-    { id: 2222, message: 'hello', sender: { userId: '2' }, createdAt: 1659018545428 },
-    { id: 3333, message: 'hey', sender: { userId: '2' }, createdAt: 1659018545428 },
-    { id: 4444, message: 'ok!', sender: { userId: '2' }, createdAt: 1659018545428 },
+    { id: '1111', message: 'what', sender: { userId: '1' }, createdAt: 1658776625730 },
+    { id: '2222', message: 'hello', sender: { userId: '2' }, createdAt: 1659018545428 },
+    { id: '3333', message: 'hey', sender: { userId: '2' }, createdAt: 1659018545428 },
+    { id: '4444', message: 'ok!', sender: { userId: '2' }, createdAt: 1659018545428 },
   ] as MessageModel[];
 
   const subject = (props: Partial<Properties> = {}) => {
@@ -62,10 +61,10 @@ describe('ChatView', () => {
 
     const ids = wrapper.find(Message).map((m) => m.prop('id'));
     expect(ids).toIncludeAllMembers([
-      1111,
-      2222,
-      3333,
-      4444,
+      '1111',
+      '2222',
+      '3333',
+      '4444',
     ]);
   });
 
@@ -83,7 +82,7 @@ describe('ChatView', () => {
 
   it('render a header Date contain Today', () => {
     const messages = [
-      { id: 111, message: 'what', createdAt: Date.now() } as MessageModel,
+      { id: '111', message: 'what', createdAt: Date.now() } as MessageModel,
     ];
 
     const wrapper = subject({ messages });
@@ -237,7 +236,7 @@ describe('ChatView', () => {
     it('returns "Today" for the current day', () => {
       const today = moment().startOf('day');
       const messages = [
-        { id: 111, message: 'what', createdAt: today.valueOf() } as MessageModel,
+        { id: '111', message: 'what', createdAt: today.valueOf() } as MessageModel,
       ];
 
       const wrapper = subject({ messages });
@@ -248,7 +247,7 @@ describe('ChatView', () => {
     it('returns "Yesterday" for the previous day', () => {
       const yesterday = moment().subtract(1, 'day').startOf('day');
       const messages = [
-        { id: 111, message: 'what', createdAt: yesterday.valueOf() } as MessageModel,
+        { id: '111', message: 'what', createdAt: yesterday.valueOf() } as MessageModel,
       ];
 
       const wrapper = subject({ messages });
@@ -260,7 +259,7 @@ describe('ChatView', () => {
       // setting the date here is not ideal as at some point this will fail
       const currentYearDate = moment('2025-12-11'); // Example date within the same year
       const messages = [
-        { id: 111, message: 'what', createdAt: currentYearDate.valueOf() } as MessageModel,
+        { id: '111', message: 'what', createdAt: currentYearDate.valueOf() } as MessageModel,
       ];
 
       const wrapper = subject({ messages });
@@ -270,7 +269,7 @@ describe('ChatView', () => {
     it('returns the formatted date for previous years', () => {
       const previousYearDate = moment('2022-07-16'); // Example date from a previous year
       const messages = [
-        { id: 111, message: 'what', createdAt: previousYearDate.valueOf() } as MessageModel,
+        { id: '111', message: 'what', createdAt: previousYearDate.valueOf() } as MessageModel,
       ];
 
       const wrapper = subject({ messages });

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -35,9 +35,9 @@ export interface Properties {
   onFetchMore: () => void;
   fetchMessages: (payload: PayloadFetchMessages) => void;
   user: User;
-  deleteMessage: (messageId: number) => void;
+  deleteMessage: (messageId: string) => void;
   editMessage: (
-    messageId: number,
+    messageId: string,
     message: string,
     mentionedUserIds: string[],
     data?: Partial<EditMessageOptions>
@@ -50,7 +50,7 @@ export interface Properties {
   conversationErrorMessage: string;
   isSecondarySidekickOpen: boolean;
   toggleSecondarySidekick: () => void;
-  openMessageInfo: (payload: { roomId: string; messageId: number }) => void;
+  openMessageInfo: (payload: { roomId: string; messageId: string }) => void;
   loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
   sendEmojiReaction: (messageId, key) => void;
   onReportUser: (payload: { reportedUserId: string }) => void;
@@ -104,7 +104,7 @@ export class ChatView extends React.Component<Properties, State> {
     this.props.openLightbox({ media: lightboxMedia, startingIndex: lightboxStartIndex });
   };
 
-  openMessageInfo = (messageId: number) => {
+  openMessageInfo = (messageId: string) => {
     this.props.openMessageInfo({ roomId: this.props.id, messageId });
 
     if (!this.props.isSecondarySidekickOpen) {
@@ -128,12 +128,11 @@ export class ChatView extends React.Component<Properties, State> {
     }
   }
 
-  isUserOwnerOfMessage(message: MessageModel) {
-    // eslint-disable-next-line eqeqeq
-    return this.props.user && message?.sender && this.props.user.id == message.sender.userId;
+  isUserOwnerOfMessage(message: { sender: { userId: string } }) {
+    return this.props.user && message?.sender && this.props.user.id === message.sender.userId;
   }
 
-  renderMessageGroup(groupMessages) {
+  renderMessageGroup(groupMessages: MessageModel[]) {
     return groupMessages.map((message, index) => {
       if (message.isAdmin) {
         return <AdminMessageContainer key={message.optimisticId || message.id} message={message} />;

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -52,7 +52,7 @@ export interface Properties {
   toggleSecondarySidekick: () => void;
   openMessageInfo: (payload: { roomId: string; messageId: string }) => void;
   loadAttachmentDetails: (payload: { media: Media; messageId: string }) => void;
-  sendEmojiReaction: (messageId, key) => void;
+  sendEmojiReaction: (messageId: string, key: string) => void;
   onReportUser: (payload: { reportedUserId: string }) => void;
   openLightbox: (payload: { media: any[]; startingIndex: number }) => void;
 }

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -1,12 +1,12 @@
 import moment from 'moment/moment';
 import { AdminMessageType, Message as MessageModel } from '../../store/messages';
 
-export function createMessageGroups(messages: MessageModel[]) {
+export function createMessageGroups(messages: MessageModel[]): MessageModel[][] {
   if (!messages.length) {
     return [];
   }
 
-  const messageGroups = [];
+  const messageGroups: MessageModel[][] = [];
   let groupIndex = 0;
   messageGroups[0] = [messages[0]];
 
@@ -21,7 +21,7 @@ export function createMessageGroups(messages: MessageModel[]) {
   return messageGroups;
 }
 
-function isRelated(message1, message2) {
+function isRelated(message1: MessageModel, message2: MessageModel) {
   return (
     message1 &&
     message2 &&

--- a/src/components/delete-message-dialog/container.test.tsx
+++ b/src/components/delete-message-dialog/container.test.tsx
@@ -7,7 +7,7 @@ describe(Container, () => {
     test('channelId', () => {
       const state = new StoreBuilder().withOtherState({
         dialogs: {
-          deleteMessageId: 123,
+          deleteMessageId: '123',
         },
         chat: {
           activeConversationId: 'channel-1',
@@ -24,7 +24,7 @@ describe(Container, () => {
     test('deleteMessageId', () => {
       const state = new StoreBuilder().withOtherState({
         dialogs: {
-          deleteMessageId: 123,
+          deleteMessageId: '123',
         },
         chat: {
           activeConversationId: 'channel-1',
@@ -33,7 +33,7 @@ describe(Container, () => {
 
       expect(Container.mapState(state.build())).toEqual(
         expect.objectContaining({
-          deleteMessageId: 123,
+          deleteMessageId: '123',
         })
       );
     });

--- a/src/components/delete-message-dialog/container.tsx
+++ b/src/components/delete-message-dialog/container.tsx
@@ -12,7 +12,7 @@ export interface PublicProperties {
 
 export interface Properties extends PublicProperties {
   channelId: string;
-  deleteMessageId: number;
+  deleteMessageId: string;
 
   deleteMessage: (payload: PayloadFetchMessages) => void;
 }

--- a/src/components/dialog-manager/container.test.tsx
+++ b/src/components/dialog-manager/container.test.tsx
@@ -84,7 +84,7 @@ describe('DialogManager', () => {
   });
 
   it('renders DeleteMessageContainer when deleteMessageId is present', () => {
-    const wrapper = subject({ deleteMessageId: 123 });
+    const wrapper = subject({ deleteMessageId: '123' });
 
     expect(wrapper).toHaveElement(DeleteMessageContainer);
   });
@@ -135,7 +135,7 @@ describe('DialogManager', () => {
         showRewardsInPopup: false,
       },
       dialogs: {
-        deleteMessageId: 123,
+        deleteMessageId: '123',
         lightbox: {
           isOpen: true,
           media: [],
@@ -168,7 +168,7 @@ describe('DialogManager', () => {
     it('returns deleteMessageId', () => {
       const props = Container.mapState(stateMock);
 
-      expect(props.deleteMessageId).toBe(123);
+      expect(props.deleteMessageId).toBe('123');
     });
 
     it('returns isReportUserModalOpen', () => {

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -18,7 +18,7 @@ export interface Properties extends PublicProperties {
   isBackupDialogOpen: boolean;
   isRewardsDialogOpen: boolean;
   isReportUserModalOpen: boolean;
-  deleteMessageId: number;
+  deleteMessageId: string;
   lightbox: {
     isOpen: boolean;
     media: any[];

--- a/src/components/message-input/index.tsx
+++ b/src/components/message-input/index.tsx
@@ -49,7 +49,7 @@ interface State {
 }
 
 export class MessageInput extends React.Component<Properties, State> {
-  state = {
+  state: State = {
     value: this.props.initialValue || '',
     mentionedUserIds: [],
     media: [],
@@ -222,6 +222,7 @@ export class MessageInput extends React.Component<Properties, State> {
         id: giphy.id.toString(),
         name: giphy.title,
         url: giphy.images.preview_gif.url,
+        type: MediaType.Image,
         mediaType: MediaType.Image,
         giphy,
       },

--- a/src/components/message-input/utils.ts
+++ b/src/components/message-input/utils.ts
@@ -5,6 +5,7 @@ export interface Media {
   id: string;
   url: string;
   name: string;
+  type: MediaType;
   nativeFile?: File;
   mediaType: MediaType;
   giphy?: any;
@@ -36,7 +37,14 @@ export const dropzoneToMedia = (files: any[]) => {
       mediaType = MediaType.File;
     }
 
-    return { id: Date.now().toString(), url: URL.createObjectURL(file), name: file.name, nativeFile: file, mediaType };
+    return {
+      id: Date.now().toString(),
+      url: URL.createObjectURL(file),
+      name: file.name,
+      nativeFile: file,
+      type: mediaType,
+      mediaType,
+    };
   });
 
   return media;

--- a/src/components/message/footer/messageFooter.tsx
+++ b/src/components/message/footer/messageFooter.tsx
@@ -1,0 +1,47 @@
+import { bemClassName } from '../../../lib/bem';
+import { MessageSendStatus } from '../../../store/messages';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+import moment from 'moment';
+
+interface MessageFooterProps {
+  isEditing: boolean;
+  sendStatus: MessageSendStatus;
+  updatedAt: number;
+  createdAt: number;
+  showTimestamp: boolean;
+}
+
+const cn = bemClassName('message');
+
+export const MessageFooter = ({ isEditing, sendStatus, updatedAt, createdAt, showTimestamp }: MessageFooterProps) => {
+  if (isEditing) {
+    return null;
+  }
+
+  const isSendStatusFailed = sendStatus === MessageSendStatus.FAILED;
+  const footerElements = [];
+
+  if (!!updatedAt && !isSendStatusFailed) {
+    footerElements.push(<span key='edited'>(Edited)</span>);
+  }
+  if (!isSendStatusFailed && showTimestamp) {
+    footerElements.push(
+      <div key='time' {...cn('time')}>
+        {moment(createdAt).format('h:mm A')}
+      </div>
+    );
+  }
+  if (isSendStatusFailed) {
+    footerElements.push(
+      <div key='failure' {...cn('failure-message')}>
+        Failed to send <IconAlertCircle size={16} />
+      </div>
+    );
+  }
+
+  if (footerElements.length === 0) {
+    return null;
+  }
+
+  return <div {...cn('footer')}>{footerElements}</div>;
+};

--- a/src/components/message/hooks.test.tsx
+++ b/src/components/message/hooks.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { MediaDownloadStatus } from '../../store/messages';
+import { MediaType } from '../../store/messages';
+import { MessagesFetchState } from '../../store/channels';
+import { useLoadAttachmentEffect } from './hooks/useLoadAttachmentEffect';
+import { useContextMenu } from './hooks/useContextMenu';
+
+describe('loadAttachmentEffect', () => {
+  it('calls loadAttachmentDetails if no media url and messagesFetchStatus is success', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = { url: null, type: MediaType.Image };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
+
+    expect(loadAttachmentDetails).toHaveBeenCalledWith({
+      media,
+      messageId,
+    });
+  });
+
+  it('calls loadAttachmentDetails if url is a matrix media url and messagesFetchStatus is success', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = { url: 'mxc://some-test-matrix-url', type: MediaType.Image };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
+
+    expect(loadAttachmentDetails).toHaveBeenCalledWith({
+      media,
+      messageId,
+    });
+  });
+
+  it('does not call loadAttachmentDetails if messagesFetchStatus is not success', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = { url: null, type: MediaType.Image };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.FAILED));
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if url is defined and not a matrix media url', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = { url: 'some-test-url', type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if media download status is failed', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if media download status is loading', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Loading };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+});
+
+describe('useContextMenu', () => {
+  it('should not trigger menu when text is selected', () => {
+    const onOpen = jest.fn();
+    const { result } = renderHook(() => useContextMenu({ onOpen }));
+
+    // Mock window.getSelection to return selected text
+    const mockSelection = {
+      toString: () => 'selected text',
+    };
+    Object.defineProperty(window, 'getSelection', {
+      value: () => mockSelection,
+    });
+
+    const event = {
+      button: 2,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      pageX: 100,
+      pageY: 200,
+    };
+
+    result.current.handler(event as any);
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('should trigger menu on right click with no text selected', () => {
+    const onOpen = jest.fn();
+    const { result } = renderHook(() => useContextMenu({ onOpen }));
+
+    // Mock window.getSelection to return no selected text
+    const mockSelection = {
+      toString: () => '',
+    };
+    Object.defineProperty(window, 'getSelection', {
+      value: () => mockSelection,
+    });
+
+    const event = {
+      button: 2,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      pageX: 100,
+      pageY: 200,
+    };
+
+    result.current.handler(event as any);
+
+    expect(onOpen).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(result.current.position).toEqual({ x: 100, y: 200 });
+  });
+
+  it('should not trigger menu on left click', () => {
+    const onOpen = jest.fn();
+    const { result } = renderHook(() => useContextMenu({ onOpen }));
+
+    // Mock window.getSelection to return no selected text
+    const mockSelection = {
+      toString: () => '',
+    };
+    Object.defineProperty(window, 'getSelection', {
+      value: () => mockSelection,
+    });
+
+    const event = {
+      button: 0, // Left click
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      pageX: 100,
+      pageY: 200,
+    };
+
+    result.current.handler(event as any);
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/message/hooks/useContextMenu.ts
+++ b/src/components/message/hooks/useContextMenu.ts
@@ -1,0 +1,44 @@
+import { useState, MouseEvent } from 'react';
+
+interface ContextMenuProps {
+  onOpen: () => void;
+}
+
+interface ContextMenuReturn {
+  position: {
+    x: number;
+    y: number;
+  };
+  handler: (event: MouseEvent) => void;
+}
+
+export const useContextMenu = ({ onOpen }: ContextMenuProps): ContextMenuReturn => {
+  const [menuX, setMenuX] = useState(0);
+  const [menuY, setMenuY] = useState(0);
+
+  const handleContextMenu = (event: MouseEvent) => {
+    if (typeof window !== 'undefined' && window.getSelection) {
+      const selectedText = window.getSelection().toString();
+      if (selectedText.length > 0) {
+        return;
+      }
+    }
+
+    if (event.button === 2) {
+      event.preventDefault();
+      event.stopPropagation();
+      const { pageX, pageY } = event;
+      onOpen();
+      setMenuX(pageX);
+      setMenuY(pageY);
+    }
+  };
+
+  return {
+    position: {
+      x: menuX,
+      y: menuY,
+    },
+    handler: handleContextMenu,
+  };
+};

--- a/src/components/message/hooks/useLoadAttachmentEffect.ts
+++ b/src/components/message/hooks/useLoadAttachmentEffect.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { MessagesFetchState } from '../../../store/channels';
+import { MediaDownloadStatus } from '../../../store/messages';
+
+export const useLoadAttachmentEffect = (
+  media: any,
+  messageId: string,
+  loadAttachmentDetails: (payload: { media: any; messageId: string }) => void,
+  messagesFetchStatus: MessagesFetchState
+) => {
+  useEffect(() => {
+    const isLoading = media?.downloadStatus === MediaDownloadStatus.Loading;
+    const hasFailed = media?.downloadStatus === MediaDownloadStatus.Failed;
+    if (
+      media &&
+      (!media.url || media.url.startsWith('mxc://')) &&
+      !isLoading &&
+      !hasFailed &&
+      messagesFetchStatus === MessagesFetchState.SUCCESS
+    ) {
+      loadAttachmentDetails({ media, messageId });
+    }
+    // `media` is re-rendering constantly - excluding until we figure out why
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    messagesFetchStatus,
+    messageId,
+    loadAttachmentDetails,
+    media?.downloadStatus,
+  ]);
+};

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
 import {
@@ -9,7 +9,6 @@ import {
   MessageAttachment,
 } from '../../store/messages';
 import { LinkPreview } from '../link-preview';
-import { getProvider } from '../../lib/cloudinary/provider';
 import { MessageInput } from '../message-input/container';
 import { MessagesFetchState, User } from '../../store/channels';
 import { ParentMessage as ParentMessageType } from '../../lib/chat/types';
@@ -27,9 +26,9 @@ import { MessageFooter } from './footer/messageFooter';
 import { Reactions } from './reactions/reactions';
 import { useContextMenu } from './hooks/useContextMenu';
 import { MessageMenu, MessageMenuProps } from './menu/messageMenu';
+import { useLoadAttachmentEffect } from './hooks/useLoadAttachmentEffect';
 
 import './styles.scss';
-import { useLoadAttachmentEffect } from './hooks/useLoadAttachmentEffect';
 
 const cn = bemClassName('message');
 
@@ -115,10 +114,6 @@ export const Message: React.FC<Properties> = ({
   const [isDropdownMenuOpen, setIsDropdownMenuOpen] = useState(false);
 
   const isMenuTriggerAlwaysVisible = sendStatus === MessageSendStatus.FAILED;
-
-  const senderAvatarUrl = useMemo(() => {
-    return getProvider().getSourceUrl(sender.profileImage);
-  }, [sender.profileImage]);
 
   useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, messagesFetchStatus);
 
@@ -386,7 +381,7 @@ export const Message: React.FC<Properties> = ({
       {showSenderAvatar && (
         <div {...cn('left')}>
           <div {...cn('author-avatar')}>
-            <Avatar size='medium' imageURL={senderAvatarUrl} tabIndex={-1} />
+            <Avatar size='medium' imageURL={sender.profileImage} tabIndex={-1} />
           </div>
         </div>
       )}

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -137,11 +137,6 @@ export const Message: React.FC<Properties> = ({
     return getProvider().getSourceUrl(sender.profileImage);
   }, [sender.profileImage]);
 
-  // RICKY TODO: Fix whatever the fuck is changing this constantly
-  // useEffect(() => {
-  //   console.log('media', media);
-  // }, [media]);
-
   useEffect(() => {
     if (
       media &&

--- a/src/components/message/media/messageMedia.tsx
+++ b/src/components/message/media/messageMedia.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import AttachmentCards from '../../../platform-apps/channels/attachment-cards';
+import { Media, MediaDownloadStatus, MediaType, MessageAttachment } from '../../../store/messages';
+import { getPlaceholderDimensions } from '../utils';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+import { Blurhash } from 'react-blurhash';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+import { bemClassName } from '../../../lib/bem';
+
+const cn = bemClassName('message');
+
+interface MessageMediaProps {
+  media: Media;
+  onImageClick: (media: Media) => void;
+  openAttachmentPreview: (attachment: MessageAttachment) => void;
+}
+
+export const MessageMedia = ({ media, onImageClick, openAttachmentPreview }: MessageMediaProps) => {
+  const { type, url, name, downloadStatus, mimetype } = media;
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const blurhash = media['xyz.amorgan.blurhash'];
+  const { width, height } = getPlaceholderDimensions(media.width, media.height);
+  const isMatrixUrl = url?.startsWith('mxc://');
+
+  const handleImageLoad = () => {
+    setIsImageLoaded(true);
+  };
+
+  const renderPlaceholderContent = (
+    hasFailed: boolean,
+    isLoading: boolean,
+    blurhash: string,
+    width: number,
+    height: number
+  ) => (
+    <>
+      {hasFailed ? (
+        <IconAlertCircle size={32} {...cn('icon', 'failed')} />
+      ) : blurhash ? (
+        <Blurhash hash={blurhash} width={width} height={height} resolutionX={16} resolutionY={12} punch={1.5} />
+      ) : (
+        <div {...cn('placeholder-box')} />
+      )}
+      {isLoading && <Spinner {...cn('icon', 'loading')} />}
+    </>
+  );
+
+  if (!url || isMatrixUrl) {
+    const isLoading = downloadStatus === MediaDownloadStatus.Loading;
+    const hasFailed = downloadStatus === MediaDownloadStatus.Failed;
+
+    return (
+      <>
+        {mimetype?.includes('application') || mimetype?.includes('audio') ? (
+          <AttachmentCards attachments={[{ name, url: '', type: MediaType.Unknown }]} onAttachmentClicked={() => {}} />
+        ) : (
+          <div {...cn('placeholder-container')} style={{ width, height }}>
+            <div {...cn('placeholder-content')}>
+              {renderPlaceholderContent(hasFailed, isLoading, blurhash, width, height)}
+            </div>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  if (type === MediaType.Image) {
+    return (
+      <div {...cn('block-image')} onClick={() => onImageClick(media)}>
+        <img src={url} alt={name} onLoad={handleImageLoad} style={!isImageLoaded ? { width, height } : {}} />
+      </div>
+    );
+  } else if (type === MediaType.Video) {
+    return (
+      <div {...cn('block-video')}>
+        <video controls>
+          <source src={url} />
+        </video>
+      </div>
+    );
+  } else if (type === MediaType.File) {
+    const attachment = { url, name, type, mimetype };
+    return (
+      <div {...cn('attachment')} onClick={() => openAttachmentPreview(attachment)}>
+        <AttachmentCards attachments={[attachment]} onAttachmentClicked={() => openAttachmentPreview(attachment)} />
+      </div>
+    );
+  } else if (type === MediaType.Audio) {
+    return (
+      <div {...cn('block-audio')}>
+        <audio controls controlsList='nodownload nofullscreen noplaybackrate'>
+          <source src={url} type={mimetype} />
+        </audio>
+      </div>
+    );
+  }
+  return null;
+};

--- a/src/components/message/menu/messageMenu.tsx
+++ b/src/components/message/menu/messageMenu.tsx
@@ -1,0 +1,88 @@
+import { bemClassName } from '../../../lib/bem';
+import {
+  MessageMenu as MessageMenuComponent,
+  Properties as MessageMenuComponentProps,
+} from '../../../platform-apps/channels/messages-menu';
+import { MediaType } from '../../../store/messages';
+import { Media } from '../../../store/messages';
+import { MessageSendStatus } from '../../../store/messages';
+
+const cn = bemClassName('message');
+
+export interface MessageMenuProps
+  extends Pick<
+    MessageMenuComponentProps,
+    | 'onDelete'
+    | 'onEdit'
+    | 'onReply'
+    | 'onInfo'
+    | 'onDownload'
+    | 'onCopy'
+    | 'onOpenChange'
+    | 'onCloseMenu'
+    | 'onReportUser'
+  > {
+  isOwner: boolean;
+  message: string;
+  sendStatus: MessageSendStatus;
+  media: Media;
+  isMenuOpen?: boolean;
+  isMenuFlying?: boolean;
+}
+
+export const MessageMenu = ({
+  isOwner,
+  message,
+  sendStatus,
+  media,
+  onDelete,
+  onEdit,
+  onReply,
+  onInfo,
+  onDownload,
+  onCopy,
+  onOpenChange,
+  onCloseMenu,
+  onReportUser,
+  isMenuOpen = false,
+  isMenuFlying = false,
+}: MessageMenuProps) => {
+  const canEditMessage =
+    isOwner && message && sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED;
+
+  const canDeleteMessage = isOwner && sendStatus !== MessageSendStatus.IN_PROGRESS;
+
+  const canReportUser = !isOwner && sendStatus !== MessageSendStatus.IN_PROGRESS;
+
+  const canReply = sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED;
+
+  const canViewInfo = sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED;
+
+  const canDownload = media?.type === MediaType.Image && media?.mimetype !== 'image/gif';
+
+  const canCopy = media?.type === MediaType.Image && media?.mimetype !== 'image/gif';
+
+  return (
+    <MessageMenuComponent
+      {...cn('menu-item')}
+      canEdit={canEditMessage}
+      canDelete={canDeleteMessage}
+      canReply={canReply}
+      canReportUser={canReportUser}
+      canViewInfo={canViewInfo}
+      canDownload={canDownload}
+      canCopy={canCopy}
+      onDelete={onDelete}
+      onEdit={onEdit}
+      onReply={onReply}
+      onInfo={onInfo}
+      onDownload={onDownload}
+      onCopy={onCopy}
+      onOpenChange={onOpenChange}
+      onCloseMenu={onCloseMenu}
+      onReportUser={onReportUser}
+      isMenuOpen={isMenuOpen}
+      isMenuFlying={isMenuFlying}
+    />
+  );
+};

--- a/src/components/message/menu/messageMenu.vitest.tsx
+++ b/src/components/message/menu/messageMenu.vitest.tsx
@@ -1,0 +1,220 @@
+import { vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MessageMenu } from './messageMenu';
+import { MessageSendStatus, MediaType } from '../../../store/messages';
+
+describe('MessageMenu', () => {
+  const defaultProps = {
+    isOwner: true,
+    message: 'Test message',
+    sendStatus: MessageSendStatus.SUCCESS,
+    media: {
+      type: MediaType.Image,
+      mimetype: 'image/jpeg',
+      url: 'https://example.com/image.jpg',
+      height: 800,
+      width: 600,
+      name: 'test-image.jpg',
+    },
+    isMenuOpen: true,
+    onDelete: vi.fn(),
+    onEdit: vi.fn(),
+    onReply: vi.fn(),
+    onInfo: vi.fn(),
+    onDownload: vi.fn(),
+    onCopy: vi.fn(),
+    onOpenChange: vi.fn(),
+    onCloseMenu: vi.fn(),
+    onReportUser: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Owner permissions', () => {
+    it('should allow editing when user is owner and message is sent', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /edit/i })).toBeEnabled();
+    });
+
+    it('should disable editing when message is in progress', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.IN_PROGRESS} />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
+    });
+
+    it('should disable editing when message failed to send', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.FAILED} />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
+    });
+
+    it('should allow deletion when user is owner', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /delete/i })).toBeEnabled();
+    });
+
+    it('should disable deletion when message is in progress', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.IN_PROGRESS} />);
+      expect(screen.queryByRole('menuitem', { name: /delete/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Non-owner permissions', () => {
+    it('should not show edit or delete options for non-owners', () => {
+      render(<MessageMenu {...defaultProps} isOwner={false} />);
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    });
+
+    it('should allow reporting for non-owners', () => {
+      render(<MessageMenu {...defaultProps} isOwner={false} />);
+      expect(screen.getByRole('menuitem', { name: /report/i })).toBeEnabled();
+    });
+
+    it('should disable reporting when message is in progress', () => {
+      render(<MessageMenu {...defaultProps} isOwner={false} sendStatus={MessageSendStatus.IN_PROGRESS} />);
+      expect(screen.queryByRole('menuitem', { name: /report/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Owner state combinations', () => {
+    it('should show all owner actions when owner and message is sent', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /edit/i })).toBeEnabled();
+      expect(screen.getByRole('menuitem', { name: /delete/i })).toBeEnabled();
+      expect(screen.queryByRole('button', { name: /report/i })).not.toBeInTheDocument();
+    });
+
+    it('should disable all owner actions when message is in progress', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.IN_PROGRESS} />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: /delete/i })).not.toBeInTheDocument();
+    });
+
+    it('should show only report option for non-owner with sent message', () => {
+      render(<MessageMenu {...defaultProps} isOwner={false} />);
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /report/i })).toBeEnabled();
+    });
+
+    it('should handle empty message state for owner', () => {
+      render(<MessageMenu {...defaultProps} message='' />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /delete/i })).toBeEnabled();
+    });
+
+    it('should handle empty message state for non-owner', () => {
+      render(<MessageMenu {...defaultProps} isOwner={false} message='' />);
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /report/i })).toBeEnabled();
+    });
+
+    it('should handle failed message state for owner', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.FAILED} />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /delete/i })).toBeEnabled();
+    });
+  });
+
+  describe('Media handling', () => {
+    it('should enable download for non-GIF images', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /download/i })).toBeEnabled();
+    });
+
+    it('should disable download for GIF images', () => {
+      render(<MessageMenu {...defaultProps} media={{ ...defaultProps.media, mimetype: 'image/gif' }} />);
+      expect(screen.queryByRole('menuitem', { name: /download/i })).not.toBeInTheDocument();
+    });
+
+    it('should enable copy for non-GIF images', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /copy/i })).toBeEnabled();
+    });
+
+    it('should disable copy for GIF images', () => {
+      render(<MessageMenu {...defaultProps} media={{ ...defaultProps.media, mimetype: 'image/gif' }} />);
+      expect(screen.queryByRole('menuitem', { name: /copy/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Reply functionality', () => {
+    it('should enable reply for sent messages', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /reply/i })).toBeEnabled();
+    });
+
+    it('should disable reply when message is in progress', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.IN_PROGRESS} />);
+      expect(screen.queryByRole('menuitem', { name: /reply/i })).not.toBeInTheDocument();
+    });
+
+    it('should disable reply when message failed to send', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.FAILED} />);
+      expect(screen.queryByRole('menuitem', { name: /reply/i })).not.toBeInTheDocument();
+    });
+
+    it('should call onReply when reply button is clicked', async () => {
+      render(<MessageMenu {...defaultProps} />);
+      fireEvent.click(screen.getByRole('menuitem', { name: /reply/i }));
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(defaultProps.onReply).toHaveBeenCalled();
+    });
+  });
+
+  describe('Info viewing', () => {
+    it('should enable info viewing for sent messages', () => {
+      render(<MessageMenu {...defaultProps} />);
+      expect(screen.getByRole('menuitem', { name: /info/i })).toBeEnabled();
+    });
+
+    it('should disable info viewing when message is in progress', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.IN_PROGRESS} />);
+      expect(screen.queryByRole('menuitem', { name: /info/i })).not.toBeInTheDocument();
+    });
+
+    it('should disable info viewing when message failed to send', () => {
+      render(<MessageMenu {...defaultProps} sendStatus={MessageSendStatus.FAILED} />);
+      expect(screen.queryByRole('menuitem', { name: /info/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Event handlers', () => {
+    it('should call onDelete when delete button is clicked', async () => {
+      render(<MessageMenu {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(defaultProps.onDelete).toHaveBeenCalled();
+    });
+
+    it('should call onEdit when edit button is clicked', async () => {
+      render(<MessageMenu {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('menuitem', { name: /edit/i }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(defaultProps.onEdit).toHaveBeenCalled();
+    });
+
+    it('should call onReply when reply button is clicked', async () => {
+      render(<MessageMenu {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('menuitem', { name: /reply/i }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(defaultProps.onReply).toHaveBeenCalled();
+    });
+
+    it('should call onReportUser when report button is clicked', () => {
+      render(<MessageMenu {...defaultProps} isOwner={false} />);
+      fireEvent.click(screen.getByRole('menuitem', { name: /report/i }));
+      expect(defaultProps.onReportUser).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/message/reactions/reactions.tsx
+++ b/src/components/message/reactions/reactions.tsx
@@ -1,0 +1,19 @@
+import { bemClassName } from '../../../lib/bem';
+
+const cn = bemClassName('message');
+
+interface ReactionsProps {
+  reactions: Record<string, number>;
+}
+
+export const Reactions = ({ reactions }: ReactionsProps) => {
+  return (
+    <div {...cn('reactions')}>
+      {Object.entries(reactions).map(([key, value]) => (
+        <div key={key} {...cn('reaction-icon')}>
+          {key} <span>{value}</span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/message/utils.ts
+++ b/src/components/message/utils.ts
@@ -1,0 +1,18 @@
+export const getPlaceholderDimensions = (w: number, h: number) => {
+  const width = w || 300;
+  const height = h || 200;
+  const maxWidth = 520;
+  const maxHeight = 640;
+  const aspectRatio = width / height;
+  let finalWidth = width;
+  let finalHeight = height;
+  if (height > maxHeight) {
+    finalHeight = maxHeight;
+    finalWidth = maxHeight * aspectRatio;
+  }
+  if (finalWidth > maxWidth) {
+    finalWidth = maxWidth;
+    finalHeight = maxWidth / aspectRatio;
+  }
+  return { width: finalWidth, height: finalHeight };
+};

--- a/src/components/wallet-select/index.tsx
+++ b/src/components/wallet-select/index.tsx
@@ -47,7 +47,7 @@ export class WalletSelect extends React.Component<Properties> {
         <div {...cn('connecting-indicator')}>
           <div {...cn('connecting-wallet-name')}>{this.state.selectedWalletName}</div>
           <Button isLoading={this.props.isConnecting} variant={ButtonVariant.Secondary}>
-            {}
+            &nbsp;
           </Button>
         </div>
       );

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -10,7 +10,7 @@ export interface MatrixProfileInfo {
 }
 
 export interface ParentMessage {
-  messageId: number;
+  messageId: string;
   userId: string;
 
   message?: string;

--- a/src/platform-apps/channels/attachment-cards/attachment-card.tsx
+++ b/src/platform-apps/channels/attachment-cards/attachment-card.tsx
@@ -4,10 +4,11 @@ import classNames from 'classnames';
 import './styles.scss';
 import { IconVideoRecorder, IconXClose } from '@zero-tech/zui/icons';
 import { IconButton } from '@zero-tech/zui/components';
+import { MediaType } from '../../../store/messages';
 
 export interface Attachment {
   name: string;
-  type: string;
+  type: MediaType;
   url: string;
 }
 

--- a/src/platform-apps/channels/messages-menu/index.tsx
+++ b/src/platform-apps/channels/messages-menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import React, { createRef, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 import { DropdownMenu } from '@zero-tech/zui/components';
@@ -42,7 +42,7 @@ export interface Properties {
 export class MessageMenu extends React.Component<Properties> {
   ref = createRef();
 
-  renderMenuOption(icon, label) {
+  renderMenuOption(icon: ReactNode, label: string) {
     return (
       <div className={'option'}>
         {icon} {label}

--- a/src/store/dialogs/index.ts
+++ b/src/store/dialogs/index.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export type DialogState = {
-  deleteMessageId: number;
+  deleteMessageId: string;
   lightbox: {
     isOpen: boolean;
     media: any[];
@@ -22,7 +22,7 @@ const slice = createSlice({
   name: 'dialog',
   initialState,
   reducers: {
-    openDeleteMessage: (state, action: PayloadAction<number>) => {
+    openDeleteMessage: (state, action: PayloadAction<string>) => {
       state.deleteMessageId = action.payload;
     },
     closeDeleteMessage: (state) => {

--- a/src/store/message-info/index.ts
+++ b/src/store/message-info/index.ts
@@ -10,7 +10,7 @@ export enum SagaActionTypes {
   CloseMessageInfo = 'message-info/close-message-info',
 }
 
-export const openMessageInfo = createAction<{ messageId: number }>(SagaActionTypes.OpenMessageInfo);
+export const openMessageInfo = createAction<{ messageId: string }>(SagaActionTypes.OpenMessageInfo);
 export const closeMessageInfo = createAction(SagaActionTypes.CloseMessageInfo);
 
 export type MessageInfoState = {

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -29,6 +29,7 @@ export enum MediaType {
   Video = 'video',
   Audio = 'audio',
   File = 'file',
+  Unknown = 'unknown',
 }
 
 export enum MediaDownloadStatus {
@@ -101,6 +102,13 @@ export interface Message {
   readBy?: User[];
   isPost: boolean;
   reactions?: { [key: string]: number };
+  isHidden?: boolean;
+}
+
+export interface MessageAttachment {
+  name: string;
+  url: string;
+  mimetype?: string;
 }
 
 export interface EditMessageOptions {

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -76,7 +76,7 @@ export enum MessageSendStatus {
 }
 
 export interface Message {
-  id: number;
+  id: string;
   message?: string;
   parentMessageText?: string;
   parentMessageMedia?: Media;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -36,7 +36,7 @@ import { getUserSubHandle } from '../../lib/user';
 export interface Payload {
   channelId: string;
   referenceTimestamp?: number;
-  messageId?: number;
+  messageId?: string;
 }
 export interface QueryUploadPayload {
   api_key: string;
@@ -54,7 +54,7 @@ export interface FileUploadResult {
 
 export interface EditPayload {
   channelId: string;
-  messageId?: number;
+  messageId?: string;
   message?: string;
   mentionedUserIds?: string[];
   data?: Partial<EditMessageOptions>;
@@ -65,7 +65,7 @@ export interface SendPayload {
   message?: string;
   mentionedUserIds?: string[];
   parentMessage?: ParentMessage;
-  parentMessageId?: number;
+  parentMessageId?: string;
   parentMessageUserId?: string;
   file?: FileUploadResult;
   optimisticId?: string;


### PR DESCRIPTION
### What does this do?

Handful of changes in this one in order to get it out.

Refactored the message component. It was very hard to read and maintain, plus it was using `any` all over the place.
I've broken out a lot of the render methods into their own components and cleaned up the typing.

Also, calling the cloudinary provider for the avatar url inline was causing some extra memory usage, so that's been moved to a memo.

There was a bug where we were calling a saga function in the main render path.

The tests ended up being a decent rewrite. A lot of them are no longer testable for various reasons, but we should be in a fairly comparable position.