### PR TITLE
feat(feed/components/show-more-button): add ShowMoreButton component for truncating long posts in feed

### DIFF
--- a/src/apps/feed/components/show-more-button/index.tsx
+++ b/src/apps/feed/components/show-more-button/index.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react';
+import classNames from 'classnames';
+import styles from './styles.module.scss';
+
+interface ShowMoreButtonProps {
+  className?: string;
+
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export const ShowMoreButton: FC<ShowMoreButtonProps> = ({ className, onClick }) => {
+  return (
+    <button
+      className={classNames(styles.ShowMore, className)}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick(e);
+      }}
+    >
+      Show more
+    </button>
+  );
+};

--- a/src/apps/feed/components/show-more-button/index.vitest.tsx
+++ b/src/apps/feed/components/show-more-button/index.vitest.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ShowMoreButton } from '.';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+describe('ShowMoreButton', () => {
+  const renderShowMore = (props = {}) => {
+    const defaultProps = {
+      onClick: vi.fn(),
+      ...props,
+    };
+
+    return render(<ShowMoreButton {...defaultProps} />);
+  };
+
+  it('should render the "Show more" text', () => {
+    renderShowMore();
+    expect(screen.getByText('Show more')).toBeInTheDocument();
+  });
+
+  it('should apply custom className when provided', () => {
+    const customClass = 'custom-class';
+    renderShowMore({ className: customClass });
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(customClass);
+  });
+
+  it('should call onClick handler when clicked', () => {
+    const onClick = vi.fn();
+    renderShowMore({ onClick });
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should stop event propagation when clicked', () => {
+    const onClick = vi.fn();
+    const containerClick = vi.fn();
+
+    render(
+      <div onClick={containerClick}>
+        <ShowMoreButton onClick={onClick} />
+      </div>
+    );
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalled();
+    expect(containerClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/apps/feed/components/show-more-button/styles.module.scss
+++ b/src/apps/feed/components/show-more-button/styles.module.scss
@@ -1,0 +1,14 @@
+.ShowMore {
+  color: var(--color-secondary-11);
+  background: none;
+  border: none;
+  padding: 4px 0;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
### What does this do?
- Adding a new ShowMoreButton component that handles the expansion of truncated posts, along with its styles and tests.

### Why are we making this change?
- To improve feed readability by collapsing long posts (>280 characters or >3 line breaks) with a "Show more" button, similar to Twitter's implementation.

### How do I test this?
- run tests as usual
- this component is not yet wired up in the UI

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
