### PR TITLE
fix(message-menu): prevent editing of undecryptable (hidden) messages in message menu

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -285,6 +285,7 @@ export const Message: React.FC<Properties> = ({
         onReportUser={onMenuReportUser}
         isMenuOpen={isMenuOpen}
         isMenuFlying={isMenuFlying}
+        isHidden={isHidden}
       />
     );
   };

--- a/src/components/message/menu/messageMenu.tsx
+++ b/src/components/message/menu/messageMenu.tsx
@@ -28,6 +28,7 @@ export interface MessageMenuProps
   media: Media;
   isMenuOpen?: boolean;
   isMenuFlying?: boolean;
+  isHidden?: boolean;
 }
 
 export const MessageMenu = ({
@@ -46,9 +47,14 @@ export const MessageMenu = ({
   onReportUser,
   isMenuOpen = false,
   isMenuFlying = false,
+  isHidden = false,
 }: MessageMenuProps) => {
   const canEditMessage =
-    isOwner && message && sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED;
+    isOwner &&
+    message &&
+    !isHidden &&
+    sendStatus !== MessageSendStatus.IN_PROGRESS &&
+    sendStatus !== MessageSendStatus.FAILED;
 
   const canDeleteMessage = isOwner && sendStatus !== MessageSendStatus.IN_PROGRESS;
 

--- a/src/components/message/menu/messageMenu.vitest.tsx
+++ b/src/components/message/menu/messageMenu.vitest.tsx
@@ -16,6 +16,7 @@ describe('MessageMenu', () => {
       width: 600,
       name: 'test-image.jpg',
     },
+    isHidden: false,
     isMenuOpen: true,
     onDelete: vi.fn(),
     onEdit: vi.fn(),
@@ -36,6 +37,11 @@ describe('MessageMenu', () => {
     it('should allow editing when user is owner and message is sent', () => {
       render(<MessageMenu {...defaultProps} />);
       expect(screen.getByRole('menuitem', { name: /edit/i })).toBeEnabled();
+    });
+
+    it('should disable editing when message is hidden', () => {
+      render(<MessageMenu {...defaultProps} isHidden={true} />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
     });
 
     it('should disable editing when message is in progress', () => {
@@ -83,6 +89,12 @@ describe('MessageMenu', () => {
       expect(screen.getByRole('menuitem', { name: /edit/i })).toBeEnabled();
       expect(screen.getByRole('menuitem', { name: /delete/i })).toBeEnabled();
       expect(screen.queryByRole('button', { name: /report/i })).not.toBeInTheDocument();
+    });
+
+    it('should disable editing but allow deletion when message is hidden', () => {
+      render(<MessageMenu {...defaultProps} isHidden={true} />);
+      expect(screen.queryByRole('menuitem', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /delete/i })).toBeEnabled();
     });
 
     it('should disable all owner actions when message is in progress', () => {


### PR DESCRIPTION
### What does this do?
- We're adding an isHidden check to the canEditMessage condition in the message menu to prevent editing of messages that cannot be decrypted.

### Why are we making this change?
- To maintain data integrity and security by preventing users from editing messages they cannot decrypt, which could lead to data loss or corruption.

### How do I test this?
- run tests as usual
- run UI and check message menu on messages that are hidden

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
