### PR TITLE
feat(hooks): add useMatrixMedia hook and documentation

### DIFF
--- a/src/lib/hooks/README.md
+++ b/src/lib/hooks/README.md
@@ -1,0 +1,164 @@
+# React Hooks
+
+This directory contains custom React hooks used throughout the application.
+
+## useMatrixMedia Hook
+
+### Overview
+
+The `useMatrixMedia` hook is a React hook designed to handle Matrix media content efficiently. It provides a unified interface for handling both encrypted and non-encrypted media, with built-in caching and error handling.
+
+### Features
+
+- Automatic handling of encrypted and non-encrypted media
+- Built-in caching using React Query
+- Support for thumbnails
+- Automatic error handling and retries
+- Loading state management
+- Type safety with TypeScript
+
+### Usage
+
+#### Basic Usage
+
+```typescript
+import { useMatrixMedia } from '../../lib/hooks/useMatrixMedia';
+
+function MyComponent() {
+  const {
+    data: mediaUrl,
+    isPending,
+    isError,
+  } = useMatrixMedia({
+    url: 'mxc://matrix.org/image.jpg',
+    type: MediaType.Image,
+    name: 'test-image',
+  });
+
+  if (isPending) return <LoadingSpinner />;
+  if (isError) return <ErrorMessage />;
+
+  return <img src={mediaUrl} alt='Matrix media' />;
+}
+```
+
+#### Handling Encrypted Files
+
+```typescript
+const { data: mediaUrl } = useMatrixMedia({
+  file: {
+    url: 'mxc://matrix.org/encrypted-file',
+    key: 'encryption-key',
+    iv: 'initialization-vector',
+    hashes: { sha256: 'file-hash' },
+  },
+  type: MediaType.File,
+  mimetype: 'application/pdf',
+});
+```
+
+#### Requesting Thumbnails
+
+```typescript
+const { data: thumbnailUrl } = useMatrixMedia(
+  {
+    url: 'mxc://matrix.org/image.jpg',
+    type: MediaType.Image,
+  },
+  { isThumbnail: true }
+);
+```
+
+### API
+
+#### Parameters
+
+##### media (Media | undefined)
+
+The media object containing either:
+
+- `url`: Direct URL to the media
+- `file`: Encrypted file data
+- `type`: Type of media (Image, Video, File, etc.)
+- `name`: Name of the media file
+- `mimetype`: MIME type of the media
+- `width` and `height`: Dimensions (for images)
+
+##### options (UseMatrixMediaOptions)
+
+Optional configuration object:
+
+- `isThumbnail`: Boolean indicating whether to request a thumbnail version
+
+#### Return Value
+
+```typescript
+interface UseMatrixMediaResult {
+  data: string | null; // The resolved media URL
+  isPending: boolean; // Loading state
+  isError: boolean; // Error state
+  error: Error | null; // Error object if any
+}
+```
+
+### Caching
+
+The hook uses React Query for caching with the following configuration:
+
+- Cache duration: 24 hours
+- Automatic background refetching
+- Deduplication of requests
+- Error retry logic
+
+### Error Handling
+
+The hook provides comprehensive error handling:
+
+- Automatic retries for failed requests
+- Error state management
+- Detailed error information
+- Graceful fallbacks
+
+### Best Practices
+
+1. **Always Check Loading State**
+
+```typescript
+const { data, isPending } = useMatrixMedia(media);
+if (isPending) return <LoadingSpinner />;
+```
+
+2. **Handle Errors Gracefully**
+
+```typescript
+const { data, isError, error } = useMatrixMedia(media);
+if (isError) return <ErrorMessage error={error} />;
+```
+
+3. **Use TypeScript for Type Safety**
+
+```typescript
+const { data } = useMatrixMedia<MediaType.Image>(media);
+```
+
+4. **Consider Using Thumbnails for Large Images**
+
+```typescript
+const { data: thumbnailUrl } = useMatrixMedia(media, { isThumbnail: true });
+```
+
+### Performance Considerations
+
+- The hook caches media URLs for 24 hours
+- Duplicate requests are automatically deduplicated
+- Background refetching ensures data freshness
+- Memory usage is optimized through React Query's cache management
+
+### Contributing
+
+When contributing to this hook:
+
+1. Add tests for new features
+2. Update documentation
+3. Consider performance implications
+4. Follow TypeScript best practices

