### PR TITLE
fix(components/post): prevent horizontal overflow in posts and truncate long zids with ellipsis

### DIFF
--- a/src/apps/feed/components/post/actions/feed/styles.module.scss
+++ b/src/apps/feed/components/post/actions/feed/styles.module.scss
@@ -2,6 +2,16 @@
   background: none !important;
 }
 
+.Container {
+  span {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
+  }
+}
+
 .Disabled {
   pointer-events: none;
   opacity: 0.5;

--- a/src/apps/feed/components/post/styles.module.scss
+++ b/src/apps/feed/components/post/styles.module.scss
@@ -5,6 +5,8 @@
 .Container {
   display: flex;
   gap: 8px;
+  max-width: 100%;
+  overflow-x: hidden;
 
   &:not([has-author]) {
     [class*='_Header'] {
@@ -41,6 +43,8 @@
 .Post {
   padding: 0;
   flex: 1;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .Body {


### PR DESCRIPTION
### What does this do?
We're adding max-width constraints and overflow handling to both post containers and ZID displays in feed actions, because long ZIDs and post content were causing undesirable horizontal scrolling that broke the layout and user experience.

### How do I test this?
Run tests as usual.
Run UI and check posts where the content, such as zids, are long to check there is no overflow/horizontal scroll.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
