### PR TITLE
feat: revoke blob urls when changing conversations

### DIFF
--- a/src/components/message/hooks.test.tsx
+++ b/src/components/message/hooks.test.tsx
@@ -12,7 +12,7 @@ import { useContextMenu } from './hooks/useContextMenu';
 describe('loadAttachmentEffect', () => {
   it('calls loadAttachmentDetails if no media url and messagesFetchStatus is success', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: null, type: MediaType.Image, height: 100, width: 100, name: 'test-name' };
+    const media = { url: null, type: MediaType.File, height: 100, width: 100, name: 'test-name' };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
@@ -27,7 +27,7 @@ describe('loadAttachmentEffect', () => {
     const loadAttachmentDetails = jest.fn();
     const media = {
       url: 'mxc://some-test-matrix-url',
-      type: MediaType.Image,
+      type: MediaType.Video,
       height: 100,
       width: 100,
       name: 'test-name',

--- a/src/components/message/hooks.test.tsx
+++ b/src/components/message/hooks.test.tsx
@@ -12,7 +12,7 @@ import { useContextMenu } from './hooks/useContextMenu';
 describe('loadAttachmentEffect', () => {
   it('calls loadAttachmentDetails if no media url and messagesFetchStatus is success', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: null, type: MediaType.Image };
+    const media = { url: null, type: MediaType.Image, height: 100, width: 100, name: 'test-name' };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
@@ -25,7 +25,13 @@ describe('loadAttachmentEffect', () => {
 
   it('calls loadAttachmentDetails if url is a matrix media url and messagesFetchStatus is success', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: 'mxc://some-test-matrix-url', type: MediaType.Image };
+    const media = {
+      url: 'mxc://some-test-matrix-url',
+      type: MediaType.Image,
+      height: 100,
+      width: 100,
+      name: 'test-name',
+    };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
@@ -38,7 +44,7 @@ describe('loadAttachmentEffect', () => {
 
   it('does not call loadAttachmentDetails if messagesFetchStatus is not success', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: null, type: MediaType.Image };
+    const media = { url: null, type: MediaType.Image, height: 100, width: 100, name: 'test-name' };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.FAILED));
@@ -48,7 +54,14 @@ describe('loadAttachmentEffect', () => {
 
   it('does not call loadAttachmentDetails if url is defined and not a matrix media url', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: 'some-test-url', type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed };
+    const media = {
+      url: 'some-test-url',
+      type: MediaType.Image,
+      downloadStatus: MediaDownloadStatus.Failed,
+      height: 100,
+      width: 100,
+      name: 'test-name',
+    };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
@@ -58,7 +71,14 @@ describe('loadAttachmentEffect', () => {
 
   it('does not call loadAttachmentDetails if media download status is failed', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Failed };
+    const media = {
+      url: null,
+      type: MediaType.Image,
+      downloadStatus: MediaDownloadStatus.Failed,
+      height: 100,
+      width: 100,
+      name: 'test-name',
+    };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
@@ -68,7 +88,31 @@ describe('loadAttachmentEffect', () => {
 
   it('does not call loadAttachmentDetails if media download status is loading', () => {
     const loadAttachmentDetails = jest.fn();
-    const media = { url: null, type: MediaType.Image, downloadStatus: MediaDownloadStatus.Loading };
+    const media = {
+      url: null,
+      type: MediaType.Image,
+      downloadStatus: MediaDownloadStatus.Loading,
+      height: 100,
+      width: 100,
+      name: 'test-name',
+    };
+    const messageId = 'test-id';
+
+    renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));
+
+    expect(loadAttachmentDetails).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadAttachmentDetails if media mime type is an image', () => {
+    const loadAttachmentDetails = jest.fn();
+    const media = {
+      url: null,
+      type: MediaType.Image,
+      height: 100,
+      width: 100,
+      name: 'test-name',
+      mimetype: 'image/png',
+    };
     const messageId = 'test-id';
 
     renderHook(() => useLoadAttachmentEffect(media, messageId, loadAttachmentDetails, MessagesFetchState.SUCCESS));

--- a/src/components/message/hooks/useLoadAttachmentEffect.ts
+++ b/src/components/message/hooks/useLoadAttachmentEffect.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { MessagesFetchState } from '../../../store/channels';
-import { Media, MediaDownloadStatus } from '../../../store/messages';
+import { Media, MediaDownloadStatus, MediaType } from '../../../store/messages';
 
 export const useLoadAttachmentEffect = (
   media: Media,
@@ -9,8 +9,7 @@ export const useLoadAttachmentEffect = (
   messagesFetchStatus: MessagesFetchState
 ) => {
   useEffect(() => {
-    const isImage = media?.mimetype?.startsWith('image/');
-
+    const isImage = media?.type === MediaType.Image;
     const isLoading = media?.downloadStatus === MediaDownloadStatus.Loading;
     const hasFailed = media?.downloadStatus === MediaDownloadStatus.Failed;
     if (

--- a/src/components/message/hooks/useLoadAttachmentEffect.ts
+++ b/src/components/message/hooks/useLoadAttachmentEffect.ts
@@ -1,25 +1,37 @@
 import { useEffect } from 'react';
 import { MessagesFetchState } from '../../../store/channels';
-import { MediaDownloadStatus } from '../../../store/messages';
+import { Media, MediaDownloadStatus } from '../../../store/messages';
 
 export const useLoadAttachmentEffect = (
-  media: any,
+  media: Media,
   messageId: string,
   loadAttachmentDetails: (payload: { media: any; messageId: string }) => void,
   messagesFetchStatus: MessagesFetchState
 ) => {
   useEffect(() => {
+    const isImage = media?.mimetype?.startsWith('image/');
+    const isEncrypted = !!media?.file;
+    const isMatrixUrl = media?.url?.startsWith('mxc://') || media?.file?.url?.startsWith('mxc://');
+    const isBlobUrl = media?.url?.startsWith('blob:');
+
     const isLoading = media?.downloadStatus === MediaDownloadStatus.Loading;
     const hasFailed = media?.downloadStatus === MediaDownloadStatus.Failed;
+
+    // We need to load attachment details for:
+    // 1. Non-image files with Matrix URLs
+    // 2. Encrypted image files that don't have a blob URL yet
+    // 3. Encrypted non-image files
     if (
       media &&
-      (!media.url || media.url.startsWith('mxc://')) &&
+      ((!isImage && isMatrixUrl) || (isEncrypted && isImage && !isBlobUrl)) &&
       !isLoading &&
       !hasFailed &&
       messagesFetchStatus === MessagesFetchState.SUCCESS
     ) {
+      console.log('Loading attachment details for:', { messageId, isImage, isEncrypted, isMatrixUrl, isBlobUrl });
       loadAttachmentDetails({ media, messageId });
     }
+
     // `media` is re-rendering constantly - excluding until we figure out why
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -27,5 +39,6 @@ export const useLoadAttachmentEffect = (
     messageId,
     loadAttachmentDetails,
     media?.downloadStatus,
+    media?.url,
   ]);
 };

--- a/src/components/message/hooks/useLoadAttachmentEffect.ts
+++ b/src/components/message/hooks/useLoadAttachmentEffect.ts
@@ -10,28 +10,19 @@ export const useLoadAttachmentEffect = (
 ) => {
   useEffect(() => {
     const isImage = media?.mimetype?.startsWith('image/');
-    const isEncrypted = !!media?.file;
-    const isMatrixUrl = media?.url?.startsWith('mxc://') || media?.file?.url?.startsWith('mxc://');
-    const isBlobUrl = media?.url?.startsWith('blob:');
 
     const isLoading = media?.downloadStatus === MediaDownloadStatus.Loading;
     const hasFailed = media?.downloadStatus === MediaDownloadStatus.Failed;
-
-    // We need to load attachment details for:
-    // 1. Non-image files with Matrix URLs
-    // 2. Encrypted image files that don't have a blob URL yet
-    // 3. Encrypted non-image files
     if (
       media &&
-      ((!isImage && isMatrixUrl) || (isEncrypted && isImage && !isBlobUrl)) &&
+      !isImage &&
+      (!media.url || media.url.startsWith('mxc://')) &&
       !isLoading &&
       !hasFailed &&
       messagesFetchStatus === MessagesFetchState.SUCCESS
     ) {
-      console.log('Loading attachment details for:', { messageId, isImage, isEncrypted, isMatrixUrl, isBlobUrl });
       loadAttachmentDetails({ media, messageId });
     }
-
     // `media` is re-rendering constantly - excluding until we figure out why
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -39,6 +30,5 @@ export const useLoadAttachmentEffect = (
     messageId,
     loadAttachmentDetails,
     media?.downloadStatus,
-    media?.url,
   ]);
 };

--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -12,6 +12,11 @@ import AttachmentCards from '../../platform-apps/channels/attachment-cards';
 import { MessageMedia } from './media/messageMedia';
 import { MessageFooter } from './footer/messageFooter';
 
+const mockUseMatrixImage = jest.fn();
+jest.mock('../../lib/hooks/useMatrixImage', () => ({
+  useMatrixImage: (file) => mockUseMatrixImage(file),
+}));
+
 describe('message', () => {
   const sender = {
     firstName: 'John',
@@ -30,6 +35,17 @@ describe('message', () => {
     return shallow(<Message {...allProps} />);
   };
 
+  beforeEach(() => {
+    mockUseMatrixImage.mockImplementation((file) => {
+      const url = file?.url || (typeof file === 'string' ? file : null);
+      return {
+        data: url,
+        isPending: false,
+        isError: false,
+      };
+    });
+  });
+
   it('renders message text', () => {
     const wrapper = subject({ message: 'the message' });
 
@@ -39,7 +55,16 @@ describe('message', () => {
   });
 
   it('renders message video', () => {
-    const wrapper = subject({ media: { url: 'https://image.com/video.mp4', type: MediaType.Video } });
+    const wrapper = subject({
+      media: {
+        url: 'https://image.com/video.mp4',
+        type: MediaType.Video,
+        // Add these properties to avoid undefined errors
+        file: null,
+        width: 100,
+        height: 100,
+      },
+    });
 
     const messageMedia = wrapper.find(MessageMedia);
     expect(messageMedia.exists()).toBe(true);

--- a/src/components/message/media/messageMedia.tsx
+++ b/src/components/message/media/messageMedia.tsx
@@ -18,7 +18,6 @@ interface MessageMediaProps {
 
 export const MessageMedia = ({ media, onImageClick, openAttachmentPreview }: MessageMediaProps) => {
   const { type, url, name, downloadStatus, mimetype, file } = media;
-  console.log('XXXX MessageMedia render:', file?.url);
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const blurhash = media['xyz.amorgan.blurhash'];
   const { width, height } = getPlaceholderDimensions(media.width, media.height);

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -420,8 +420,8 @@ export function getAccessToken(): string | null {
   return chat.get().matrix.getAccessToken();
 }
 
-export function mxcUrlToHttp(mxcUrl: string): string {
-  return chat.get().matrix.mxcUrlToHttp(mxcUrl);
+export function mxcUrlToHttp(mxcUrl: string, isThumbnail: boolean = false): string {
+  return chat.get().matrix.mxcUrlToHttp(mxcUrl, isThumbnail);
 }
 
 export function getProfileInfo(userId: string): Promise<{

--- a/src/lib/chat/matrix/types.ts
+++ b/src/lib/chat/matrix/types.ts
@@ -1,3 +1,5 @@
+import { EncryptedFile } from 'matrix-js-sdk/lib/types';
+
 export enum ConnectionStatus {
   Connected = 'connected',
   Connecting = 'connecting',
@@ -46,4 +48,8 @@ export enum NotifiableEventType {
 export enum ReadReceiptPreferenceType {
   Public = 'public',
   Private = 'private',
+}
+
+export function isEncryptedFile(file: EncryptedFile | { url: string }): file is EncryptedFile {
+  return 'key' in file && 'iv' in file && 'hashes' in file && 'sha256' in file.hashes;
 }

--- a/src/lib/hooks/useMatrixImage.ts
+++ b/src/lib/hooks/useMatrixImage.ts
@@ -1,40 +1,39 @@
 import { useQuery } from '@tanstack/react-query';
-import { chat } from '../../lib/chat';
-import { isFileUploadedToMatrix } from '../../lib/chat/matrix/media';
-import { useEffect, useRef } from 'react';
+import { decryptFile, isFileUploadedToMatrix } from '../../lib/chat/matrix/media';
+import { EncryptedFile } from 'matrix-js-sdk/lib/types';
+import { MediaType } from '../../store/messages';
+import { isEncryptedFile } from '../chat/matrix/types';
+import { useRef } from 'react';
 
 interface UseMatrixImageOptions {
   isThumbnail?: boolean;
 }
 
-export function useMatrixImage(url: string | undefined, options: UseMatrixImageOptions = {}) {
+export function useMatrixImage(fileOrUrl: EncryptedFile | string | undefined, options: UseMatrixImageOptions = {}) {
   const { isThumbnail = false } = options;
+  const isFile = typeof fileOrUrl === 'object';
+  const isEncrypted = isFile && isEncryptedFile(fileOrUrl);
+  const file = isEncrypted ? fileOrUrl : { url: fileOrUrl };
 
-  // ref to store the blob URL
   const blobUrlRef = useRef<string | undefined>();
 
   const result = useQuery({
-    queryKey: ['matrix', 'file', { url, isThumbnail }],
+    queryKey: ['matrix', 'file', { url: file.url, isThumbnail }],
     queryFn: async () => {
-      if (!url) {
-        return undefined;
+      if (!file.url) return;
+
+      if (!isFileUploadedToMatrix(file.url)) {
+        return file.url;
       }
 
-      const matrixClient = chat.get().matrix;
-
-      if (!isFileUploadedToMatrix(url)) {
-        return url;
-      }
-
-      const downloadedUrl = await matrixClient.downloadFile(url, isThumbnail);
+      const imageUrl = await decryptFile(file, MediaType.Image, { isThumbnail });
 
       // store the blob URL in the ref
-      blobUrlRef.current = downloadedUrl;
-      return downloadedUrl;
+      blobUrlRef.current = imageUrl;
+      return imageUrl;
     },
-    enabled: !!url,
+    enabled: !!file.url,
     staleTime: 1000 * 60 * 60 * 24,
-
     // Set garbage collection time to 0 to immediately remove query data from cache when
     // the component unmounts. This is critical for blob URLs to:
     // 1. Prevent memory leaks by ensuring revoked blob URLs aren't kept in React Query's cache
@@ -42,17 +41,6 @@ export function useMatrixImage(url: string | undefined, options: UseMatrixImageO
     // 3. Work in conjunction with our cleanup effect that revokes the blob URL on unmount
     gcTime: 0,
   });
-
-  // revoke the blob URL when the component unmounts for memory management
-  useEffect(() => {
-    return () => {
-      const blobUrl = blobUrlRef.current;
-      if (blobUrl && typeof blobUrl === 'string' && blobUrl.startsWith('blob:')) {
-        URL.revokeObjectURL(blobUrl);
-        blobUrlRef.current = undefined;
-      }
-    };
-  }, [url]);
 
   return result;
 }

--- a/src/lib/hooks/useMatrixImage.ts
+++ b/src/lib/hooks/useMatrixImage.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { chat } from '../../lib/chat';
 import { isFileUploadedToMatrix } from '../../lib/chat/matrix/media';
+import { useEffect, useRef } from 'react';
 
 interface UseMatrixImageOptions {
   isThumbnail?: boolean;
@@ -9,11 +10,14 @@ interface UseMatrixImageOptions {
 export function useMatrixImage(url: string | undefined, options: UseMatrixImageOptions = {}) {
   const { isThumbnail = false } = options;
 
-  return useQuery({
+  // ref to store the blob URL
+  const blobUrlRef = useRef<string | undefined>();
+
+  const result = useQuery({
     queryKey: ['matrix', 'file', { url, isThumbnail }],
     queryFn: async () => {
       if (!url) {
-        return url;
+        return undefined;
       }
 
       const matrixClient = chat.get().matrix;
@@ -22,9 +26,33 @@ export function useMatrixImage(url: string | undefined, options: UseMatrixImageO
         return url;
       }
 
-      return matrixClient.downloadFile(url, isThumbnail);
+      const downloadedUrl = await matrixClient.downloadFile(url, isThumbnail);
+
+      // store the blob URL in the ref
+      blobUrlRef.current = downloadedUrl;
+      return downloadedUrl;
     },
     enabled: !!url,
     staleTime: 1000 * 60 * 60 * 24,
+
+    // Set garbage collection time to 0 to immediately remove query data from cache when
+    // the component unmounts. This is critical for blob URLs to:
+    // 1. Prevent memory leaks by ensuring revoked blob URLs aren't kept in React Query's cache
+    // 2. Force a refetch when returning to this component rather than using a stale/revoked URL
+    // 3. Work in conjunction with our cleanup effect that revokes the blob URL on unmount
+    gcTime: 0,
   });
+
+  // revoke the blob URL when the component unmounts for memory management
+  useEffect(() => {
+    return () => {
+      const blobUrl = blobUrlRef.current;
+      if (blobUrl && typeof blobUrl === 'string' && blobUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(blobUrl);
+        blobUrlRef.current = undefined;
+      }
+    };
+  }, [url]);
+
+  return result;
 }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -47,6 +47,15 @@ export interface Media {
   downloadStatus?: MediaDownloadStatus;
   blurhash?: string;
   mimetype?: string;
+  file?: {
+    url: string;
+    key: string;
+    iv: string;
+    hashes: {
+      sha256: string;
+    };
+    v: string;
+  };
 }
 
 export interface MessagesResponse {

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -6,6 +6,7 @@ import { createNormalizedSlice, removeAll } from '../normalized';
 import { LinkPreview } from '../../lib/link-preview';
 import { ParentMessage } from '../../lib/chat/types';
 import { User } from '../authentication/types';
+import { EncryptedFile } from 'matrix-js-sdk/lib/types';
 
 export interface AttachmentUploadResult {
   name: string;
@@ -47,15 +48,7 @@ export interface Media {
   downloadStatus?: MediaDownloadStatus;
   blurhash?: string;
   mimetype?: string;
-  file?: {
-    url: string;
-    key: string;
-    iv: string;
-    hashes: {
-      sha256: string;
-    };
-    v: string;
-  };
+  file?: EncryptedFile;
 }
 
 export interface MessagesResponse {


### PR DESCRIPTION
### What does this do?
- We're improving the useMatrixImage hook to properly clean up blob URLs when components unmount and setting React Query's garbage collection time to zero.

### Why are we making this change?
- To prevent memory leaks during long sessions by ensuring blob URLs are properly revoked and removed from React Query's cache when they're no longer needed.

### How do I test this?
- run tests as usual
- run ui and switch conversations > check image blob urls are revoked and then updated when switching back to the original conversation you were on.
- test sending image messages and receiving image messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
