### PR TITLE
refactor(message-menu): disable reply functionality for GIF messages

### DIFF
--- a/src/components/message/menu/messageMenu.tsx
+++ b/src/components/message/menu/messageMenu.tsx
@@ -60,7 +60,8 @@ export const MessageMenu = ({
 
   const canReportUser = !isOwner && sendStatus !== MessageSendStatus.IN_PROGRESS;
 
-  const canReply = sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED;
+  const canReply =
+    sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED && !isGiphyMessage(media);
 
   const canViewInfo = sendStatus !== MessageSendStatus.IN_PROGRESS && sendStatus !== MessageSendStatus.FAILED;
 
@@ -91,4 +92,8 @@ export const MessageMenu = ({
       isMenuFlying={isMenuFlying}
     />
   );
+};
+
+const isGiphyMessage = (media: Media) => {
+  return media?.type === MediaType.Image && media?.mimetype === 'image/gif';
 };

--- a/src/components/message/menu/messageMenu.vitest.tsx
+++ b/src/components/message/menu/messageMenu.vitest.tsx
@@ -168,6 +168,11 @@ describe('MessageMenu', () => {
       expect(screen.queryByRole('menuitem', { name: /reply/i })).not.toBeInTheDocument();
     });
 
+    it('should disable reply when message is a GIF', () => {
+      render(<MessageMenu {...defaultProps} media={{ ...defaultProps.media, mimetype: 'image/gif' }} />);
+      expect(screen.queryByRole('menuitem', { name: /reply/i })).not.toBeInTheDocument();
+    });
+
     it('should call onReply when reply button is clicked', async () => {
       render(<MessageMenu {...defaultProps} />);
       fireEvent.click(screen.getByRole('menuitem', { name: /reply/i }));


### PR DESCRIPTION
### What does this do?
- We're modifying the canReply logic in the MessageMenu component to disable replies for GIF messages by checking the mimetype.

### Why are we making this change?
- To maintain consistency with the mobile app's limitations where GIF messages cannot be replied to due to Matrix Rust SDK compatibility issues.

### How do I test this?
- run tests as usual
- run UI and check that reply option is not available on gif messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
