### PR TITLE
fix(message/user-search): regex escaping in highlightFilter to prevent app crash when typing special characters

### DIFF
--- a/src/components/messenger/lib/utils.test.ts
+++ b/src/components/messenger/lib/utils.test.ts
@@ -57,6 +57,45 @@ describe('highlightFilter', () => {
     expect(result[1].props.children).toEqual('lo');
     expect(result[2]).toEqual(' World');
   });
+
+  it('handles special regex characters in filter', () => {
+    const text = 'Hello? World';
+    const filter = '?';
+
+    const result = highlightFilter(text, filter);
+
+    expect(result.length).toEqual(3);
+    expect(result[0]).toEqual('Hello');
+    expect(result[1].type).toEqual('span');
+    expect(result[1].props.children).toEqual('?');
+    expect(result[2]).toEqual(' World');
+  });
+
+  it('handles multiple special regex characters in filter', () => {
+    const text = 'Hello? World*';
+    const filter = '? World*';
+
+    const result = highlightFilter(text, filter);
+
+    expect(result.length).toEqual(3);
+    expect(result[0]).toEqual('Hello');
+    expect(result[1].type).toEqual('span');
+    expect(result[1].props.children).toEqual('? World*');
+    expect(result[2]).toEqual('');
+  });
+
+  it('handles special regex characters in text but not in filter', () => {
+    const text = 'Hello? World*';
+    const filter = 'World';
+
+    const result = highlightFilter(text, filter);
+
+    expect(result.length).toEqual(3);
+    expect(result[0]).toEqual('Hello? ');
+    expect(result[1].type).toEqual('span');
+    expect(result[1].props.children).toEqual('World');
+    expect(result[2]).toEqual('*');
+  });
 });
 
 describe(getOtherMembersTypingDisplayText, () => {

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -20,7 +20,8 @@ export const conversationToOption = (conversation: Channel): Option[] => {
 };
 
 export const highlightFilter = (text, filter) => {
-  const regex = new RegExp(`(${filter})`, 'i');
+  const escapedFilter = filter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`(${escapedFilter})`, 'i');
 
   if (filter !== '' && text) {
     return text.split(regex).map((part, index) =>


### PR DESCRIPTION
### What does this do?
- We're adding proper regex character escaping to the highlightFilter function 

### Why are we making this change?
- To prevent the app from crashing when users type @ after special characters like question marks, which was causing an invalid regex pattern error.

### How do I test this?
- run tests as usual
- run UI and enter characters in message input/user search 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
