### PR TITLE
fix(matrix-client): prevent duplicate avatar updates by properly comparing MXC and blob URLs in profile sync

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -851,7 +851,20 @@ export class MatrixClient implements IChatClient {
       await this.matrix.setDisplayName(displayName);
     }
 
-    if (avatarUrl && currentProfileInfo.avatar_url !== avatarUrl) {
+    // Only update avatar if both URLs exist and they're different MXC URLs
+    if (avatarUrl && currentProfileInfo.avatar_url) {
+      // Convert both URLs to MXC format for comparison
+      const currentMxcUrl = currentProfileInfo.avatar_url.startsWith('mxc://')
+        ? currentProfileInfo.avatar_url
+        : this.mxcUrlToHttp(currentProfileInfo.avatar_url);
+
+      const newMxcUrl = avatarUrl.startsWith('mxc://') ? avatarUrl : this.mxcUrlToHttp(avatarUrl);
+
+      if (currentMxcUrl !== newMxcUrl) {
+        await this.matrix.setAvatarUrl(avatarUrl);
+      }
+    } else if (avatarUrl && !currentProfileInfo.avatar_url) {
+      // If there's no current avatar but we have a new one, set it
       await this.matrix.setAvatarUrl(avatarUrl);
     }
   }


### PR DESCRIPTION
### What does this do?
- We're modifying the URL comparison logic in verifyMatrixProfileIsSynced to properly handle both MXC and blob URLs when comparing avatars.

### Why are we making this change?
- We're fixing a bug where the system was incorrectly detecting avatar differences between blob and MXC URLs, causing unnecessary avatar update messages to be sent to every conversation on page refresh.

### How do I test this?
- run tests as usual
- run UI and check for avatar admin messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
