### PR TITLE
feat(post-input): add media selection menu to post input

### DIFF
--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -10,6 +10,7 @@ import ImageCards from '../../../../platform-apps/channels/image-cards';
 import { PublicProperties as PublicPropertiesContainer } from './container';
 import { ViewModes } from '../../../../shared-components/theme-engine';
 import { IconFaceSmile } from '@zero-tech/zui/icons';
+import { PostMediaMenu } from './menu';
 
 import { bemClassName } from '../../../../lib/bem';
 import classNames from 'classnames';
@@ -137,13 +138,18 @@ export class PostInput extends React.Component<Properties, State> {
       media: media.filter((m) => m.id !== mediaToRemove.id),
     });
 
-    this.props.onPostInputRendered(this.textareaRef);
+    if (this.props.onPostInputRendered) {
+      this.props.onPostInputRendered(this.textareaRef);
+    }
   };
 
   mediaSelected = (newMedia: Media[]): void => {
     const mediaToAdd = newMedia[0] ? [newMedia[0]] : [];
     this.setState({ media: mediaToAdd });
-    this.props.onPostInputRendered(this.textareaRef);
+
+    if (this.props.onPostInputRendered) {
+      this.props.onPostInputRendered(this.textareaRef);
+    }
   };
 
   imagesSelected = (acceptedFiles): void => {
@@ -231,6 +237,7 @@ export class PostInput extends React.Component<Properties, State> {
                   <div {...cn('actions')}>
                     <div {...cn('icon-wrapper')}>
                       <IconButton onClick={this.openEmojis} Icon={IconFaceSmile} size={26} />
+                      {featureFlags.enablePostMedia && <PostMediaMenu onSelected={this.mediaSelected} />}
                       <AnimatePresence>
                         {this.state.value.length > SHOW_MAX_LABEL_THRESHOLD && (
                           <motion.span

--- a/src/apps/feed/components/post-input/menu/index.tsx
+++ b/src/apps/feed/components/post-input/menu/index.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import Dropzone from 'react-dropzone';
+import { bytesToMB, dropzoneToMedia, Media } from '../../../../../components/message-input/utils';
+import { IconPlus } from '@zero-tech/zui/icons';
+import { IconButton, ToastNotification } from '@zero-tech/zui/components';
+import { config } from '../../../../../config';
+
+import './styles.scss';
+
+export interface Properties {
+  onSelected: (images: Media[]) => void;
+}
+
+interface State {
+  isDropRejectedNotificationOpen: boolean;
+}
+
+export class PostMediaMenu extends React.Component<Properties, State> {
+  state = { isDropRejectedNotificationOpen: false };
+
+  imagesSelected = (acceptedFiles): void => {
+    this.setState({ isDropRejectedNotificationOpen: false });
+
+    const newImages: Media[] = dropzoneToMedia(acceptedFiles);
+
+    if (newImages.length) {
+      this.props.onSelected(newImages);
+    }
+  };
+
+  renderToastNotification = () => {
+    const maxSize = bytesToMB(config.cloudinary.max_file_size);
+
+    return (
+      <ToastNotification
+        viewportClassName='post-media-toast-notification'
+        title=''
+        description={`File exceeds ${maxSize} size limit`}
+        actionAltText=''
+        positionVariant='left'
+        openToast={this.state.isDropRejectedNotificationOpen}
+      />
+    );
+  };
+
+  onDropRejected = (rejectedFiles) => {
+    const rejectedFile = rejectedFiles[0];
+    if (rejectedFile?.errors[0]?.code === 'file-too-large') {
+      this.setState({ isDropRejectedNotificationOpen: true });
+    }
+  };
+
+  render() {
+    return (
+      <>
+        <Dropzone
+          onDropRejected={this.onDropRejected}
+          onDrop={this.imagesSelected}
+          accept={{ 'image/*': [] }}
+          maxSize={config.cloudinary.max_file_size}
+        >
+          {({ getRootProps, getInputProps, open }) => (
+            <div className='post-media-menu'>
+              <div {...getRootProps({ className: 'post-media-menu__dropzone' })}>
+                <input {...getInputProps()} />
+                <IconButton onClick={open} Icon={IconPlus} size={26} />
+              </div>
+            </div>
+          )}
+        </Dropzone>
+        {this.renderToastNotification()}
+      </>
+    );
+  }
+}

--- a/src/apps/feed/components/post-input/menu/styles.scss
+++ b/src/apps/feed/components/post-input/menu/styles.scss
@@ -1,0 +1,15 @@
+.post-media-menu {
+  &__dropzone {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: var(--color-grey-100);
+    }
+  }
+}


### PR DESCRIPTION
### What does this do?
We're adding a new PostMediaMenu component to the post input that allows users to explicitly select media files via a plus icon button.

### Why are we making this change?
We're making these changes to provide users with an additional, more intuitive way to add media to their posts, complementing the existing drag-and-drop and paste functionality.

### How do I test this?
Run tests as usual
Run UI and look for '+' icon on post input

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
