### PR TITLE
fix(loading-screen/messenger-app): loading screen should only render on initial load and not when switching to conversations that have unread messages

### DIFF
--- a/src/apps/messenger/Main.test.tsx
+++ b/src/apps/messenger/Main.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import { Container as Main, Properties } from './Main';
 import { MessengerChat } from '../../components/messenger/chat';
 import { MembersSidekick } from '../../components/sidekick/variants/members-sidekick';
+import { LoadingScreenContainer } from '../../components/loading-screen';
 
 jest.mock('../../lib/web3/thirdweb/client', () => ({
   getThirdWebClient: jest.fn(),
@@ -42,5 +43,35 @@ describe(Main, () => {
     });
 
     expect(wrapper).toHaveElement(MembersSidekick);
+  });
+
+  it('renders LoadingScreenContainer when isJoiningConversation is true and isValidConversation is false', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isJoiningConversation: true,
+      isValidConversation: false,
+    });
+
+    expect(wrapper).toHaveElement(LoadingScreenContainer);
+  });
+
+  it('does not render LoadingScreenContainer when isJoiningConversation is false and isValidConversation is true', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isJoiningConversation: false,
+      isValidConversation: true,
+    });
+
+    expect(wrapper).not.toHaveElement(LoadingScreenContainer);
+  });
+
+  it('should not render messenger chat container when conversations have not loaded', () => {
+    const wrapper = subject({
+      context: { isAuthenticated: true },
+      isValidConversation: true,
+      isConversationsLoaded: false,
+    });
+
+    expect(wrapper).not.toHaveElement(MessengerChat);
   });
 });

--- a/src/apps/messenger/Main.tsx
+++ b/src/apps/messenger/Main.tsx
@@ -8,6 +8,7 @@ import { DevPanelContainer } from '../../components/dev-panel/container';
 import { FeatureFlag } from '../../components/feature-flag';
 import { ConversationsSidekick } from '../../components/sidekick/variants/conversations-sidekick';
 import { MembersSidekick } from '../../components/sidekick/variants/members-sidekick';
+import { LoadingScreenContainer } from '../../components/loading-screen';
 
 import styles from './Main.module.scss';
 
@@ -47,7 +48,9 @@ export class Container extends React.Component<Properties> {
           <>
             <ConversationsSidekick />
             <div className={styles.Split}>
-              <MessengerChat />
+              {this.props.isJoiningConversation && !this.props.isValidConversation && <LoadingScreenContainer />}
+
+              {this.props.isConversationsLoaded && this.props.isValidConversation && <MessengerChat />}
             </div>
             {this.props.isConversationsLoaded && <MembersSidekick />}
 

--- a/src/components/loading-screen/index.tsx
+++ b/src/components/loading-screen/index.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { connectContainer } from '../../store/redux-container';
 import { RootState } from '../../store/reducer';
 import { IconLogoZero } from '@zero-tech/zui/icons';
+import { getLoadingMessage } from './utils';
+import { Panel, PanelBody } from '../layout/panel';
 
 import { bemClassName } from '../../lib/bem';
 import './styles.scss';
-import { getLoadingMessage } from './utils';
 
 const cn = bemClassName('loading-screen');
 
@@ -39,19 +40,21 @@ export class Container extends React.Component<Properties> {
     const loadingMessage = getLoadingMessage(progress);
 
     return (
-      <div {...cn('')}>
-        <div {...cn('content')}>
-          <div {...cn('icon-container')}>
-            <IconLogoZero {...cn('icon')} size={64} />
-          </div>
-          <div {...cn('progress-container')}>
-            <div {...cn('progress-bar')}>
-              <div {...cn('progress-indicator')} style={{ width: `${visualProgress}%` }}></div>
+      <Panel {...cn('')}>
+        <PanelBody {...cn('panel')}>
+          <div {...cn('content')}>
+            <div {...cn('icon-container')}>
+              <IconLogoZero {...cn('icon')} size={64} />
             </div>
+            <div {...cn('progress-container')}>
+              <div {...cn('progress-bar')}>
+                <div {...cn('progress-indicator')} style={{ width: `${visualProgress}%` }}></div>
+              </div>
+            </div>
+            <div {...cn('message')}>{loadingMessage}</div>
           </div>
-          <div {...cn('message')}>{loadingMessage}</div>
-        </div>
-      </div>
+        </PanelBody>
+      </Panel>
     );
   }
 }

