### PR TITLE
feat(lightbox): integrate lightbox with post media display

### DIFF
--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -3,24 +3,27 @@ import { IconAlertCircle } from '@zero-tech/zui/icons';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { getPlaceholderDimensions } from './utils';
 import { PostMedia as PostMediaType } from './types';
+import { useDispatch } from 'react-redux';
+import { openLightbox } from '../../../../store/dialogs';
 
 import styles from './styles.module.scss';
 
 interface PostMediaProps {
   media: PostMediaType;
-  onImageClick?: (media: PostMediaType) => void;
 }
 
-export const PostMedia = ({ media, onImageClick }: PostMediaProps) => {
+export const PostMedia = ({ media }: PostMediaProps) => {
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const { width, height } = getPlaceholderDimensions(media.width, media.height);
+  const dispatch = useDispatch();
 
   const handleImageLoad = () => {
     setIsImageLoaded(true);
   };
 
-  const onClick = () => {
-    onImageClick?.(media);
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    dispatch(openLightbox({ media: [media], startingIndex: 0, hasActions: false }));
   };
 
   const renderPlaceholderContent = () => (
@@ -43,7 +46,7 @@ export const PostMedia = ({ media, onImageClick }: PostMediaProps) => {
   }
 
   return (
-    <div className={styles.BlockImage} onClick={onClick}>
+    <div className={styles.BlockImage} onClick={handleClick}>
       <img src={media.url} alt={media.name} onLoad={handleImageLoad} style={!isImageLoaded ? { width, height } : {}} />
     </div>
   );

--- a/src/apps/feed/components/post-media/styles.module.scss
+++ b/src/apps/feed/components/post-media/styles.module.scss
@@ -2,6 +2,7 @@
   position: relative;
   width: 100%;
   margin-top: 16px;
+  cursor: pointer;
 
   img {
     display: block;

--- a/src/components/dialog-manager/container.test.tsx
+++ b/src/components/dialog-manager/container.test.tsx
@@ -27,6 +27,7 @@ describe('DialogManager', () => {
         isOpen: false,
         media: [],
         startingIndex: 0,
+        hasActions: true,
       },
       closeCreateBackupDialog: () => null,
       closeRestoreBackupDialog: () => null,
@@ -134,7 +135,7 @@ describe('DialogManager', () => {
 
   it('renders Lightbox when lightbox.isOpen is true', () => {
     const wrapper = subject({
-      lightbox: { isOpen: true, media: [], startingIndex: 0 },
+      lightbox: { isOpen: true, media: [], startingIndex: 0, hasActions: true },
     });
 
     expect(wrapper).toHaveElement(Lightbox);
@@ -142,7 +143,7 @@ describe('DialogManager', () => {
 
   it('does not render Lightbox when lightbox.isOpen is false', () => {
     const wrapper = subject({
-      lightbox: { isOpen: false, media: [], startingIndex: 0 },
+      lightbox: { isOpen: false, media: [], startingIndex: 0, hasActions: true },
     });
 
     expect(wrapper).not.toHaveElement(Lightbox);
@@ -166,6 +167,7 @@ describe('DialogManager', () => {
           isOpen: true,
           media: [],
           startingIndex: 0,
+          hasActions: true,
         },
       },
       reportUser: {
@@ -216,6 +218,7 @@ describe('DialogManager', () => {
         isOpen: true,
         media: [],
         startingIndex: 0,
+        hasActions: true,
       });
     });
   });

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -26,6 +26,7 @@ export interface Properties extends PublicProperties {
     isOpen: boolean;
     media: any[];
     startingIndex: number;
+    hasActions: boolean;
   };
 
   closeCreateBackupDialog: () => void;
@@ -128,6 +129,7 @@ export class Container extends React.Component<Properties> {
         items={this.props.lightbox.media}
         startingIndex={this.props.lightbox.startingIndex}
         onClose={this.closeLightbox}
+        hasActions={this.props.lightbox.hasActions}
       />
     );
   };

--- a/src/components/lightbox/index.tsx
+++ b/src/components/lightbox/index.tsx
@@ -22,9 +22,11 @@ export interface LightboxProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getSource: (options: { src: string; options: any }) => string;
   };
+  /** Whether to show action buttons (copy/download). Defaults to true */
+  hasActions?: boolean;
 }
 
-export const Lightbox = ({ items, startingIndex = 0, onClose, provider }: LightboxProps) => {
+export const Lightbox = ({ items, startingIndex = 0, onClose, provider, hasActions = true }: LightboxProps) => {
   const [index, setIndex] = useState(startingIndex);
   const [isCopied, setIsCopied] = useState(false);
   const currentItem = items[index];
@@ -160,7 +162,7 @@ export const Lightbox = ({ items, startingIndex = 0, onClose, provider }: Lightb
       <div className={styles.Controls}>
         <div className={styles.TopBar}>
           <div className={styles.Tools}>
-            {!isCurrentItemGif && (
+            {!isCurrentItemGif && hasActions && (
               <>
                 <IconButton onClick={copyImage} Icon={IconCopy2} size='large' isFilled={isCopied} />
                 <IconButton onClick={downloadImage} Icon={IconDownload2} size='large' />

--- a/src/store/dialogs/index.ts
+++ b/src/store/dialogs/index.ts
@@ -6,6 +6,7 @@ export type DialogState = {
     isOpen: boolean;
     media: any[];
     startingIndex: number;
+    hasActions?: boolean;
   };
 };
 
@@ -15,6 +16,7 @@ export const initialState: DialogState = {
     isOpen: false,
     media: [],
     startingIndex: 0,
+    hasActions: true,
   },
 };
 
@@ -28,11 +30,12 @@ const slice = createSlice({
     closeDeleteMessage: (state) => {
       state.deleteMessageId = null;
     },
-    openLightbox: (state, action: PayloadAction<{ media: any[]; startingIndex: number }>) => {
+    openLightbox: (state, action: PayloadAction<{ media: any[]; startingIndex: number; hasActions?: boolean }>) => {
       state.lightbox = {
         isOpen: true,
         media: action.payload.media,
         startingIndex: action.payload.startingIndex,
+        hasActions: action.payload.hasActions,
       };
     },
     closeLightbox: (state) => {


### PR DESCRIPTION
### What does this do?
We're updating the Lightbox component to work with post media by adding the hasActions prop to control action button visibility.

### Why are we making this change?
We're making these changes to enable post media to be viewed in the lightbox while maintaining a consistent user experience across the application.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
