### PR TITLE
Fix: Refactor other room member sagas

### DIFF
--- a/src/lib/chat/matrix/event-type-handlers/roomMessage.ts
+++ b/src/lib/chat/matrix/event-type-handlers/roomMessage.ts
@@ -1,7 +1,8 @@
 import { EventType } from 'matrix-js-sdk';
-import { put } from 'redux-saga/effects';
+import { put, select } from 'redux-saga/effects';
 import { receive } from '../../../../store/channels';
 import { MSC3575RoomData } from 'matrix-js-sdk/lib/sliding-sync';
+import { rawChannel } from '../../../../store/channels/selectors';
 
 type RoomMessageEvent = {
   type: EventType.RoomMessage | EventType.RoomMessageEncrypted;
@@ -17,6 +18,9 @@ export const isRoomMessageEvent = (event: unknown): event is RoomMessageEvent =>
 };
 
 export function* handleRoomMessageEvent(_event: RoomMessageEvent, roomId: string, roomData: MSC3575RoomData) {
+  const channel = yield select((state) => rawChannel(state, roomId));
+  if (channel.bumpStamp === roomData.bump_stamp) return;
+
   // Ensure the bump stamp is updated when new messages are received
   yield put(
     receive({


### PR DESCRIPTION
### What does this do?
Refactors the other room member sagas to be batched and debounced.
If a large channel was syncing, we would trigger a redux action with every member join event which was flooding the store with updates. Now they're debounced and instead of using the payload of the event, we just update with the data from the room itself so that we don't have to rely on the event payloads. This should keep things much simpler and more optimized

### Why are we making this change?
Background events were spamming the redux store when syncing channels. Since we have a lot of components that re-render unnecessarily, this was causing some UI jank.