### PR TITLE
feat(post-link-preview): add post link preview component with youtube support

### DIFF
--- a/src/apps/feed/components/post/link-preview/index.tsx
+++ b/src/apps/feed/components/post/link-preview/index.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
+import styles from './styles.module.scss';
+import { detectLinkType, fetchPreviewFromUrl } from './utils';
+
+export type PostLinkPreviewType = 'youtube';
+
+export interface PostLinkPreviewData {
+  title: string;
+  thumbnailUrl?: string;
+  authorName?: string;
+  authorHandle?: string;
+  videoId?: string;
+}
+
+interface PostLinkPreviewProps {
+  url: string;
+  className?: string;
+}
+
+export const PostLinkPreview: React.FC<PostLinkPreviewProps> = ({ url, className }) => {
+  const [previewData, setPreviewData] = useState<PostLinkPreviewData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [type, setType] = useState<PostLinkPreviewType | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    const linkType = detectLinkType(url);
+    if (!linkType) {
+      return;
+    }
+    setType(linkType);
+  }, [url]);
+
+  useEffect(() => {
+    if (!type) return;
+
+    const fetchData = async () => {
+      try {
+        setError(null);
+        const data = await fetchPreviewFromUrl(url, type);
+        setPreviewData(data);
+      } catch (err) {
+        setError('Failed to load preview');
+        console.error('Error fetching link preview:', err);
+      }
+    };
+
+    fetchData();
+  }, [url, type]);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (previewData?.videoId) {
+      setIsPlaying(true);
+    }
+  };
+
+  if (!type) return null;
+
+  if (error || !previewData) {
+    return null;
+  }
+
+  return (
+    <div className={classNames(styles.Container, className, { [styles.Playing]: isPlaying })} onClick={handleClick}>
+      {isPlaying ? (
+        <div className={styles.VideoWrapper}>
+          <iframe
+            className={styles.VideoPlayer}
+            src={`https://www.youtube.com/embed/${previewData?.videoId}?autoplay=1`}
+            title={previewData?.title || ''}
+            allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+            allowFullScreen
+          />
+        </div>
+      ) : (
+        <div className={styles.Thumbnail}>
+          <img src={previewData?.thumbnailUrl} alt={previewData?.title || ''} />
+          <div className={styles.PlayButton}>
+            <svg viewBox='0 0 24 24' fill='currentColor'>
+              <path d='M8 5v14l11-7z' />
+            </svg>
+          </div>
+        </div>
+      )}
+      <div className={styles.Content}>
+        <div className={styles.Title}>{previewData?.title}</div>
+        {previewData?.authorName && (
+          <div className={styles.Author}>
+            {previewData.authorName}
+            {previewData?.authorHandle && <span className={styles.Handle}>{previewData.authorHandle}</span>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/apps/feed/components/post/link-preview/styles.module.scss
+++ b/src/apps/feed/components/post/link-preview/styles.module.scss
@@ -1,0 +1,115 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../../glass';
+
+.Container {
+  overflow: hidden;
+  margin-top: 8px;
+  cursor: pointer;
+
+  &.Playing {
+    cursor: default;
+  }
+}
+
+.Thumbnail {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%; // 16:9 aspect ratio
+  opacity: 0;
+  animation: fadeIn 1s ease-in;
+  animation-fill-mode: forwards;
+  background-color: rgba(17, 18, 19, 0.5);
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 8px;
+  }
+}
+
+.VideoWrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%; // 16:9 aspect ratio
+  background-color: rgba(17, 18, 19, 0.5);
+  border-radius: 8px;
+  opacity: 0;
+  animation: fadeIn 1s ease-in;
+  animation-fill-mode: forwards;
+}
+
+.VideoPlayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 8px;
+}
+
+.PlayButton {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 68px;
+  height: 48px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: theme.$color-secondary-11;
+  transition: background-color 0.1s ease, transform 0.1s ease;
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  .Thumbnail:hover & {
+    background-color: theme.$color-secondary-11;
+    transform: translate(-50%, -50%) scale(1.1);
+    color: rgba(0, 0, 0, 0.8);
+  }
+}
+
+.Content {
+  padding: 12px 0 0;
+  opacity: 0;
+  animation: fadeIn 1s ease-in;
+  animation-fill-mode: forwards;
+}
+
+.Title {
+  @include glass-text-secondary-color;
+
+  font-weight: 600;
+}
+
+.Author {
+  @include glass-text-secondary-color;
+
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.Handle {
+  @include glass-text-secondary-color;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/apps/feed/components/post/link-preview/utils.ts
+++ b/src/apps/feed/components/post/link-preview/utils.ts
@@ -1,6 +1,6 @@
 import { PostLinkPreviewType, PostLinkPreviewData } from './index';
 
-const YOUTUBE_REGEX = /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/;
+const YOUTUBE_REGEX = /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/;
 
 export function detectLinkType(url: string): PostLinkPreviewType | null {
   if (!url) return null;

--- a/src/apps/feed/components/post/link-preview/utils.ts
+++ b/src/apps/feed/components/post/link-preview/utils.ts
@@ -1,0 +1,56 @@
+import { PostLinkPreviewType, PostLinkPreviewData } from './index';
+
+const YOUTUBE_REGEX = /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/;
+
+export function detectLinkType(url: string): PostLinkPreviewType | null {
+  if (!url) return null;
+  if (YOUTUBE_REGEX.test(url)) return 'youtube';
+  return null;
+}
+
+export async function fetchYoutubePreview(videoId: string): Promise<PostLinkPreviewData> {
+  if (!videoId) {
+    throw new Error('Video ID is required');
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`
+    );
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch YouTube preview');
+    }
+
+    const data = await response.json();
+
+    if (!data?.title) {
+      throw new Error('Invalid YouTube response');
+    }
+
+    return {
+      title: data.title,
+      authorName: data.author_name || '',
+      authorHandle: data.author_url || '',
+      thumbnailUrl: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
+      videoId,
+    };
+  } catch (error) {
+    console.error('Error fetching YouTube preview:', error);
+    throw new Error('Failed to fetch YouTube preview');
+  }
+}
+
+export async function fetchPreviewFromUrl(url: string, type: PostLinkPreviewType): Promise<PostLinkPreviewData> {
+  if (!url || !type) {
+    throw new Error('URL and type are required');
+  }
+
+  if (type === 'youtube') {
+    const match = url.match(YOUTUBE_REGEX);
+    if (!match?.[1]) throw new Error('Invalid YouTube URL');
+    return fetchYoutubePreview(match[1]);
+  }
+
+  throw new Error('Unsupported URL type');
+}


### PR DESCRIPTION
### What does this do?
Adding two new files (index.tsx and styles.module.scss) that create a link preview component with YouTube support.

### Why are we making this change?
To enhance user experience by allowing inline preview and playback of links shared in posts.

### How do I test this?
run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
