### PR TITLE
refactor(components/message): disable reactions for GIF messages

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -291,6 +291,8 @@ export const Message: React.FC<Properties> = ({
   };
 
   const renderMenu = () => {
+    const isGif = media?.mimetype === 'image/gif';
+
     return (
       <div
         {...cn(
@@ -301,7 +303,8 @@ export const Message: React.FC<Properties> = ({
         )}
         onClick={handleCloseMenu}
       >
-        <IconButton {...cn('menu-item')} onClick={openReactionPicker} Icon={IconHeart} size={32} />
+        {!isGif && <IconButton {...cn('menu-item')} onClick={openReactionPicker} Icon={IconHeart} size={32} />}
+
         <Menu isMenuOpen={isMessageMenuOpen} />
       </div>
     );


### PR DESCRIPTION
### What does this do?
- We're modifying the renderMenu function in the Message component to hide the reaction button for GIF messages.

### Why are we making this change?
- To maintain consistency with the iOS app where reactions are disabled for GIF messages due to Matrix Rust SDK compatibility issues.

### How do I test this?
- run tests as usual
- check reactions are disabled on gif messages

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
