### PR TITLE
fix(logout-confirmation-modal): prevent non-serializable event data in logout modal logout action

### DIFF
--- a/src/components/logout-confirmation-modal/index.tsx
+++ b/src/components/logout-confirmation-modal/index.tsx
@@ -52,6 +52,10 @@ export class LogoutConfirmationModal extends React.Component<Properties> {
     this.props.onClose();
   };
 
+  logout = () => {
+    this.props.onLogout();
+  };
+
   render() {
     return (
       <Modal
@@ -62,7 +66,7 @@ export class LogoutConfirmationModal extends React.Component<Properties> {
         secondaryText='Cancel'
         secondaryVariant={Variant.Secondary}
         secondaryColor={Color.Greyscale}
-        onPrimary={this.props.onLogout}
+        onPrimary={this.logout}
         onSecondary={this.close}
         onClose={this.close}
       >


### PR DESCRIPTION
### What does this do?
- We're adding a logout method to the LogoutConfirmationModal component that calls onLogout without passing event data.

### Why are we making this change?
- To prevent non-serializable event data from reaching Redux actions, which improves performance and follows Redux best practices.

### How do I test this?
- run tests as usual
- run UI > open logout dialog > click logout > check console and performance

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
