### PR TITLE
Removing unread count while sync is incomplete

### DIFF
--- a/src/lib/chat/matrix/matrix-adapter.ts
+++ b/src/lib/chat/matrix/matrix-adapter.ts
@@ -2,7 +2,6 @@ import { Channel, ConversationStatus } from '../../../store/channels';
 import matrixClientInstance from './matrix-client-instance';
 import { IN_ROOM_MEMBERSHIP_STATES } from './types';
 import { Room } from 'matrix-js-sdk/lib/models/room';
-import { NotificationCountType } from 'matrix-js-sdk/lib/models/room';
 import { User } from '../../../store/channels';
 import { User as MatrixUser } from 'matrix-js-sdk/lib/models/user';
 import { extractUserIdFromMatrixId } from './utils';

--- a/src/lib/chat/matrix/matrix-adapter.ts
+++ b/src/lib/chat/matrix/matrix-adapter.ts
@@ -44,10 +44,6 @@ export class MatrixAdapter {
     const createdAt = matrixClientInstance.getRoomCreatedAt(room);
     const labels = Object.keys(room.tags || {});
     const [admins, mods] = matrixClientInstance.getRoomAdminsAndMods(room);
-    const unreadCount = {
-      total: room.getUnreadNotificationCount(),
-      highlight: room.getUnreadNotificationCount(NotificationCountType.Highlight),
-    };
 
     const members = MatrixAdapter.getRoomMembers(room.roomId);
 
@@ -60,7 +56,6 @@ export class MatrixAdapter {
       memberHistory: members.memberHistory,
       totalMembers: members.totalMembers,
       createdAt,
-      unreadCount,
       conversationStatus: ConversationStatus.CREATED,
       adminMatrixIds: admins,
       moderatorIds: mods,


### PR DESCRIPTION
### What does this do?
The unread count is not accurate while the sliding sync is running, so we'll rely on regular matrix events for this information

### Why are we making this change?
Fixes an issue where sometimes channels will load in with 1 unread count, even though they are fully read