### PR TITLE
fix(logout-confirmation-modal): prevent non-serializable event data in logout modal close action

### DIFF
--- a/src/components/logout-confirmation-modal/index.tsx
+++ b/src/components/logout-confirmation-modal/index.tsx
@@ -48,6 +48,10 @@ export class LogoutConfirmationModal extends React.Component<Properties> {
     );
   }
 
+  close = () => {
+    this.props.onClose();
+  };
+
   render() {
     return (
       <Modal
@@ -59,8 +63,8 @@ export class LogoutConfirmationModal extends React.Component<Properties> {
         secondaryVariant={Variant.Secondary}
         secondaryColor={Color.Greyscale}
         onPrimary={this.props.onLogout}
-        onSecondary={this.props.onClose}
-        onClose={this.props.onClose}
+        onSecondary={this.close}
+        onClose={this.close}
       >
         <div {...cn()}>
           {!this.props.backupExists && this.noBackupText}


### PR DESCRIPTION
### What does this do?
- We're adding a close method to the LogoutConfirmationModal component that calls onClose without passing event data.

### Why are we making this change?
- To prevent non-serializable event data from reaching Redux actions, which improves performance and follows Redux best practices.

### How do I test this?
- run tests as usual
- run UI > open logout dialog > click close icon or secondary button > check console and check performance

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
