### PR TITLE
feat(home): add scroll position restoration to home app

### DIFF
--- a/src/apps/home/index.tsx
+++ b/src/apps/home/index.tsx
@@ -1,12 +1,14 @@
 import { useRouteMatch } from 'react-router-dom';
 import { PostView } from '../feed/components/post-view-container';
 import { Feed } from '../feed/components/feed';
+import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
 
 import styles from './styles.module.scss';
 
 export const HomeApp = () => {
   const route = useRouteMatch<{ postId: string }>('/home/:postId');
   const postId = route?.params?.postId;
+  useScrollPosition(postId);
 
   if (postId) {
     return (


### PR DESCRIPTION
### What does this do?
- We're adding the useScrollPosition hook to the HomeApp component to handle scroll position restoration.

### Why are we making this change?
- We're making these changes to enable scroll position restoration when navigating to and from posts in the home view.

### How do I test this?
- run tests as usual
- run UI > navigate to home app > scroll down to a post and click > click back button > check post is in view

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
