### PR TITLE
Remove link previews from redux

### DIFF
--- a/src/components/message/index.test.tsx
+++ b/src/components/message/index.test.tsx
@@ -17,6 +17,11 @@ jest.mock('../../lib/hooks/useMatrixMedia', () => ({
   useMatrixMedia: (file) => mockUseMatrixMedia(file),
 }));
 
+const mockUseLinkPreview = jest.fn();
+jest.mock('../../lib/hooks/useLinkPreview', () => ({
+  useLinkPreview: (message: string | undefined) => mockUseLinkPreview(message),
+}));
+
 describe('message', () => {
   const sender = {
     firstName: 'John',
@@ -44,6 +49,17 @@ describe('message', () => {
         isError: false,
       };
     });
+    mockUseLinkPreview.mockImplementation(() => {
+      return {
+        data: null,
+        isPending: false,
+        isError: false,
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('renders message text', () => {
@@ -325,15 +341,21 @@ describe('message', () => {
   });
 
   it('renders LinkPreview when there is a message', () => {
+    const message = 'message text accompanying link preview';
     const preview = {
       url: 'http://url.com/index.cfm',
       type: LinkPreviewType.Photo,
       title: 'the-title',
       description: 'the description',
     };
-    const message = 'message text accompanying link preview';
 
-    const wrapper = subject({ preview, message, hidePreview: false });
+    mockUseLinkPreview.mockReturnValue({
+      data: preview,
+      isPending: false,
+      isError: false,
+    });
+
+    const wrapper = subject({ message, hidePreview: false });
 
     expect(wrapper.find(LinkPreview).props()).toEqual(expect.objectContaining(preview));
     expect(wrapper.find(ContentHighlighter).first().prop('message').includes(message)).toBeTruthy();
@@ -347,45 +369,75 @@ describe('message', () => {
       description: 'the description',
     };
 
-    const wrapper = subject({ preview, message: undefined, hidePreview: false });
+    mockUseLinkPreview.mockReturnValue({
+      data: preview,
+      isPending: false,
+      isError: false,
+    });
+
+    const wrapper = subject({ message: undefined, hidePreview: false });
 
     expect(wrapper.find(LinkPreview).props()).toEqual(expect.objectContaining(preview));
   });
 
   it('does not render LinkPreview when there is a message but hidePreview is true', () => {
+    const message = 'message text accompanying link preview';
     const preview = {
       url: 'http://url.com/index.cfm',
       type: LinkPreviewType.Photo,
       title: 'the-title',
       description: 'the description',
     };
-    const message = 'message text accompanying link preview';
 
-    const wrapper = subject({ preview, message, hidePreview: true });
+    mockUseLinkPreview.mockReturnValue({
+      data: preview,
+      isPending: false,
+      isError: false,
+    });
+
+    const wrapper = subject({ message, hidePreview: true });
 
     expect(wrapper.find(LinkPreview)).toEqual({});
   });
 
   it('renders remove link preview icon when there is a message owned by current user', () => {
+    const message = 'message';
+    const id = 'id';
+    const onEdit = jest.fn();
     const preview = {
       url: 'http://url.com/index.cfm',
       type: LinkPreviewType.Photo,
       title: 'the-title',
       description: 'the description',
     };
-    const message = 'message';
-    const id = 'id';
-    const onEdit = jest.fn();
 
-    const wrapper = subject({ messageId: id, preview, message, hidePreview: false, isOwner: true, onEdit });
+    mockUseLinkPreview.mockReturnValue({
+      data: preview,
+      isPending: false,
+      isError: false,
+    });
+
+    const wrapper = subject({ messageId: id, message, hidePreview: false, isOwner: true, onEdit });
 
     expect(wrapper.find(LinkPreview).simulate('remove'));
     expect(onEdit).toHaveBeenCalledWith(id, message, [], { hidePreview: true });
   });
 
   it('does not render link preview if there is a file', () => {
+    const preview = {
+      url: 'http://url.com/index.cfm',
+      type: LinkPreviewType.Photo,
+      title: 'the-title',
+      description: 'the description',
+    };
+
+    mockUseLinkPreview.mockReturnValue({
+      data: preview,
+      isPending: false,
+      isError: false,
+    });
+
     const wrapper = subject({
-      preview: { url: 'example.com' },
       hidePreview: false,
       media: { url: 'https://image.com/image.png', type: MediaType.Image },
     });
@@ -394,8 +446,20 @@ describe('message', () => {
   });
 
   it('does not render link preview if message is a reply', () => {
+    const preview = {
+      url: 'http://url.com/index.cfm',
+      type: LinkPreviewType.Photo,
+      title: 'the-title',
+      description: 'the description',
+    };
+
+    mockUseLinkPreview.mockReturnValue({
+      data: preview,
+      isPending: false,
+      isError: false,
+    });
+
     const wrapper = subject({
-      preview: { url: 'example.com' },
       hidePreview: false,
       parentMessageText: 'quoted message',
     });

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -30,6 +30,7 @@ import { useMatrixMedia } from '../../lib/hooks/useMatrixMedia';
 import { MatrixAvatar } from '../matrix-avatar';
 
 import './styles.scss';
+import { useLinkPreview } from '../../lib/hooks/useLinkPreview';
 
 const cn = bemClassName('message');
 
@@ -95,7 +96,6 @@ export const Message: React.FC<Properties> = ({
   sender,
   mentionedUsers,
   hidePreview,
-  preview,
   admin,
   optimisticId,
   rootMessageId,
@@ -112,6 +112,8 @@ export const Message: React.FC<Properties> = ({
   const media = useMemo(() => {
     return mediaMessage ? mediaMessage.media : baseMedia;
   }, [mediaMessage, baseMedia]);
+
+  const { data: linkPreview } = useLinkPreview(message);
 
   const isMenuTriggerAlwaysVisible = sendStatus === MessageSendStatus.FAILED;
 
@@ -368,17 +370,17 @@ export const Message: React.FC<Properties> = ({
 
   const renderLinkPreview = () => {
     if (
-      !preview?.title ||
-      !preview?.description ||
-      !preview?.type ||
-      !preview?.url ||
+      !linkPreview?.title ||
+      !linkPreview?.description ||
+      !linkPreview?.type ||
+      !linkPreview?.url ||
       hidePreview ||
       media ||
       parentMessageText
     ) {
       return null;
     }
-    return <LinkPreview url={preview.url} {...preview} allowRemove={false} onRemove={onRemovePreview} />;
+    return <LinkPreview url={linkPreview.url} {...linkPreview} allowRemove={false} onRemove={onRemovePreview} />;
   };
 
   return (
@@ -405,7 +407,7 @@ export const Message: React.FC<Properties> = ({
           })
         )}
       >
-        {(message || media || preview) && (
+        {(message || media || linkPreview) && (
           <>
             {showAuthorName && !isEditing && (
               <div {...cn('author-name')}>

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -85,7 +85,6 @@ export function mapMatrixMessage(matrixEvent: Partial<IEvent>, sdkMatrixClient: 
       primaryZID: '',
     },
     isPost: false,
-    preview: null,
     sendStatus: MessageSendStatus.SUCCESS,
     isAdmin: false,
     optimisticId: content.optimisticId,
@@ -128,7 +127,6 @@ export function mapEventToAdminMessage(matrixEvent: IEvent): Message {
     sender: ADMIN_USER,
     mentionedUsers: [],
     hidePreview: false,
-    preview: null,
     sendStatus: MessageSendStatus.SUCCESS,
     isPost: false,
   };
@@ -162,7 +160,6 @@ export function mapEventToPostMessage(matrixEvent: IEvent, sdkMatrixClient: SDKM
     isAdmin: false,
     mentionedUsers: [],
     hidePreview: false,
-    preview: null,
     sendStatus: MessageSendStatus.SUCCESS,
     isPost: true,
     media,

--- a/src/lib/hooks/useLinkPreview.ts
+++ b/src/lib/hooks/useLinkPreview.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLinkPreviews } from '../../store/messages/api';
+import { getFirstUrl } from '../../store/messages/utils';
+
+interface UseLinkPreviewOptions {
+  enabled?: boolean;
+}
+
+export function useLinkPreview(message: string | undefined, options: UseLinkPreviewOptions = {}) {
+  const { enabled = true } = options;
+  const firstUrl = message ? getFirstUrl(message) : undefined;
+
+  return useQuery({
+    queryKey: ['linkPreview', firstUrl],
+    queryFn: async () => {
+      if (!firstUrl) return null;
+      const result = await getLinkPreviews(firstUrl);
+      return result.success ? result.body : null;
+    },
+    enabled: enabled && !!firstUrl,
+  });
+}

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -3,7 +3,6 @@ import { createAction } from '@reduxjs/toolkit';
 
 import { createNormalizedSlice, removeAll } from '../normalized';
 
-import { LinkPreview } from '../../lib/link-preview';
 import { ParentMessage } from '../../lib/chat/types';
 import { User } from '../authentication/types';
 import { EncryptedFile } from 'matrix-js-sdk/lib/types';
@@ -85,7 +84,6 @@ export interface Message {
   sender: Sender;
   mentionedUsers: { id: string }[];
   hidePreview: boolean;
-  preview: LinkPreview;
   media?: Media;
   image?: Media;
   admin?: {

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -59,7 +59,6 @@ export function createOptimisticMessageObject(
       primaryZID: user.primaryZID,
     },
     updatedAt: 0,
-    preview: null,
     media,
     sendStatus: MessageSendStatus.IN_PROGRESS,
     isPost: false,
@@ -67,7 +66,13 @@ export function createOptimisticMessageObject(
 }
 
 export function extractLink(messageText: string): linkifyType[] {
-  return linkifyjs.find(messageText || '');
+  return linkifyjs.find(messageText);
+}
+
+export function getFirstUrl(message: string) {
+  const link: linkifyType[] = extractLink(message);
+  if (!link.length) return;
+  return link[0].href;
 }
 
 export const enum FileType {


### PR DESCRIPTION
### What does this do?
Removes Redux/Saga from being responsible for link previews. This data is only used when rendering messages so it's unnecessary to ensure it's loaded and stored in redux. Instead, react query will handle caching that data and only fetching it when we need to render a preview.

This is a necessary prerequisite to making some message optimizations in Redux since it's locking down message processing to being a saga specific task due to managing the previews.
