### PR TITLE
feat(posts): implement media posts using FormData

### DIFF
--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -141,7 +141,8 @@ export class PostInput extends React.Component<Properties, State> {
   };
 
   mediaSelected = (newMedia: Media[]): void => {
-    this.setState({ media: [...this.state.media, ...newMedia] });
+    const mediaToAdd = newMedia[0] ? [newMedia[0]] : [];
+    this.setState({ media: mediaToAdd });
     this.props.onPostInputRendered(this.textareaRef);
   };
 
@@ -150,7 +151,7 @@ export class PostInput extends React.Component<Properties, State> {
       ? this.props.dropzoneToMedia(acceptedFiles)
       : dropzoneToMedia(acceptedFiles);
     if (newImages.length) {
-      this.mediaSelected(newImages);
+      this.mediaSelected([newImages[0]]);
     }
   };
 

--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -21,6 +21,7 @@ import { Media, addImagePreview, dropzoneToMedia, windowClipboard } from '../../
 import { EmojiPicker } from '../../../../components/message-input/emoji-picker/emoji-picker';
 import { MatrixAvatar } from '../../../../components/matrix-avatar';
 import { POST_MAX_LENGTH } from '../../lib/constants';
+import { featureFlags } from '../../../../lib/feature-flags';
 
 const SHOW_MAX_LABEL_THRESHOLD = 0.8 * POST_MAX_LENGTH;
 