--- a/src/components/loading-screen/styles.scss
+++ b/src/components/loading-screen/styles.scss
@@ -1,7 +1,11 @@
 .loading-screen {
-  display: flex;
-  justify-content: center;
-  height: 100%;
+  margin: 24px 8px 24px 0;
+
+  &__panel {
+    height: 100%;
+    padding: 16px;
+    border-radius: 8px !important;
+  }
 
   &__content {
     display: flex;
@@ -9,6 +13,7 @@
     align-items: center;
     justify-content: center;
     gap: 32px;
+    height: 100%;
   }
 
   &__icon-container {

--- a/src/components/messenger/chat/index.test.tsx
+++ b/src/components/messenger/chat/index.test.tsx
@@ -82,7 +82,7 @@ describe(DirectMessageChat, () => {
   });
 
   it('renders users typing', function () {
-    const wrapper = subject({ otherMembersTypingInRoom: ['Johnny', 'Dale'], isJoiningConversation: false });
+    const wrapper = subject({ otherMembersTypingInRoom: ['Johnny', 'Dale'] });
 
     expect(wrapper.find('.direct-message-chat__typing-indicator')).toHaveText('Johnny and Dale are typing...');
   });
@@ -94,7 +94,7 @@ describe(DirectMessageChat, () => {
       const mentionedUserIds = ['ef698a51-1cea-42f8-a078-c0f96ed03c9e'];
       const channelId = 'the-channel-id';
 
-      const wrapper = subject({ sendMessage, activeConversationId: channelId, isJoiningConversation: false });
+      const wrapper = subject({ sendMessage, activeConversationId: channelId });
 
       wrapper.find(MessageInput).simulate('submit', message, mentionedUserIds, []);
 
@@ -126,7 +126,7 @@ describe(DirectMessageChat, () => {
       const message = 'test message';
       const channelId = 'the-channel-id';
 
-      const wrapper = subject({ sendMessage, activeConversationId: channelId, isJoiningConversation: false });
+      const wrapper = subject({ sendMessage, activeConversationId: channelId });
 
       wrapper.find(MessageInput).simulate('submit', message, [], [{ id: 'file-id', name: 'file-name' } as Media]);
 
@@ -139,7 +139,6 @@ describe(DirectMessageChat, () => {
       const wrapper = subject({
         activeConversationId: '5',
         directMessage: { otherMembers: [] } as any,
-        isJoiningConversation: false,
       });
       const input = wrapper.find(MessageInput);
 

--- a/src/components/messenger/chat/index.tsx
+++ b/src/components/messenger/chat/index.tsx
@@ -19,7 +19,6 @@ import { MessageInput } from '../../message-input/container';
 import { searchMentionableUsersForChannel } from '../../../platform-apps/channels/util/api';
 import { Media } from '../../message-input/utils';
 import { ConversationHeaderContainer as ConversationHeader } from '../conversation-header/container';
-import { LoadingScreenContainer } from '../../loading-screen';
 
 import './styles.scss';
 import { rawChannelSelector } from '../../../store/channels/saga';
@@ -149,10 +148,6 @@ export class Container extends React.Component<Properties> {
     return <div className='direct-message-chat__typing-indicator'>{text}</div>;
   };
 
-  renderLoadingScreen = () => {
-    return <LoadingScreenContainer />;
-  };
-
   render() {
     if ((!this.props.activeConversationId || !this.props.directMessage) && !this.props.isJoiningConversation) {
       return null;
@@ -164,7 +159,6 @@ export class Container extends React.Component<Properties> {
 
         <PanelBody className='direct-message-chat__panel'>
           <div className='direct-message-chat__content'>
-            {this.props.isJoiningConversation && this.renderLoadingScreen()}
             {!this.props.isJoiningConversation && (
               <>
                 <ChatViewContainer
@@ -177,20 +171,18 @@ export class Container extends React.Component<Properties> {
               </>
             )}
 
-            {!this.props.isJoiningConversation && (
-              <div className='direct-message-chat__footer-position'>
-                <div className='direct-message-chat__footer'>
-                  <MessageInput
-                    id={this.props.activeConversationId}
-                    onSubmit={this.handleSendMessage}
-                    getUsersForMentions={this.searchMentionableUsers}
-                    reply={this.props.directMessage?.reply}
-                    onRemoveReply={this.props.onRemoveReply}
-                  />
-                  {this.renderTypingIndicators()}
-                </div>
+            <div className='direct-message-chat__footer-position'>
+              <div className='direct-message-chat__footer'>
+                <MessageInput
+                  id={this.props.activeConversationId}
+                  onSubmit={this.handleSendMessage}
+                  getUsersForMentions={this.searchMentionableUsers}
+                  reply={this.props.directMessage?.reply}
+                  onRemoveReply={this.props.onRemoveReply}
+                />
+                {this.renderTypingIndicators()}
               </div>
-            )}
+            </div>
 
             {this.isLeaveGroupDialogOpen && this.renderLeaveGroupDialog()}
           </div>


### PR DESCRIPTION
### What does this do?
- loading screen should only render on initial load when on messenger app

### Why are we making this change?
- improve ux 

### How do I test this?
- run tests as usual
- run ui and refresh page on messenger app
- when running ui, switch conversation with new messages and check loading screen does not render

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
