### PR TITLE
feat(profile-app): add scroll position restoration to profile app

### DIFF
--- a/src/apps/profile/index.tsx
+++ b/src/apps/profile/index.tsx
@@ -2,12 +2,14 @@ import { useRouteMatch } from 'react-router-dom';
 import { UserPanel } from './panels/UserPanel';
 import { Switcher } from './panels/Switcher';
 import { PostView } from '../feed/components/post-view-container';
+import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
 
 import styles from './styles.module.scss';
 
 export const ProfileApp = () => {
   const route = useRouteMatch<{ zid: string; postId?: string }>('/profile/:zid/:postId?');
   const postId = route?.params?.postId;
+  useScrollPosition(postId);
 
   return (
     <div className={styles.Wrapper}>

--- a/src/apps/profile/index.vitest.tsx
+++ b/src/apps/profile/index.vitest.tsx
@@ -2,9 +2,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { useRouteMatch } from 'react-router-dom';
 import { ProfileApp } from './';
+import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
 
 vi.mock('react-router-dom', () => ({
   useRouteMatch: vi.fn(),
+}));
+
+vi.mock('../../lib/hooks/useScrollPosition', () => ({
+  useScrollPosition: vi.fn(),
 }));
 
 vi.mock('./panels/UserPanel', () => ({
@@ -21,6 +26,7 @@ vi.mock('../feed/components/post-view-container', () => ({
 
 describe('ProfileApp', () => {
   const mockUseRouteMatch = useRouteMatch as unknown as ReturnType<typeof vi.fn>;
+  const mockUseScrollPosition = useScrollPosition as unknown as ReturnType<typeof vi.fn>;
 
   it('should render Switcher and UserPanel when not viewing a post', () => {
     mockUseRouteMatch.mockReturnValue({
@@ -47,5 +53,27 @@ describe('ProfileApp', () => {
     expect(screen.getByTestId('post-view')).toHaveTextContent('post123');
     expect(screen.queryByTestId('switcher')).not.toBeInTheDocument();
     expect(screen.queryByTestId('user-panel')).not.toBeInTheDocument();
+  });
+
+  it('should call useScrollPosition with postId when viewing a post', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123', postId: 'post123' },
+      path: '/profile/user123/post123',
+    });
+
+    render(<ProfileApp />);
+
+    expect(mockUseScrollPosition).toHaveBeenCalledWith('post123');
+  });
+
+  it('should not call useScrollPosition when not viewing a post', () => {
+    mockUseRouteMatch.mockReturnValue({
+      params: { zid: 'user123' },
+      path: '/profile/user123',
+    });
+
+    render(<ProfileApp />);
+
+    expect(mockUseScrollPosition).toHaveBeenCalledWith(undefined);
   });
 });


### PR DESCRIPTION
### What does this do?
- We're adding the useScrollPosition hook to the ProfileApp component to handle scroll position restoration.

### Why are we making this change?
- We're making these changes to enable scroll position restoration when navigating to and from posts in the profile view.

### How do I test this?
- run tests as usual
- run UI > navigate to profile app > scroll down to a post and click > click back button > check post is in view

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
