### PR TITLE
feat(app-bar/current-user): add toggle behavior to user profile button

### DIFF
--- a/src/components/app-bar/current-user/index.vitest.tsx
+++ b/src/components/app-bar/current-user/index.vitest.tsx
@@ -71,6 +71,7 @@ vi.mock('../../verify-id-dialog', () => ({
 
 const mockTotalRewardsViewed = vi.fn();
 const mockOpenUserProfile = vi.fn();
+const mockCloseUserProfile = vi.fn();
 const mockCloseVerifyIdDialog = vi.fn();
 const mockOpenVerifyIdDialog = vi.fn();
 
@@ -155,6 +156,26 @@ describe('CurrentUser Component', () => {
     fireEvent.click(containerElement);
 
     expect(mockOpenUserProfile).toHaveBeenCalled();
+    expect(mockTotalRewardsViewed).toHaveBeenCalled();
+  });
+
+  it('should close user profile when clicked while open', () => {
+    currentMockHook = {
+      ...DEFAULT_HOOK_RETURN,
+      onClick: () => {
+        mockCloseUserProfile();
+        mockTotalRewardsViewed();
+      },
+    };
+
+    const { container } = render(<CurrentUser />);
+
+    const containerElement = container.querySelector('.Container');
+    expect(containerElement).toBeInTheDocument();
+
+    fireEvent.click(containerElement);
+
+    expect(mockCloseUserProfile).toHaveBeenCalled();
     expect(mockTotalRewardsViewed).toHaveBeenCalled();
   });
 

--- a/src/components/app-bar/current-user/lib/useCurrentUserDetails.ts
+++ b/src/components/app-bar/current-user/lib/useCurrentUserDetails.ts
@@ -3,7 +3,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { RootState } from '../../../../store/reducer';
 import { totalRewardsViewed } from '../../../../store/rewards';
-import { openUserProfile } from '../../../../store/user-profile';
+import { openUserProfile, closeUserProfile, Stage } from '../../../../store/user-profile';
+import { userProfileStageSelector } from '../../../../store/user-profile/selectors';
 import {
   primaryZIDSelector,
   userFirstNameSelector,
@@ -35,11 +36,16 @@ export const useCurrentUserDetails = (): CurrentUserDetailsReturn => {
   const primaryZID = useSelector(primaryZIDSelector);
   const firstName = useSelector(userFirstNameSelector);
   const profileImage = useSelector(userProfileImageSelector);
+  const userProfileStage = useSelector(userProfileStageSelector);
 
   const [isVerifyIdDialogOpen, setIsVerifyIdDialogOpen] = useState(false);
 
   const handleOnClick = () => {
-    dispatch(openUserProfile());
+    if (userProfileStage === Stage.None) {
+      dispatch(openUserProfile());
+    } else {
+      dispatch(closeUserProfile());
+    }
     dispatch(totalRewardsViewed());
   };
 


### PR DESCRIPTION
### What does this do?
- We're modifying the user profile click handler to toggle between opening and closing the profile instead of always opening it.

### Why are we making this change?
- To improve user experience by allowing users to close the profile with the same button they used to open it.

### How do I test this?
- run tests as usual
- run UI > click user profile avatar to open, click again to close

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
