### PR TITLE
chore: enable `enableProfile` flag

### DIFF
--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -33,5 +33,5 @@ export const productionFlags: FeatureFlagDefinitions = {
       'a8df265e-5e4c-46e9-a6e5-9da8684f96ac',
     ],
   },
-  enableProfile: { defaultValue: false },
+  enableProfile: { defaultValue: true },
 };


### PR DESCRIPTION
### What does this do?

- Enables the `enableProfile` flag by default on production.