### PR TITLE
feat(matrix-client/matrix-saga) add matrix progress callback tracking for secure backup restoration

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -71,7 +71,7 @@ export interface IChatClient {
   getSecureBackup: () => Promise<MatrixKeyBackupInfo>;
   generateSecureBackup: () => Promise<any>;
   saveSecureBackup: (key: string) => Promise<void>;
-  restoreSecureBackup: (recoveryKey: string) => Promise<void>;
+  restoreSecureBackup: (recoveryKey: string, onProgress?: (progress) => void) => Promise<void>;
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
   uploadFile(file: File): Promise<string>;
   downloadFile(fileUrl: string): Promise<any>;
@@ -197,8 +197,8 @@ export class Chat {
     await this.client.saveSecureBackup(key);
   }
 
-  async restoreSecureBackup(recoveryKey: string): Promise<any> {
-    return this.client.restoreSecureBackup(recoveryKey);
+  async restoreSecureBackup(recoveryKey: string, onProgress?: (progress) => void): Promise<any> {
+    return this.client.restoreSecureBackup(recoveryKey, onProgress);
   }
 
   async displayDeviceList(userIds: string[]) {

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -5,6 +5,7 @@ import { FileUploadResult } from '../../store/messages/saga';
 import { MatrixProfileInfo, ParentMessage, User } from './types';
 import { MemberNetworks } from '../../store/users/types';
 import type { MatrixKeyBackupInfo } from './types';
+import { ImportRoomKeyProgressData } from 'matrix-js-sdk/lib/crypto-api';
 
 export interface RealtimeChatEvents {
   receiveNewMessage: (channelId: string, message: Message) => void;
@@ -71,7 +72,10 @@ export interface IChatClient {
   getSecureBackup: () => Promise<MatrixKeyBackupInfo>;
   generateSecureBackup: () => Promise<any>;
   saveSecureBackup: (key: string) => Promise<void>;
-  restoreSecureBackup: (recoveryKey: string, onProgress?: (progress) => void) => Promise<void>;
+  restoreSecureBackup: (
+    recoveryKey: string,
+    onProgress?: (progress: ImportRoomKeyProgressData) => void
+  ) => Promise<void>;
   getRoomIdForAlias: (alias: string) => Promise<string | undefined>;
   uploadFile(file: File): Promise<string>;
   downloadFile(fileUrl: string): Promise<any>;
@@ -197,7 +201,10 @@ export class Chat {
     await this.client.saveSecureBackup(key);
   }
 
-  async restoreSecureBackup(recoveryKey: string, onProgress?: (progress) => void): Promise<any> {
+  async restoreSecureBackup(
+    recoveryKey: string,
+    onProgress?: (progress: ImportRoomKeyProgressData) => void
+  ): Promise<any> {
     return this.client.restoreSecureBackup(recoveryKey, onProgress);
   }
 

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -319,9 +319,7 @@ export class MatrixClient implements IChatClient {
     await this.accessSecretStorage(async () => {
       await this.cryptoApi.loadSessionBackupPrivateKeyFromSecretStorage();
       const recoverInfo = await this.cryptoApi.restoreKeyBackup({
-        progressCallback: (progress) => {
-          onProgress?.(progress);
-        },
+        progressCallback: onProgress,
       });
       if (!recoverInfo) {
         throw new Error('Backup broken or not there');

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -22,7 +22,7 @@ import {
   IndexedDBCryptoStore,
   ICreateClientOpts,
 } from 'matrix-js-sdk';
-import { CryptoApi, CryptoCallbacks, decodeRecoveryKey } from 'matrix-js-sdk/lib/crypto-api';
+import { CryptoApi, CryptoCallbacks, decodeRecoveryKey, ImportRoomKeyProgressData } from 'matrix-js-sdk/lib/crypto-api';
 import { RealtimeChatEvents, IChatClient } from './';
 import {
   mapEventToAdminMessage,
@@ -308,7 +308,7 @@ export class MatrixClient implements IChatClient {
     }
   }
 
-  async restoreSecureBackup(recoveryKey: string, onProgress?: (progress) => void) {
+  async restoreSecureBackup(recoveryKey: string, onProgress?: (progress: ImportRoomKeyProgressData) => void) {
     const backupInfo = await this.cryptoApi.getKeyBackupInfo();
     if (!backupInfo) {
       throw new Error('Backup broken or not there');

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -308,7 +308,7 @@ export class MatrixClient implements IChatClient {
     }
   }
 
-  async restoreSecureBackup(recoveryKey: string) {
+  async restoreSecureBackup(recoveryKey: string, onProgress?: (progress) => void) {
     const backupInfo = await this.cryptoApi.getKeyBackupInfo();
     if (!backupInfo) {
       throw new Error('Backup broken or not there');
@@ -318,7 +318,11 @@ export class MatrixClient implements IChatClient {
     this.secretStorageKey = privateKey;
     await this.accessSecretStorage(async () => {
       await this.cryptoApi.loadSessionBackupPrivateKeyFromSecretStorage();
-      const recoverInfo = await this.cryptoApi.restoreKeyBackup();
+      const recoverInfo = await this.cryptoApi.restoreKeyBackup({
+        progressCallback: (progress) => {
+          onProgress?.(progress);
+        },
+      });
       if (!recoverInfo) {
         throw new Error('Backup broken or not there');
       }

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -28,6 +28,20 @@ export enum BackupStage {
 
 export type GeneratedRecoveryKey = string | null;
 
+export type RestoreProgress = {
+  stage: string;
+  total: number;
+  successes: number;
+  failures: number;
+};
+
+export const initialRestoreProgressState: RestoreProgress = {
+  stage: '',
+  total: 0,
+  successes: 0,
+  failures: 0,
+};
+
 export type MatrixState = {
   isLoaded: boolean;
   backupExists: boolean;
@@ -38,6 +52,7 @@ export type MatrixState = {
   deviceId: string;
   isBackupDialogOpen: boolean;
   backupStage: BackupStage;
+  restoreProgress: RestoreProgress;
 };
 
 export const initialState: MatrixState = {
@@ -50,6 +65,7 @@ export const initialState: MatrixState = {
   deviceId: '',
   isBackupDialogOpen: false,
   backupStage: BackupStage.UserGeneratePrompt, // Assume there is no backup by default
+  restoreProgress: initialRestoreProgressState,
 };
 
 export const getBackup = createAction(SagaActionTypes.GetBackup);
@@ -95,6 +111,9 @@ const slice = createSlice({
     setBackupRestored: (state, action: PayloadAction<MatrixState['backupRestored']>) => {
       state.backupRestored = action.payload;
     },
+    setRestoreProgress: (state, action: PayloadAction<MatrixState['restoreProgress']>) => {
+      state.restoreProgress = action.payload;
+    },
   },
 });
 
@@ -108,5 +127,6 @@ export const {
   setBackupStage,
   setBackupExists,
   setBackupRestored,
+  setRestoreProgress,
 } = slice.actions;
 export const { reducer } = slice;

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -24,11 +24,11 @@ import { rootReducer } from '../reducer';
 import { throwError } from 'redux-saga-test-plan/providers';
 import { StoreBuilder } from '../test/store';
 import { waitForChatConnectionCompletion } from '../chat/saga';
-import { BackupStage } from '.';
+import { BackupStage, initialRestoreProgressState } from '.';
 
 const chatClient = {
   generateSecureBackup: () => null,
-  restoreSecureBackup: (_key) => null,
+  restoreSecureBackup: (_key, _progressCallback) => null,
   saveSecureBackup: (_backup) => null,
 };
 
@@ -195,7 +195,7 @@ describe(restoreBackup, () => {
   it('tries to restore a backup', async () => {
     await subject(restoreBackup, { payload: 'recovery-key' })
       .withReducer(rootReducer)
-      .call([chatClient, chatClient.restoreSecureBackup], 'recovery-key')
+      .provide([[matchers.call.like({ context: chatClient, fn: chatClient.restoreSecureBackup }), undefined]])
       .run();
   });
 
@@ -263,6 +263,7 @@ describe(clearBackupState, () => {
         successMessage: 'Stuff happened',
         errorMessage: 'An error',
         backupStage: BackupStage.SystemGeneratePrompt,
+        restoreProgress: initialRestoreProgressState,
       },
     };
     const { storeState } = await subject(clearBackupState)
@@ -275,6 +276,7 @@ describe(clearBackupState, () => {
       successMessage: '',
       errorMessage: '',
       backupStage: BackupStage.SystemGeneratePrompt,
+      restoreProgress: initialRestoreProgressState,
     });
   });
 });


### PR DESCRIPTION
### What does this do?
- Adding progress tracking functionality to the secure backup restoration process by implementing a progress callback in the Matrix client and handling it in our saga.

### Why are we making this change?
- To provide users with real-time feedback during the secure backup restoration process, improving the user experience by showing the current stage and progress of the operation.

### How do I test this?
- run tests as usual
- Note - this is not yet wired up - these changes only add the matrix progressCallback and the necessary changes re updating the restore progress state 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
