### PR TITLE
refactor(loading-screen): move loading screen to messenger main

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,10 +10,9 @@ import { AppBar } from './components/app-bar/container';
 import { DialogManager } from './components/dialog-manager/container';
 import { ThemeEngine } from './components/theme-engine';
 import { BackgroundStyleProvider } from './lib/providers/BackgroundStyleProvider';
-import { LoadingScreenContainer } from './components/loading-screen/';
 
 export const App = () => {
-  const { isAuthenticated, mainClassName, videoBackgroundSrc, wrapperClassName, showLoadingScreen } = useAppMain();
+  const { isAuthenticated, mainClassName, videoBackgroundSrc, wrapperClassName } = useAppMain();
 
   return (
     // See: ZOS-115
@@ -21,8 +20,6 @@ export const App = () => {
     <ZUIProvider>
       <BackgroundStyleProvider />
       <div className={mainClassName}>
-        {showLoadingScreen && <LoadingScreenContainer />}
-
         {isAuthenticated && (
           <>
             {videoBackgroundSrc && <VideoBackground src={videoBackgroundSrc} />}
@@ -42,7 +39,6 @@ export const App = () => {
 const useAppMain = () => {
   const isAuthenticated = useSelector((state: RootState) => !!state.authentication.user?.data);
   const background = useSelector((state: RootState) => state.background.selectedMainBackground);
-  const loadingProgress = useSelector((state: RootState) => state.chat.loadingConversationProgress);
 
   const videoBackgroundSrc = getMainBackgroundVideoSrc(background);
   const mainClassName = classNames('main', 'messenger-full-screen', getMainBackgroundClass(background), {
@@ -51,14 +47,12 @@ const useAppMain = () => {
   });
 
   const wrapperClassName = 'app-main-wrapper';
-  const showLoadingScreen = isAuthenticated && loadingProgress !== 100;
 
   return {
     isAuthenticated,
     mainClassName,
     videoBackgroundSrc,
     wrapperClassName,
-    showLoadingScreen,
   };
 };
 

--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 
 import { Container as Main, Properties } from './Main';
 import { MessengerChat } from '../../components/messenger/chat';
-import { JoiningConversationDialog } from '../../components/joining-conversation-dialog';
 import { MembersSidekick } from '../../components/sidekick/variants/members-sidekick';
 
 jest.mock('../../lib/web3/thirdweb/client', () => ({
@@ -29,40 +28,10 @@ describe(Main, () => {
     return shallow(<Main {...allProps} />);
   };
 
-  it('renders JoiningConversationDialog when isJoiningConversation is true and isValidConversation is false', () => {
-    const wrapper = subject({
-      context: { isAuthenticated: true },
-      isJoiningConversation: true,
-      isValidConversation: false,
-    });
-
-    expect(wrapper).toHaveElement(JoiningConversationDialog);
-  });
-
-  it('does not render JoiningConversationDialog when isJoiningConversation is false and isValidConversation is true', () => {
-    const wrapper = subject({
-      context: { isAuthenticated: true },
-      isJoiningConversation: false,
-      isValidConversation: true,
-    });
-
-    expect(wrapper).not.toHaveElement(JoiningConversationDialog);
-  });
-
   it('renders direct message chat component when conversations loaded and is valid', () => {
     const wrapper = subject({ context: { isAuthenticated: true }, isValidConversation: true });
 
     expect(wrapper).toHaveElement(MessengerChat);
-  });
-
-  it('should not render messenger chat container when conversations have not loaded', () => {
-    const wrapper = subject({
-      context: { isAuthenticated: true },
-      isValidConversation: true,
-      isConversationsLoaded: false,
-    });
-
-    expect(wrapper).not.toHaveElement(MessengerChat);
   });
 
   it('should render members sidekick when is secondary sidekick open', () => {

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -6,7 +6,6 @@ import { withContext as withAuthenticationContext } from '../../components/authe
 import { MessengerChat } from '../../components/messenger/chat';
 import { DevPanelContainer } from '../../components/dev-panel/container';
 import { FeatureFlag } from '../../components/feature-flag';
-import { JoiningConversationDialog } from '../../components/joining-conversation-dialog';
 import { ConversationsSidekick } from '../../components/sidekick/variants/conversations-sidekick';
 import { MembersSidekick } from '../../components/sidekick/variants/members-sidekick';
 
@@ -48,9 +47,7 @@ export class Container extends React.Component<Properties> {
           <>
             <ConversationsSidekick />
             <div className={styles.Split}>
-              {this.props.isJoiningConversation && !this.props.isValidConversation && <JoiningConversationDialog />}
-
-              {this.props.isConversationsLoaded && this.props.isValidConversation && <MessengerChat />}
+              <MessengerChat />
             </div>
             {this.props.isConversationsLoaded && <MembersSidekick />}
 

--- a/src/components/loading-screen/styles.scss
+++ b/src/components/loading-screen/styles.scss
@@ -1,19 +1,13 @@
 .loading-screen {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: #000000;
-  z-index: 1000;
   display: flex;
   justify-content: center;
-  align-items: center;
+  height: 100%;
 
   &__content {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     gap: 32px;
   }
 

--- a/src/components/loading-screen/utils.ts
+++ b/src/components/loading-screen/utils.ts
@@ -1,12 +1,10 @@
 export const getLoadingMessage = (progress: number): string => {
-  if (progress < 30) {
+  if (progress < 40) {
     return 'Connecting to server...';
-  } else if (progress < 50) {
+  } else if (progress < 60) {
     return 'Loading conversations...';
-  } else if (progress < 70) {
-    return 'Decrypting messages...';
   } else if (progress < 90) {
-    return 'Finalizing...';
+    return 'Joining conversation...';
   } else {
     return 'Ready to chat!';
   }

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -35,6 +35,7 @@ describe(DirectMessageChat, () => {
       otherMembersTypingInRoom: [],
       onAddLabel: () => null,
       onRemoveLabel: () => null,
+
       ...props,
     };
 
@@ -81,7 +82,7 @@ describe(DirectMessageChat, () => {
   });
 
   it('renders users typing', function () {
-    const wrapper = subject({ otherMembersTypingInRoom: ['Johnny', 'Dale'] });
+    const wrapper = subject({ otherMembersTypingInRoom: ['Johnny', 'Dale'], isJoiningConversation: false });
 
     expect(wrapper.find('.direct-message-chat__typing-indicator')).toHaveText('Johnny and Dale are typing...');
   });
@@ -93,7 +94,7 @@ describe(DirectMessageChat, () => {
       const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
       const channelId = 'the-channel-id';
 
-      const wrapper = subject({ sendMessage, activeConversationId: channelId });
+      const wrapper = subject({ sendMessage, activeConversationId: channelId, isJoiningConversation: false });
 
       wrapper.find(MessageInput).simulate('submit', message, mentionedUserIds, []);
 
@@ -110,6 +111,7 @@ describe(DirectMessageChat, () => {
         sendMessage,
         activeConversationId: channelId,
         directMessage: { reply, otherMembers: [] } as any,
+        isJoiningConversation: false,
       });
 
       wrapper.find(MessageInput).simulate('submit', message, [], []);
@@ -124,7 +126,7 @@ describe(DirectMessageChat, () => {
       const message = 'test message';
       const channelId = 'the-channel-id';
 
-      const wrapper = subject({ sendMessage, activeConversationId: channelId });
+      const wrapper = subject({ sendMessage, activeConversationId: channelId, isJoiningConversation: false });
 
       wrapper.find(MessageInput).simulate('submit', message, [], [{ id: 'file-id', name: 'file-name' } as Media]);
 
@@ -134,7 +136,11 @@ describe(DirectMessageChat, () => {
     });
 
     it('searches for user mentions', async () => {
-      const wrapper = subject({ activeConversationId: '5', directMessage: { otherMembers: [] } as any });
+      const wrapper = subject({
+        activeConversationId: '5',
+        directMessage: { otherMembers: [] } as any,
+        isJoiningConversation: false,
+      });
       const input = wrapper.find(MessageInput);
 
       await input.prop('getUsersForMentions')('bob');

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -19,6 +19,7 @@ import { MessageInput } from '../../message-input/container';
 import { searchMentionableUsersForChannel } from '../../../platform-apps/channels/util/api';
 import { Media } from '../../message-input/utils';
 import { ConversationHeaderContainer as ConversationHeader } from '../conversation-header/container';
+import { LoadingScreenContainer } from '../../loading-screen';
 
 import './styles.scss';
 import { rawChannelSelector } from '../../../store/channels/saga';
@@ -148,6 +149,10 @@ export class Container extends React.Component<Properties> {
     return <div className='direct-message-chat__typing-indicator'>{text}</div>;
   };
 
+  renderLoadingScreen = () => {
+    return <LoadingScreenContainer />;
+  };
+
   render() {
     if ((!this.props.activeConversationId || !this.props.directMessage) && !this.props.isJoiningConversation) {
       return null;
@@ -156,8 +161,10 @@ export class Container extends React.Component<Properties> {
     return (
       <Panel className={classNames('direct-message-chat', 'direct-message-chat--full-screen')}>
         {!this.props.isJoiningConversation && <ConversationHeader />}
+
         <PanelBody className='direct-message-chat__panel'>
           <div className='direct-message-chat__content'>
+            {this.props.isJoiningConversation && this.renderLoadingScreen()}
             {!this.props.isJoiningConversation && (
               <>
                 <ChatViewContainer
@@ -170,18 +177,20 @@ export class Container extends React.Component<Properties> {
               </>
             )}
 
-            <div className='direct-message-chat__footer-position'>
-              <div className='direct-message-chat__footer'>
-                <MessageInput
-                  id={this.props.activeConversationId}
-                  onSubmit={this.handleSendMessage}
-                  getUsersForMentions={this.searchMentionableUsers}
-                  reply={this.props.directMessage?.reply}
-                  onRemoveReply={this.props.onRemoveReply}
-                />
-                {this.renderTypingIndicators()}
+            {!this.props.isJoiningConversation && (
+              <div className='direct-message-chat__footer-position'>
+                <div className='direct-message-chat__footer'>
+                  <MessageInput
+                    id={this.props.activeConversationId}
+                    onSubmit={this.handleSendMessage}
+                    getUsersForMentions={this.searchMentionableUsers}
+                    reply={this.props.directMessage?.reply}
+                    onRemoveReply={this.props.onRemoveReply}
+                  />
+                  {this.renderTypingIndicators()}
+                </div>
               </div>
-            </div>
+            )}
 
             {this.isLeaveGroupDialogOpen && this.renderLeaveGroupDialog()}
           </div>


### PR DESCRIPTION
### What does this do?
- move loading screen to messenger main

### Why are we making this change?
- improve ux

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
