### PR TITLE
fix(chat-view): improve chat view rendering with proper opacity transition

### DIFF
--- a/src/components/chat-view-container/styles.scss
+++ b/src/components/chat-view-container/styles.scss
@@ -119,6 +119,15 @@
 .messages__container {
   padding-top: 100px;
 
+  // Use transition because nested elements can't background blur
+  // if a parent element has an animation attribute
+  // Note: background blur does not work during the `transition`
+  opacity: 0;
+  transition: opacity 100ms ease-out;
+  &--rendered {
+    opacity: 1;
+  }
+
   .message__header {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
### What does this do?
We're fixing the chat view container's opacity transition to ensure content appears smoothly after rendering instead of abruptly.

### Why are we making this change?
- The current implementation causes content to appear suddenly which creates a jarring user experience, whereas a smooth transition provides a more polished feel when navigating between conversations.

### How do I test this?
- run tests as usual
- run UI and switch conversations in messenger app

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
