### PR TITLE
feat(loading-screen): add dynamic loading messages to improve user feedback during matrix connection process

### DIFF
--- a/src/components/loading-screen/index.tsx
+++ b/src/components/loading-screen/index.tsx
@@ -6,6 +6,7 @@ import { IconLogoZero } from '@zero-tech/zui/icons';
 
 import { bemClassName } from '../../lib/bem';
 import './styles.scss';
+import { getLoadingMessage } from './utils';
 
 const cn = bemClassName('loading-screen');
 
@@ -35,6 +36,8 @@ export class Container extends React.Component<Properties> {
     // before the screen transitions away
     const visualProgress = progress >= 90 ? 100 : (progress * 100) / 90;
 
+    const loadingMessage = getLoadingMessage(progress);
+
     return (
       <div {...cn('')}>
         <div {...cn('content')}>
@@ -46,7 +49,7 @@ export class Container extends React.Component<Properties> {
               <div {...cn('progress-indicator')} style={{ width: `${visualProgress}%` }}></div>
             </div>
           </div>
-          <div {...cn('message')}>Decrypting Messages...</div>
+          <div {...cn('message')}>{loadingMessage}</div>
         </div>
       </div>
     );

--- a/src/components/loading-screen/utils.ts
+++ b/src/components/loading-screen/utils.ts
@@ -1,0 +1,13 @@
+export const getLoadingMessage = (progress: number): string => {
+  if (progress < 30) {
+    return 'Connecting to server...';
+  } else if (progress < 50) {
+    return 'Loading conversations...';
+  } else if (progress < 70) {
+    return 'Decrypting messages...';
+  } else if (progress < 90) {
+    return 'Finalizing...';
+  } else {
+    return 'Ready to chat!';
+  }
+};


### PR DESCRIPTION
### What does this do?
- We're adding a utility function that provides different loading messages based on the current progress percentage of the Matrix connection process.

### Why are we making these changes?
- To give users more detailed feedback about what's hap

### How do I test this?
- run ui and refresh to see the loading screen

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
