### PR TITLE
Fix: Small fixes with Sliding Sync

### DIFF
--- a/src/store/channels-list/utils.ts
+++ b/src/store/channels-list/utils.ts
@@ -48,6 +48,10 @@ export function* updateChannelWithRoomData(roomId: string, roomData: MSC3575Room
       if (relatesTo && relatesTo.rel_type === MatrixConstants.REPLACE) {
         id = relatesTo.event_id;
       }
+      // Only add the placeholder event if it's not already in the timeline (to avoid duplicates from edits)
+      if (acc.find((e) => e.event_id === id)) {
+        return acc;
+      }
       acc.push({
         ...evt,
         event_id: id,


### PR DESCRIPTION
### What does this do?
If a message is decrypting, it could be included twice in encrypted conversations when using the initial sync response.
Adding a check to prevent that.

Also cleaning up a call to get users from redux to use the new matrix ids hook.