### PR TITLE
Fix: Add refresh token to matrix

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -32,6 +32,7 @@ export interface RealtimeChatEvents {
   roomLabelChange: (roomId: string, labels: string[]) => void;
   messageEmojiReactionChange: (roomId: string, reaction: any) => void;
   receiveRoomData: (roomId: string, roomData: MSC3575RoomData) => void;
+  tokenRefreshLogout: () => void;
 }
 
 export class Chat {

--- a/src/lib/chat/matrix-client.vitest.ts
+++ b/src/lib/chat/matrix-client.vitest.ts
@@ -284,7 +284,6 @@ describe('MatrixClient', () => {
       expect(mockSessionStorage.set).toHaveBeenCalledWith({
         userId: '@new-user:matrix.org',
         deviceId: 'new-device',
-        accessToken: 'new-access-token',
       });
     });
   });

--- a/src/lib/chat/session-storage.test.ts
+++ b/src/lib/chat/session-storage.test.ts
@@ -17,7 +17,6 @@ describe('session storage', () => {
   it('sets localStorage vars', async () => {
     const matrixSession = {
       deviceId: 'abc123',
-      accessToken: 'token-4321',
       userId: '@bob:zos-matrix',
     };
 
@@ -26,7 +25,6 @@ describe('session storage', () => {
     client.set(matrixSession);
 
     expect(setItem).toHaveBeenCalledWith('mxz_device_id', 'abc123');
-    expect(setItem).toHaveBeenCalledWith('mxz_access_token_abc123', 'token-4321');
     expect(setItem).toHaveBeenCalledWith('mxz_user_id', '@bob:zos-matrix');
   });
 
@@ -37,21 +35,18 @@ describe('session storage', () => {
     client.clear();
 
     expect(removeItem).toHaveBeenCalledWith('mxz_device_id');
-    expect(removeItem).toHaveBeenCalledWith('mxz_access_token_abc123');
     expect(removeItem).toHaveBeenCalledWith('mxz_user_id');
   });
 
   it('gets from localStorage vars', async () => {
     const matrixSession = {
       deviceId: 'abc123',
-      accessToken: 'token-4321',
       userId: '@bob:zos-matrix',
     };
 
     const getItem = jest.fn((key) => {
       return {
         mxz_device_id: 'abc123',
-        mxz_access_token_abc123: 'token-4321',
         mxz_user_id: '@bob:zos-matrix',
       }[key];
     });
@@ -65,7 +60,6 @@ describe('session storage', () => {
     const getItem = jest.fn((key) => {
       return {
         mxz_device_id: '',
-        mxz_access_token_abc123: 'token-4321',
         mxz_user_id: '@bob:zos-matrix',
       }[key];
     });

--- a/src/lib/chat/session-storage.ts
+++ b/src/lib/chat/session-storage.ts
@@ -1,6 +1,5 @@
 export interface ChatSession {
   deviceId: string;
-  accessToken: string;
   userId: string;
 }
 
@@ -8,10 +7,7 @@ export class SessionStorage {
   constructor(private storage = localStorage) {}
 
   clear() {
-    const deviceId = this.storage.getItem('mxz_device_id');
-
     this.storage.removeItem('mxz_device_id');
-    this.storage.removeItem(`mxz_access_token_${deviceId}`);
     this.storage.removeItem('mxz_user_id');
 
     const allKeys = Object.keys(this.storage);
@@ -21,7 +17,6 @@ export class SessionStorage {
 
   set(session: ChatSession) {
     this.storage.setItem('mxz_device_id', session.deviceId);
-    this.storage.setItem(`mxz_access_token_${session.deviceId}`, session.accessToken);
     this.storage.setItem('mxz_user_id', session.userId);
   }
 
@@ -32,7 +27,6 @@ export class SessionStorage {
 
     return {
       deviceId,
-      accessToken: this.storage.getItem(`mxz_access_token_${deviceId}`),
       userId: this.storage.getItem('mxz_user_id'),
     };
   }

--- a/src/store/chat/bus.ts
+++ b/src/store/chat/bus.ts
@@ -101,6 +101,7 @@ export function createChatConnection(userId: string, chatAccessToken: string, ch
     const roomLabelChange = (roomId, labels) => emit({ type: Events.RoomLabelChange, payload: { roomId, labels } });
     const messageEmojiReactionChange = (roomId, reaction) =>
       emit({ type: Events.MessageEmojiReactionChange, payload: { roomId, reaction } });
+    const tokenRefreshLogout = () => emit({ type: Events.InvalidToken });
 
     chatClient.initChat({
       receiveNewMessage,
@@ -121,6 +122,7 @@ export function createChatConnection(userId: string, chatAccessToken: string, ch
       roomLabelChange,
       messageEmojiReactionChange,
       receiveRoomData,
+      tokenRefreshLogout,
     });
 
     connectionPromise = chatClient.connect(userId, chatAccessToken);

--- a/src/store/matrix/index.ts
+++ b/src/store/matrix/index.ts
@@ -15,6 +15,7 @@ export enum SagaActionTypes {
   CloseRestoreBackupDialog = 'chat/close-restore-backup-dialog',
   VerifyCreatedKey = 'chat/verify-created-key',
   VerifyRestorationKey = 'chat/verify-restoration-key',
+  InvalidToken = 'chat/invalid-token',
 }
 
 export enum CreateBackupStage {

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -27,6 +27,7 @@ import { waitForChatConnectionCompletion } from '../chat/saga';
 import * as Sentry from '@sentry/browser';
 import type { MatrixKeyBackupInfo } from '../../lib/chat/types';
 import { GeneratedSecretStorageKey } from 'matrix-js-sdk/lib/crypto-api';
+import { publishUserLogout } from '../authentication/saga';
 
 export function* saga() {
   yield spawn(listenForUserLogin);
@@ -43,11 +44,16 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.OpenRestoreBackupDialog, userInitiatedRestoreBackupDialog);
   yield takeLatest(SagaActionTypes.VerifyCreatedKey, proceedToVerifyCreatedKey);
   yield takeLatest(SagaActionTypes.VerifyRestorationKey, proceedToVerifyRestorationKey);
+  yield takeLatest(SagaActionTypes.InvalidToken, handleInvalidToken);
 
   // For debugging
   yield takeLatest(SagaActionTypes.DebugDeviceList, debugDeviceList);
   yield takeLatest(SagaActionTypes.DebugRoomKeys, debugRoomKeys);
   yield takeLatest(SagaActionTypes.FetchDeviceInfo, getDeviceInfo);
+}
+
+export function* handleInvalidToken() {
+  yield call(publishUserLogout);
 }
 
 export function* getBackup() {


### PR DESCRIPTION
### What does this do?
Updates how we handle tokens in matrix and introduces refresh tokens.
The access token has been removed from local storage and is now fetched every time the user comes to the app. When the token expires, a new token will be fetched using the refresh token. If that operation fails, the user will be logged out.

### Why are we making this change?
User matrix access tokens are expiring due to us saving the token to local storage and never updating it unless the user either clears local storage manually, or logs out. When this happens, we don't have a way to respond to the 401s properly.
The matrix-js-sdk swallows the 401 errors and just returns null values, so we respond to those values and display invalid states to users in the UI.

The only way I've found to properly handle this situation is to implement the refresh token. The token refresh function also gives us the ability to know if the token is bad and can't be refreshed, which allows us to log the user out.

### How do I test this?
You can leave the console open and see the refresh token endpoint get called occasionally.
