### PR TITLE
chore: bump zui version (`1.24.0`) -> (`1.25.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.9",
         "@web3-react/walletlink-connector": "^6.2.13",
-        "@zero-tech/zui": "^1.24.0",
+        "@zero-tech/zui": "^1.25.0",
         "assert": "^2.1.0",
         "blurhash": "^2.0.5",
         "buffer": "^6.0.3",
@@ -12810,10 +12810,9 @@
       "dev": true
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.24.0.tgz",
-      "integrity": "sha512-bXEDQyws8nkg0hT9sT/aLIJjPRmE6tFHKZz5ARC8Msj8vkd2E+M4DY67tpwdbtDPAYh0RN4ujVtkOy2eH0tMtA==",
-      "license": "ISC",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.25.0.tgz",
+      "integrity": "sha512-DRULjyMnl8ElU0OZuSwqQ8QGL1ur6ZhBKab7f6K03XR0pRTdHSn+8zQAKsC/YMKAU3itXMkTUPc55C0ufUa1AA==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.1.2",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -53438,9 +53437,9 @@
       "dev": true
     },
     "@zero-tech/zui": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.24.0.tgz",
-      "integrity": "sha512-bXEDQyws8nkg0hT9sT/aLIJjPRmE6tFHKZz5ARC8Msj8vkd2E+M4DY67tpwdbtDPAYh0RN4ujVtkOy2eH0tMtA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.25.0.tgz",
+      "integrity": "sha512-DRULjyMnl8ElU0OZuSwqQ8QGL1ur6ZhBKab7f6K03XR0pRTdHSn+8zQAKsC/YMKAU3itXMkTUPc55C0ufUa1AA==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.1.2",
         "@radix-ui/react-accordion": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/network-connector": "^6.1.9",
     "@web3-react/walletlink-connector": "^6.2.13",
-    "@zero-tech/zui": "^1.24.0",
+    "@zero-tech/zui": "^1.25.0",
     "assert": "^2.1.0",
     "blurhash": "^2.0.5",
     "buffer": "^6.0.3",


### PR DESCRIPTION
- chore: bump zui version (`1.24.0`) -> (`1.25.0`)