### PR TITLE
fix(chat-view): prevent matrix encrypted message and display "Message hidden" for encrypted messages in chat view

### DIFF
--- a/src/components/chat-view-container/utils.test.ts
+++ b/src/components/chat-view-container/utils.test.ts
@@ -291,6 +291,18 @@ describe(processMessages, () => {
     expect(processed[0]).toBe(messages[0]);
     expect(processed[1]).toBe(messages[1]);
   });
+
+  it('sets message content to "Message hidden" for hidden messages', () => {
+    const messages = [
+      stubMessage({ id: '1', message: 'original message', isHidden: true }),
+      stubMessage({ id: '2', message: 'normal message', isHidden: false }),
+    ];
+
+    const { messages: processed } = processMessages(messages);
+
+    expect(processed[0].message).toBe('Message hidden');
+    expect(processed[1].message).toBe('normal message');
+  });
 });
 
 function stubMessage(attrs: Partial<MessageModel> = {}) {

--- a/src/components/chat-view-container/utils.ts
+++ b/src/components/chat-view-container/utils.ts
@@ -99,6 +99,14 @@ export function processMessages(messages: MessageModel[]) {
 
   // Process regular messages
   const processedMessages = messages.map((message) => {
+    // Handle hidden messages
+    if (message.isHidden) {
+      message = {
+        ...message,
+        message: 'Message hidden',
+      };
+    }
+
     // Handle parent messages
     if (message.parentMessageId) {
       const parentMessage = messagesById.get(message.parentMessageId);


### PR DESCRIPTION
### What does this do?
- Adding logic to set message content to "Message hidden" when isHidden is true in the processMessages function

### Why are we making this change?
- To ensure encrypted messages that can't be decrypted show a consistent "Message hidden" message in the chat view instead of showing Matrix errors

### How do I test this?
- run tests as usual
- run UI and check chat view when opening a conversation with encrypted messages for correct message hidden message

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
  
  Before
<img width="569" alt="Screenshot 2025-04-09 at 13 26 02" src="https://github.com/user-attachments/assets/d4d496b4-10f6-44be-baa4-73fd366198df" />

 After
<img width="558" alt="Screenshot 2025-04-09 at 13 26 49" src="https://github.com/user-attachments/assets/9314a5f1-cacc-4590-b484-b08a8c2602d7" />
