### PR TITLE
feat(lib/hooks): add useScrollPosition hook

### DIFF
--- a/src/lib/hooks/useScrollPosition.ts
+++ b/src/lib/hooks/useScrollPosition.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+export const useScrollPosition = (postId?: string) => {
+  const scrollPositionRef = useRef<number>(0);
+  const clickedPostIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (postId) {
+      scrollPositionRef.current = window.scrollY;
+      clickedPostIdRef.current = postId;
+    } else if (clickedPostIdRef.current) {
+      requestAnimationFrame(() => {
+        window.scrollTo(0, scrollPositionRef.current);
+
+        const postElement = document.querySelector(`[data-post-id="${clickedPostIdRef.current}"]`);
+        if (postElement) {
+          postElement.scrollIntoView({
+            behavior: 'instant',
+            block: 'center',
+          });
+        }
+
+        clickedPostIdRef.current = null;
+      });
+    }
+  }, [postId]);
+
+  return {
+    getScrollPosition: () => scrollPositionRef.current,
+    getClickedPostId: () => clickedPostIdRef.current,
+  };
+};

--- a/src/lib/hooks/useScrollPosition.ts
+++ b/src/lib/hooks/useScrollPosition.ts
@@ -15,7 +15,7 @@ export const useScrollPosition = (postId?: string) => {
         const postElement = document.querySelector(`[data-post-id="${clickedPostIdRef.current}"]`);
         if (postElement) {
           postElement.scrollIntoView({
-            behavior: 'instant',
+            behavior: 'auto',
             block: 'center',
           });
         }

--- a/src/lib/hooks/useScrollPosition.vitest.ts
+++ b/src/lib/hooks/useScrollPosition.vitest.ts
@@ -46,7 +46,7 @@ describe('useScrollPosition', () => {
 
     expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
     expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'instant',
+      behavior: 'auto',
       block: 'center',
     });
   });

--- a/src/lib/hooks/useScrollPosition.vitest.ts
+++ b/src/lib/hooks/useScrollPosition.vitest.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useScrollPosition } from './useScrollPosition';
+
+// Mock window.scrollTo with a proper implementation
+vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
+  Object.defineProperty(window, 'scrollY', { value: y, writable: true });
+});
+
+vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+  cb(0);
+  return 0;
+});
+
+describe('useScrollPosition', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+    vi.clearAllMocks();
+  });
+
+  it('should store scroll position when postId is provided', () => {
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+
+    const { result } = renderHook(() => useScrollPosition('post-123'));
+
+    expect(result.current.getScrollPosition()).toBe(100);
+    expect(result.current.getClickedPostId()).toBe('post-123');
+  });
+
+  it('should restore scroll position when postId becomes undefined', () => {
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+
+    const { rerender } = renderHook(({ postId }) => useScrollPosition(postId), {
+      initialProps: { postId: 'post-123' },
+    });
+
+    const mockElement = document.createElement('div');
+    mockElement.getBoundingClientRect = vi.fn().mockReturnValue({
+      top: 50,
+      bottom: 150,
+    });
+    mockElement.scrollIntoView = vi.fn();
+    vi.spyOn(document, 'querySelector').mockReturnValue(mockElement);
+
+    rerender({ postId: undefined });
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
+    expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'instant',
+      block: 'center',
+    });
+  });
+
+  it('should handle case when post element is not found', () => {
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+
+    const { rerender } = renderHook(({ postId }) => useScrollPosition(postId), {
+      initialProps: { postId: 'post-123' },
+    });
+
+    vi.spyOn(document, 'querySelector').mockReturnValue(null);
+
+    rerender({ postId: undefined });
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
+  });
+
+  it('should not restore scroll position if no postId was previously stored', () => {
+    const { rerender } = renderHook(({ postId }) => useScrollPosition(postId), {
+      initialProps: { postId: undefined },
+    });
+
+    rerender({ postId: 'post-123' });
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/hooks/useScrollPosition.vitest.ts
+++ b/src/lib/hooks/useScrollPosition.vitest.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useScrollPosition } from './useScrollPosition';
 
-// Mock window.scrollTo with a proper implementation
 vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
   Object.defineProperty(window, 'scrollY', { value: y, writable: true });
 });


### PR DESCRIPTION
### What does this do?
- We're adding a new useScrollPosition hook to restore scroll position when navigating back from post view to feed.

### Why are we making this change?
- We're making these changes to improve user experience by maintaining scroll position context when viewing and returning from posts.

### How do I test this?
- run tests as usual
- note this is not yet wired up to the UI

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
