### PR TITLE
feat(profile): enable post viewing within profile context

### DIFF
--- a/src/apps/feed/components/post/lib/usePostRoute.ts
+++ b/src/apps/feed/components/post/lib/usePostRoute.ts
@@ -6,12 +6,15 @@ export const usePostRoute = (postId: string, channelZid?: string) => {
   const conversationId = route.params?.conversationId;
   const routeZid = route.params?.zid;
   const isHome = route.path?.startsWith('/home');
+  const isProfile = route.path?.startsWith('/profile');
 
   const navigateToPost = () => {
     if (conversationId) {
       history.push(`/conversation/${conversationId}/${postId}`);
     } else if (isHome) {
       history.push(`/home/${postId}`);
+    } else if (isProfile) {
+      history.push(`/profile/${channelZid ?? routeZid}/${postId}`);
     } else {
       history.push(`/feed/${channelZid ?? routeZid}/${postId}`);
     }

--- a/src/apps/feed/components/post/lib/usePostRoute.vitest.tsx
+++ b/src/apps/feed/components/post/lib/usePostRoute.vitest.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePostRoute } from './usePostRoute';
+import { useHistory, useRouteMatch } from 'react-router-dom';
+
+vi.mock('react-router-dom', () => ({
+  useHistory: vi.fn(),
+  useRouteMatch: vi.fn(),
+}));
+
+describe('usePostRoute', () => {
+  const mockPush = vi.fn();
+  const mockUseHistory = useHistory as unknown as ReturnType<typeof vi.fn>;
+  const mockUseRouteMatch = useRouteMatch as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseHistory.mockReturnValue({ push: mockPush });
+  });
+
+  it('should navigate to conversation post when in conversation context', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { conversationId: 'conv123' },
+      path: '/conversation/conv123',
+    });
+
+    const { result } = renderHook(() => usePostRoute('post123'));
+    result.current.navigateToPost();
+
+    expect(mockPush).toHaveBeenCalledWith('/conversation/conv123/post123');
+  });
+
+  it('should navigate to home post when in home context', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: {},
+      path: '/home',
+    });
+
+    const { result } = renderHook(() => usePostRoute('post123'));
+    result.current.navigateToPost();
+
+    expect(mockPush).toHaveBeenCalledWith('/home/post123');
+  });
+
+  it('should navigate to profile post when in profile context', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123' },
+      path: '/profile/user123',
+    });
+
+    const { result } = renderHook(() => usePostRoute('post123'));
+    result.current.navigateToPost();
+
+    expect(mockPush).toHaveBeenCalledWith('/profile/user123/post123');
+  });
+
+  it('should use channelZid over routeZid in profile context', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123' },
+      path: '/profile/user123',
+    });
+
+    const { result } = renderHook(() => usePostRoute('post123', 'channel123'));
+    result.current.navigateToPost();
+
+    expect(mockPush).toHaveBeenCalledWith('/profile/channel123/post123');
+  });
+
+  it('should navigate to feed post when in feed context', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'channel123' },
+      path: '/feed/channel123',
+    });
+
+    const { result } = renderHook(() => usePostRoute('post123'));
+    result.current.navigateToPost();
+
+    expect(mockPush).toHaveBeenCalledWith('/feed/channel123/post123');
+  });
+
+  it('should use channelZid over routeZid in feed context', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123' },
+      path: '/feed/user123',
+    });
+
+    const { result } = renderHook(() => usePostRoute('post123', 'channel123'));
+    result.current.navigateToPost();
+
+    expect(mockPush).toHaveBeenCalledWith('/feed/channel123/post123');
+  });
+});

--- a/src/apps/profile/index.tsx
+++ b/src/apps/profile/index.tsx
@@ -1,15 +1,28 @@
+import { useRouteMatch } from 'react-router-dom';
 import { UserPanel } from './panels/UserPanel';
 import { Switcher } from './panels/Switcher';
+import { PostView } from '../feed/components/post-view-container';
+import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
 
 import styles from './styles.module.scss';
 
 export const ProfileApp = () => {
+  const route = useRouteMatch<{ zid: string; postId?: string }>('/profile/:zid/:postId?');
+  const postId = route?.params?.postId;
+  useScrollPosition(postId);
+
   return (
     <div className={styles.Wrapper}>
-      <Switcher />
-      <div>
-        <UserPanel />
-      </div>
+      {postId ? (
+        <PostView postId={postId} isFeed={true} />
+      ) : (
+        <>
+          <Switcher />
+          <div>
+            <UserPanel />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/apps/profile/index.tsx
+++ b/src/apps/profile/index.tsx
@@ -2,14 +2,12 @@ import { useRouteMatch } from 'react-router-dom';
 import { UserPanel } from './panels/UserPanel';
 import { Switcher } from './panels/Switcher';
 import { PostView } from '../feed/components/post-view-container';
-import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
 
 import styles from './styles.module.scss';
 
 export const ProfileApp = () => {
   const route = useRouteMatch<{ zid: string; postId?: string }>('/profile/:zid/:postId?');
   const postId = route?.params?.postId;
-  useScrollPosition(postId);
 
   return (
     <div className={styles.Wrapper}>

--- a/src/apps/profile/index.vitest.tsx
+++ b/src/apps/profile/index.vitest.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useRouteMatch } from 'react-router-dom';
+import { ProfileApp } from './';
+
+vi.mock('react-router-dom', () => ({
+  useRouteMatch: vi.fn(),
+}));
+
+vi.mock('./panels/UserPanel', () => ({
+  UserPanel: () => <div data-testid='user-panel' />,
+}));
+
+vi.mock('./panels/Switcher', () => ({
+  Switcher: () => <div data-testid='switcher' />,
+}));
+
+vi.mock('../feed/components/post-view-container', () => ({
+  PostView: ({ postId }: { postId: string }) => <div data-testid='post-view'>{postId}</div>,
+}));
+
+describe('ProfileApp', () => {
+  const mockUseRouteMatch = useRouteMatch as unknown as ReturnType<typeof vi.fn>;
+
+  it('should render Switcher and UserPanel when not viewing a post', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123' },
+      path: '/profile/user123',
+    });
+
+    render(<ProfileApp />);
+
+    expect(screen.getByTestId('switcher')).toBeInTheDocument();
+    expect(screen.getByTestId('user-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-view')).not.toBeInTheDocument();
+  });
+
+  it('should render PostView when viewing a post', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123', postId: 'post123' },
+      path: '/profile/user123/post123',
+    });
+
+    render(<ProfileApp />);
+
+    expect(screen.getByTestId('post-view')).toBeInTheDocument();
+    expect(screen.getByTestId('post-view')).toHaveTextContent('post123');
+    expect(screen.queryByTestId('switcher')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('user-panel')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### What does this do?
We're modifying the profile app to handle post viewing within the profile context instead of redirecting to the feed app.

### Why are we making this change?
To provide a more focused and contextual post viewing experience within user profiles

### How do I test this?
- run tests as usual
- run UI > go to profile > click post

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
