### PR TITLE
fix(messenger-list): prevent matrix encrypted message and display "Message hidden" for encrypted messages in messenger list

### DIFF
--- a/src/components/messenger/list/index.test.tsx
+++ b/src/components/messenger/list/index.test.tsx
@@ -348,6 +348,32 @@ describe('messenger-list', () => {
           'Jack: recent message',
         ]);
       });
+
+      it('displays "Message hidden" for hidden messages in the preview', () => {
+        const state = subject([
+          {
+            id: 'convo-1',
+            lastMessage: {
+              message: 'The last message',
+              sender: { firstName: 'Jack' },
+              isHidden: true,
+            },
+          },
+          {
+            id: 'convo-2',
+            lastMessage: {
+              message: 'Second message last',
+              sender: { firstName: 'Jack' },
+              isHidden: false,
+            },
+          },
+        ]);
+
+        expect(state.conversations.map((c) => c.messagePreview)).toEqual([
+          'Jack: Message hidden',
+          'Jack: Second message last',
+        ]);
+      });
     });
 
     test('previewDisplayDate', () => {

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -346,6 +346,14 @@ function addLastMessageMeta(state: RootState): any {
     // Use the most recent valid message or fall back to the lastMessage
     let mostRecentMessage = filteredMessages[0] || conversation.lastMessage;
 
+    // If the message is hidden, set its content to "Message hidden" before generating the preview
+    if (mostRecentMessage?.isHidden) {
+      mostRecentMessage = {
+        ...mostRecentMessage,
+        message: 'Message hidden',
+      };
+    }
+
     return {
       ...conversation,
       mostRecentMessage,


### PR DESCRIPTION
### What does this do?
- Adding logic to set message content to "Message hidden" when isHidden is true in the addLastMessageMeta function

### Why are we making this change?
- To ensure encrypted messages that can't be decrypted show a consistent "Message hidden" message in the messenger list instead of showing Matrix errors

### How do I test this?
- run tests as usual
- run UI and check encrypted conversations message preview in the conversation list

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?

Before: 
<img width="313" alt="Screenshot 2025-04-09 at 13 25 45" src="https://github.com/user-attachments/assets/b44bc4ff-f3de-4d8c-81e2-133426f458ea" />


After:
<img width="293" alt="Screenshot 2025-04-09 at 13 26 41" src="https://github.com/user-attachments/assets/1e527382-bb66-45fc-950e-35dd2c2d270c" />
