### PR TITLE
feat(components/post): add data-post-id attribute to Post wrapper component for scroll restoration

### DIFF
--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -200,7 +200,14 @@ const Wrapper = ({ children, postId, variant, channelZid }: WrapperProps) => {
   };
 
   return (
-    <div className={styles.Wrapper} data-variant={variant} onClick={handleOnClick} tabIndex={0} role='button'>
+    <div
+      className={styles.Wrapper}
+      data-variant={variant}
+      data-post-id={postId}
+      onClick={handleOnClick}
+      tabIndex={0}
+      role='button'
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
### What does this do?
- We're adding a data-post-id attribute to the Post component wrapper div.

### Why are we making this change?
- We're making these changes to enable scroll position restoration by allowing the hook to find the clicked post element in the DOM.

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
