### PR TITLE
fix(matrix-saga): update backup restoration check to consider both trust and decryption key matches

### DIFF
--- a/src/store/matrix/saga.test.ts
+++ b/src/store/matrix/saga.test.ts
@@ -437,7 +437,7 @@ describe(receiveBackupData, () => {
 
     const { returnValue, storeState } = await subject(receiveBackupData, {
       crossSigning: true,
-      trustInfo: { trusted: false },
+      trustInfo: { trusted: false, matchesDecryptionKey: false },
     })
       .withReducer(rootReducer, state.build())
       .run();
@@ -453,6 +453,21 @@ describe(receiveBackupData, () => {
     const { returnValue, storeState } = await subject(receiveBackupData, {
       crossSigning: true,
       trustInfo: { trusted: true },
+    })
+      .withReducer(rootReducer, state.build())
+      .run();
+
+    expect(storeState.matrix.backupExists).toBe(true);
+    expect(storeState.matrix.backupRestored).toBe(true);
+    expect(returnValue).toEqual({ backupExists: true, backupRestored: true });
+  });
+
+  it('sets metadata if backup exists and is not trusted but matches the decryption key', async () => {
+    const state = new StoreBuilder().withOtherState({ matrix: { backupExists: true, backupRestored: false } });
+
+    const { returnValue, storeState } = await subject(receiveBackupData, {
+      crossSigning: true,
+      trustInfo: { trusted: false, matchesDecryptionKey: true },
     })
       .withReducer(rootReducer, state.build())
       .run();

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -66,8 +66,8 @@ export function* receiveBackupData(existingBackup: MatrixKeyBackupInfo | null) {
     backupRestored = false;
   } else {
     backupExists = !!existingBackup?.trustInfo;
-    // If the backup is trusted locally, usable, or matches the decryption key, then we consider it restored
-    // There are cases when only one of the two is true but in either case
+    // If the backup is trusted locally, or usable and matches the decryption key, then we consider it restored
+    // There are cases when only two of the three are true but in either case
     // we've found the backup is sufficient to decrypt everything
     backupRestored =
       backupExists && (existingBackup.trustInfo.trusted || existingBackup.trustInfo.matchesDecryptionKey);

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -66,10 +66,11 @@ export function* receiveBackupData(existingBackup: MatrixKeyBackupInfo | null) {
     backupRestored = false;
   } else {
     backupExists = !!existingBackup?.trustInfo;
-    // If the backup is trusted locally or usable, then we consider it restored
+    // If the backup is trusted locally, usable, or matches the decryption key, then we consider it restored
     // There are cases when only one of the two is true but in either case
     // we've found the backup is sufficient to decrypt everything
-    backupRestored = backupExists && existingBackup.trustInfo.trusted;
+    backupRestored =
+      backupExists && (existingBackup.trustInfo.trusted || existingBackup.trustInfo.matchesDecryptionKey);
   }
 
   yield put(setBackupExists(backupExists));


### PR DESCRIPTION
### What does this do?
- We're updating the logic in receiveBackupData to consider a backup as restored if it either has trusted status or matches the decryption key.

### Why are we making this change?
- To ensure backup restoration works correctly in cases where we can decrypt messages even if the trust state isn't fully established, while maintaining security through the trusted status check.

### How do I test this?
- run tests as usual
- run UI and run the restore secure backup flow

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
