### PR TITLE
feat(components/post): add text truncation with ellipsis and smooth expansion for long posts (based on analyze post content logic)

### DIFF
--- a/src/apps/feed/components/post-view-container/index.tsx
+++ b/src/apps/feed/components/post-view-container/index.tsx
@@ -55,6 +55,7 @@ export const PostView = ({ postId, isFeed }: PostViewProps) => {
                 userMeowBalance={userMeowBalance}
                 variant='expanded'
                 channelZid={post.channelZid}
+                isSinglePostView={true}
               />
               <CommentInput channelZid={post.channelZid} isFeed={isFeed} postId={postId} />
             </div>

--- a/src/apps/feed/components/post/styles.module.scss
+++ b/src/apps/feed/components/post/styles.module.scss
@@ -45,6 +45,10 @@
 
 .Body {
   font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  white-space: pre-wrap;
+  transition: max-height 0.2s ease-out;
 
   > p:first-child {
     margin-top: 0;
@@ -53,11 +57,29 @@
   > p:last-child {
     margin-bottom: 0;
   }
+
+  &.Truncated {
+    p {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      line-clamp: 3;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      position: relative;
+    }
+  }
+
+  .Date {
+    display: block;
+    margin-top: 16px;
+  }
 }
 
 .Text {
   white-space: pre-wrap;
   word-break: break-word;
+  margin: 0;
 }
 
 .Details {
@@ -105,6 +127,7 @@
 .Date {
   font-size: 12px;
   line-height: normal;
+  margin-top: 4px;
 
   @include glass-text-secondary-color;
 }

--- a/src/apps/feed/components/show-more-button/styles.module.scss
+++ b/src/apps/feed/components/show-more-button/styles.module.scss
@@ -2,7 +2,7 @@
   color: var(--color-secondary-11);
   background: none;
   border: none;
-  padding: 4px 0;
+  padding: 0;
   cursor: pointer;
   font-size: 14px;
   font-weight: 400;


### PR DESCRIPTION
### What does this do?
- Adding proper text truncation with ellipsis, smooth transitions, and a "Show more" button to posts that exceed 280 characters or 3 line breaks.

### Why are we making this change?
- To improve feed readability and user experience by collapsing long posts while maintaining easy access to their full content, similar to Twitter's implementation.

### How do I test this?
- run tests as usual
- run UI > render posts and check long post content is truncated with show more button displayed

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
