### PR TITLE
feat(feed): wire up link preview component in posts

### DIFF
--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -13,6 +13,8 @@ import { ShowMoreButton } from '../show-more-button';
 import { analyzePostContent } from '../../lib/analyzePostContent';
 import { usePostRoute } from './lib/usePostRoute';
 import Linkify from 'linkify-react';
+import { PostLinkPreview } from './link-preview';
+import { detectLinkType } from './link-preview/utils';
 
 import classNames from 'classnames';
 import styles from './styles.module.scss';
@@ -81,11 +83,17 @@ export const Post = ({
 
   const multilineText = useMemo(
     () =>
-      displayText?.split('\n').map((line, index) => (
-        <p key={index} className={styles.Text}>
-          {line}
-        </p>
-      )),
+      displayText?.split('\n').map((line, index) => {
+        const linkType = detectLinkType(line);
+        const hasPreview = linkType !== null;
+
+        return (
+          <div key={index}>
+            <p className={styles.Text}>{line}</p>
+            {hasPreview && <PostLinkPreview url={line} />}
+          </div>
+        );
+      }),
     [displayText]
   );
 


### PR DESCRIPTION
### What does this do?
Adding link detection and rendering of the PostLinkPreview component within the post's text content.

### Why are we making this change?
To enable automatic link preview functionality for any YouTube links shared within posts.

### How do I test this?
run tests as usual
run UI and post a youtube link

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
