### PR TITLE
fix(settings-panel): typo in background option name

### DIFF
--- a/src/components/messenger/user-profile/settings-panel/index.tsx
+++ b/src/components/messenger/user-profile/settings-panel/index.tsx
@@ -75,7 +75,7 @@ export class SettingsPanel extends React.Component<Properties> {
 
     mainBackgroundItems.push({
       id: MainBackground.AnimatedGreenParticles,
-      label: this.renderSelectInputLabel('Greeen Particle (Animated)'),
+      label: this.renderSelectInputLabel('Green Particle (Animated)'),
       onSelect: () => this.setMainBackground(MainBackground.AnimatedGreenParticles),
     });
 


### PR DESCRIPTION
### What does this do?
- typo in background option name

