### PR TITLE
Fix avatar change message when joining a channel

### DIFF
--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -179,7 +179,7 @@ function getRoomReactionAdminData(content, sender) {
 }
 
 function getRoomMemberAdminData(content, targetUserId, previousContent?) {
-  if (previousContent && previousContent?.avatar_url !== content.avatar_url) {
+  if (previousContent?.avatar_url && previousContent?.avatar_url !== content.avatar_url) {
     return { type: AdminMessageType.MEMBER_AVATAR_CHANGED, userId: targetUserId };
   }
 

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -179,7 +179,7 @@ function getRoomReactionAdminData(content, sender) {
 }
 
 function getRoomMemberAdminData(content, targetUserId, previousContent?) {
-  if (previousContent?.avatar_url !== content.avatar_url) {
+  if (previousContent && previousContent?.avatar_url !== content.avatar_url) {
     return { type: AdminMessageType.MEMBER_AVATAR_CHANGED, userId: targetUserId };
   }
 


### PR DESCRIPTION
### What does this do?

When joining a channel you have no `previousContent`, so it's always going to display an avatar change message.
Now checking for `previousContent` as well
