### PR TITLE
feat(feed): add scroll position restoration to feed app

### DIFF
--- a/src/apps/feed/index.tsx
+++ b/src/apps/feed/index.tsx
@@ -1,7 +1,8 @@
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route, Redirect, useRouteMatch } from 'react-router-dom';
 
 import { useOwnedZids } from '../../lib/hooks/useOwnedZids';
 import { parseWorldZid } from '../../lib/zid';
+import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
 
 import { Feed } from './components/feed';
 import { Sidekick } from './components/sidekick';
@@ -14,6 +15,10 @@ import { getLastActiveFeed } from '../../lib/last-feed';
 import styles from './styles.module.scss';
 
 export const FeedApp = () => {
+  const route = useRouteMatch<{ postId: string }>('/feed/:zid/:postId');
+  const postId = route?.params?.postId;
+  useScrollPosition(postId);
+
   return (
     <div className={styles.Feed}>
       <Sidekick />


### PR DESCRIPTION
### What does this do?
- We're adding the useScrollPosition hook to the FeedApp component to handle scroll position restoration.

### Why are we making this change?
- We're making these changes to enable scroll position restoration when navigating to and from posts in the feed view.

### How do I test this?
- run tests as usual
- run Ui, navigate to feed app, scroll down to a post, click post to expand, and the click back. Check post clicked is in view

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