--- a/src/lib/hooks/useMatrixMedia.ts
+++ b/src/lib/hooks/useMatrixMedia.ts
@@ -1,0 +1,74 @@
+import { useQuery } from '@tanstack/react-query';
+import { chat } from '../../lib/chat';
+import { isFileUploadedToMatrix, decryptFile } from '../../lib/chat/matrix/media';
+import { Media } from '../../store/messages';
+
+interface UseMatrixMediaOptions {
+  isThumbnail?: boolean;
+}
+
+interface UseMatrixMediaResult {
+  data: string | null;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+}
+
+/**
+ * A React hook for handling Matrix media (images, videos, files) with support for both encrypted and non-encrypted content.
+ * Uses React Query for efficient caching and state management.
+ *
+ * @param media - The media object containing either a direct URL or encrypted file data
+ * @param options - Optional configuration for media handling
+ * @param options.isThumbnail - Whether to request a thumbnail version of the media
+ *
+ * @returns An object containing:
+ * - data: The resolved media URL (string | null)
+ * - isPending: Loading state indicator
+ * - isError: Error state indicator
+ * - error: Error object if any
+ */
+
+export function useMatrixMedia(media: Media | undefined, options: UseMatrixMediaOptions = {}): UseMatrixMediaResult {
+  const { isThumbnail = false } = options;
+
+  return useQuery({
+    queryKey: [
+      'matrix',
+      'media',
+      {
+        url: media?.url || media?.file?.url,
+        type: media?.type,
+        isThumbnail,
+        isEncrypted: !!media?.file,
+      },
+    ],
+    queryFn: async () => {
+      if (!media) {
+        return null;
+      }
+
+      const matrixClient = chat.get().matrix;
+
+      // For encrypted files
+      if (media.file) {
+        try {
+          return await decryptFile(media.file, media.mimetype);
+        } catch (error) {
+          console.error('Failed to decrypt file:', error);
+          throw error;
+        }
+      }
+
+      // For non-encrypted files
+      if (media.url && isFileUploadedToMatrix(media.url)) {
+        return matrixClient.downloadFile(media.url, isThumbnail);
+      }
+
+      // If it's not a Matrix URL, return the original URL
+      return media.url || null;
+    },
+    enabled: !!media && (!!media.url || !!media.file),
+    staleTime: 1000 * 60 * 60 * 24, // 24 hours
+  });
+}

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -6,6 +6,7 @@ import { createNormalizedSlice, removeAll } from '../normalized';
 import { LinkPreview } from '../../lib/link-preview';
 import { ParentMessage } from '../../lib/chat/types';
 import { User } from '../authentication/types';
+import { EncryptedFile } from 'matrix-js-sdk/lib/types';
 
 export interface AttachmentUploadResult {
   name: string;
@@ -47,6 +48,7 @@ export interface Media {
   downloadStatus?: MediaDownloadStatus;
   blurhash?: string;
   mimetype?: string;
+  file?: EncryptedFile;
 }
 
 export interface MessagesResponse {


### PR DESCRIPTION
### What does this do?
- Adds a new useMatrixMedia hook and its documentation to provide a unified, type-safe way to handle both encrypted and non-encrypted Matrix media with built-in caching.

### Why are we making this change?
- To replace the old loadAttachmentDetails approach with a more maintainable solution that provides better type safety, caching, and a consistent way to handle media across the application.

### How do I test this?
- run tests as usual
- note this is not yet wired up or being used - this will be done in a follow up PR

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
