### PR TITLE
feat(maintenance-mode): add maintenance mode detection to show maintenance page when server is unavailable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,22 @@ import { AppBar } from './components/app-bar/container';
 import { DialogManager } from './components/dialog-manager/container';
 import { ThemeEngine } from './components/theme-engine';
 import { BackgroundStyleProvider } from './lib/providers/BackgroundStyleProvider';
+import { Maintenance } from './maintenance';
+import { selectIsInMaintenance } from './store/maintenance';
 
 export const App = () => {
   const { isAuthenticated, mainClassName, videoBackgroundSrc, wrapperClassName } = useAppMain();
+  const isInMaintenance = useSelector(selectIsInMaintenance);
+
+  // If the server is in maintenance mode, show the maintenance page
+  if (isInMaintenance) {
+    return (
+      <ZUIProvider>
+        <BackgroundStyleProvider />
+        <Maintenance />
+      </ZUIProvider>
+    );
+  }
 
   return (
     // See: ZOS-115

--- a/src/store/maintenance/api.ts
+++ b/src/store/maintenance/api.ts
@@ -1,0 +1,23 @@
+import { get } from '../../lib/api/rest';
+
+export async function checkServerStatus(): Promise<{ isInMaintenance: boolean }> {
+  try {
+    await get('/');
+    return {
+      isInMaintenance: false,
+    };
+  } catch (error: any) {
+    // Check if the error is a 503 with Maintenance reason
+    if (error?.response?.status === 503 && error?.response?.body?.reason === 'Maintenance') {
+      return {
+        isInMaintenance: true,
+      };
+    }
+
+    // For other errors, we don't assume maintenance mode
+    console.error('Failed to check server status:', error);
+    return {
+      isInMaintenance: false,
+    };
+  }
+}

--- a/src/store/maintenance/index.ts
+++ b/src/store/maintenance/index.ts
@@ -1,0 +1,30 @@
+import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export const SagaActionTypes = {
+  CheckServerStatus: 'maintenance/checkServerStatus',
+};
+
+export const checkServerStatus = createAction(SagaActionTypes.CheckServerStatus);
+
+export interface MaintenanceState {
+  isInMaintenance: boolean;
+}
+
+const initialState: MaintenanceState = {
+  isInMaintenance: false,
+};
+
+export const slice = createSlice({
+  name: 'maintenance',
+  initialState,
+  reducers: {
+    setMaintenanceStatus: (state, action: PayloadAction<boolean>) => {
+      state.isInMaintenance = action.payload;
+    },
+  },
+});
+
+export const { setMaintenanceStatus } = slice.actions;
+export const { reducer } = slice;
+
+export const selectIsInMaintenance = (state: { maintenance: MaintenanceState }) => state.maintenance.isInMaintenance;

--- a/src/store/maintenance/saga.ts
+++ b/src/store/maintenance/saga.ts
@@ -1,0 +1,19 @@
+import { takeLatest, put, call } from 'redux-saga/effects';
+import { checkServerStatus as checkServerStatusApi } from './api';
+import { setMaintenanceStatus, SagaActionTypes } from '.';
+
+export function* checkServerStatus() {
+  try {
+    const { isInMaintenance } = yield call(checkServerStatusApi);
+    yield put(setMaintenanceStatus(isInMaintenance));
+  } catch (error) {
+    console.error('Error checking server status:', error);
+    // If we can't reach the server, don't assume it's in maintenance
+    // This prevents false positives when there are network issues
+    yield put(setMaintenanceStatus(false));
+  }
+}
+
+export function* saga() {
+  yield takeLatest(SagaActionTypes.CheckServerStatus, checkServerStatus);
+}

--- a/src/store/page-load/saga.ts
+++ b/src/store/page-load/saga.ts
@@ -3,6 +3,7 @@ import { setEntryPath, setIsComplete, setShowAndroidDownload } from '.';
 import { getHistory, getNavigator } from '../../lib/browser';
 import { getCurrentUser } from '../authentication/saga';
 import { Events as AuthEvents, getAuthChannel } from '../authentication/channels';
+import { checkServerStatus } from '../maintenance';
 
 const anonymousPaths = [
   '/get-access',
@@ -14,6 +15,8 @@ export function* saga() {
   const history = yield call(getHistory);
   const navigator = yield call(getNavigator);
   const isMobileDevice = /Mobi|Android/i.test(navigator.userAgent);
+
+  yield put(checkServerStatus());
 
   if (isMobileDevice) {
     history.replace({ pathname: '/restricted' });

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -27,6 +27,7 @@ import { reducer as reportUser } from './report-user';
 import { reducer as thirdweb } from './thirdweb';
 import { reducer as panels } from './panels';
 import { reducer as activeZApp } from './active-zapp';
+import { reducer as maintenance } from './maintenance';
 
 export const rootReducer = combineReducers({
   pageload,
@@ -56,6 +57,7 @@ export const rootReducer = combineReducers({
   thirdweb,
   panels,
   activeZApp,
+  maintenance,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -28,6 +28,7 @@ import { saga as notifications } from './notifications/saga';
 import { saga as reportUser } from './report-user/saga';
 import { saga as thirdweb } from './thirdweb/saga';
 import { saga as activeZApp } from './active-zapp/saga';
+import { saga as maintenance } from './maintenance/saga';
 
 export function* rootSaga() {
   const allSagas = {
@@ -59,6 +60,7 @@ export function* rootSaga() {
     reportUser,
     thirdweb,
     activeZApp,
+    maintenance,
   };
 
   yield all(


### PR DESCRIPTION
### What does this do?
We're adding a maintenance mode detection system that checks the server status and displays a maintenance page when the server is in maintenance mode.

### Why are we making this change?
- To provide users with clear feedback when the server is undergoing maintenance instead of showing cryptic errors or a blank screen.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
