### PR TITLE
refactor(verify-key-phrase): replace zui input component with zui password input component

### DIFF
--- a/src/components/secure-backup/verify-key-phrase/index.test.tsx
+++ b/src/components/secure-backup/verify-key-phrase/index.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 
 import { VerifyKeyPhrase, Properties } from '.';
 
-import { Alert, Input } from '@zero-tech/zui/components';
+import { Alert, PasswordInput } from '@zero-tech/zui/components';
 
 describe(VerifyKeyPhrase, () => {
   const subject = (props: Partial<Properties> = {}) => {
@@ -19,7 +19,7 @@ describe(VerifyKeyPhrase, () => {
     const onChange = jest.fn();
     const wrapper = subject({ onChange });
 
-    wrapper.find(Input).simulate('change', 'test-key-phrase');
+    wrapper.find(PasswordInput).simulate('change', 'test-key-phrase');
 
     expect(onChange).toHaveBeenCalledWith('test-key-phrase');
   });

--- a/src/components/secure-backup/verify-key-phrase/index.tsx
+++ b/src/components/secure-backup/verify-key-phrase/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { bemClassName } from '../../../lib/bem';
 
-import { Alert, Input } from '@zero-tech/zui/components';
+import { Alert, PasswordInput } from '@zero-tech/zui/components';
 
 import '../styles.scss';
 
@@ -38,11 +38,12 @@ export class VerifyKeyPhrase extends React.Component<Properties, State> {
           <p {...cn('secondary-text')}>Confirm that you have safely stored your backup phrase by entering it below</p>
 
           <div {...cn('input-container')}>
-            <Input
+            <PasswordInput
               placeholder='Enter your backup phrase'
               onChange={this.trackKeyPhrase}
               value={this.keyPhrase}
               error={!!this.props.errorMessage}
+              size='large'
             />
 
             {this.props.errorMessage && (


### PR DESCRIPTION
### What does this do?
- replaces zui input component with zui password input component

### Why are we making this change?
- hide/display password entered 
- use correct input type

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
