### PR TITLE
Add `verifyMatrixProfileIsSynced` 

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -84,6 +84,7 @@ export interface IChatClient {
     isThumbnail: boolean,
     batchSize: number
   ): Promise<{ [fileUrl: string]: string }>;
+  verifyMatrixProfileIsSynced(profileInfo: MatrixProfileInfo): Promise<void>;
   editProfile(profileInfo: MatrixProfileInfo): Promise<void>;
   getAccessToken(): string | null;
   mxcUrlToHttp(mxcUrl: string): string;
@@ -399,6 +400,10 @@ export function getProfileInfo(userId: string): Promise<{
 
 export async function getAliasForRoomId(roomId: string) {
   return chat.get().matrix.getAliasForRoomId(roomId);
+}
+
+export async function verifyMatrixProfileIsSynced(profileInfo: MatrixProfileInfo) {
+  return chat.get().matrix.verifyMatrixProfileIsSynced(profileInfo);
 }
 
 const ClientFactory = {

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -842,6 +842,20 @@ export class MatrixClient implements IChatClient {
     return downloadResultsMap;
   }
 
+  async verifyMatrixProfileIsSynced(profileInfo: MatrixProfileInfo) {
+    await this.waitForConnection();
+    const { displayName, avatarUrl } = profileInfo;
+    const currentProfileInfo = await this.getProfileInfo(this.userId);
+
+    if (displayName && currentProfileInfo.displayname !== displayName) {
+      await this.matrix.setDisplayName(displayName);
+    }
+
+    if (avatarUrl && currentProfileInfo.avatar_url !== avatarUrl) {
+      await this.matrix.setAvatarUrl(avatarUrl);
+    }
+  }
+
   async editProfile(profileInfo: MatrixProfileInfo = {}) {
     await this.waitForConnection();
     if (profileInfo.displayName) {
@@ -1683,7 +1697,6 @@ export class MatrixClient implements IChatClient {
 
   private mapUser(matrixId: string): UserModel {
     const user = this.matrix.getUser(matrixId);
-
     return {
       userId: matrixId,
       matrixId,


### PR DESCRIPTION
### What does this do?

For some users we're having this sort of data in synapse database:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/f45a84c6-dd2b-4016-a321-437508f99922" />

This PR adds an additional check for users so that their ZERO profile info (displayname, avatar) gets synced with their matrix profile state. (so that the displayname here is actually their name, not a uuid).

Also added a Sentry log where i think the bug is occurring.
