### PR TITLE
feat(app-bar): add clickable home app navigation to zero app logo in app bar

### DIFF
--- a/src/components/app-bar/index.tsx
+++ b/src/components/app-bar/index.tsx
@@ -121,9 +121,9 @@ export class AppBar extends React.Component<Properties, State> {
     return (
       <>
         <div {...cn('', zAppIsFullscreen && 'zapp-fullscreen')}>
-          <div {...cn('logo-wrapper')}>
+          <Link to='/home' {...cn('logo-wrapper')}>
             <IconLogoZero size={24} />
-          </div>
+          </Link>
           <LegacyPanel {...cn('container')} ref={this.containerRef}>
             <AppLink
               Icon={IconHome}

--- a/src/components/app-bar/index.vitest.tsx
+++ b/src/components/app-bar/index.vitest.tsx
@@ -157,4 +157,13 @@ describe(AppBar, () => {
       expect(panel.classList.contains('no-hover')).toBe(false);
     });
   });
+
+  describe('Logo Navigation', () => {
+    it('should navigate to home when clicking the logo', () => {
+      const { getByTestId } = renderComponent({});
+      const logoLink = getByTestId('icon-logo-zero').closest('a');
+
+      expect(logoLink).toHaveAttribute('to', '/home');
+    });
+  });
 });


### PR DESCRIPTION
### What: 
- adding a Link component around the IconLogoZero to make it navigate to the home page when clicked.

### Why: 
- To provide a standard UX pattern where clicking the logo returns users to the home page.

### How do I test this?
- run tests as usual
- run UI and click zero app logo in app bar > check navigates to Home app 

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
