### PR TITLE
feat(feed/lib): add analyzePostContent utility for consistent post truncation logic

### DIFF
--- a/src/apps/feed/lib/analyzePostContent.ts
+++ b/src/apps/feed/lib/analyzePostContent.ts
@@ -1,0 +1,53 @@
+interface PostContentAnalysis {
+  shouldTruncate: boolean;
+  truncatedContent: string | null;
+  lineBreakCount: number;
+  characterCount: number;
+}
+
+/**
+ * Analyzes post content to determine if it needs truncation and how it should be truncated.
+ * Posts are truncated if they:
+ * 1. Exceed 280 characters
+ * 2. Have more than 3 line breaks
+ *
+ * @param content - The post content to analyze
+ * @returns Analysis result containing truncation info
+ */
+export const analyzePostContent = (content: string | undefined | null): PostContentAnalysis => {
+  if (!content) {
+    return {
+      shouldTruncate: false,
+      truncatedContent: null,
+      lineBreakCount: 0,
+      characterCount: 0,
+    };
+  }
+
+  const lineBreakCount = (content.match(/\n/g) || []).length;
+  const characterCount = content.length;
+  const shouldTruncate = characterCount > 280 || lineBreakCount > 3;
+
+  if (!shouldTruncate) {
+    return {
+      shouldTruncate: false,
+      truncatedContent: null,
+      lineBreakCount,
+      characterCount,
+    };
+  }
+
+  let truncatedContent: string;
+  if (lineBreakCount > 3) {
+    truncatedContent = content.split('\n').slice(0, 3).join('\n');
+  } else {
+    truncatedContent = content.slice(0, 280);
+  }
+
+  return {
+    shouldTruncate,
+    truncatedContent,
+    lineBreakCount,
+    characterCount,
+  };
+};

--- a/src/apps/feed/lib/analyzePostContent.vitest.ts
+++ b/src/apps/feed/lib/analyzePostContent.vitest.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { analyzePostContent } from './analyzePostContent';
+
+describe('analyzePostContent', () => {
+  it('should handle empty content', () => {
+    const result = analyzePostContent('');
+    expect(result).toEqual({
+      shouldTruncate: false,
+      truncatedContent: null,
+      lineBreakCount: 0,
+      characterCount: 0,
+    });
+  });
+
+  it('should handle null or undefined content', () => {
+    expect(analyzePostContent(null)).toEqual({
+      shouldTruncate: false,
+      truncatedContent: null,
+      lineBreakCount: 0,
+      characterCount: 0,
+    });
+
+    expect(analyzePostContent(undefined)).toEqual({
+      shouldTruncate: false,
+      truncatedContent: null,
+      lineBreakCount: 0,
+      characterCount: 0,
+    });
+  });
+
+  it('should not truncate content within limits', () => {
+    const content = 'This is a normal post\nwith two\nline breaks';
+    const result = analyzePostContent(content);
+    expect(result).toEqual({
+      shouldTruncate: false,
+      truncatedContent: null,
+      lineBreakCount: 2,
+      characterCount: content.length,
+    });
+  });
+
+  it('should truncate content with too many line breaks', () => {
+    const content = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5';
+    const result = analyzePostContent(content);
+    expect(result).toEqual({
+      shouldTruncate: true,
+      truncatedContent: 'Line 1\nLine 2\nLine 3',
+      lineBreakCount: 4,
+      characterCount: content.length,
+    });
+  });
+
+  it('should truncate content exceeding character limit', () => {
+    const content = 'a'.repeat(300);
+    const result = analyzePostContent(content);
+    expect(result).toEqual({
+      shouldTruncate: true,
+      truncatedContent: 'a'.repeat(280),
+      lineBreakCount: 0,
+      characterCount: 300,
+    });
+  });
+
+  it('should prioritize line break truncation over character count', () => {
+    const content = 'a'.repeat(300) + '\n'.repeat(4);
+    const result = analyzePostContent(content);
+    const expectedLines = content.split('\n').slice(0, 3).join('\n');
+
+    expect(result).toEqual({
+      shouldTruncate: true,
+      truncatedContent: expectedLines,
+      lineBreakCount: 4,
+      characterCount: content.length,
+    });
+  });
+});


### PR DESCRIPTION
### What does this do?
Extracting post truncation logic into a dedicated utility function with comprehensive test coverage to handle character count, line breaks, and content analysis.

### Why are we making this change?
To improve code maintainability and reusability by centralizing post truncation logic in one place, making it easier to test and modify truncation rules across all feed views.

### How do I test this?
Run tests as usual
Note :: this is not yet wired up to be used in UI

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
