### PR TITLE
Fix notification counts in encrypted rooms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ZERO",
       "version": "1.344.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@craco/craco": "^7.1.0",
         "@emotion/react": "^11.9.3",
@@ -50,7 +51,7 @@
         "lodash.kebabcase": "^4.1.1",
         "lodash.uniqby": "^4.7.0",
         "matrix-encrypt-attachment": "^1.0.3",
-        "matrix-js-sdk": "^37.3.0",
+        "matrix-js-sdk": "^37.4.0",
         "millify": "^6.1.0",
         "moment": "^2.29.4",
         "normalizr": "^3.6.2",
@@ -30620,9 +30621,9 @@
       "integrity": "sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA=="
     },
     "node_modules/matrix-js-sdk": {
-      "version": "37.3.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-37.3.0.tgz",
-      "integrity": "sha512-uYpXEucA+y9b116Hn+zG+X+u2GE2dACh+aN0BhiJDL/LtvhQgrXT4ZLG/N7OizomoHHF+i/WetDhi+rzDJQdDw==",
+      "version": "37.4.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-37.4.0.tgz",
+      "integrity": "sha512-blNkfswy9PbzXJor/SErL7KCj6ZC7n+PjeA20spikWyyLNBl/+duS4Noc9Cnf82mERbuFOIms5eN4Mcqn9Q7xw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -66288,9 +66289,9 @@
       "integrity": "sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA=="
     },
     "matrix-js-sdk": {
-      "version": "37.3.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-37.3.0.tgz",
-      "integrity": "sha512-uYpXEucA+y9b116Hn+zG+X+u2GE2dACh+aN0BhiJDL/LtvhQgrXT4ZLG/N7OizomoHHF+i/WetDhi+rzDJQdDw==",
+      "version": "37.4.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-37.4.0.tgz",
+      "integrity": "sha512-blNkfswy9PbzXJor/SErL7KCj6ZC7n+PjeA20spikWyyLNBl/+duS4Noc9Cnf82mERbuFOIms5eN4Mcqn9Q7xw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@matrix-org/matrix-sdk-crypto-wasm": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "web3-utils": "^4.1.1"
   },
   "scripts": {
-    "start": "vite --force",
+    "start": "vite",
     "build": "tsc && NODE_OPTIONS='--max-old-space-size=6144' vite build",
     "test": "craco test --env=node",
     "test:vitest": "vitest",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash.kebabcase": "^4.1.1",
     "lodash.uniqby": "^4.7.0",
     "matrix-encrypt-attachment": "^1.0.3",
-    "matrix-js-sdk": "^37.3.0",
+    "matrix-js-sdk": "^37.4.0",
     "millify": "^6.1.0",
     "moment": "^2.29.4",
     "normalizr": "^3.6.2",
@@ -79,7 +79,7 @@
     "web3-utils": "^4.1.1"
   },
   "scripts": {
-    "start": "vite",
+    "start": "vite --force",
     "build": "tsc && NODE_OPTIONS='--max-old-space-size=6144' vite build",
     "test": "craco test --env=node",
     "test:vitest": "vitest",

--- a/patches/matrix-js-sdk+37.4.0.patch
+++ b/patches/matrix-js-sdk+37.4.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/matrix-js-sdk/lib/models/room.js b/node_modules/matrix-js-sdk/lib/models/room.js
+index 11449c2..2bc1cbb 100644
+--- a/node_modules/matrix-js-sdk/lib/models/room.js
++++ b/node_modules/matrix-js-sdk/lib/models/room.js
+@@ -1157,13 +1157,19 @@ export class Room extends ReadReceipt {
+       }
+       var events = timeline.getEvents();
+       var highlightCount = 0;
++      var lastEvent = events[events.length - 1];
++      var lastEventId = lastEvent ? lastEvent.getId() : null;
+       for (var i = events.length - 1; i >= 0; i--) {
+         var _pushActions$tweaks;
+         if (i === events.length - maxHistory) return; // limit reached
+ 
+         var _event = events[i];
++        // If the user has read the event, then the counting is done.
+         if (this.hasUserReadEvent(this.client.getUserId(), _event.getId())) {
+-          // If the user has read the event, then the counting is done.
++          // If the read event is the last event in the timeline, reset total count
++          if (threadId === "main" && _event.getId() === lastEventId) {
++            this.setUnreadNotificationCount(NotificationCountType.Total, 0);
++          }
+           break;
+         }
+         var pushActions = this.client.getPushActionsForEvent(_event);

--- a/src/lib/chat/matrix-client.vitest.ts
+++ b/src/lib/chat/matrix-client.vitest.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MatrixClient } from './matrix-client';
 import { ConnectionStatus, MatrixConstants, ReadReceiptPreferenceType, CustomEventType } from './matrix/types';
-import { EventType, MsgType, ReceiptType } from 'matrix-js-sdk/lib/matrix';
+import { EventType, MsgType } from 'matrix-js-sdk/lib/matrix';
 import { RelationType } from 'matrix-js-sdk/lib/@types/event';
 
 // Add fetch mock type

--- a/src/lib/chat/matrix-client.vitest.ts
+++ b/src/lib/chat/matrix-client.vitest.ts
@@ -102,6 +102,7 @@ const createMockRoom = (overrides = {}) => ({
   getReceiptsForEvent: vi.fn().mockReturnValue([]),
   hasEncryptionStateEvent: vi.fn().mockReturnValue(false),
   getInvitedAndJoinedMemberCount: vi.fn().mockReturnValue(2),
+  setUnreadNotificationCount: vi.fn(),
   on: vi.fn(),
   ...overrides,
 });
@@ -577,8 +578,7 @@ describe('MatrixClient', () => {
       await matrixClient.connect('@test:matrix.org', 'test-access-token');
       await matrixClient.markRoomAsRead(roomId);
 
-      expect(mockMatrix.sendReadReceipt).toHaveBeenCalledWith(latestEvent, ReceiptType.ReadPrivate);
-      expect(mockMatrix.setRoomReadMarkers).toHaveBeenCalledWith(roomId, 'latest-event-id');
+      expect(mockMatrix.setRoomReadMarkers).toHaveBeenCalledWith(roomId, 'latest-event-id', undefined, latestEvent);
     });
 
     it('gets room alias correctly', async () => {

--- a/src/lib/chat/slidingSync.ts
+++ b/src/lib/chat/slidingSync.ts
@@ -23,6 +23,7 @@ const REQUIRED_STATE_LIST = [
   [EventType.RoomCreate, ''],
   [CustomEventType.GROUP_TYPE, MSC3575_WILDCARD],
   [EventType.RoomMember, MSC3575_WILDCARD],
+  [EventType.Receipt, ''],
 ];
 
 // the things to fetch when a user clicks on a room
@@ -38,6 +39,7 @@ const UNENCRYPTED_SUBSCRIPTION_NAME = 'unencrypted';
 const UNENCRYPTED_SUBSCRIPTION = {
   required_state: [
     [EventType.RoomMember, MSC3575_WILDCARD],
+    [EventType.Receipt, ''],
   ],
   ...DEFAULT_ROOM_SUBSCRIPTION_INFO,
 };

--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -70,11 +70,6 @@ export function* updateChannelWithRoomData(roomId: string, roomData: MSC3575Room
   initialChannelUpdates.messages = messages;
   initialChannelUpdates.lastMessage = lastMessage;
 
-  initialChannelUpdates.unreadCount = {
-    total: roomData.notification_count,
-    highlight: roomData.highlight_count,
-  };
-
   return {
     ...baseChannel,
     bumpStamp: roomData.bump_stamp,


### PR DESCRIPTION
### What does this do?
Adds a patch to matrix-js-sdk to fix notification counts in encrypted rooms.
I'll be opening an issue with the sdk to talk about how we can fix this in there instead of handling it as a patch, but for now 

### Why are we making this change?
Unread notification counts have had some odd issues with sliding sync.
1. Sliding sync doesn't have accurate counts for encrypted rooms. I've removed relying on this data.
2. Read receipts weren't properly updating unread counts. I've added a patch to matrix-js-sdk to fix this.