### PR TITLE
Fix Sidekick un-rendering after visiting zApp

### DIFF
--- a/src/apps/app-router.tsx
+++ b/src/apps/app-router.tsx
@@ -60,9 +60,11 @@ const Sidekick = () => {
    */
   const renderSidekick = !(location.pathname.startsWith('/home') || isActiveZApp) || userProfileStage !== Stage.None;
 
-  if (renderSidekick) {
-    return <SidekickContainer className={!renderSidekick ? styles.sidekickHidden : ''} />;
-  } else if (!isFullscreenZApp) {
-    return <div className={styles.sidekickSpace} />;
-  }
+  return (
+    <>
+      {!renderSidekick && !isFullscreenZApp && <div className={styles.sidekickSpace} />}
+      {/* Sidekick needs to stay in the dom since it's element is referenced in a portal */}
+      <SidekickContainer className={!renderSidekick ? styles.sidekickHidden : ''} />
+    </>
+  );
 };

--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -147,13 +147,6 @@ export class AppBar extends React.Component<Properties, State> {
               to={messengerPath}
               onLinkClick={this.unhoverContainer}
             />
-            <AppLink
-              Icon={IconWorld}
-              isActive={isActive('explorer')}
-              label='World Explorer'
-              to='/explorer'
-              onLinkClick={this.unhoverContainer}
-            />
             {featureFlags.enableNotificationsApp && (
               <AppLink
                 Icon={this.renderNotificationIcon}
@@ -163,6 +156,13 @@ export class AppBar extends React.Component<Properties, State> {
                 onLinkClick={this.unhoverContainer}
               />
             )}
+            <AppLink
+              Icon={IconWorld}
+              isActive={isActive('explorer')}
+              label='World Explorer'
+              to='/explorer'
+              onLinkClick={this.unhoverContainer}
+            />
             {featureFlags.enableAuraZApp && (
               <AppLink
                 Icon={IconAura}


### PR DESCRIPTION
### What does this do?

Fixes the sidekick breaking after using a zApp.
It's element is referenced in a portal so it needs to stay in the dom.

Also changing the app icon order to put the zApps at the bottom of the list
