### PR TITLE
Fix profile images in panels (overview/edit profile)

### DIFF
--- a/src/components/messenger/user-profile/overview-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.test.tsx
@@ -91,7 +91,7 @@ describe(OverviewPanel, () => {
 
     wrapper
       .find(Button)
-      .filterWhere((n) => n.prop('startEnhancer')?.type === IconUser1)
+      .filterWhere((n) => (n.prop('startEnhancer') as React.ReactElement)?.type === IconUser1)
       .prop('onPress')();
 
     expect(onOpenEditProfile).toHaveBeenCalled();
@@ -103,7 +103,7 @@ describe(OverviewPanel, () => {
 
     wrapper
       .find(Button)
-      .filterWhere((n) => n.prop('startEnhancer')?.type === IconLock1)
+      .filterWhere((n) => (n.prop('startEnhancer') as React.ReactElement)?.type === IconLock1)
       .prop('onPress')();
 
     expect(onOpenBackupDialog).toHaveBeenCalled();
@@ -128,7 +128,7 @@ describe(OverviewPanel, () => {
 
     wrapper
       .find(Button)
-      .filterWhere((n) => n.prop('startEnhancer')?.type === IconSettings2)
+      .filterWhere((n) => (n.prop('startEnhancer') as React.ReactElement)?.type === IconSettings2)
       .prop('onPress')();
 
     expect(onOpenSettings).toHaveBeenCalled();
@@ -142,7 +142,7 @@ describe(OverviewPanel, () => {
 
     wrapper
       .find(Button)
-      .filterWhere((n) => n.prop('startEnhancer')?.type === IconDownload2)
+      .filterWhere((n) => (n.prop('startEnhancer') as React.ReactElement)?.type === IconDownload2)
       .prop('onPress')();
 
     expect(onOpenDownloads).toHaveBeenCalled();
@@ -154,7 +154,7 @@ describe(OverviewPanel, () => {
 
     wrapper
       .find(Button)
-      .filterWhere((n) => n.prop('startEnhancer')?.type === IconWallet3)
+      .filterWhere((n) => (n.prop('startEnhancer') as React.ReactElement)?.type === IconWallet3)
       .prop('onPress')();
 
     expect(onOpenAccountManagement).toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe(OverviewPanel, () => {
 
     wrapper
       .find(Button)
-      .filterWhere((n) => n.prop('startEnhancer')?.type === IconLink1)
+      .filterWhere((n) => (n.prop('startEnhancer') as React.ReactElement)?.type === IconLink1)
       .prop('onPress')();
 
     expect(onOpenLinkedAccounts).toHaveBeenCalled();

--- a/src/components/messenger/user-profile/overview-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.test.tsx
@@ -1,11 +1,24 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+
+import { mount } from 'enzyme';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { OverviewPanel, Properties } from '.';
-import { PanelHeader } from '../../list/panel-header';
 
-import { Image } from '@zero-tech/zui/components';
+import { Image, Modal } from '@zero-tech/zui/components';
 import { Button } from '@zero-tech/zui/components/Button';
-import { IconCurrencyEthereum } from '@zero-tech/zui/icons';
+import {
+  IconCurrencyEthereum,
+  IconLink1,
+  IconDownload2,
+  IconLock1,
+  IconSettings2,
+  IconUser1,
+  IconWallet3,
+} from '@zero-tech/zui/icons';
 
 import { bem } from '../../../../lib/bem';
 
@@ -13,8 +26,16 @@ const c = bem('.overview-panel');
 
 const featureFlags = { enableRewards: false, enableUserSettings: false, enableLinkedAccounts: false };
 
+const queryClient = new QueryClient();
+
 jest.mock('../../../../lib/feature-flags', () => ({
   featureFlags: featureFlags,
+}));
+jest.mock('./rewards-item/container', () => ({
+  RewardsItemContainer: () => null, // Mock implementation returns null
+}));
+jest.mock('../../../../lib/hooks/useMatrixImage', () => ({
+  useMatrixImage: (image: string) => ({ data: image }), // Mock hook returns the input directly
 }));
 
 describe(OverviewPanel, () => {
@@ -37,15 +58,18 @@ describe(OverviewPanel, () => {
       ...props,
     };
 
-    return shallow(<OverviewPanel {...allProps} />);
+    return mount(
+      <QueryClientProvider client={queryClient}>
+        <OverviewPanel {...allProps} />
+      </QueryClientProvider>
+    );
   };
 
   it('publishes onBack event', () => {
     const onBack = jest.fn();
     const wrapper = subject({ onBack });
 
-    wrapper.find(PanelHeader).simulate('back');
-
+    wrapper.find('.messenger-panel__back').prop('onClick')({ preventDefault: () => {} } as React.MouseEvent);
     expect(onBack).toHaveBeenCalled();
   });
 
@@ -53,7 +77,10 @@ describe(OverviewPanel, () => {
     const onOpenLogoutDialog = jest.fn();
     const wrapper = subject({ onOpenLogoutDialog });
 
-    wrapper.find(c('footer-button')).simulate('press');
+    const className = c('footer-button');
+    const button = wrapper.find(className).first();
+    // @ts-ignore
+    button.prop('onPress')();
 
     expect(onOpenLogoutDialog).toHaveBeenCalled();
   });
@@ -62,7 +89,10 @@ describe(OverviewPanel, () => {
     const onOpenEditProfile = jest.fn();
     const wrapper = subject({ onOpenEditProfile });
 
-    wrapper.find(Button).at(1).simulate('press');
+    wrapper
+      .find(Button)
+      .filterWhere((n) => n.prop('startEnhancer')?.type === IconUser1)
+      .prop('onPress')();
 
     expect(onOpenEditProfile).toHaveBeenCalled();
   });
@@ -71,7 +101,10 @@ describe(OverviewPanel, () => {
     const onOpenBackupDialog = jest.fn();
     const wrapper = subject({ onOpenBackupDialog });
 
-    wrapper.find(Button).at(3).simulate('press');
+    wrapper
+      .find(Button)
+      .filterWhere((n) => n.prop('startEnhancer')?.type === IconLock1)
+      .prop('onPress')();
 
     expect(onOpenBackupDialog).toHaveBeenCalled();
   });
@@ -82,7 +115,7 @@ describe(OverviewPanel, () => {
     const onOpenRewards = jest.fn();
     const wrapper = subject({ onOpenRewards });
 
-    wrapper.find(c('rewards')).simulate('click');
+    wrapper.find(c('rewards')).prop('onClick')({ preventDefault: () => {} } as React.MouseEvent);
 
     expect(onOpenRewards).toHaveBeenCalled();
   });
@@ -93,7 +126,10 @@ describe(OverviewPanel, () => {
     const onOpenSettings = jest.fn();
     const wrapper = subject({ onOpenSettings });
 
-    wrapper.find(Button).at(4).simulate('press');
+    wrapper
+      .find(Button)
+      .filterWhere((n) => n.prop('startEnhancer')?.type === IconSettings2)
+      .prop('onPress')();
 
     expect(onOpenSettings).toHaveBeenCalled();
   });
@@ -104,7 +140,10 @@ describe(OverviewPanel, () => {
     const onOpenDownloads = jest.fn();
     const wrapper = subject({ onOpenDownloads });
 
-    wrapper.find(Button).at(5).simulate('press');
+    wrapper
+      .find(Button)
+      .filterWhere((n) => n.prop('startEnhancer')?.type === IconDownload2)
+      .prop('onPress')();
 
     expect(onOpenDownloads).toHaveBeenCalled();
   });
@@ -113,7 +152,10 @@ describe(OverviewPanel, () => {
     const onOpenAccountManagement = jest.fn();
     const wrapper = subject({ onManageAccounts: onOpenAccountManagement });
 
-    wrapper.find(Button).at(2).simulate('press');
+    wrapper
+      .find(Button)
+      .filterWhere((n) => n.prop('startEnhancer')?.type === IconWallet3)
+      .prop('onPress')();
 
     expect(onOpenAccountManagement).toHaveBeenCalled();
   });
@@ -124,7 +166,10 @@ describe(OverviewPanel, () => {
     const onOpenLinkedAccounts = jest.fn();
     const wrapper = subject({ onOpenLinkedAccounts });
 
-    wrapper.find(Button).at(6).simulate('press');
+    wrapper
+      .find(Button)
+      .filterWhere((n) => n.prop('startEnhancer')?.type === IconLink1)
+      .prop('onPress')();
 
     expect(onOpenLinkedAccounts).toHaveBeenCalled();
   });
@@ -132,14 +177,12 @@ describe(OverviewPanel, () => {
   it('opens the invite dialog', () => {
     const wrapper = subject({});
 
-    wrapper.find(Button).at(0).simulate('press');
+    act(() => {
+      wrapper.find(Button).at(0).prop('onPress')();
+    });
+    wrapper.update();
 
-    expect(wrapper).toHaveState('isInviteDialogOpen', true);
-  });
-
-  it('renders subhandle when subhandle prop is provided', () => {
-    const wrapper = subject({ subHandle: '0://subhandle' });
-    expect(wrapper.find(c('sub-handle'))).toHaveText('0://subhandle');
+    expect(wrapper.find(Modal).prop('open')).toBe(true);
   });
 
   it('renders custom image when image prop is provided', () => {

--- a/src/components/messenger/user-profile/overview-panel/index.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 
 import { bemClassName } from '../../../../lib/bem';
 
@@ -22,6 +22,7 @@ import { featureFlags } from '../../../../lib/feature-flags';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 
 import './styles.scss';
+import { useMatrixImage } from '../../../../lib/hooks/useMatrixImage';
 
 const cn = bemClassName('overview-panel');
 
@@ -41,73 +42,68 @@ export interface Properties {
   onOpenLinkedAccounts: () => void;
 }
 
-interface State {
-  isInviteDialogOpen: boolean;
-}
+export const OverviewPanel: React.FC<Properties> = (props) => {
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
+  const { data: imageUrl } = useMatrixImage(props.image);
 
-export class OverviewPanel extends React.Component<Properties, State> {
-  state = {
-    isInviteDialogOpen: false,
+  const navigateBack = () => {
+    props.onBack();
   };
 
-  navigateBack = () => {
-    this.props.onBack();
+  const openInviteDialog = () => {
+    setIsInviteDialogOpen(true);
   };
 
-  openInviteDialog = () => {
-    this.setState({ isInviteDialogOpen: true });
+  const closeInviteDialog = () => {
+    setIsInviteDialogOpen(false);
   };
 
-  closeInviteDialog = () => {
-    this.setState({ isInviteDialogOpen: false });
-  };
-
-  renderInviteDialog = (): JSX.Element => {
+  const renderInviteDialog = (): JSX.Element => {
     return (
-      <Modal open={this.state.isInviteDialogOpen} onOpenChange={this.closeInviteDialog}>
-        <InviteDialogContainer onClose={this.closeInviteDialog} />
+      <Modal open={isInviteDialogOpen} onOpenChange={closeInviteDialog}>
+        <InviteDialogContainer onClose={closeInviteDialog} />
       </Modal>
     );
   };
 
-  openLogoutDialog = () => {
-    this.props.onOpenLogoutDialog();
+  const openLogoutDialog = () => {
+    props.onOpenLogoutDialog();
   };
 
-  openBackupDialog = () => {
-    this.props.onOpenBackupDialog();
+  const openBackupDialog = () => {
+    props.onOpenBackupDialog();
   };
 
-  openEditProfile = () => {
-    this.props.onOpenEditProfile();
+  const openEditProfile = () => {
+    props.onOpenEditProfile();
   };
 
-  openRewards = () => {
-    this.props.onOpenRewards();
+  const openRewards = () => {
+    props.onOpenRewards();
   };
 
-  openSettings = () => {
-    this.props.onOpenSettings();
+  const openSettings = () => {
+    props.onOpenSettings();
   };
 
-  openDownloads = () => {
-    this.props.onOpenDownloads();
+  const openDownloads = () => {
+    props.onOpenDownloads();
   };
 
-  onManageAccounts = () => {
-    this.props.onManageAccounts();
+  const onManageAccounts = () => {
+    props.onManageAccounts();
   };
 
-  openLinkedAccounts = () => {
-    this.props.onOpenLinkedAccounts();
+  const openLinkedAccounts = () => {
+    props.onOpenLinkedAccounts();
   };
 
-  renderDetails = () => {
+  const renderDetails = () => {
     return (
       <div {...cn('details')}>
         <div {...cn('image-conatiner')}>
-          {this.props.image ? (
-            <Image {...cn('image')} src={this.props.image} alt='Custom Profile Image' />
+          {imageUrl ? (
+            <Image {...cn('image')} src={imageUrl} alt='Custom Profile Image' />
           ) : (
             <div {...cn('image')}>
               <IconCurrencyEthereum size={50} />
@@ -116,20 +112,20 @@ export class OverviewPanel extends React.Component<Properties, State> {
         </div>
 
         <div {...cn('name-container')}>
-          {<div {...cn('name')}>{this.props.name}</div>}
-          {this.props.subHandle && <div {...cn('sub-handle')}>{this.props.subHandle}</div>}
+          <div {...cn('name')}>{props.name}</div>
+          {props.subHandle && <div {...cn('sub-handle')}>{props.subHandle}</div>}
         </div>
       </div>
     );
   };
 
-  renderActions() {
+  const renderActions = () => {
     return (
       <div {...cn('action-button-container')}>
         <Button
           {...cn('action-button', 'highlighted')}
           variant={ButtonVariant.Secondary}
-          onPress={this.openInviteDialog}
+          onPress={openInviteDialog}
           startEnhancer={<IconPlus size={20} isFilled />}
         >
           Invite Friends
@@ -138,7 +134,7 @@ export class OverviewPanel extends React.Component<Properties, State> {
         <Button
           {...cn('action-button')}
           variant={ButtonVariant.Secondary}
-          onPress={this.openEditProfile}
+          onPress={openEditProfile}
           startEnhancer={<IconUser1 size={20} />}
           color={ButtonColor.Greyscale}
         >
@@ -148,7 +144,7 @@ export class OverviewPanel extends React.Component<Properties, State> {
         <Button
           {...cn('action-button')}
           variant={ButtonVariant.Secondary}
-          onPress={this.onManageAccounts}
+          onPress={onManageAccounts}
           startEnhancer={<IconWallet3 size={20} />}
           color={ButtonColor.Greyscale}
         >
@@ -158,7 +154,7 @@ export class OverviewPanel extends React.Component<Properties, State> {
         <Button
           {...cn('action-button')}
           variant={ButtonVariant.Secondary}
-          onPress={this.openBackupDialog}
+          onPress={openBackupDialog}
           startEnhancer={<IconLock1 size={20} />}
           color={ButtonColor.Greyscale}
         >
@@ -169,7 +165,7 @@ export class OverviewPanel extends React.Component<Properties, State> {
           <Button
             {...cn('action-button')}
             variant={ButtonVariant.Secondary}
-            onPress={this.openSettings}
+            onPress={openSettings}
             startEnhancer={<IconSettings2 size={20} />}
             color={ButtonColor.Greyscale}
           >
@@ -180,7 +176,7 @@ export class OverviewPanel extends React.Component<Properties, State> {
         <Button
           {...cn('action-button')}
           variant={ButtonVariant.Secondary}
-          onPress={this.openDownloads}
+          onPress={openDownloads}
           startEnhancer={<IconDownload2 size={20} />}
           color={ButtonColor.Greyscale}
         >
@@ -191,7 +187,7 @@ export class OverviewPanel extends React.Component<Properties, State> {
           <Button
             {...cn('action-button')}
             variant={ButtonVariant.Secondary}
-            onPress={this.openLinkedAccounts}
+            onPress={openLinkedAccounts}
             startEnhancer={<IconLink1 size={20} />}
             color={ButtonColor.Greyscale}
           >
@@ -200,56 +196,54 @@ export class OverviewPanel extends React.Component<Properties, State> {
         )}
       </div>
     );
-  }
+  };
 
-  renderFooter() {
+  const renderFooter = () => {
     return (
       <div {...cn('footer')}>
         <Button
           {...cn('footer-button')}
           variant={ButtonVariant.Secondary}
           color={ButtonColor.Greyscale}
-          onPress={this.openLogoutDialog}
+          onPress={openLogoutDialog}
           startEnhancer={<IconLogOut3 size={20} />}
         >
           Log Out
         </Button>
       </div>
     );
-  }
+  };
 
-  renderRewards() {
+  const renderRewards = () => {
     return (
-      <div {...cn('rewards')} onClick={this.openRewards}>
+      <div {...cn('rewards')} onClick={openRewards}>
         <RewardsItemContainer />
       </div>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div {...cn()}>
-        <div {...cn('header-container')}>
-          <PanelHeader title={'Profile'} onBack={this.navigateBack} />
-        </div>
+  return (
+    <div {...cn()}>
+      <div {...cn('header-container')}>
+        <PanelHeader title={'Profile'} onBack={navigateBack} />
+      </div>
 
-        <ScrollbarContainer variant='on-hover'>
-          <div {...cn('panel-content-wrapper')}>
-            <div {...cn('body')}>
-              <div {...cn('section')}>
-                {this.renderDetails()}
-                {featureFlags.enableRewards && this.renderRewards()}
-              </div>
-
-              {this.renderActions()}
+      <ScrollbarContainer variant='on-hover'>
+        <div {...cn('panel-content-wrapper')}>
+          <div {...cn('body')}>
+            <div {...cn('section')}>
+              {renderDetails()}
+              {featureFlags.enableRewards && renderRewards()}
             </div>
 
-            {this.renderFooter()}
+            {renderActions()}
           </div>
-        </ScrollbarContainer>
 
-        {this.renderInviteDialog()}
-      </div>
-    );
-  }
-}
+          {renderFooter()}
+        </div>
+      </ScrollbarContainer>
+
+      {renderInviteDialog()}
+    </div>
+  );
+};

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -9,11 +9,11 @@ export function inputEvent(attrs = {}) {
 }
 
 export function buttonLabelled(wrapper, label) {
-  return wrapper.findWhere((node) => node.type() === Button && node.children().text() === label);
+  return wrapper.findWhere((node) => node.type() === Button && node.prop('children') === label);
 }
 
 export function pressButton(wrapper, label: string) {
-  buttonLabelled(wrapper, label).simulate('press');
+  buttonLabelled(wrapper, label).prop('onPress')();
 }
 
 export async function releaseThread() {


### PR DESCRIPTION
### What does this do?
Fixes the profile images in the user panels (overview and edit profile)
I missed these 2 profile images when doing the profile image refactor.
Since we're using the useMatrixImage hook, I converted them to function components as well