### PR TITLE
fix(edit-profile): null value warning in EditProfile SelectInput component

### DIFF
--- a/src/components/edit-profile/index.tsx
+++ b/src/components/edit-profile/index.tsx
@@ -204,7 +204,7 @@ export class EditProfile extends React.Component<Properties, State> {
                     items={this.menuItems}
                     label=''
                     placeholder={this.props.currentPrimaryZID || 'None (wallet address)'}
-                    value={this.state.primaryZID}
+                    value={this.state.primaryZID || ''}
                     itemSize='spacious'
                     menuClassName={c('zid-select-menu')}
                   />


### PR DESCRIPTION
### What does this do?
- We're changing the value prop of the SelectInput component to use an empty string as fallback when primaryZID is null.

### Why are we making this change?
- We're making these changes to resolve a React warning about null values being passed to input components.

### How do I test this?
- run tests as usual
- run UI > open profile > edit profile > check console for errors when no zid selected

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
