### PR TITLE
refactor(create-optimistic-message-object): set correct mimetype for GIPHY messages in optimistic message creation

### DIFF
--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -28,7 +28,7 @@ export function createOptimisticMessageObject(
       type: file.mediaType,
       url: file.giphy ? file.giphy.images.downsized.url : file.url,
       name: file.name,
-      mimetype: file.nativeFile ? file.nativeFile.type : null,
+      mimetype: file.giphy ? 'image/gif' : file.nativeFile ? file.nativeFile.type : null,
       // Not sure why these are in our types as I don't think we use them at all
       // I'm guessing this is for rendering a loaded message when the image hasn't downloaded yet
       // but we're not doing that yet.


### PR DESCRIPTION
### What does this do?
- We're modifying the createOptimisticMessageObject function to set the mimetype to 'image/gif' for GIPHY messages during optimistic message creation.

### Why are we making this change?
- To ensure that reaction and reply options are disabled immediately when a GIPHY message is sent, rather than only after a page refresh, by correctly identifying GIPHY messages from the moment they appear in the UI.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
