### PR TITLE
refactor(secure-backup): separate backup creation and restoration flows

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -15,7 +15,7 @@ import { Channel, ConversationStatus, denormalize, onReply } from '../../store/c
 import { ChatView } from './chat-view';
 import { AuthenticationState } from '../../store/authentication/types';
 import { EditPayload, Payload as PayloadFetchMessages } from '../../store/messages/saga';
-import { openBackupDialog } from '../../store/matrix';
+import { openCreateBackupDialog } from '../../store/matrix';
 import { ParentMessage } from '../../lib/chat/types';
 import { openDeleteMessage, openLightbox } from '../../store/dialogs';
 import { openMessageInfo } from '../../store/message-info';
@@ -30,7 +30,7 @@ export interface Properties extends PublicProperties {
   user: AuthenticationState['user'];
   editMessage: (payload: EditPayload) => void;
   onReply: ({ reply }: { reply: ParentMessage }) => void;
-  openBackupDialog: () => void;
+  openCreateBackupDialog: () => void;
   isSecondarySidekickOpen: boolean;
   openDeleteMessage: (messageId: string) => void;
   toggleSecondarySidekick: () => void;
@@ -76,7 +76,7 @@ export class Container extends React.Component<Properties> {
       fetchMessages,
       editMessage,
       onReply,
-      openBackupDialog,
+      openCreateBackupDialog,
       openDeleteMessage,
       openMessageInfo,
       toggleSecondarySidekick,
@@ -242,7 +242,7 @@ export class Container extends React.Component<Properties> {
           onReply={this.props.onReply}
           onReportUser={this.onReportUser}
           conversationErrorMessage={this.conversationErrorMessage}
-          onHiddenMessageInfoClick={this.props.openBackupDialog}
+          onHiddenMessageInfoClick={this.props.openCreateBackupDialog}
           ref={this.chatViewRef}
           isSecondarySidekickOpen={this.props.isSecondarySidekickOpen}
           toggleSecondarySidekick={this.props.toggleSecondarySidekick}

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { RootState } from '../../store/reducer';
 import { connectContainer } from '../../store/redux-container';
-import { SecureBackupContainer } from '../secure-backup/container';
-import { closeBackupDialog } from '../../store/matrix';
+// import { SecureBackupContainer } from '../secure-backup/container';
+import { closeCreateBackupDialog, closeRestoreBackupDialog } from '../../store/matrix';
 import { LogoutConfirmationModalContainer } from '../logout-confirmation-modal/container';
 import { RewardsModalContainer } from '../rewards-modal/container';
 import { closeRewardsDialog } from '../../store/rewards';
@@ -11,11 +11,14 @@ import { closeDeleteMessage, closeLightbox } from '../../store/dialogs';
 import { ReportUserContainer } from '../report-user-dialog/container';
 import { closeReportUserModal } from '../../store/report-user';
 import { Lightbox } from '../lightbox';
+
 export interface PublicProperties {}
 
 export interface Properties extends PublicProperties {
   displayLogoutModal: boolean;
-  isBackupDialogOpen: boolean;
+  // isBackupDialogOpen: boolean;
+  isCreateBackupDialogOpen: boolean;
+  isRestoreBackupDialogOpen: boolean;
   isRewardsDialogOpen: boolean;
   isReportUserModalOpen: boolean;
   deleteMessageId: string;
@@ -25,7 +28,9 @@ export interface Properties extends PublicProperties {
     startingIndex: number;
   };
 
-  closeBackupDialog: () => void;
+  // closeBackupDialog: () => void;
+  closeCreateBackupDialog: () => void;
+  closeRestoreBackupDialog: () => void;
   closeRewardsDialog: () => void;
   closeDeleteMessage: () => void;
   closeReportUserModal: () => void;
@@ -36,7 +41,7 @@ export class Container extends React.Component<Properties> {
   static mapState(state: RootState) {
     const {
       authentication: { displayLogoutModal },
-      matrix: { isBackupDialogOpen },
+      matrix: { isCreateBackupDialogOpen, isRestoreBackupDialogOpen },
       dialogs: { deleteMessageId, lightbox },
       reportUser: { isReportUserModalOpen },
       rewards,
@@ -44,7 +49,8 @@ export class Container extends React.Component<Properties> {
 
     return {
       displayLogoutModal,
-      isBackupDialogOpen,
+      isCreateBackupDialogOpen,
+      isRestoreBackupDialogOpen,
       isRewardsDialogOpen: rewards.showRewardsInPopup,
       deleteMessageId,
       isReportUserModalOpen,
@@ -53,11 +59,22 @@ export class Container extends React.Component<Properties> {
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
-    return { closeBackupDialog, closeRewardsDialog, closeDeleteMessage, closeReportUserModal, closeLightbox };
+    return {
+      closeCreateBackupDialog,
+      closeRestoreBackupDialog,
+      closeRewardsDialog,
+      closeDeleteMessage,
+      closeReportUserModal,
+      closeLightbox,
+    };
   }
 
-  closeBackup = () => {
-    this.props.closeBackupDialog();
+  closeCreateBackup = () => {
+    this.props.closeCreateBackupDialog();
+  };
+
+  closeRestoreBackup = () => {
+    this.props.closeRestoreBackupDialog();
   };
 
   closeRewards = () => {
@@ -76,9 +93,19 @@ export class Container extends React.Component<Properties> {
     this.props.closeLightbox();
   };
 
-  renderSecureBackupDialog = (): JSX.Element => {
-    return <SecureBackupContainer onClose={this.closeBackup} />;
+  renderCreateBackupDialog = (): JSX.Element => {
+    // new component for create backup dialog (split from secure backup)
+    return <>CREATE</>;
   };
+
+  renderRestoreBackupDialog = (): JSX.Element => {
+    // new component for restore backup dialog (split from secure backup)
+    return <>RESTORE</>;
+  };
+
+  // renderSecureBackupDialog = (): JSX.Element => {
+  //   return <SecureBackupContainer onClose={this.closeBackup} />;
+  // };
 
   renderLogoutDialog = (): JSX.Element => {
     return <LogoutConfirmationModalContainer />;
@@ -115,7 +142,9 @@ export class Container extends React.Component<Properties> {
   render() {
     return (
       <>
-        {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()}
+        {/* {this.props.isBackupDialogOpen && this.renderSecureBackupDialog()} */}
+        {this.props.isCreateBackupDialogOpen && this.renderCreateBackupDialog()}
+        {this.props.isRestoreBackupDialogOpen && this.renderRestoreBackupDialog()}
         {this.props.displayLogoutModal && this.renderLogoutDialog()}
         {this.props.isRewardsDialogOpen && this.renderRewardsDialog()}
         {this.props.deleteMessageId && this.renderDeleteMessageDialog()}

--- a/src/components/messenger/user-profile/container.tsx
+++ b/src/components/messenger/user-profile/container.tsx
@@ -18,7 +18,7 @@ import {
   openLinkedAccounts,
 } from '../../../store/user-profile';
 import { logout } from '../../../store/authentication';
-import { openBackupDialog } from '../../../store/matrix';
+import { openCreateBackupDialog, openRestoreBackupDialog } from '../../../store/matrix';
 import { openRewardsDialog } from '../../../store/rewards';
 
 export interface PublicProperties {}
@@ -26,9 +26,12 @@ export interface PublicProperties {}
 export interface Properties extends PublicProperties {
   currentUser: User;
   stage: Stage;
+  backupExists: boolean;
+  backupRestored: boolean;
 
   logout: () => void;
-  openBackupDialog: () => void;
+  openCreateBackupDialog: () => void;
+  openRestoreBackupDialog: () => void;
   openUserProfile: () => void;
   closeUserProfile: () => void;
   openEditProfile: () => void;
@@ -41,7 +44,7 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   static mapState(state: RootState): Partial<Properties> {
-    const { userProfile } = state;
+    const { userProfile, matrix } = state;
     const currentUser = currentUserSelector(state);
 
     return {
@@ -51,6 +54,8 @@ export class Container extends React.Component<Properties> {
         displaySubHandle: getUserSubHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
       } as User,
       stage: userProfile.stage,
+      backupExists: matrix.backupExists,
+      backupRestored: matrix.backupRestored,
     };
   }
 
@@ -59,7 +64,8 @@ export class Container extends React.Component<Properties> {
       logout,
       openUserProfile,
       closeUserProfile,
-      openBackupDialog,
+      openCreateBackupDialog,
+      openRestoreBackupDialog,
       openEditProfile,
       openRewardsDialog,
       openSettings,
@@ -68,6 +74,14 @@ export class Container extends React.Component<Properties> {
       openLinkedAccounts,
     };
   }
+
+  onBackup = () => {
+    if (this.props.backupExists && !this.props.backupRestored) {
+      this.props.openRestoreBackupDialog();
+    } else {
+      this.props.openCreateBackupDialog();
+    }
+  };
 
   render() {
     return (
@@ -78,7 +92,7 @@ export class Container extends React.Component<Properties> {
         subHandle={this.props.currentUser.displaySubHandle}
         onClose={this.props.closeUserProfile}
         onLogout={this.props.logout}
-        onBackup={this.props.openBackupDialog}
+        onBackup={this.onBackup}
         onEdit={this.props.openEditProfile}
         onBackToOverview={this.props.openUserProfile}
         onRewards={this.props.openRewardsDialog}

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -9,20 +9,42 @@ export enum SagaActionTypes {
   DebugDeviceList = 'chat/debug-device-list',
   DebugRoomKeys = 'chat/debug-room-keys',
   FetchDeviceInfo = 'chat/fetch-device-info',
-  OpenBackupDialog = 'chat/open-backup-dialog',
-  CloseBackupDialog = 'chat/close-backup-dialog',
-  VerifyKey = 'chat/verify-key',
+  // OpenBackupDialog = 'chat/open-backup-dialog',
+  // CloseBackupDialog = 'chat/close-backup-dialog',
+  // VerifyKey = 'chat/verify-key',
+  OpenCreateBackupDialog = 'chat/open-create-backup-dialog',
+  OpenRestoreBackupDialog = 'chat/open-restore-backup-dialog',
+  CloseCreateBackupDialog = 'chat/close-create-backup-dialog',
+  CloseRestoreBackupDialog = 'chat/close-restore-backup-dialog',
+  VerifyCreatedKey = 'chat/verify-created-key',
+  VerifyRestorationKey = 'chat/verify-restoration-key',
 }
 
-export enum BackupStage {
+// export enum BackupStage {
+//   UserGeneratePrompt = 'user_generate_prompt',
+//   UserRestorePrompt = 'user_restore_prompt',
+//   SystemGeneratePrompt = 'system_generate_prompt',
+//   SystemRestorePrompt = 'system_restore_prompt',
+//   RecoveredBackupInfo = 'recovered_backup_info',
+//   VerifyKeyPhrase = 'verify_key_phrase',
+//   GenerateBackup = 'generate_backup',
+//   RestoreBackup = 'restore_backup',
+//   Success = 'success',
+// }
+
+export enum CreateBackupStage {
   UserGeneratePrompt = 'user_generate_prompt',
-  UserRestorePrompt = 'user_restore_prompt',
   SystemGeneratePrompt = 'system_generate_prompt',
-  SystemRestorePrompt = 'system_restore_prompt',
-  RecoveredBackupInfo = 'recovered_backup_info',
-  VerifyKeyPhrase = 'verify_key_phrase',
   GenerateBackup = 'generate_backup',
+  VerifyKeyPhrase = 'verify_key_phrase',
+  Success = 'success',
+}
+
+export enum RestoreBackupStage {
+  UserRestorePrompt = 'user_restore_prompt',
+  SystemRestorePrompt = 'system_restore_prompt',
   RestoreBackup = 'restore_backup',
+  RecoveredBackupInfo = 'recovered_backup_info',
   Success = 'success',
 }
 
@@ -50,8 +72,11 @@ export type MatrixState = {
   successMessage: string;
   errorMessage: string;
   deviceId: string;
-  isBackupDialogOpen: boolean;
-  backupStage: BackupStage;
+  // isBackupDialogOpen: boolean;
+  isCreateBackupDialogOpen: boolean;
+  isRestoreBackupDialogOpen: boolean;
+  createBackupStage: CreateBackupStage;
+  restoreBackupStage: RestoreBackupStage;
   restoreProgress: RestoreProgress;
 };
 
@@ -63,8 +88,11 @@ export const initialState: MatrixState = {
   successMessage: '',
   errorMessage: '',
   deviceId: '',
-  isBackupDialogOpen: false,
-  backupStage: BackupStage.UserGeneratePrompt, // Assume there is no backup by default
+  // isBackupDialogOpen: false,
+  isCreateBackupDialogOpen: false,
+  isRestoreBackupDialogOpen: false,
+  createBackupStage: CreateBackupStage.UserGeneratePrompt,
+  restoreBackupStage: RestoreBackupStage.UserRestorePrompt,
   restoreProgress: initialRestoreProgressState,
 };
 
@@ -76,9 +104,15 @@ export const clearBackup = createAction(SagaActionTypes.ClearBackup);
 export const debugDeviceList = createAction<string[]>(SagaActionTypes.DebugDeviceList);
 export const debugRoomKeys = createAction<string>(SagaActionTypes.DebugRoomKeys);
 export const fetchDeviceInfo = createAction<string[]>(SagaActionTypes.FetchDeviceInfo);
-export const openBackupDialog = createAction(SagaActionTypes.OpenBackupDialog);
-export const closeBackupDialog = createAction(SagaActionTypes.CloseBackupDialog);
-export const proceedToVerifyKey = createAction(SagaActionTypes.VerifyKey);
+// export const openBackupDialog = createAction(SagaActionTypes.OpenBackupDialog);
+// export const closeBackupDialog = createAction(SagaActionTypes.CloseBackupDialog);
+// export const proceedToVerifyKey = createAction(SagaActionTypes.VerifyKey);
+export const openCreateBackupDialog = createAction(SagaActionTypes.OpenCreateBackupDialog);
+export const openRestoreBackupDialog = createAction(SagaActionTypes.OpenRestoreBackupDialog);
+export const closeCreateBackupDialog = createAction(SagaActionTypes.CloseCreateBackupDialog);
+export const closeRestoreBackupDialog = createAction(SagaActionTypes.CloseRestoreBackupDialog);
+export const verifyCreatedKey = createAction(SagaActionTypes.VerifyCreatedKey);
+export const verifyRestorationKey = createAction(SagaActionTypes.VerifyRestorationKey);
 
 const slice = createSlice({
   name: 'matrix',
@@ -99,11 +133,23 @@ const slice = createSlice({
     setDeviceId: (state, action: PayloadAction<MatrixState['deviceId']>) => {
       state.deviceId = action.payload;
     },
-    setIsBackupDialogOpen: (state, action: PayloadAction<MatrixState['isBackupDialogOpen']>) => {
-      state.isBackupDialogOpen = action.payload;
+    setIsCreateBackupDialogOpen: (state, action: PayloadAction<MatrixState['isCreateBackupDialogOpen']>) => {
+      state.isCreateBackupDialogOpen = action.payload;
     },
-    setBackupStage: (state, action: PayloadAction<MatrixState['backupStage']>) => {
-      state.backupStage = action.payload;
+    setIsRestoreBackupDialogOpen: (state, action: PayloadAction<MatrixState['isRestoreBackupDialogOpen']>) => {
+      state.isRestoreBackupDialogOpen = action.payload;
+    },
+    // setIsBackupDialogOpen: (state, action: PayloadAction<MatrixState['isBackupDialogOpen']>) => {
+    //   state.isBackupDialogOpen = action.payload;
+    // },
+    // setBackupStage: (state, action: PayloadAction<MatrixState['backupStage']>) => {
+    //   state.backupStage = action.payload;
+    // },
+    setCreateBackupStage: (state, action: PayloadAction<MatrixState['createBackupStage']>) => {
+      state.createBackupStage = action.payload;
+    },
+    setRestoreBackupStage: (state, action: PayloadAction<MatrixState['restoreBackupStage']>) => {
+      state.restoreBackupStage = action.payload;
     },
     setBackupExists: (state, action: PayloadAction<MatrixState['backupExists']>) => {
       state.backupExists = action.payload;
@@ -119,12 +165,16 @@ const slice = createSlice({
 
 export const {
   setLoaded,
-  setIsBackupDialogOpen,
+  // setIsBackupDialogOpen,
+  setIsCreateBackupDialogOpen,
+  setIsRestoreBackupDialogOpen,
   setGeneratedRecoveryKey,
   setSuccessMessage,
   setErrorMessage,
   setDeviceId,
-  setBackupStage,
+  // setBackupStage,
+  setCreateBackupStage,
+  setRestoreBackupStage,
   setBackupExists,
   setBackupRestored,
   setRestoreProgress,

--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -5,18 +5,26 @@ import { expectSaga, stubDelay } from '../../test/saga';
 import { chat, getSecureBackup } from '../../lib/chat';
 import {
   clearBackupState,
-  closeBackupDialog,
+  // closeBackupDialog,
+  closeCreateBackupDialog,
+  closeRestoreBackupDialog,
   generateBackup,
   getBackup,
   ensureUserHasBackup,
   restoreBackup,
-  proceedToVerifyKey,
+  // proceedToVerifyKey,
   saveBackup,
   handleBackupUserPrompts,
   checkBackupOnFirstSentMessage,
-  systemInitiatedBackupDialog,
-  userInitiatedBackupDialog,
+  // systemInitiatedBackupDialog,
+  // userInitiatedBackupDialog,
   receiveBackupData,
+  userInitiatedCreateBackupDialog,
+  proceedToVerifyCreatedKey,
+  proceedToVerifyRestorationKey,
+  systemInitiatedCreateBackupDialog,
+  systemInitiatedRestoreBackupDialog,
+  userInitiatedRestoreBackupDialog,
 } from './saga';
 import { performUnlessLogout } from '../utils';
 
@@ -24,7 +32,7 @@ import { rootReducer } from '../reducer';
 import { throwError } from 'redux-saga-test-plan/providers';
 import { StoreBuilder } from '../test/store';
 import { waitForChatConnectionCompletion } from '../chat/saga';
-import { BackupStage, initialRestoreProgressState } from '.';
+import { CreateBackupStage, RestoreBackupStage, initialRestoreProgressState } from '.';
 
 const chatClient = {
   generateSecureBackup: () => null,
@@ -98,7 +106,7 @@ describe(generateBackup, () => {
       .withReducer(rootReducer)
       .run();
 
-    expect(storeState.matrix.backupStage).toEqual(BackupStage.GenerateBackup);
+    expect(storeState.matrix.createBackupStage).toEqual(CreateBackupStage.GenerateBackup);
   });
 
   it('handles error during backup generation', async () => {
@@ -106,7 +114,7 @@ describe(generateBackup, () => {
     const { storeState } = await subject(generateBackup)
       .provide([[call([chatClient, chatClient.generateSecureBackup]), throwError(error)]])
       .withReducer(rootReducer)
-      .call(userInitiatedBackupDialog)
+      .call(userInitiatedCreateBackupDialog)
       .run();
 
     expect(storeState.matrix.errorMessage).toEqual('Failed to generate backup key. Please try again.');
@@ -186,7 +194,7 @@ describe(saveBackup, () => {
       expect(storeState.matrix.errorMessage).toEqual(
         'The phrase you entered does not match. Backup phrases are case sensitive'
       );
-      expect(storeState.matrix.backupStage).not.toEqual(BackupStage.Success);
+      expect(storeState.matrix.createBackupStage).not.toEqual(CreateBackupStage.Success);
     });
   });
 });
@@ -215,42 +223,72 @@ describe(restoreBackup, () => {
       .run();
 
     expect(storeState.matrix.successMessage).toEqual('Login successfully verified!');
-    expect(storeState.matrix.backupStage).toEqual(BackupStage.Success);
+    expect(storeState.matrix.restoreBackupStage).toEqual(RestoreBackupStage.Success);
   });
 
   it('sets failure state if restoring fails', async () => {
-    const { storeState } = await subject(restoreBackup, { payload: 'recovery-key' })
-      .provide([
-        [
-          matchers.call.like({ context: chatClient, fn: chatClient.restoreSecureBackup }),
-          throwError(new Error('simulated error')),
-        ],
-      ])
-      .withReducer(rootReducer)
-      .run();
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(storeState.matrix.errorMessage).toEqual('Failed to restore backup: Check your recovery key and try again');
+    try {
+      const { storeState } = await subject(restoreBackup, { payload: 'recovery-key' })
+        .provide([
+          [
+            matchers.call.like({ context: chatClient, fn: chatClient.restoreSecureBackup }),
+            throwError(new Error('simulated error')),
+          ],
+        ])
+        .withReducer(rootReducer)
+        .run();
+
+      expect(storeState.matrix.errorMessage).toEqual('Failed to restore backup: Check your recovery key and try again');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });
 
-describe(proceedToVerifyKey, () => {
-  it('sets stage to RestoreBackup when no existing key is found', async () => {
-    const initialState = { matrix: { generatedRecoveryKey: null } };
-    const { storeState } = await subject(proceedToVerifyKey)
-      .withReducer(rootReducer, initialState as any)
-      .run();
+// describe(proceedToVerifyKey, () => {
+//   it('sets stage to RestoreBackup when no existing key is found', async () => {
+//     const initialState = { matrix: { generatedRecoveryKey: null } };
+//     const { storeState } = await subject(proceedToVerifyKey)
+//       .withReducer(rootReducer, initialState as any)
+//       .run();
 
-    expect(storeState.matrix.backupStage).toEqual(BackupStage.RestoreBackup);
-  });
+//     expect(storeState.matrix.backupStage).toEqual(BackupStage.RestoreBackup);
+//   });
 
-  it('sets stage to VerifyKeyPhrase when existing key is found', async () => {
+//   it('sets stage to VerifyKeyPhrase when existing key is found', async () => {
+//     const initialState = { matrix: { generatedRecoveryKey: 'existing-key' } };
+
+//     const { storeState } = await subject(proceedToVerifyKey)
+//       .withReducer(rootReducer, initialState as any)
+//       .run();
+
+//     expect(storeState.matrix.backupStage).toEqual(BackupStage.VerifyKeyPhrase);
+//   });
+// });
+
+describe(proceedToVerifyCreatedKey, () => {
+  it('sets create backup stage to VerifyKeyPhrase ', async () => {
     const initialState = { matrix: { generatedRecoveryKey: 'existing-key' } };
 
-    const { storeState } = await subject(proceedToVerifyKey)
+    const { storeState } = await subject(proceedToVerifyCreatedKey)
       .withReducer(rootReducer, initialState as any)
       .run();
 
-    expect(storeState.matrix.backupStage).toEqual(BackupStage.VerifyKeyPhrase);
+    expect(storeState.matrix.createBackupStage).toEqual(CreateBackupStage.VerifyKeyPhrase);
+  });
+});
+
+describe(proceedToVerifyRestorationKey, () => {
+  it('sets restore backup stage to RestoreBackup ', async () => {
+    const initialState = { matrix: { generatedRecoveryKey: null } };
+
+    const { storeState } = await subject(proceedToVerifyRestorationKey)
+      .withReducer(rootReducer, initialState as any)
+      .run();
+
+    expect(storeState.matrix.restoreBackupStage).toEqual(RestoreBackupStage.RestoreBackup);
   });
 });
 
@@ -262,7 +300,8 @@ describe(clearBackupState, () => {
         generatedRecoveryKey: 'a key',
         successMessage: 'Stuff happened',
         errorMessage: 'An error',
-        backupStage: BackupStage.SystemGeneratePrompt,
+        createBackupStage: CreateBackupStage.SystemGeneratePrompt,
+        restoreBackupStage: RestoreBackupStage.SystemRestorePrompt,
         restoreProgress: initialRestoreProgressState,
       },
     };
@@ -275,7 +314,8 @@ describe(clearBackupState, () => {
       isLoaded: false,
       successMessage: '',
       errorMessage: '',
-      backupStage: BackupStage.SystemGeneratePrompt,
+      createBackupStage: CreateBackupStage.SystemGeneratePrompt,
+      restoreBackupStage: RestoreBackupStage.SystemRestorePrompt,
       restoreProgress: initialRestoreProgressState,
     });
   });
@@ -283,34 +323,34 @@ describe(clearBackupState, () => {
 
 describe('secure backup status management', () => {
   describe(ensureUserHasBackup, () => {
-    it('opens the backup dialog if backup does not exist', async () => {
-      const initialState = { matrix: { isBackupDialogOpen: false } };
+    it('opens the create backup dialog if backup does not exist', async () => {
+      const initialState = { matrix: { isCreateBackupDialogOpen: false } };
 
       await subject(ensureUserHasBackup)
         .withReducer(rootReducer, initialState as any)
         .provide([
           [call(getSecureBackup), undefined],
           stubDelay(5000),
-          [call(systemInitiatedBackupDialog), undefined],
+          [call(systemInitiatedCreateBackupDialog), undefined],
         ])
-        .call(systemInitiatedBackupDialog)
+        .call(systemInitiatedCreateBackupDialog)
         .run();
     });
 
-    it('does not open the backup dialog if backup exists', async () => {
-      const initialState = { matrix: { isBackupDialogOpen: false } };
+    it('does not open the create backup dialog if backup exists', async () => {
+      const initialState = { matrix: { isCreateBackupDialogOpen: false } };
 
       await subject(ensureUserHasBackup)
         .withReducer(rootReducer, initialState as any)
         .provide([
           [call(getSecureBackup), { backupInfo: {}, trustInfo: { trusted: true }, crossSigning: false }],
         ])
-        .not.call(systemInitiatedBackupDialog)
+        .not.call(systemInitiatedCreateBackupDialog)
         .run();
     });
 
-    it('does not open the backup if user logs out during wait period', async () => {
-      const initialState = { matrix: { isBackupDialogOpen: false } };
+    it('does not open the create backup dialog if user logs out during wait period', async () => {
+      const initialState = { matrix: { isCreateBackupDialogOpen: false } };
 
       await subject(ensureUserHasBackup)
         .withReducer(rootReducer, initialState as any)
@@ -318,24 +358,48 @@ describe('secure backup status management', () => {
           [call(getSecureBackup), undefined],
           [call(performUnlessLogout, delay(10000)), false],
         ])
-        .not.call(systemInitiatedBackupDialog)
+        .not.call(systemInitiatedCreateBackupDialog)
         .run();
     });
   });
 
-  describe(closeBackupDialog, () => {
-    it('closes the backup dialog and sets stage', async () => {
-      const initialState = {
-        matrix: {
-          isBackupDialogOpen: true,
-        },
-      };
+  // describe(closeBackupDialog, () => {
+  //   it('closes the backup dialog and sets stage', async () => {
+  //     const initialState = {
+  //       matrix: {
+  //         isBackupDialogOpen: true,
+  //       },
+  //     };
 
-      const { storeState } = await subject(closeBackupDialog)
+  //     const { storeState } = await subject(closeBackupDialog)
+  //       .withReducer(rootReducer, initialState as any)
+  //       .run();
+
+  //     expect(storeState.matrix.isBackupDialogOpen).toBe(false);
+  //   });
+  // });
+
+  describe(closeCreateBackupDialog, () => {
+    it('closes the create backup dialog', async () => {
+      const initialState = { matrix: { isCreateBackupDialogOpen: true } };
+
+      const { storeState } = await subject(closeCreateBackupDialog)
         .withReducer(rootReducer, initialState as any)
         .run();
 
-      expect(storeState.matrix.isBackupDialogOpen).toBe(false);
+      expect(storeState.matrix.isCreateBackupDialogOpen).toBe(false);
+    });
+  });
+
+  describe(closeRestoreBackupDialog, () => {
+    it('closes the restore backup dialog', async () => {
+      const initialState = { matrix: { isRestoreBackupDialogOpen: true } };
+
+      const { storeState } = await subject(closeRestoreBackupDialog)
+        .withReducer(rootReducer, initialState as any)
+        .run();
+
+      expect(storeState.matrix.isRestoreBackupDialogOpen).toBe(false);
     });
   });
 });
@@ -350,21 +414,21 @@ describe(handleBackupUserPrompts, () => {
       .withReducer(rootReducer, new StoreBuilder().build());
   }
 
-  it('opens the backup dialog and sets stage if user has not restored their backup', async () => {
+  it('opens the restore backup dialog and sets stage if user has not restored their backup', async () => {
     await subject({
       crossSigning: true,
       trustInfo: { trusted: false },
     })
-      .provide([[call(systemInitiatedBackupDialog), undefined]])
+      .provide([[call(systemInitiatedRestoreBackupDialog), undefined]])
       .not.call(performUnlessLogout, call(checkBackupOnFirstSentMessage))
-      .call(systemInitiatedBackupDialog)
+      .call(systemInitiatedRestoreBackupDialog)
       .run();
   });
 
   it('waits for first sent message if user does not have a backup', async () => {
     await subject(null)
       .call(performUnlessLogout, call(checkBackupOnFirstSentMessage))
-      .not.call(systemInitiatedBackupDialog)
+      .not.call(systemInitiatedCreateBackupDialog)
       .run();
   });
 
@@ -374,60 +438,126 @@ describe(handleBackupUserPrompts, () => {
       trustInfo: { trusted: true },
     })
       .not.call(performUnlessLogout, call(checkBackupOnFirstSentMessage))
-      .not.call(systemInitiatedBackupDialog)
+      .not.call(systemInitiatedCreateBackupDialog)
       .run();
   });
 });
 
-describe(systemInitiatedBackupDialog, () => {
-  it('opens the backup dialog in SystemGeneratePrompt state if user has no backup', async () => {
+describe(systemInitiatedCreateBackupDialog, () => {
+  it('opens the create backup dialog in SystemGeneratePrompt state if user has no backup', async () => {
     const state = new StoreBuilder().withoutBackup();
-    const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+    const { storeState } = await subject(systemInitiatedCreateBackupDialog)
+      .withReducer(rootReducer, state.build())
+      .run();
 
-    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.SystemGeneratePrompt);
+    expect(storeState.matrix.isCreateBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.createBackupStage).toBe(CreateBackupStage.SystemGeneratePrompt);
   });
 
-  it('opens the backup dialog in SystemRestorePrompt state if user has an unrestored backup', async () => {
+  // it('opens the backup dialog in SystemRestorePrompt state if user has an unrestored backup', async () => {
+  //   const state = new StoreBuilder().withUnrestoredBackup();
+  //   const { storeState } = await subject(systemInitiatedCreateBackupDialog)
+  //     .withReducer(rootReducer, state.build())
+  //     .run();
+
+  //   expect(storeState.matrix.isBackupDialogOpen).toBe(true);
+  //   expect(storeState.matrix.restoreBackupStage).toBe(RestoreBackupStage.SystemRestorePrompt);
+  // });
+
+  // it('opens the backup dialog in RecoveredBackupInfo state if user has a restored backup', async () => {
+  //   const state = new StoreBuilder().withRestoredBackup();
+  //   const { storeState } = await subject(systemInitiatedRestoreBackupDialog)
+  //     .withReducer(rootReducer, state.build())
+  //     .run();
+
+  //   expect(storeState.matrix.isBackupDialogOpen).toBe(true);
+  //   expect(storeState.matrix.restoreBackupStage).toBe(RestoreBackupStage.RecoveredBackupInfo);
+  // });
+});
+
+describe(systemInitiatedRestoreBackupDialog, () => {
+  it('opens the restore backup dialog in SystemRestorePrompt state if user has an unrestored backup', async () => {
     const state = new StoreBuilder().withUnrestoredBackup();
-    const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+    const { storeState } = await subject(systemInitiatedRestoreBackupDialog)
+      .withReducer(rootReducer, state.build())
+      .run();
 
-    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.SystemRestorePrompt);
+    expect(storeState.matrix.isRestoreBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.restoreBackupStage).toBe(RestoreBackupStage.SystemRestorePrompt);
   });
 
-  it('opens the backup dialog in RecoveredBackupInfo state if user has a restored backup', async () => {
+  it('opens the restore backup dialog in RecoveredBackupInfo state if user has a restored backup', async () => {
     const state = new StoreBuilder().withRestoredBackup();
-    const { storeState } = await subject(systemInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+    const { storeState } = await subject(systemInitiatedRestoreBackupDialog)
+      .withReducer(rootReducer, state.build())
+      .run();
 
-    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.RecoveredBackupInfo);
+    expect(storeState.matrix.isRestoreBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.restoreBackupStage).toBe(RestoreBackupStage.RecoveredBackupInfo);
   });
 });
 
-describe(userInitiatedBackupDialog, () => {
-  it('opens the backup dialog in UserGeneratePrompt state if user has no backup', async () => {
+describe(userInitiatedCreateBackupDialog, () => {
+  it('opens the create backup dialog in UserGeneratePrompt state if user has no backup', async () => {
     const state = new StoreBuilder().withoutBackup();
-    const { storeState } = await subject(userInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+    const { storeState } = await subject(userInitiatedCreateBackupDialog).withReducer(rootReducer, state.build()).run();
 
-    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.UserGeneratePrompt);
+    expect(storeState.matrix.isCreateBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.createBackupStage).toBe(CreateBackupStage.UserGeneratePrompt);
   });
 
-  it('opens the backup dialog in UserRestorePrompt state if user has an unrestored backup', async () => {
-    const state = new StoreBuilder().withUnrestoredBackup();
-    const { storeState } = await subject(userInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+  // it('opens the backup dialog in UserRestorePrompt state if user has an unrestored backup', async () => {
+  //   const state = new StoreBuilder().withUnrestoredBackup();
+  //   const { storeState } = await subject(userInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
 
-    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.UserRestorePrompt);
-  });
+  //   expect(storeState.matrix.isBackupDialogOpen).toBe(true);
+  //   expect(storeState.matrix.backupStage).toBe(BackupStage.UserRestorePrompt);
+  // });
 
-  it('opens the backup dialog in RecoveredBackupInfo state if user has a restored backup', async () => {
+  // it('opens the backup dialog in RecoveredBackupInfo state if user has a restored backup', async () => {
+  //   const state = new StoreBuilder().withRestoredBackup();
+  //   const { storeState } = await subject(userInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+
+  //   expect(storeState.matrix.isBackupDialogOpen).toBe(true);
+  //   expect(storeState.matrix.backupStage).toBe(BackupStage.RecoveredBackupInfo);
+  // });
+
+  it('does not open the backup dialog if user has a restored backup', async () => {
     const state = new StoreBuilder().withRestoredBackup();
-    const { storeState } = await subject(userInitiatedBackupDialog).withReducer(rootReducer, state.build()).run();
+    const { storeState } = await subject(userInitiatedCreateBackupDialog).withReducer(rootReducer, state.build()).run();
 
-    expect(storeState.matrix.isBackupDialogOpen).toBe(true);
-    expect(storeState.matrix.backupStage).toBe(BackupStage.RecoveredBackupInfo);
+    expect(storeState.matrix.isCreateBackupDialogOpen).toBe(false);
+  });
+});
+
+describe(userInitiatedRestoreBackupDialog, () => {
+  it('opens the restore backup dialog in UserRestorePrompt state if user has an unrestored backup', async () => {
+    const state = new StoreBuilder().withUnrestoredBackup();
+    const { storeState } = await subject(userInitiatedRestoreBackupDialog)
+      .withReducer(rootReducer, state.build())
+      .run();
+
+    expect(storeState.matrix.isRestoreBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.restoreBackupStage).toBe(RestoreBackupStage.UserRestorePrompt);
+  });
+
+  it('opens the restore backup dialog in RecoveredBackupInfo state if user has a restored backup', async () => {
+    const state = new StoreBuilder().withRestoredBackup();
+    const { storeState } = await subject(userInitiatedRestoreBackupDialog)
+      .withReducer(rootReducer, state.build())
+      .run();
+
+    expect(storeState.matrix.isRestoreBackupDialogOpen).toBe(true);
+    expect(storeState.matrix.restoreBackupStage).toBe(RestoreBackupStage.RecoveredBackupInfo);
+  });
+
+  it('does not open the restore backup dialog if user has no backup', async () => {
+    const state = new StoreBuilder().withoutBackup();
+    const { storeState } = await subject(userInitiatedRestoreBackupDialog)
+      .withReducer(rootReducer, state.build())
+      .run();
+
+    expect(storeState.matrix.isRestoreBackupDialogOpen).toBe(false);
   });
 });
 

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -8,9 +8,15 @@ import {
   setErrorMessage,
   setLoaded,
   setSuccessMessage,
-  setIsBackupDialogOpen,
-  setBackupStage,
-  BackupStage,
+  // setIsBackupDialogOpen,
+  // setBackupStage,
+  // BackupStage,
+  setIsCreateBackupDialogOpen,
+  setIsRestoreBackupDialogOpen,
+  setCreateBackupStage,
+  setRestoreBackupStage,
+  CreateBackupStage,
+  RestoreBackupStage,
   setBackupExists,
   setBackupRestored,
   setRestoreProgress,
@@ -34,9 +40,15 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.SaveBackup, saveBackup);
   yield takeLatest(SagaActionTypes.RestoreBackup, restoreBackup);
   yield takeLatest(SagaActionTypes.ClearBackup, clearBackupState);
-  yield takeLatest(SagaActionTypes.OpenBackupDialog, userInitiatedBackupDialog);
-  yield takeLatest(SagaActionTypes.CloseBackupDialog, closeBackupDialog);
-  yield takeLatest(SagaActionTypes.VerifyKey, proceedToVerifyKey);
+  // yield takeLatest(SagaActionTypes.OpenBackupDialog, userInitiatedBackupDialog);
+  yield takeLatest(SagaActionTypes.CloseCreateBackupDialog, closeCreateBackupDialog);
+  yield takeLatest(SagaActionTypes.CloseRestoreBackupDialog, closeRestoreBackupDialog);
+  // yield takeLatest(SagaActionTypes.VerifyKey, proceedToVerifyKey);
+
+  yield takeLatest(SagaActionTypes.OpenCreateBackupDialog, userInitiatedCreateBackupDialog);
+  yield takeLatest(SagaActionTypes.OpenRestoreBackupDialog, userInitiatedRestoreBackupDialog);
+  yield takeLatest(SagaActionTypes.VerifyCreatedKey, proceedToVerifyCreatedKey);
+  yield takeLatest(SagaActionTypes.VerifyRestorationKey, proceedToVerifyRestorationKey);
 
   // For debugging
   yield takeLatest(SagaActionTypes.DebugDeviceList, debugDeviceList);
@@ -80,7 +92,7 @@ export function* receiveBackupData(existingBackup: MatrixKeyBackupInfo | null) {
 
 export function* generateBackup() {
   yield put(setErrorMessage(''));
-  yield put(setBackupStage(BackupStage.GenerateBackup));
+  yield put(setCreateBackupStage(CreateBackupStage.GenerateBackup));
 
   const chatClient = yield call(chat.get);
 
@@ -89,18 +101,26 @@ export function* generateBackup() {
     yield put(setGeneratedRecoveryKey(key.encodedPrivateKey));
   } catch (error) {
     yield put(setErrorMessage('Failed to generate backup key. Please try again.'));
-    yield call(userInitiatedBackupDialog);
+    yield call(userInitiatedCreateBackupDialog);
   }
 }
 
-export function* proceedToVerifyKey() {
-  const existingKey: string | null = yield select((state) => state.matrix.generatedRecoveryKey);
+// export function* proceedToVerifyKey() {
+//   const existingKey: string | null = yield select((state) => state.matrix.generatedRecoveryKey);
 
-  if (existingKey) {
-    yield put(setBackupStage(BackupStage.VerifyKeyPhrase));
-  } else {
-    yield put(setBackupStage(BackupStage.RestoreBackup));
-  }
+//   if (existingKey) {
+//     yield put(setBackupStage(BackupStage.VerifyKeyPhrase));
+//   } else {
+//     yield put(setBackupStage(BackupStage.RestoreBackup));
+//   }
+// }
+
+export function* proceedToVerifyCreatedKey() {
+  yield put(setCreateBackupStage(CreateBackupStage.VerifyKeyPhrase));
+}
+
+export function* proceedToVerifyRestorationKey() {
+  yield put(setRestoreBackupStage(RestoreBackupStage.RestoreBackup));
 }
 
 export function* saveBackup(action) {
@@ -120,7 +140,7 @@ export function* saveBackup(action) {
 
     yield put(setGeneratedRecoveryKey(null));
     yield call(getBackup);
-    yield put(setBackupStage(BackupStage.Success));
+    yield put(setCreateBackupStage(CreateBackupStage.Success));
     yield put(setSuccessMessage('Account backup successful'));
     yield put(setErrorMessage(''));
   } catch {
@@ -153,7 +173,7 @@ export function* restoreBackup(action) {
     yield cancel(progressTask);
 
     yield call(getBackup);
-    yield put(setBackupStage(BackupStage.Success));
+    yield put(setRestoreBackupStage(RestoreBackupStage.Success));
     yield put(setSuccessMessage('Login successfully verified!'));
   } catch (e: any) {
     Sentry.captureException(e, {
@@ -203,27 +223,58 @@ export function* ensureUserHasBackup() {
   const backup = yield call(getSecureBackup);
   if (!backup) {
     if (yield call(performUnlessLogout, delay(5000))) {
-      yield call(systemInitiatedBackupDialog);
+      yield call(systemInitiatedCreateBackupDialog);
     }
   }
 }
 
-export function* closeBackupDialog() {
-  yield put(setIsBackupDialogOpen(false));
+export function* closeCreateBackupDialog() {
+  yield put(setIsCreateBackupDialogOpen(false));
 }
 
-export function* userInitiatedBackupDialog() {
-  const { backupExists, backupRestored } = yield select((state) => state.matrix);
+export function* closeRestoreBackupDialog() {
+  yield put(setIsRestoreBackupDialogOpen(false));
+}
+
+// export function* userInitiatedBackupDialog() {
+//   const { backupExists, backupRestored } = yield select((state) => state.matrix);
+
+//   if (!backupExists) {
+//     yield put(setBackupStage(BackupStage.UserGeneratePrompt));
+//   } else if (!backupRestored) {
+//     yield put(setBackupStage(BackupStage.UserRestorePrompt));
+//   } else {
+//     yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
+//   }
+
+//   yield put(setIsBackupDialogOpen(true));
+// }
+
+export function* userInitiatedCreateBackupDialog() {
+  const { backupExists } = yield select((state) => state.matrix);
 
   if (!backupExists) {
-    yield put(setBackupStage(BackupStage.UserGeneratePrompt));
-  } else if (!backupRestored) {
-    yield put(setBackupStage(BackupStage.UserRestorePrompt));
+    yield put(setCreateBackupStage(CreateBackupStage.UserGeneratePrompt));
+    yield put(setIsCreateBackupDialogOpen(true));
   } else {
-    yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
+    yield put(setErrorMessage('A backup already exists. Please use the restore flow instead.'));
   }
+}
 
-  yield put(setIsBackupDialogOpen(true));
+export function* userInitiatedRestoreBackupDialog() {
+  const { backupExists, backupRestored } = yield select((state) => state.matrix);
+
+  if (backupExists) {
+    if (!backupRestored) {
+      yield put(setRestoreBackupStage(RestoreBackupStage.UserRestorePrompt));
+      yield put(setIsRestoreBackupDialogOpen(true));
+    } else {
+      yield put(setRestoreBackupStage(RestoreBackupStage.RecoveredBackupInfo));
+      yield put(setIsRestoreBackupDialogOpen(true));
+    }
+  } else {
+    yield put(setErrorMessage('No backup exists to restore. Please create a backup first.'));
+  }
 }
 
 function* listenForUserLogout() {
@@ -248,31 +299,56 @@ export function* handleBackupUserPrompts() {
     return;
   }
 
-  const { backupExists, backupRestored } = yield call(getBackup);
-  if (!backupExists) {
-    return yield call(performUnlessLogout, call(checkBackupOnFirstSentMessage));
-  }
+  try {
+    const { backupExists, backupRestored } = yield call(getBackup);
+    if (!backupExists) {
+      return yield call(performUnlessLogout, call(checkBackupOnFirstSentMessage));
+    }
 
-  if (backupRestored) {
-    return;
-  }
+    if (backupRestored) {
+      return;
+    }
 
-  yield call(systemInitiatedBackupDialog);
+    yield call(systemInitiatedRestoreBackupDialog);
+  } catch (e) {
+    console.error('Error handling backup user prompts:', e);
+  }
 }
 
-export function* systemInitiatedBackupDialog() {
-  const { backupExists, backupRestored } = yield select((state) => state.matrix);
+// export function* systemInitiatedBackupDialog() {
+//   const { backupExists, backupRestored } = yield select((state) => state.matrix);
+
+//   if (!backupExists) {
+//     yield put(setBackupStage(BackupStage.SystemGeneratePrompt));
+//   } else if (!backupRestored) {
+//     yield put(setBackupStage(BackupStage.SystemRestorePrompt));
+//   } else {
+//     // Probably never trigger this stage by the system but keep it as a default case
+//     yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
+//   }
+
+//   yield put(setIsBackupDialogOpen(true));
+// }
+
+export function* systemInitiatedCreateBackupDialog() {
+  const { backupExists } = yield select((state) => state.matrix);
 
   if (!backupExists) {
-    yield put(setBackupStage(BackupStage.SystemGeneratePrompt));
-  } else if (!backupRestored) {
-    yield put(setBackupStage(BackupStage.SystemRestorePrompt));
-  } else {
-    // Probably never trigger this stage by the system but keep it as a default case
-    yield put(setBackupStage(BackupStage.RecoveredBackupInfo));
+    yield put(setCreateBackupStage(CreateBackupStage.SystemGeneratePrompt));
+    yield put(setIsCreateBackupDialogOpen(true));
+  }
+}
+
+export function* systemInitiatedRestoreBackupDialog() {
+  const { backupExists, backupRestored } = yield select((state) => state.matrix);
+
+  if (backupExists && !backupRestored) {
+    yield put(setRestoreBackupStage(RestoreBackupStage.SystemRestorePrompt));
+  } else if (backupExists && backupRestored) {
+    yield put(setRestoreBackupStage(RestoreBackupStage.RecoveredBackupInfo));
   }
 
-  yield put(setIsBackupDialogOpen(true));
+  yield put(setIsRestoreBackupDialogOpen(true));
 }
 
 export function* checkBackupOnFirstSentMessage() {


### PR DESCRIPTION
### What does this do?
- This PR separates the backup creation and restoration flows.

### Why are we making this change?
- To improve user experience, prevent accidental backup creation when a backup already exists, and enhance maintainability by ensuring changes in one flow don't affect the other.

NOTE :: This is a work in progress. I'll be adding separate containers for the create and restore backup flows next.

### How do I test this?
- Run tests as usual
- Note :: dialogs are not yet wired up to test when running the UI. You can run the UI and check which dialog container element is rendered (CREATE or RESTORE) however, these will not be cleared correctly.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
