### PR TITLE
chore: flip `enableUserProfiles` flag to `true` for `production`

### DIFF
--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -34,5 +34,5 @@ export const productionFlags: FeatureFlagDefinitions = {
     ],
   },
   enableProfile: { defaultValue: true },
-  enableUserProfiles: { defaultValue: false },
+  enableUserProfiles: { defaultValue: true },
 };


### PR DESCRIPTION
### What does this do?

- Flips `enableUserProfiles` flag to `true` for `production`.
