### PR TITLE
fix(components/message): media re-rendering flicker when editing messages

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -402,59 +402,49 @@ export const Message: React.FC<Properties> = ({
       >
         {(message || media || preview) && (
           <>
-            {!isEditing && (
-              <>
-                {showAuthorName && (
-                  <div {...cn('author-name')}>
-                    {sender.firstName} {sender.lastName}
-                  </div>
-                )}
-                {media && (
-                  <MessageMedia
-                    media={media}
-                    onImageClick={onImageClick}
-                    openAttachmentPreview={openAttachmentPreview}
-                    effectiveMediaUrl={effectiveMediaUrl}
-                    isLoading={isMediaLoading}
-                    isError={isMediaError}
-                  />
-                )}
-                {renderLinkPreview()}
-                <ParentMessage
-                  message={parentMessageText}
-                  senderIsCurrentUser={parentSenderIsCurrentUser}
-                  senderFirstName={parentSenderFirstName}
-                  senderLastName={parentSenderLastName}
-                  media={parentMessageMedia}
-                  messageId={parentMessageId}
-                  onMessageClick={onParentMessageClick}
-                />
-                {renderBody()}
-              </>
+            {showAuthorName && !isEditing && (
+              <div {...cn('author-name')}>
+                {sender.firstName} {sender.lastName}
+              </div>
             )}
 
+            {media && (
+              <MessageMedia
+                media={media}
+                onImageClick={onImageClick}
+                openAttachmentPreview={openAttachmentPreview}
+                effectiveMediaUrl={effectiveMediaUrl}
+                isLoading={isMediaLoading}
+                isError={isMediaError}
+              />
+            )}
+
+            {!isEditing && renderLinkPreview()}
+
+            {!isEditing && (
+              <ParentMessage
+                message={parentMessageText}
+                senderIsCurrentUser={parentSenderIsCurrentUser}
+                senderFirstName={parentSenderFirstName}
+                senderLastName={parentSenderLastName}
+                media={parentMessageMedia}
+                messageId={parentMessageId}
+                onMessageClick={onParentMessageClick}
+              />
+            )}
+
+            {!isEditing && renderBody()}
+
             {isEditing && message && (
-              <>
-                {media && (
-                  <MessageMedia
-                    media={media}
-                    onImageClick={onImageClick}
-                    openAttachmentPreview={openAttachmentPreview}
-                    effectiveMediaUrl={effectiveMediaUrl}
-                    isLoading={isMediaLoading}
-                    isError={isMediaError}
-                  />
-                )}
-                <div {...cn('block-edit')}>
-                  <MessageInput
-                    initialValue={message}
-                    onSubmit={editMessageFromInput}
-                    getUsersForMentions={getUsersForMentions}
-                    isEditing={isEditing}
-                    renderAfterInput={editActions}
-                  />
-                </div>
-              </>
+              <div {...cn('block-edit')}>
+                <MessageInput
+                  initialValue={message}
+                  onSubmit={editMessageFromInput}
+                  getUsersForMentions={getUsersForMentions}
+                  isEditing={isEditing}
+                  renderAfterInput={editActions}
+                />
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
### What does this do?
- We're restructuring the JSX in the Message component to keep the MessageMedia component mounted consistently regardless of edit state.

### Why are we making this change?
-  To prevent media from disappearing and reappearing when toggling edit mode, which creates a jarring user experience.

### How do I test this?
- run tests as usual
- run UI > edit message with media > check for re-rendering

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
