### PR TITLE
Fix: Matrix client instance reset

### DIFF
--- a/src/lib/chat/chat.vitest.ts
+++ b/src/lib/chat/chat.vitest.ts
@@ -111,6 +111,9 @@ describe('Chat', () => {
 
     mockMatrixClient = {
       matrix: mockMatrix,
+      createRoom: vi.fn((options) => mockMatrix.createRoom(options)),
+      getRoom: vi.fn((roomId) => mockMatrix.getRoom(roomId)),
+      invite: vi.fn((roomId, userId) => mockMatrix.invite(roomId, userId)),
       connect: vi.fn().mockResolvedValue('@test:matrix.org'),
       waitForConnection: vi.fn().mockResolvedValue(undefined),
       init: vi.fn(),

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -74,7 +74,7 @@ export class Chat {
    * @returns Partial<Channel>[]
    */
   getChannels(): Partial<Channel>[] {
-    return Matrix.client
+    return this.client
       .getRooms()
       .filter((room) => IN_ROOM_MEMBERSHIP_STATES.includes(room.getMyMembership()))
       .map((room) => MatrixAdapter.mapRoomToChannel(room));

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -4,7 +4,7 @@ import { MatrixClient } from './matrix-client';
 import { FileUploadResult } from '../../store/messages/saga';
 import { MatrixProfileInfo, ParentMessage, PowerLevels, User } from './types';
 import { MSC3575RoomData } from 'matrix-js-sdk/lib/sliding-sync';
-import matrixClientInstance from './matrix/matrix-client-instance';
+import Matrix from './matrix/matrix-client-instance';
 import { CustomEventType, IN_ROOM_MEMBERSHIP_STATES } from './matrix/types';
 import { MatrixAdapter } from './matrix/matrix-adapter';
 import { MemberNetworks } from '../../store/users/types';
@@ -51,17 +51,17 @@ export class Chat {
   }
 
   async getRoomNameById(roomId: string) {
-    const room = this.client.matrix.getRoom(roomId);
+    const room = this.client.getRoom(roomId);
     return room.name;
   }
 
   async getRoomAvatarById(roomId: string) {
-    const room = this.client.matrix.getRoom(roomId);
+    const room = this.client.getRoom(roomId);
     return this.client.getRoomAvatar(room);
   }
 
   getRoomGroupTypeById(roomId: string) {
-    const room = this.client.matrix.getRoom(roomId);
+    const room = this.client.getRoom(roomId);
     return this.client.getRoomGroupType(room);
   }
 
@@ -74,7 +74,7 @@ export class Chat {
    * @returns Partial<Channel>[]
    */
   getChannels(): Partial<Channel>[] {
-    return matrixClientInstance.matrix
+    return Matrix.client
       .getRooms()
       .filter((room) => IN_ROOM_MEMBERSHIP_STATES.includes(room.getMyMembership()))
       .map((room) => MatrixAdapter.mapRoomToChannel(room));
@@ -139,14 +139,14 @@ export class Chat {
       options.name = name;
     }
 
-    const result = await this.client.matrix.createRoom(options);
+    const result = await this.client.createRoom(options);
     // Any room is only set as a DM based on a single user. We'll use the first one.
-    await setAsDM(this.client.matrix, result.room_id, users[0].matrixId);
+    await setAsDM(this.client, result.room_id, users[0].matrixId);
 
-    const room = this.client.matrix.getRoom(result.room_id);
+    const room = this.client.getRoom(result.room_id);
     this.client.initializeRoomEventHandlers(room);
     for (const user of users) {
-      await this.client.matrix.invite(result.room_id, user.matrixId);
+      await this.client.invite(result.room_id, user.matrixId);
     }
     return MatrixAdapter.mapRoomToChannel(room);
   }
@@ -189,13 +189,13 @@ export class Chat {
       options.name = name;
     }
 
-    const result = await this.client.matrix.createRoom(options);
-    await setAsDM(this.client.matrix, result?.room_id, users[0].matrixId);
+    const result = await this.client.createRoom(options);
+    await setAsDM(this.client, result?.room_id, users[0].matrixId);
 
-    const room = this.client.matrix.getRoom(result?.room_id);
+    const room = this.client.getRoom(result?.room_id);
     this.client.initializeRoomEventHandlers(room);
     for (const user of users) {
-      await this.client.matrix.invite(result?.room_id, user.matrixId);
+      await this.client.invite(result?.room_id, user.matrixId);
     }
     return MatrixAdapter.mapRoomToChannel(room);
   }
@@ -320,15 +320,15 @@ export class Chat {
 }
 
 export async function getRoomIdForAlias(alias: string) {
-  return chat.get().getRoomIdForAlias(alias);
+  return Matrix.client.getRoomIdForAlias(alias);
 }
 
 export async function isRoomMember(userId: string, roomId: string) {
-  return await matrixClientInstance.isRoomMember(userId, roomId);
+  return await Matrix.client.isRoomMember(userId, roomId);
 }
 
 export async function getSecureBackup() {
-  return await matrixClientInstance.getSecureBackup();
+  return await Matrix.client.getSecureBackup();
 }
 
 export async function uploadImageUrl(
@@ -340,31 +340,31 @@ export async function uploadImageUrl(
   rootMessageId: string,
   optimisticId: string
 ) {
-  return await matrixClientInstance.uploadImageUrl(channelId, url, width, height, size, rootMessageId, optimisticId);
+  return await Matrix.client.uploadImageUrl(channelId, url, width, height, size, rootMessageId, optimisticId);
 }
 
 export async function sendTypingEvent(roomId: string, isTyping: boolean) {
-  return await matrixClientInstance.sendTypingEvent(roomId, isTyping);
+  return await Matrix.client.sendTypingEvent(roomId, isTyping);
 }
 
 export async function setUserAsModerator(roomId: string, userId: string) {
-  return await matrixClientInstance.setUserAsModerator(roomId, userId);
+  return await Matrix.client.setUserAsModerator(roomId, userId);
 }
 
 export async function removeUserAsModerator(roomId: string, userId: string) {
-  return await matrixClientInstance.removeUserAsModerator(roomId, userId);
+  return await Matrix.client.removeUserAsModerator(roomId, userId);
 }
 
 export async function setReadReceiptPreference(preference: string) {
-  return await matrixClientInstance.setReadReceiptPreference(preference);
+  return await Matrix.client.setReadReceiptPreference(preference);
 }
 
 export async function getReadReceiptPreference() {
-  return await matrixClientInstance.getReadReceiptPreference();
+  return await Matrix.client.getReadReceiptPreference();
 }
 
 export async function getMessageReadReceipts(roomId: string, messageId: string) {
-  return await matrixClientInstance.getMessageReadReceipts(roomId, messageId);
+  return await Matrix.client.getMessageReadReceipts(roomId, messageId);
 }
 
 export async function uploadFileMessage(
@@ -374,19 +374,19 @@ export async function uploadFileMessage(
   optimisticId = '',
   isPost: boolean = false
 ) {
-  return matrixClientInstance.uploadFileMessage(channelId, media, rootMessageId, optimisticId, isPost);
+  return Matrix.client.uploadFileMessage(channelId, media, rootMessageId, optimisticId, isPost);
 }
 
 export async function addRoomToLabel(roomId: string, label: string) {
-  return await matrixClientInstance.addRoomToLabel(roomId, label);
+  return await Matrix.client.addRoomToLabel(roomId, label);
 }
 
 export async function removeRoomFromLabel(roomId: string, label: string) {
-  return await matrixClientInstance.removeRoomFromLabel(roomId, label);
+  return await Matrix.client.removeRoomFromLabel(roomId, label);
 }
 
 export async function sendPostByChannelId(channelId: string, message: string, optimisticId?: string) {
-  return matrixClientInstance.sendPostsByChannelId(channelId, message, optimisticId);
+  return Matrix.client.sendPostsByChannelId(channelId, message, optimisticId);
 }
 
 export async function sendMeowReactionEvent(
@@ -395,27 +395,27 @@ export async function sendMeowReactionEvent(
   postOwnerId: string,
   meowAmount: number
 ) {
-  return matrixClientInstance.sendMeowReactionEvent(roomId, postMessageId, postOwnerId, meowAmount);
+  return Matrix.client.sendMeowReactionEvent(roomId, postMessageId, postOwnerId, meowAmount);
 }
 
 export async function sendEmojiReactionEvent(roomId: string, messageId: string, key: string) {
-  return matrixClientInstance.sendEmojiReactionEvent(roomId, messageId, key);
+  return Matrix.client.sendEmojiReactionEvent(roomId, messageId, key);
 }
 
 export async function getPostMessageReactions(roomId: string) {
-  return matrixClientInstance.getPostMessageReactions(roomId);
+  return Matrix.client.getPostMessageReactions(roomId);
 }
 
 export async function getMessageEmojiReactions(roomId: string) {
-  return matrixClientInstance.getMessageEmojiReactions(roomId);
+  return Matrix.client.getMessageEmojiReactions(roomId);
 }
 
 export async function uploadFile(file: File): Promise<string> {
-  return matrixClientInstance.uploadFile(file);
+  return Matrix.client.uploadFile(file);
 }
 
 export async function downloadFile(fileUrl: string) {
-  return matrixClientInstance.downloadFile(fileUrl);
+  return Matrix.client.downloadFile(fileUrl);
 }
 
 export async function batchDownloadFiles(
@@ -423,41 +423,41 @@ export async function batchDownloadFiles(
   isThumbnail: boolean = false,
   batchSize: number = 25
 ): Promise<{ [fileUrl: string]: string }> {
-  return matrixClientInstance.batchDownloadFiles(fileUrls, isThumbnail, batchSize);
+  return Matrix.client.batchDownloadFiles(fileUrls, isThumbnail, batchSize);
 }
 
 export async function editProfile(profileInfo: MatrixProfileInfo) {
-  return matrixClientInstance.editProfile(profileInfo);
+  return Matrix.client.editProfile(profileInfo);
 }
 
 export function getAccessToken(): string | null {
-  return matrixClientInstance.getAccessToken();
+  return Matrix.client.getAccessToken();
 }
 
 export function mxcUrlToHttp(mxcUrl: string): string {
-  return matrixClientInstance.mxcUrlToHttp(mxcUrl);
+  return Matrix.client.mxcUrlToHttp(mxcUrl);
 }
 
 export function getProfileInfo(userId: string): Promise<{
   avatar_url?: string;
   displayname?: string;
 }> {
-  return matrixClientInstance.getProfileInfo(userId);
+  return Matrix.client.getProfileInfo(userId);
 }
 
 export async function getAliasForRoomId(roomId: string) {
-  return matrixClientInstance.getAliasForRoomId(roomId);
+  return Matrix.client.getAliasForRoomId(roomId);
 }
 
 export async function verifyMatrixProfileDisplayNameIsSynced(displayName: string) {
-  return chat.get().matrix.verifyMatrixProfileDisplayNameIsSynced(displayName);
+  return Matrix.client.verifyMatrixProfileDisplayNameIsSynced(displayName);
 }
 
 let chatClient: Chat;
 export const chat = {
   get() {
     if (!chatClient) {
-      chatClient = new Chat(matrixClientInstance, () => {
+      chatClient = new Chat(Matrix.client, () => {
         chatClient = null;
       });
     }

--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -67,8 +67,8 @@ import { RelationType } from 'matrix-js-sdk/lib/@types/event';
 export const USER_TYPING_TIMEOUT = 5000; // 5s
 
 export class MatrixClient {
-  matrix: SDKMatrixClient = null;
-  cryptoApi: CryptoApi = null;
+  private matrix: SDKMatrixClient = null;
+  private cryptoApi: CryptoApi = null;
   private events: RealtimeChatEvents = null;
   private connectionStatus = ConnectionStatus.Disconnected;
 
@@ -86,12 +86,47 @@ export class MatrixClient {
     this.addConnectionAwaiter();
   }
 
+  /**
+   * Matrix SDK methods to expose on the MatrixClient instance
+   */
+  createRoom: SDKMatrixClient['createRoom'] = (options) => {
+    return this.matrix.createRoom(options);
+  };
+
+  decryptEventIfNeeded: SDKMatrixClient['decryptEventIfNeeded'] = (event, options) => {
+    return this.matrix.decryptEventIfNeeded(event, options);
+  };
+
+  getAccessToken: SDKMatrixClient['getAccessToken'] = () => {
+    return this.matrix.getAccessToken();
+  };
+
+  getRoom: SDKMatrixClient['getRoom'] = (roomId) => {
+    return this.matrix.getRoom(roomId);
+  };
+
+  getRooms: SDKMatrixClient['getRooms'] = () => {
+    return this.matrix.getRooms();
+  };
+
+  getUser: SDKMatrixClient['getUser'] = (userId) => {
+    return this.matrix.getUser(userId);
+  };
+
+  getAccountData: SDKMatrixClient['getAccountData'] = (type) => {
+    return this.matrix.getAccountData(type);
+  };
+
+  invite: SDKMatrixClient['invite'] = (roomId, userId) => {
+    return this.matrix.invite(roomId, userId);
+  };
+
+  setAccountData: SDKMatrixClient['setAccountData'] = (type, content) => {
+    return this.matrix.setAccountData(type, content);
+  };
+
   init(events: RealtimeChatEvents) {
     this.events = events;
-  }
-
-  getAccessToken(): string | null {
-    return this.matrix.getAccessToken();
   }
 
   async connect(userId: string, accessToken: string) {

--- a/src/lib/chat/matrix/matrix-adapter.ts
+++ b/src/lib/chat/matrix/matrix-adapter.ts
@@ -1,5 +1,5 @@
 import { Channel, ConversationStatus, User } from '../../../store/channels';
-import matrixClientInstance from './matrix-client-instance';
+import Matrix from './matrix-client-instance';
 import { Room } from 'matrix-js-sdk/lib/models/room';
 import { User as MatrixUser } from 'matrix-js-sdk/lib/models/user';
 import { extractUserIdFromMatrixId } from './utils';
@@ -11,12 +11,12 @@ export class MatrixAdapter {
    * @returns Partial<Channel>
    */
   public static mapRoomToChannel(room: Room): Partial<Channel> {
-    const icon = matrixClientInstance.getRoomAvatar(room);
-    const createdAt = matrixClientInstance.getRoomCreatedAt(room);
+    const icon = Matrix.client.getRoomAvatar(room);
+    const createdAt = Matrix.client.getRoomCreatedAt(room);
     const labels = Object.keys(room.tags || {});
-    const [admins, mods] = matrixClientInstance.getRoomAdminsAndMods(room);
+    const [admins, mods] = Matrix.client.getRoomAdminsAndMods(room);
 
-    const members = matrixClientInstance.getRoomMembers(room.roomId);
+    const members = Matrix.client.getRoomMembers(room.roomId);
 
     return {
       id: room.roomId,

--- a/src/lib/chat/matrix/matrix-client-instance.ts
+++ b/src/lib/chat/matrix/matrix-client-instance.ts
@@ -1,5 +1,20 @@
 import { MatrixClient } from '../matrix-client';
 
-const matrixClientInstance = new MatrixClient();
+class MatrixInstance {
+  private _clientInstance: MatrixClient;
 
-export default matrixClientInstance;
+  constructor() {
+    this._clientInstance = new MatrixClient();
+  }
+
+  get client() {
+    return this._clientInstance;
+  }
+
+  resetClientInstance() {
+    this._clientInstance = new MatrixClient();
+  }
+}
+
+const Matrix = new MatrixInstance();
+export default Matrix;

--- a/src/lib/chat/matrix/utils.ts
+++ b/src/lib/chat/matrix/utils.ts
@@ -1,9 +1,10 @@
-import { EventType, MatrixClient as SDKMatrixClient } from 'matrix-js-sdk/lib/matrix';
+import { EventType } from 'matrix-js-sdk/lib/matrix';
 import { User as ChannelMember } from '../../../store/channels';
 import isEqual from 'lodash.isequal';
+import { MatrixClient } from '../matrix-client';
 
 // Copied from the matrix-react-sdk
-export async function setAsDM(matrix: SDKMatrixClient, roomId: string, userId: string): Promise<void> {
+export async function setAsDM(matrix: MatrixClient, roomId: string, userId: string): Promise<void> {
   const mDirectEvent = matrix.getAccountData(EventType.Direct);
   const currentContent = mDirectEvent?.getContent() || {};
 

--- a/src/store/channels-list/event-type-handlers/handle-room-data-events.ts
+++ b/src/store/channels-list/event-type-handlers/handle-room-data-events.ts
@@ -6,7 +6,7 @@ import { handleRoomMessageEvent, isRoomMessageEvent } from './room-message';
 import { spawn } from 'redux-saga/effects';
 
 export function* handleRoomDataEvents(roomId: string, roomData: MSC3575RoomData, client: MatrixClient) {
-  const room = client.matrix.getRoom(roomId);
+  const room = client.getRoom(roomId);
   if (!room) return;
 
   for (const event of roomData.required_state) {

--- a/src/store/channels-list/saga.ts
+++ b/src/store/channels-list/saga.ts
@@ -14,7 +14,7 @@ import { channelSelector } from '../channels/selectors';
 import { setIsConversationsLoaded } from '../chat';
 import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { MSC3575RoomData } from 'matrix-js-sdk/lib/sliding-sync';
-import matrixClientInstance from '../../lib/chat/matrix/matrix-client-instance';
+import Matrix from '../../lib/chat/matrix/matrix-client-instance';
 import { userSelector } from '../users/selectors';
 import { handleRoomDataEvents } from './event-type-handlers/handle-room-data-events';
 
@@ -28,7 +28,7 @@ export function* fetchChannels() {
   yield put(setIsConversationsLoaded(true));
   const conversationBus = yield call(getConversationsBus);
   yield put(conversationBus, { type: ConversationEvents.ConversationsLoaded });
-  yield call(matrixClientInstance.waitForConnection);
+  yield call(Matrix.client.waitForConnection);
   // Setup the channels with event handlers
   yield call([chatClient, chatClient.setupConversations]);
 }
@@ -121,7 +121,7 @@ function* batchedRoomDataAction(action: RoomDataAction) {
   pendingRoomData = [];
 
   for (const update of batchedUpdates) {
-    yield call(handleRoomDataEvents, update.roomId, update.roomData, matrixClientInstance);
+    yield call(handleRoomDataEvents, update.roomId, update.roomData, Matrix.client);
     if (update.roomData.initial) {
       const mappedChannel: Partial<Channel> = yield call(updateChannelWithRoomData, update.roomId, update.roomData);
       yield spawn(receiveChannel, mappedChannel);

--- a/src/store/matrix/saga.ts
+++ b/src/store/matrix/saga.ts
@@ -27,6 +27,7 @@ import { waitForChatConnectionCompletion } from '../chat/saga';
 import * as Sentry from '@sentry/browser';
 import type { MatrixKeyBackupInfo } from '../../lib/chat/types';
 import { GeneratedSecretStorageKey } from 'matrix-js-sdk/lib/crypto-api';
+import Matrix from '../../lib/chat/matrix/matrix-client-instance';
 import { publishUserLogout } from '../authentication/saga';
 
 export function* saga() {
@@ -259,6 +260,7 @@ function* listenForUserLogout() {
   while (true) {
     yield take(userChannel, AuthEvents.UserLogout);
     yield call(receiveBackupData, null);
+    yield call(() => Matrix.resetClientInstance());
   }
 }
 

--- a/src/store/users/saga.ts
+++ b/src/store/users/saga.ts
@@ -8,7 +8,7 @@ import { queryClient } from '../../lib/web3/rainbowkit/provider';
 import { verifyMatrixProfileDisplayNameIsSynced as verifyMatrixProfileDisplayNameIsSyncedAPI } from '../../lib/chat';
 import { currentUserSelector } from '../authentication/selectors';
 import { isTelegramMatrixId } from '../../lib/chat/matrix/utils';
-import matrixClientInstance from '../../lib/chat/matrix/matrix-client-instance';
+import Matrix from '../../lib/chat/matrix/matrix-client-instance';
 import { MatrixAdapter } from '../../lib/chat/matrix/matrix-adapter';
 import { User } from '../channels';
 export function* clearUsers() {
@@ -76,7 +76,7 @@ export function* getUsersByMatrixIds(matrixIds: string[]) {
   for (const matrixId of matrixIds) {
     const telegramUsers = [];
     if (isTelegramMatrixId(matrixId)) {
-      const matrixUser = matrixClientInstance.matrix.getUser(matrixId);
+      const matrixUser = Matrix.client.getUser(matrixId);
       if (matrixUser) {
         const user = MatrixAdapter.mapMatrixUserToUser(matrixUser);
         telegramUsers.push(user);


### PR DESCRIPTION
### What does this do?
Reworks the matrix client instance to support resetting the instance when the user logs out.
This only supported being created once, which didn't work well when users logged out then back in without refreshing.

Also, I took the opportunity to clean up the api a bit so that it's more cohesive.
Now the SDK methods are wrapped so that there is a single interface for interacting with Matrix

### Why are we making this change?
Logging out and then back in results in a broken matrix instance