@@ -190,7 +191,7 @@ export class PostInput extends React.Component<Properties, State> {
           noClick
           accept={this.mimeTypes}
           maxSize={config.cloudinary.max_file_size}
-          disabled={true}
+          disabled={!featureFlags.enablePostMedia}
         >
           {({ getRootProps }) => (
             <div {...getRootProps({ ...cn('drop-zone-text-area') })}>

--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -19,6 +19,10 @@ export const PostMedia = ({ media, onImageClick }: PostMediaProps) => {
     setIsImageLoaded(true);
   };
 
+  const onClick = () => {
+    onImageClick?.(media);
+  };
+
   const renderPlaceholderContent = () => (
     <>
       {media.filecoinStatus === 'failed' ? (
@@ -39,7 +43,7 @@ export const PostMedia = ({ media, onImageClick }: PostMediaProps) => {
   }
 
   return (
-    <div className={styles.BlockImage} onClick={() => onImageClick?.(media)}>
+    <div className={styles.BlockImage} onClick={onClick}>
       <img src={media.url} alt={media.name} onLoad={handleImageLoad} style={!isImageLoaded ? { width, height } : {}} />
     </div>
   );

--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { IconAlertCircle } from '@zero-tech/zui/icons';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { getPlaceholderDimensions } from './utils';
-import { PostMedia as PostMediaType, PostMediaType as MediaType } from './types';
+import { PostMedia as PostMediaType } from './types';
 
 import styles from './styles.module.scss';
 
@@ -38,26 +38,9 @@ export const PostMedia = ({ media, onImageClick }: PostMediaProps) => {
     );
   }
 
-  if (media.type === MediaType.Image) {
-    return (
-      <div className={styles.BlockImage} onClick={() => onImageClick?.(media)}>
-        <img
-          src={media.url}
-          alt={media.name}
-          onLoad={handleImageLoad}
-          style={!isImageLoaded ? { width, height } : {}}
-        />
-      </div>
-    );
-  } else if (media.type === MediaType.Video) {
-    return (
-      <div className={styles.BlockVideo}>
-        <video controls>
-          <source src={media.url} />
-        </video>
-      </div>
-    );
-  }
-
-  return null;
+  return (
+    <div className={styles.BlockImage} onClick={() => onImageClick?.(media)}>
+      <img src={media.url} alt={media.name} onLoad={handleImageLoad} style={!isImageLoaded ? { width, height } : {}} />
+    </div>
+  );
 };

--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+import { getPlaceholderDimensions } from './utils';
+import { PostMedia as PostMediaType, PostMediaType as MediaType } from './types';
+
+import styles from './styles.module.scss';
+
+interface PostMediaProps {
+  media: PostMediaType;
+  onImageClick?: (media: PostMediaType) => void;
+}
+
+export const PostMedia = ({ media, onImageClick }: PostMediaProps) => {
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const { width, height } = getPlaceholderDimensions(media.width, media.height);
+
+  const handleImageLoad = () => {
+    setIsImageLoaded(true);
+  };
+
+  const renderPlaceholderContent = () => (
+    <>
+      {media.filecoinStatus === 'failed' ? (
+        <IconAlertCircle size={32} className={styles.Failed} />
+      ) : (
+        <div className={styles.Placeholder} />
+      )}
+      {media.filecoinStatus === 'pending' && <Spinner className={styles.Loading} />}
+    </>
+  );
+
+  if (!media.url) {
+    return (
+      <div className={styles.PlaceholderContainer} style={{ width, height }}>
+        <div className={styles.PlaceholderContent}>{renderPlaceholderContent()}</div>
+      </div>
+    );
+  }
+
+  if (media.type === MediaType.Image) {
+    return (
+      <div className={styles.BlockImage} onClick={() => onImageClick?.(media)}>
+        <img
+          src={media.url}
+          alt={media.name}
+          onLoad={handleImageLoad}
+          style={!isImageLoaded ? { width, height } : {}}
+        />
+      </div>
+    );
+  } else if (media.type === MediaType.Video) {
+    return (
+      <div className={styles.BlockVideo}>
+        <video controls>
+          <source src={media.url} />
+        </video>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/src/apps/feed/components/post-media/styles.module.scss
+++ b/src/apps/feed/components/post-media/styles.module.scss
@@ -1,0 +1,95 @@
+.BlockImage {
+  position: relative;
+  width: 100%;
+  margin-top: 16px;
+
+  img {
+    display: block;
+    margin: auto;
+    max-width: 100%;
+    max-height: 520px;
+    border-radius: 16px;
+    border: 1px solid rgba(52, 56, 60, 0.5);
+  }
+
+  animation: fadein 1s ease-in forwards;
+}
+
+.BlockVideo {
+  position: relative;
+  width: 100%;
+  margin-top: 16px;
+
+  video {
+    display: block;
+    margin: auto;
+    max-width: 100%;
+    max-height: 520px;
+    border-radius: 16px;
+    border: 1px solid rgba(52, 56, 60, 0.5);
+  }
+}
+
+.PlaceholderContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 16px auto 0;
+  max-width: 100%;
+  max-height: 520px;
+}
+
+.PlaceholderContent {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.Placeholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  filter: blur(2px);
+  background-color: rgba(54, 93, 87, 0.2);
+  border: 1px solid rgba(52, 56, 60, 0.5);
+}
+
+.Loading {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(90deg, rgba(54, 93, 87, 0.2) 25%, rgba(54, 93, 87, 0.4) 50%, rgba(54, 93, 87, 0.2) 75%);
+  background-size: 600px 100%;
+  animation: fadein 1s ease-in forwards, loadingShimmer 2s infinite linear;
+}
+
+.Failed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: none;
+  border: none;
+  color: var(--color-failure-11);
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes loadingShimmer {
+  0% {
+    background-position: -600px 0;
+  }
+  100% {
+    background-position: 600px 0;
+  }
+}

--- a/src/apps/feed/components/post-media/styles.module.scss
+++ b/src/apps/feed/components/post-media/styles.module.scss
@@ -15,21 +15,6 @@
   animation: fadein 1s ease-in forwards;
 }
 
-.BlockVideo {
-  position: relative;
-  width: 100%;
-  margin-top: 16px;
-
-  video {
-    display: block;
-    margin: auto;
-    max-width: 100%;
-    max-height: 520px;
-    border-radius: 16px;
-    border: 1px solid rgba(52, 56, 60, 0.5);
-  }
-}
-
 .PlaceholderContainer {
   display: flex;
   justify-content: center;

--- a/src/apps/feed/components/post-media/types.ts
+++ b/src/apps/feed/components/post-media/types.ts
@@ -1,0 +1,17 @@
+export enum PostMediaType {
+  Image = 'image',
+  Video = 'video',
+}
+
+export interface PostMedia {
+  id: string;
+  url: string;
+  name: string;
+  type: PostMediaType;
+  width?: number;
+  height?: number;
+  filecoinCid?: string;
+  filecoinStatus?: 'pending' | 'completed' | 'failed';
+  createdAt?: string;
+  updatedAt?: string;
+}

--- a/src/apps/feed/components/post-media/types.ts
+++ b/src/apps/feed/components/post-media/types.ts
@@ -1,6 +1,5 @@
 export enum PostMediaType {
   Image = 'image',
-  Video = 'video',
 }
 
 export interface PostMedia {

--- a/src/apps/feed/components/post-media/utils.ts
+++ b/src/apps/feed/components/post-media/utils.ts
@@ -1,0 +1,18 @@
+export const getPlaceholderDimensions = (w: number, h: number) => {
+  const width = w || 300;
+  const height = h || 200;
+  const maxWidth = 520;
+  const maxHeight = 640;
+  const aspectRatio = width / height;
+  let finalWidth = width;
+  let finalHeight = height;
+  if (height > maxHeight) {
+    finalHeight = maxHeight;
+    finalWidth = maxHeight * aspectRatio;
+  }
+  if (finalWidth > maxWidth) {
+    finalWidth = maxWidth;
+    finalHeight = maxWidth / aspectRatio;
+  }
+  return { width: finalWidth, height: finalHeight };
+};

--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -16,6 +16,8 @@ import { usePostRoute } from './lib/usePostRoute';
 import Linkify from 'linkify-react';
 import { PostLinkPreview } from './link-preview';
 import { detectLinkType } from './link-preview/utils';
+import { PostMedia } from '../post-media';
+import { PostMedia as PostMediaType } from '../post-media/types';
 
 import classNames from 'classnames';
 import styles from './styles.module.scss';
@@ -41,6 +43,7 @@ export interface PostProps {
   isSinglePostView?: boolean;
   authorPrimaryZid?: string;
   authorPublicAddress?: string;
+  media?: PostMediaType;
 
   meowPost: (postId: string, meowAmount: string) => void;
 }
@@ -65,6 +68,7 @@ export const Post = ({
   isSinglePostView = false,
   authorPrimaryZid,
   authorPublicAddress,
+  media,
 }: PostProps) => {
   const isMeowsEnabled = featureFlags.enableMeows;
   const isDisabled =
@@ -125,6 +129,7 @@ export const Post = ({
               {variant === 'expanded' && (
                 <span className={styles.Date}>{moment(timestamp).format('h:mm A - D MMM YYYY')}</span>
               )}
+              {media && <PostMedia media={media} />}
             </div>
           }
           details={

--- a/src/apps/feed/lib/useSubmitPost.ts
+++ b/src/apps/feed/lib/useSubmitPost.ts
@@ -34,7 +34,7 @@ export const useSubmitPost = () => {
     /**
      * @note this mutation function is an almost exact copy of the saga logic. This will be refactored in the future.
      */
-    mutationFn: async ({ message, replyToId, channelZid }: SubmitPostParams) => {
+    mutationFn: async ({ message, media, replyToId, channelZid }: SubmitPostParams) => {
       const formattedUserPrimaryZid = userPrimaryZid.replace('0://', '');
 
       const authorAddress = featureFlags.enableZeroWalletSigning ? account?.address : connectedAddress;
@@ -47,11 +47,11 @@ export const useSubmitPost = () => {
         throw new Error('Channel ZID is invalid');
       }
 
-      if (!message || message.trim() === '') {
+      if ((!message || message.trim() === '') && (!media || media.length === 0)) {
         throw new Error('Post is empty');
       }
 
-      if (message.length > POST_MAX_LENGTH) {
+      if (message && message.length > POST_MAX_LENGTH) {
         throw new Error(`Post must be less than ${POST_MAX_LENGTH} characters`);
       }
 
@@ -95,6 +95,14 @@ export const useSubmitPost = () => {
       formData.append('walletAddress', authorAddress);
       if (replyToId) {
         formData.append('replyTo', replyToId);
+      }
+
+      if (featureFlags.enablePostMedia && media?.length) {
+        media.forEach((file, index) => {
+          if (file.nativeFile) {
+            formData.append(`media[${index}]`, file.nativeFile);
+          }
+        });
       }
 
       let res;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -37,6 +37,7 @@ export class FeatureFlags implements FeatureFlagValues {
   declare enableAuraZApp: boolean;
   declare enableProfile: boolean;
   declare enableUserProfiles: boolean;
+  declare enablePostMedia: boolean;
 
   constructor() {
     this.config = process.env.NODE_ENV === 'production' ? productionFlags : developmentFlags;

--- a/src/lib/feature-flags/development.ts
+++ b/src/lib/feature-flags/development.ts
@@ -30,4 +30,5 @@ export const developmentFlags: FeatureFlagDefinitions = {
   },
   enableProfile: { defaultValue: true },
   enableUserProfiles: { defaultValue: true },
+  enablePostMedia: { defaultValue: true },
 };

--- a/src/lib/feature-flags/flags.ts
+++ b/src/lib/feature-flags/flags.ts
@@ -26,7 +26,8 @@ export type FeatureFlagKey =
   | 'enableFeedChat'
   | 'enableAuraZApp'
   | 'enableProfile'
-  | 'enableUserProfiles';
+  | 'enableUserProfiles'
+  | 'enablePostMedia';
 
 export interface FeatureFlagConfig {
   defaultValue: boolean;

--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -35,4 +35,5 @@ export const productionFlags: FeatureFlagDefinitions = {
   },
   enableProfile: { defaultValue: true },
   enableUserProfiles: { defaultValue: true },
+  enablePostMedia: { defaultValue: false },
 };

--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -66,7 +66,7 @@ export function* fetchPost(action) {
 }
 
 export function* sendPost(action) {
-  const { channelId, message, replyToId } = action.payload;
+  const { channelId, message, replyToId, media } = action.payload;
 
   const channel = yield select(channelSelector(channelId));
 
@@ -94,7 +94,7 @@ export function* sendPost(action) {
     }
 
     // If the message contect is empty, or the channel does not have a name
-    if (!message || message.trim() === '') {
+    if ((!message || message.trim() === '') && (!media || media.length === 0)) {
       throw new Error('Post is empty');
     }
 


### PR DESCRIPTION
### What does this do?
We're updating the post creation flow to handle media files through FormData instead of separate endpoints.

### Why are we making this change?
To simplify the media upload process by using the existing post creation endpoint instead of creating new endpoints.

### How do I test this?
run tests as usual - Note : backend is not yet wired up to support media in posts

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
