### PR TITLE
Move the responsibility of setting senders to redux/saga from matrix

### DIFF
--- a/src/lib/chat/chat.vitest.ts
+++ b/src/lib/chat/chat.vitest.ts
@@ -117,7 +117,6 @@ describe('Chat', () => {
       disconnect: vi.fn().mockResolvedValue(undefined),
       reconnect: vi.fn(),
       getMessagesByChannelId: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
-      getMessageByRoomId: vi.fn().mockResolvedValue({}),
       sendMessagesByChannelId: vi.fn().mockResolvedValue({ id: 'message-id', optimisticId: 'optimistic-id' }),
       editMessage: vi.fn().mockResolvedValue({ id: 'edit-id' }),
       deleteMessageByRoomId: vi.fn().mockResolvedValue(undefined),
@@ -355,10 +354,6 @@ describe('Chat', () => {
       // Test getMessagesByChannelId
       await chat.getMessagesByChannelId(channelId);
       expect(mockMatrixClient.getMessagesByChannelId).toHaveBeenCalledWith(channelId, undefined);
-
-      // Test getMessageByRoomId
-      await chat.getMessageByRoomId(channelId, messageId);
-      expect(mockMatrixClient.getMessageByRoomId).toHaveBeenCalledWith(channelId, messageId);
 
       // Test sendMessagesByChannelId
       await chat.sendMessagesByChannelId(channelId, message, mentionedUserIds, parentMessage, null, optimisticId);

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -1,4 +1,4 @@
-import { EditMessageOptions, Message, MessagesResponse } from '../../store/messages';
+import { EditMessageOptions, Message, MessagesResponse, MessageWithoutSender } from '../../store/messages';
 import { Channel, User as UserModel } from '../../store/channels/index';
 import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
@@ -18,9 +18,9 @@ import { EventType } from 'matrix-js-sdk/lib/matrix';
 import { ImportRoomKeyProgressData } from 'matrix-js-sdk/lib/crypto-api';
 
 export interface RealtimeChatEvents {
-  receiveNewMessage: (channelId: string, message: Message) => void;
+  receiveNewMessage: (channelId: string, message: Message | MessageWithoutSender) => void;
   receiveDeleteMessage: (roomId: string, messageId: string) => void;
-  onMessageUpdated: (channelId: string, message: Message) => void;
+  onMessageUpdated: (channelId: string, message: Message | MessageWithoutSender) => void;
   receiveUnreadCount: (channelId: string, unreadCount: { total: number; highlight: number }) => void;
   onUserJoinedChannel: (channelId: string) => void;
   onUserLeft: (channelId: string, userId: string) => void;
@@ -52,7 +52,6 @@ export interface IChatClient {
   searchMyNetworksByName: (filter: string) => Promise<MemberNetworks[] | any>;
   searchMentionableUsersForChannel: (channelId: string, search: string, channelMembers?: UserModel[]) => Promise<any[]>;
   getMessagesByChannelId: (channelId: string, lastCreatedAt?: number) => Promise<MessagesResponse>;
-  getMessageByRoomId: (channelId: string, messageId: string) => Promise<any>;
   createConversation: (
     users: User[],
     name: string,
@@ -158,10 +157,6 @@ export class Chat {
 
   async leaveRoom(roomId: string, userId: string) {
     return this.client.leaveRoom(roomId, userId);
-  }
-
-  async getMessageByRoomId(channelId: string, messageId: string) {
-    return this.client.getMessageByRoomId(channelId, messageId);
   }
 
   async createConversation(users: User[], name: string = null, image: File = null) {
@@ -447,10 +442,6 @@ export async function removeRoomFromLabel(roomId: string, label: string) {
 
 export async function sendPostByChannelId(channelId: string, message: string, optimisticId?: string) {
   return matrixClientInstance.sendPostsByChannelId(channelId, message, optimisticId);
-}
-
-export async function getPostMessagesByChannelId(channelId: string, lastCreatedAt?: number) {
-  return matrixClientInstance.getPostMessagesByChannelId(channelId, lastCreatedAt);
 }
 
 export async function sendMeowReactionEvent(

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -1,6 +1,6 @@
 import { CustomEventType, MatrixConstants, MembershipStateType, NotifiableEventType } from './types';
-import { EventType, IContent, IEvent, MsgType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk/lib/matrix';
-import { AdminMessageType, MediaType, Message, MessageSendStatus } from '../../../store/messages';
+import { EventType, IContent, IEvent, MsgType } from 'matrix-js-sdk/lib/matrix';
+import { AdminMessageType, MediaType, Message, MessageSendStatus, MessageWithoutSender } from '../../../store/messages';
 import { extractUserIdFromMatrixId, getObjectDiff, parsePlainBody } from './utils';
 import { PowerLevels } from '../types';
 
@@ -54,11 +54,10 @@ export function buildMediaObject(content: IContent) {
 }
 
 // TODO: zos-619: This should be part of the MatrixAdapter
-export function mapMatrixMessage(matrixEvent: Partial<IEvent>, sdkMatrixClient: SDKMatrixClient): Message {
+export function mapMatrixMessage(matrixEvent: Partial<IEvent>): MessageWithoutSender {
   const { event_id, content, origin_server_ts, sender: senderId } = matrixEvent;
 
   const parent = matrixEvent.content['m.relates_to'];
-  const senderData = sdkMatrixClient.getUser(senderId);
 
   let messageContent = content.body;
   if (parent && parent['m.in_reply_to']) {
@@ -75,15 +74,10 @@ export function mapMatrixMessage(matrixEvent: Partial<IEvent>, sdkMatrixClient: 
     message,
     createdAt: origin_server_ts,
     updatedAt: 0,
-    sender: {
-      userId: extractUserIdFromMatrixId(senderId),
-      matrixId: senderId,
-      firstName: senderData?.displayName ?? '',
-      lastName: '',
-      profileImage: senderData?.avatarUrl ?? '',
-      profileId: '',
-      primaryZID: '',
-    },
+    // Left as undefined since we need data from redux. This will be populated in a saga
+    // as a post processing step
+    sender: undefined,
+    senderId,
     isPost: false,
     preview: null,
     sendStatus: MessageSendStatus.SUCCESS,
@@ -119,11 +113,10 @@ export function mapEventToAdminMessage(matrixEvent: IEvent): Message {
 
   return {
     id: event_id,
-    message: 'Conversation was started',
+    message: '',
     createdAt: origin_server_ts,
     isAdmin: true,
     admin: adminData,
-
     updatedAt: 0,
     sender: ADMIN_USER,
     mentionedUsers: [],
@@ -135,10 +128,9 @@ export function mapEventToAdminMessage(matrixEvent: IEvent): Message {
 }
 
 // TODO: zos-619: This should be part of the MatrixAdapter
-export function mapEventToPostMessage(matrixEvent: IEvent, sdkMatrixClient: SDKMatrixClient): Message {
+export function mapEventToPostMessage(matrixEvent: IEvent): MessageWithoutSender {
   const { event_id, content, origin_server_ts, sender: senderId } = matrixEvent;
 
-  const senderData = sdkMatrixClient.getUser(senderId);
   const { media, image, rootMessageId } = parseMediaData(matrixEvent);
 
   return {
@@ -147,18 +139,10 @@ export function mapEventToPostMessage(matrixEvent: IEvent, sdkMatrixClient: SDKM
     createdAt: origin_server_ts,
     updatedAt: 0,
     optimisticId: content.optimisticId,
-
-    sender: {
-      userId: extractUserIdFromMatrixId(senderId),
-      matrixId: senderId,
-      firstName: senderData?.displayName ?? '',
-      lastName: '',
-      profileImage: senderData?.avatarUrl ?? '',
-      profileId: '',
-      displaySubHandle: '',
-      primaryZID: '',
-    },
-
+    // Left as undefined since we need data from redux. This will be populated in a saga
+    // as a post processing step
+    sender: undefined,
+    senderId,
     isAdmin: false,
     mentionedUsers: [],
     hidePreview: false,

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -120,12 +120,7 @@ function* batchedRoomDataAction(action: RoomDataAction) {
   for (const update of batchedUpdates) {
     yield call(handleRoomDataEvents, update.roomId, update.roomData, matrixClientInstance);
     if (update.roomData.initial) {
-      const mappedChannel: Partial<Channel> = yield call(
-        updateChannelWithRoomData,
-        update.roomId,
-        update.roomData,
-        matrixClientInstance
-      );
+      const mappedChannel: Partial<Channel> = yield call(updateChannelWithRoomData, update.roomId, update.roomData);
       yield spawn(receiveChannel, mappedChannel);
     }
   }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -48,7 +48,7 @@ export interface Media {
 
 export interface MessagesResponse {
   hasMore: boolean;
-  messages: Message[];
+  messages: (Message | MessageWithoutSender)[];
 }
 export interface InfoUploadResponse {
   apiUrl: string;
@@ -102,6 +102,15 @@ export interface Message {
   reactions?: { [key: string]: number };
   isHidden?: boolean;
 }
+
+export interface MessageWithoutSender extends Message {
+  sender: undefined;
+  senderId: string;
+}
+
+export const isMessageWithoutSender = (message: Message | MessageWithoutSender): message is MessageWithoutSender => {
+  return message.sender === undefined && 'senderId' in message;
+};
 
 export interface MessageAttachment {
   name: string;

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -10,6 +10,7 @@ import {
   MediaType,
   MessageSendStatus,
   Message,
+  MessageWithoutSender,
 } from '.';
 import { receive as receiveMessage } from './';
 import { ConversationStatus, MessagesFetchState, DefaultRoomLabels } from '../channels';
@@ -95,12 +96,12 @@ export const roomLabelSelector = (channelId) => (state) => {
   return getDeepProperty(state, `normalized.channels['${channelId}'].labels`, []);
 };
 
-export function* mapMessagesAndPreview(messages: Message[], channelId: string) {
+export function* mapMessagesAndPreview(messages: (Message | MessageWithoutSender)[], channelId: string) {
   const reactions = yield call(getMessageEmojiReactions, channelId);
 
   const messagesWithSenders = yield call(mapMessageSenders, messages);
 
-  for (const message of messagesWithSenders) {
+  const newMessages = messagesWithSenders.map((message) => {
     if (message.isHidden) {
       message.message = 'Message hidden';
     }
@@ -118,9 +119,11 @@ export function* mapMessagesAndPreview(messages: Message[], channelId: string) {
         return acc;
       }, message.reactions || {});
     }
-  }
 
-  return messages;
+    return message;
+  });
+
+  return newMessages;
 }
 
 export function* fetch(action) {

--- a/src/store/messages/utils.matrix.ts
+++ b/src/store/messages/utils.matrix.ts
@@ -1,18 +1,39 @@
 import { call } from 'redux-saga/effects';
 import { getUsersByMatrixIds } from '../users/saga';
-import { Message } from '.';
+import { Message, MessageWithoutSender, isMessageWithoutSender } from '.';
 import { User } from '../channels';
 
 // takes in a list of messages, and maps the sender to a ZERO user for each message
 // this is used to display the sender's name and profile image.
 // This also ensures that the user is in redux, if they aren't, they're added.
-export function* mapMessageSenders(messages: Message[]) {
-  const matrixIds = messages.map((m) => m.sender?.matrixId).filter(Boolean);
+export function* mapMessageSenders(messages: (Message | MessageWithoutSender)[]) {
+  const matrixIds = messages
+    .map((m) => {
+      if (isMessageWithoutSender(m)) {
+        return m.senderId;
+      }
+      return m.sender?.matrixId;
+    })
+    .filter(Boolean);
   const zeroUsers: Map<string, User> = yield call(getUsersByMatrixIds, matrixIds);
 
   return messages.map((message) => {
-    message.sender = zeroUsers.get(message.sender?.matrixId) || message.sender;
-    return message;
+    let sender = message.sender;
+    if (message.sender) {
+      sender = zeroUsers.get(message.sender?.matrixId) || message.sender;
+    }
+    if (isMessageWithoutSender(message)) {
+      sender = zeroUsers.get(message.senderId) || {
+        userId: message.senderId,
+        matrixId: message.senderId,
+        firstName: '',
+        lastName: '',
+        profileImage: '',
+        profileId: '',
+        primaryZID: '',
+      };
+    }
+    return { ...message, sender };
   });
 }
 

--- a/src/store/posts/index.ts
+++ b/src/store/posts/index.ts
@@ -1,11 +1,11 @@
 import { Payload, PostPayload } from './saga';
 import { createAction, createSlice } from '@reduxjs/toolkit';
 
-import { Message } from '../messages';
+import { Message, MessageWithoutSender } from '../messages';
 
 export interface PostsResponse {
   hasMore: boolean;
-  postMessages: Message[];
+  postMessages: (Message | MessageWithoutSender)[];
 }
 
 export enum SagaActionTypes {


### PR DESCRIPTION
### What does this do?

Removes Matrix from being responsible for setting the Sender field on messages.
This is now managed in redux/saga since that's where the source of truth is for user information.

I'll be doing another follow up task eventually to make this field normalized so that it points to the actual user object in redux rather than manually updating the objects. When denormalizing a message, the sender data should just be populated automatically

### Why are we making this change?
Sender data was inconsistent with the source of user information
