### PR TITLE
refactor(chat-saga): switch to non-blocking spawn for conversation read status to improve UI responsiveness

### DIFF
--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -394,26 +394,26 @@ describe(waitForChatConnectionCompletion, () => {
     testSaga(waitForChatConnectionCompletion).next().next(true).returns(true);
   });
 
-  it('waits for load if channel list not yet loaded', () => {
-    testSaga(waitForChatConnectionCompletion)
-      .next()
-      .next(false)
-      .next('fake/chat/bus')
-      .next('fake/auth/bus')
-      // Conversation bus fires event
-      .next({ complete: {} })
-      .next()
-      .returns(true);
-  });
+  // it('waits for load if channel list not yet loaded', () => {
+  //   testSaga(waitForChatConnectionCompletion)
+  //     .next()
+  //     .next(false)
+  //     .next('fake/chat/bus')
+  //     .next('fake/auth/bus')
+  //     // Conversation bus fires event
+  //     .next({ complete: {} })
+  //     .next()
+  //     .returns(true);
+  // });
 
-  it('returns false if the channel load was aborted', () => {
-    testSaga(waitForChatConnectionCompletion)
-      .next()
-      .next(false)
-      .next('fake/chat/bus')
-      .next('fake/auth/bus')
-      // Auth bus fires user logout event
-      .next({ abort: {} })
-      .returns(false);
-  });
+  // it('returns false if the channel load was aborted', () => {
+  //   testSaga(waitForChatConnectionCompletion)
+  //     .next()
+  //     .next(false)
+  //     .next('fake/chat/bus')
+  //     .next('fake/auth/bus')
+  //     // Auth bus fires user logout event
+  //     .next({ abort: {} })
+  //     .returns(false);
+  // });
 });

--- a/src/store/chat/saga.test.ts
+++ b/src/store/chat/saga.test.ts
@@ -81,7 +81,7 @@ describe(performValidateActiveConversation, () => {
       .call(getRoomIdForAlias, '#' + alias)
       .not.call(apiJoinRoom, conversationId)
       .put(rawSetActiveConversationId(conversationId))
-      .call(markConversationAsRead, conversationId)
+      .spawn(markConversationAsRead, conversationId)
       .run();
 
     expect(storeState.chat.activeConversationId).toBe(conversationId);
@@ -170,7 +170,7 @@ describe(performValidateActiveConversation, () => {
         [matchers.call.fn(markConversationAsRead), undefined],
       ])
       .put(rawSetActiveConversationId('social-channel'))
-      .call(markConversationAsRead, 'social-channel')
+      .spawn(markConversationAsRead, 'social-channel')
       .not.call(openFirstConversation)
       .run();
   });
@@ -193,7 +193,7 @@ describe(performValidateActiveConversation, () => {
         [matchers.call.fn(getHistory), history],
       ])
       .put(rawSetActiveConversationId('convo-1'))
-      .call(markConversationAsRead, 'convo-1')
+      .spawn(markConversationAsRead, 'convo-1')
       .run();
   });
 
@@ -229,7 +229,7 @@ describe(performValidateActiveConversation, () => {
         },
       ])
       .not.put(rawSetActiveConversationId('convo-1'))
-      .call(markConversationAsRead, 'convo-1')
+      .spawn(markConversationAsRead, 'convo-1')
       .run();
   });
 });
@@ -394,28 +394,26 @@ describe(waitForChatConnectionCompletion, () => {
     testSaga(waitForChatConnectionCompletion).next().next(true).returns(true);
   });
 
-  // TODO: Fix these tests
+  it('waits for load if channel list not yet loaded', () => {
+    testSaga(waitForChatConnectionCompletion)
+      .next()
+      .next(false)
+      .next('fake/chat/bus')
+      .next('fake/auth/bus')
+      // Conversation bus fires event
+      .next({ complete: {} })
+      .next()
+      .returns(true);
+  });
 
-  // it('waits for load if channel list not yet loaded', () => {
-  //   testSaga(waitForChatConnectionCompletion)
-  //     .next()
-  //     .next(false)
-  //     .next('fake/chat/bus')
-  //     .next('fake/auth/bus')
-  //     // Conversation bus fires event
-  //     .next({ complete: {} })
-  //     .next()
-  //     .returns(true);
-  // });
-
-  // it('returns false if the channel load was aborted', () => {
-  //   testSaga(waitForChatConnectionCompletion)
-  //     .next()
-  //     .next(false)
-  //     .next('fake/chat/bus')
-  //     .next('fake/auth/bus')
-  //     // Auth bus fires user logout event
-  //     .next({ abort: {} })
-  //     .returns(false);
-  // });
+  it('returns false if the channel load was aborted', () => {
+    testSaga(waitForChatConnectionCompletion)
+      .next()
+      .next(false)
+      .next('fake/chat/bus')
+      .next('fake/auth/bus')
+      // Auth bus fires user logout event
+      .next({ abort: {} })
+      .returns(false);
+  });
 });

--- a/src/store/chat/saga.ts
+++ b/src/store/chat/saga.ts
@@ -254,7 +254,7 @@ export function* performValidateActiveConversation(activeConversationId: string)
   }
 
   // Mark conversation as read, now that it has been set as active
-  yield call(markConversationAsRead, conversationId);
+  yield spawn(markConversationAsRead, conversationId);
 }
 
 export function* closeErrorDialog() {


### PR DESCRIPTION
### What does this do?
- switching from call to spawn for conversation read status

### Why are we making this change?
- to improve UI responsiveness by making the operation non-blocking

### How do I test this?
- run tests as usual
- run UI > switch conversations with unread messages > check UI doesn't show 'blank' container for conversations

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
