### PR TITLE
Add auth handling for Vercel Preview urls

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@zer0-os:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -149,8 +149,6 @@
     "@types/react": "^18.0.0",
     "react@16.x": "^18.0.0",
     "react@17.x": "^18.0.0",
-    "@zer0-os/zos-component-library": "$@zer0-os/zos-component-library",
-    "@zero-tech/zui": "$@zero-tech/zui",
     "@radix-ui/react-popper": "1.0.0"
   }
 }

--- a/src/lib/api/rest.ts
+++ b/src/lib/api/rest.ts
@@ -18,11 +18,22 @@ function apiUrl(path: string): string {
   ].join('');
 }
 
+const headers = new Headers();
 /**
  * The zOS code now passes an 'x-app-platform' header to ensure that the
  * access_token cookie is unique for the scope of zos user.
  */
-const xPlatFormHeader = { 'X-APP-PLATFORM': 'zos' };
+headers.set('X-APP-PLATFORM', 'zos');
+
+/**
+ * Vercel preview urls are on a different domain so we can't use cookie authentication.
+ * Adding a workaround to use header based authentication for these requests when in preview mode.
+ */
+export const addVercelPreviewAuthHeader = (token: string) => {
+  if (process.env.VERCEL_ENV === 'preview') {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+};
 
 export function get<T>(path: string, filter?: RequestFilter | string, query?: any) {
   let queryData;
@@ -40,21 +51,21 @@ export function get<T>(path: string, filter?: RequestFilter | string, query?: an
     queryData = { ...queryData, ...query };
   }
 
-  return Request.get<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials().query(queryData);
+  return Request.get<T>(apiUrl(path)).set(headers).withCredentials().query(queryData);
 }
 
 export function post<T>(path: string) {
-  return Request.post<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
+  return Request.post<T>(apiUrl(path)).set(headers).withCredentials();
 }
 
 export function put<T>(path: string) {
-  return Request.put<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
+  return Request.put<T>(apiUrl(path)).set(headers).withCredentials();
 }
 
 export function patch<T>(path: string) {
-  return Request.patch<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
+  return Request.patch<T>(apiUrl(path)).set(headers).withCredentials();
 }
 
 export function del<T>(path: string) {
-  return Request.delete<T>(apiUrl(path)).set(xPlatFormHeader).withCredentials();
+  return Request.delete<T>(apiUrl(path)).set(headers).withCredentials();
 }

--- a/src/lib/api/rest.ts
+++ b/src/lib/api/rest.ts
@@ -18,20 +18,20 @@ function apiUrl(path: string): string {
   ].join('');
 }
 
-const headers = new Headers();
 /**
  * The zOS code now passes an 'x-app-platform' header to ensure that the
  * access_token cookie is unique for the scope of zos user.
  */
-headers.set('X-APP-PLATFORM', 'zos');
+const platformHeader = { 'X-APP-PLATFORM': 'zos' };
 
 /**
  * Vercel preview urls are on a different domain so we can't use cookie authentication.
  * Adding a workaround to use header based authentication for these requests when in preview mode.
  */
+let authHeader = {};
 export const addVercelPreviewAuthHeader = (token: string) => {
   if (process.env.VERCEL_ENV === 'preview') {
-    headers.set('Authorization', `Bearer ${token}`);
+    authHeader = { Authorization: `Bearer ${token}` };
   }
 };
 
@@ -51,21 +51,21 @@ export function get<T>(path: string, filter?: RequestFilter | string, query?: an
     queryData = { ...queryData, ...query };
   }
 
-  return Request.get<T>(apiUrl(path)).set(headers).withCredentials().query(queryData);
+  return Request.get<T>(apiUrl(path)).set(authHeader).set(platformHeader).withCredentials().query(queryData);
 }
 
 export function post<T>(path: string) {
-  return Request.post<T>(apiUrl(path)).set(headers).withCredentials();
+  return Request.post<T>(apiUrl(path)).set(authHeader).set(platformHeader).withCredentials();
 }
 
 export function put<T>(path: string) {
-  return Request.put<T>(apiUrl(path)).set(headers).withCredentials();
+  return Request.put<T>(apiUrl(path)).set(authHeader).set(platformHeader).withCredentials();
 }
 
 export function patch<T>(path: string) {
-  return Request.patch<T>(apiUrl(path)).set(headers).withCredentials();
+  return Request.patch<T>(apiUrl(path)).set(authHeader).set(platformHeader).withCredentials();
 }
 
 export function del<T>(path: string) {
-  return Request.delete<T>(apiUrl(path)).set(headers).withCredentials();
+  return Request.delete<T>(apiUrl(path)).set(authHeader).set(platformHeader).withCredentials();
 }

--- a/src/store/authentication/api.ts
+++ b/src/store/authentication/api.ts
@@ -1,9 +1,10 @@
 import { AuthorizationResponse, User } from './types';
-import { del, get, post } from '../../lib/api/rest';
+import { addVercelPreviewAuthHeader, del, get, post } from '../../lib/api/rest';
 import * as Sentry from '@sentry/react';
 
 export async function nonceOrAuthorize(signedWeb3Token: string): Promise<AuthorizationResponse> {
   const response = await post('/authentication/nonceOrAuthorize').set('Authorization', `Web3 ${signedWeb3Token}`);
+  addVercelPreviewAuthHeader(response.body.accessToken);
 
   return response.body;
 }
@@ -48,6 +49,7 @@ export async function getSSOToken(): Promise<{ token: string }> {
 export async function emailLogin({ email, password }: { email: string; password: string }) {
   try {
     const response = await post('/api/v2/accounts/login').send({ email, password });
+    addVercelPreviewAuthHeader(response.body.accessToken);
     return {
       success: true,
       response: response.body,


### PR DESCRIPTION
### What does this do?

I previously removed the zos-component-library from the repo but forgot to remove the .npmrc that was causing us to need github access tokens. That's been cleaned up.

This adds special auth handling for vercel preview environments. It adds the token to memory and uses it for header based authentication when the `VERCEL_ENV` var is set to `preview`. The reason we need this is because we're using cookie based authentication and cookies won't be set on domains outside our main domain