### PR TITLE
Fix user optimistic messages not being updated with event data

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -24,6 +24,7 @@ import {
   IContent,
   NotificationCount,
   NotificationCountType,
+  EventStatus,
 } from 'matrix-js-sdk/lib/matrix';
 import { CryptoApi, CryptoCallbacks, decodeRecoveryKey, ImportRoomKeyProgressData } from 'matrix-js-sdk/lib/crypto-api';
 import { RealtimeChatEvents } from './';
@@ -1199,6 +1200,9 @@ export class MatrixClient {
     removed: boolean,
     data: IRoomTimelineData
   ) {
+    if (event.getSender() === this.userId && event.status !== EventStatus.SENDING) {
+      this.publishMessageEvent(event.getEffectiveEvent());
+    }
     if (removed) return;
     if (!data.liveEvent || !!toStartOfTimeline) return;
     if (event.getTs() < this.initializationTimestamp) return;


### PR DESCRIPTION
### What does this do?
Fixes the current user's optimistic messages not being replaced with the actual event data.
For context, when switching to Sliding Sync it seems like Matrix no longer sends a handful of events related to current user's new messages. This was causing us to not update the message properly.
The only event we get is a room timeline event, so I've added some extra logic there to handle these updates