### PR TITLE
feat(posts): implement and wire up ability to post image media

### DIFF
--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -71,6 +71,7 @@ export const Feed = ({ zid, isPostingEnabled = true, userId, isLoading: isLoadin
                     variant='default'
                     authorPrimaryZid={reply.sender?.primaryZid}
                     authorPublicAddress={reply.sender?.publicAddress}
+                    mediaId={reply.mediaId}
                   />
                 </li>
               ))

--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -10,6 +10,8 @@ import ImageCards from '../../../../platform-apps/channels/image-cards';
 import { PublicProperties as PublicPropertiesContainer } from './container';
 import { ViewModes } from '../../../../shared-components/theme-engine';
 import { IconFaceSmile } from '@zero-tech/zui/icons';
+import { PostMediaMenu } from './menu';
+import { featureFlags } from '../../../../lib/feature-flags';
 
 import { bemClassName } from '../../../../lib/bem';
 import classNames from 'classnames';
@@ -136,12 +138,17 @@ export class PostInput extends React.Component<Properties, State> {
       media: media.filter((m) => m.id !== mediaToRemove.id),
     });
 
-    this.props.onPostInputRendered(this.textareaRef);
+    if (this.props.onPostInputRendered) {
+      this.props.onPostInputRendered(this.textareaRef);
+    }
   };
 
   mediaSelected = (newMedia: Media[]): void => {
-    this.setState({ media: [...this.state.media, ...newMedia] });
-    this.props.onPostInputRendered(this.textareaRef);
+    const mediaToAdd = newMedia[0] ? [newMedia[0]] : [];
+    this.setState({ media: mediaToAdd });
+    if (this.props.onPostInputRendered) {
+      this.props.onPostInputRendered(this.textareaRef);
+    }
   };
 
   imagesSelected = (acceptedFiles): void => {
@@ -149,7 +156,7 @@ export class PostInput extends React.Component<Properties, State> {
       ? this.props.dropzoneToMedia(acceptedFiles)
       : dropzoneToMedia(acceptedFiles);
     if (newImages.length) {
-      this.mediaSelected(newImages);
+      this.mediaSelected([newImages[0]]);
     }
   };
 
@@ -190,7 +197,7 @@ export class PostInput extends React.Component<Properties, State> {
           noClick
           accept={this.mimeTypes}
           maxSize={config.cloudinary.max_file_size}
-          disabled={true}
+          disabled={!featureFlags.enablePostMedia}
         >
           {({ getRootProps }) => (
             <div {...getRootProps({ ...cn('drop-zone-text-area') })}>
@@ -229,6 +236,7 @@ export class PostInput extends React.Component<Properties, State> {
                   <div {...cn('actions')}>
                     <div {...cn('icon-wrapper')}>
                       <IconButton onClick={this.openEmojis} Icon={IconFaceSmile} size={26} />
+                      {featureFlags.enablePostMedia && <PostMediaMenu onSelected={this.mediaSelected} />}
                       <AnimatePresence>
                         {this.state.value.length > SHOW_MAX_LABEL_THRESHOLD && (
                           <motion.span

--- a/src/apps/feed/components/post-input/menu/index.tsx
+++ b/src/apps/feed/components/post-input/menu/index.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import Dropzone from 'react-dropzone';
+import { bytesToMB, dropzoneToMedia, Media } from '../../../../../components/message-input/utils';
+import { IconPlus } from '@zero-tech/zui/icons';
+import { IconButton, ToastNotification } from '@zero-tech/zui/components';
+import { config } from '../../../../../config';
+
+import './styles.scss';
+
+export interface Properties {
+  onSelected: (images: Media[]) => void;
+}
+
+interface State {
+  isDropRejectedNotificationOpen: boolean;
+}
+
+export class PostMediaMenu extends React.Component<Properties, State> {
+  state = { isDropRejectedNotificationOpen: false };
+
+  imagesSelected = (acceptedFiles): void => {
+    this.setState({ isDropRejectedNotificationOpen: false });
+
+    const newImages: Media[] = dropzoneToMedia(acceptedFiles);
+
+    if (newImages.length) {
+      this.props.onSelected(newImages);
+    }
+  };
+
+  renderToastNotification = () => {
+    const maxSize = bytesToMB(config.cloudinary.max_file_size);
+
+    return (
+      <ToastNotification
+        viewportClassName='post-media-toast-notification'
+        title=''
+        description={`File exceeds ${maxSize} size limit`}
+        actionAltText=''
+        positionVariant='left'
+        openToast={this.state.isDropRejectedNotificationOpen}
+      />
+    );
+  };
+
+  onDropRejected = (rejectedFiles) => {
+    const rejectedFile = rejectedFiles[0];
+    if (rejectedFile?.errors[0]?.code === 'file-too-large') {
+      this.setState({ isDropRejectedNotificationOpen: true });
+    }
+  };
+
+  render() {
+    return (
+      <>
+        <Dropzone
+          onDropRejected={this.onDropRejected}
+          onDrop={this.imagesSelected}
+          accept={{ 'image/*': [] }}
+          maxSize={config.cloudinary.max_file_size}
+        >
+          {({ getRootProps, getInputProps, open }) => (
+            <div className='post-media-menu'>
+              <div {...getRootProps({ className: 'post-media-menu__dropzone' })}>
+                <input {...getInputProps()} />
+                <IconButton onClick={open} Icon={IconPlus} size={26} />
+              </div>
+            </div>
+          )}
+        </Dropzone>
+        {this.renderToastNotification()}
+      </>
+    );
+  }
+}

--- a/src/apps/feed/components/post-input/menu/styles.scss
+++ b/src/apps/feed/components/post-input/menu/styles.scss
@@ -1,0 +1,14 @@
+.post-media-menu {
+  &__dropzone {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: var(--color-grey-100);
+    }
+  }
+}

--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { IconAlertCircle } from '@zero-tech/zui/icons';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+import { getPlaceholderDimensions } from './utils';
+import { usePostMedia } from '../../lib/usePostMedia';
+import { useDispatch } from 'react-redux';
+import { openLightbox } from '../../../../store/dialogs';
+import { Media, MediaType } from '../../../../store/messages';
+
+import styles from './styles.module.scss';
+
+interface PostMediaProps {
+  mediaId: string;
+}
+
+export const PostMedia = ({ mediaId }: PostMediaProps) => {
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const { mediaUrl, mediaDetails, isLoading, error } = usePostMedia(mediaId);
+  const dispatch = useDispatch();
+
+  // Use fallback dimensions if mediaDetails is not yet available
+  const { width, height } = mediaDetails
+    ? getPlaceholderDimensions(mediaDetails.width, mediaDetails.height)
+    : { width: 800, height: 600 };
+
+  const handleImageLoad = () => {
+    setIsImageLoaded(true);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (mediaUrl && mediaDetails) {
+      const media: Media = {
+        type: MediaType.Image,
+        url: mediaUrl,
+        name: 'Post image',
+        width: mediaDetails.width,
+        height: mediaDetails.height,
+        mimetype: mediaDetails.mimeType,
+      };
+      dispatch(openLightbox({ media: [media], startingIndex: 0, hasActions: false }));
+    }
+  };
+
+  const renderPlaceholderContent = () => (
+    <>
+      {error ? <IconAlertCircle size={32} className={styles.Failed} /> : <div className={styles.Placeholder} />}
+      {isLoading && <Spinner className={styles.Loading} />}
+    </>
+  );
+
+  if (!mediaUrl) {
+    return (
+      <div className={styles.PlaceholderContainer} style={{ width, height }}>
+        <div className={styles.PlaceholderContent}>{renderPlaceholderContent()}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.BlockImage} onClick={handleClick}>
+      <img src={mediaUrl} alt={'post media'} onLoad={handleImageLoad} style={!isImageLoaded ? { width, height } : {}} />
+    </div>
+  );
+};

--- a/src/apps/feed/components/post-media/styles.module.scss
+++ b/src/apps/feed/components/post-media/styles.module.scss
@@ -1,0 +1,77 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.BlockImage {
+  position: relative;
+  width: 100%;
+  margin-top: 16px;
+  cursor: pointer;
+
+  img {
+    display: block;
+    margin: auto;
+    max-width: 100%;
+    max-height: 520px;
+    border-radius: 16px;
+  }
+
+  animation: fadein 1s ease-in forwards;
+}
+
+.PlaceholderContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 16px auto 0;
+  max-width: 100%;
+  max-height: 520px;
+}
+
+.PlaceholderContent {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(253, 252, 253, 0.07);
+  border-radius: 8px;
+}
+
+.Placeholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.Loading {
+  position: absolute;
+  padding: 4px;
+  border-top: 0.125rem solid theme.$color-greyscale-11;
+}
+
+.Failed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: none;
+  border: none;
+  color: var(--color-failure-11);
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes loadingShimmer {
+  0% {
+    background-position: -600px 0;
+  }
+  100% {
+    background-position: 600px 0;
+  }
+}

--- a/src/apps/feed/components/post-media/utils.ts
+++ b/src/apps/feed/components/post-media/utils.ts
@@ -1,0 +1,18 @@
+export const getPlaceholderDimensions = (w: number, h: number) => {
+  const width = w || 300;
+  const height = h || 200;
+  const maxWidth = 520;
+  const maxHeight = 640;
+  const aspectRatio = width / height;
+  let finalWidth = width;
+  let finalHeight = height;
+  if (height > maxHeight) {
+    finalHeight = maxHeight;
+    finalWidth = maxHeight * aspectRatio;
+  }
+  if (finalWidth > maxWidth) {
+    finalWidth = maxWidth;
+    finalHeight = maxWidth / aspectRatio;
+  }
+  return { width: finalWidth, height: finalHeight };
+};

--- a/src/apps/feed/components/post-view-container/index.tsx
+++ b/src/apps/feed/components/post-view-container/index.tsx
@@ -56,6 +56,7 @@ export const PostView = ({ postId, isFeed }: PostViewProps) => {
                 variant='expanded'
                 channelZid={post.channelZid}
                 isSinglePostView={true}
+                mediaId={post.mediaId}
               />
               <CommentInput channelZid={post.channelZid} isFeed={isFeed} postId={postId} />
             </div>

--- a/src/apps/feed/components/post-view-container/reply-list/index.tsx
+++ b/src/apps/feed/components/post-view-container/reply-list/index.tsx
@@ -35,6 +35,7 @@ export const Replies = ({ postId, isFeed }: RepliesProps) => {
                 numberOfReplies={reply.numberOfReplies}
                 channelZid={reply.channelZid}
                 avatarUrl={reply.sender?.avatarUrl}
+                mediaId={reply.mediaId}
               />
             </li>
           ))

--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -16,6 +16,7 @@ import { usePostRoute } from './lib/usePostRoute';
 import Linkify from 'linkify-react';
 import { PostLinkPreview } from './link-preview';
 import { detectLinkType } from './link-preview/utils';
+import { PostMedia } from '../post-media';
 
 import classNames from 'classnames';
 import styles from './styles.module.scss';
@@ -41,6 +42,7 @@ export interface PostProps {
   isSinglePostView?: boolean;
   authorPrimaryZid?: string;
   authorPublicAddress?: string;
+  mediaId?: string;
 
   meowPost: (postId: string, meowAmount: string) => void;
 }
@@ -65,6 +67,7 @@ export const Post = ({
   isSinglePostView = false,
   authorPrimaryZid,
   authorPublicAddress,
+  mediaId,
 }: PostProps) => {
   const isMeowsEnabled = featureFlags.enableMeows;
   const isDisabled =
@@ -125,6 +128,7 @@ export const Post = ({
               {variant === 'expanded' && (
                 <span className={styles.Date}>{moment(timestamp).format('h:mm A - D MMM YYYY')}</span>
               )}
+              {featureFlags.enablePostMedia && mediaId && <PostMedia mediaId={mediaId} />}
             </div>
           }
           details={
@@ -231,7 +235,6 @@ const Wrapper = ({ children, postId, variant, channelZid }: WrapperProps) => {
     </div>
   );
 };
-
 const PreventPropagation = ({ children }: { children: React.ReactNode }) => {
   return <div onClick={(e) => e.stopPropagation()}>{children}</div>;
 };

--- a/src/apps/feed/components/posts/index.tsx
+++ b/src/apps/feed/components/posts/index.tsx
@@ -30,6 +30,7 @@ export const Posts = ({
               reactions={post.reactions}
               meowPost={meowPost}
               numberOfReplies={post.numberOfReplies}
+              mediaId={post.mediaId}
             />
           </li>
         ))}

--- a/src/apps/feed/lib/usePostMedia.ts
+++ b/src/apps/feed/lib/usePostMedia.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getMediaDetails } from '../../../store/posts/media-api';
+
+const URL_REFRESH_INTERVAL = 45 * 1000; // 45 seconds (before 60-second expiration)
+
+export function usePostMedia(mediaId?: string) {
+  const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [refreshInterval, setRefreshInterval] = useState<number | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['media', mediaId],
+    queryFn: () => (mediaId ? getMediaDetails(mediaId) : null),
+    enabled: !!mediaId,
+    refetchInterval: refreshInterval ?? false,
+  });
+
+  useEffect(() => {
+    if (data?.signedUrl) {
+      setCurrentUrl(data.signedUrl);
+      // Set up refresh interval
+      const interval = setInterval(() => {
+        setRefreshInterval(URL_REFRESH_INTERVAL);
+      }, URL_REFRESH_INTERVAL);
+      return () => clearInterval(interval);
+    }
+  }, [data?.signedUrl]);
+
+  return {
+    mediaUrl: currentUrl,
+    mediaDetails: data?.media,
+    isLoading,
+    error,
+  };
+}

--- a/src/components/dialog-manager/container.test.tsx
+++ b/src/components/dialog-manager/container.test.tsx
@@ -27,6 +27,7 @@ describe('DialogManager', () => {
         isOpen: false,
         media: [],
         startingIndex: 0,
+        hasActions: true,
       },
       closeCreateBackupDialog: () => null,
       closeRestoreBackupDialog: () => null,
@@ -134,7 +135,7 @@ describe('DialogManager', () => {
 
   it('renders Lightbox when lightbox.isOpen is true', () => {
     const wrapper = subject({
-      lightbox: { isOpen: true, media: [], startingIndex: 0 },
+      lightbox: { isOpen: true, media: [], startingIndex: 0, hasActions: true },
     });
 
     expect(wrapper).toHaveElement(Lightbox);
@@ -142,7 +143,7 @@ describe('DialogManager', () => {
 
   it('does not render Lightbox when lightbox.isOpen is false', () => {
     const wrapper = subject({
-      lightbox: { isOpen: false, media: [], startingIndex: 0 },
+      lightbox: { isOpen: false, media: [], startingIndex: 0, hasActions: true },
     });
 
     expect(wrapper).not.toHaveElement(Lightbox);
@@ -166,6 +167,7 @@ describe('DialogManager', () => {
           isOpen: true,
           media: [],
           startingIndex: 0,
+          hasActions: true,
         },
       },
       reportUser: {
@@ -216,6 +218,7 @@ describe('DialogManager', () => {
         isOpen: true,
         media: [],
         startingIndex: 0,
+        hasActions: true,
       });
     });
   });

--- a/src/components/dialog-manager/container.tsx
+++ b/src/components/dialog-manager/container.tsx
@@ -26,6 +26,7 @@ export interface Properties extends PublicProperties {
     isOpen: boolean;
     media: any[];
     startingIndex: number;
+    hasActions?: boolean;
   };
 
   closeCreateBackupDialog: () => void;
@@ -127,6 +128,7 @@ export class Container extends React.Component<Properties> {
         }}
         items={this.props.lightbox.media}
         startingIndex={this.props.lightbox.startingIndex}
+        hasActions={this.props.lightbox.hasActions}
         onClose={this.closeLightbox}
       />
     );

--- a/src/components/lightbox/index.tsx
+++ b/src/components/lightbox/index.tsx
@@ -15,6 +15,7 @@ import styles from './styles.module.scss';
 export interface LightboxProps {
   items: Media[];
   startingIndex?: number;
+  hasActions?: boolean;
   onClose?: (e?: React.MouseEvent) => void;
   provider: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,7 +25,7 @@ export interface LightboxProps {
   };
 }
 
-export const Lightbox = ({ items, startingIndex = 0, onClose, provider }: LightboxProps) => {
+export const Lightbox = ({ items, startingIndex = 0, onClose, provider, hasActions = true }: LightboxProps) => {
   const [index, setIndex] = useState(startingIndex);
   const [isCopied, setIsCopied] = useState(false);
   const currentItem = items[index];
@@ -160,7 +161,7 @@ export const Lightbox = ({ items, startingIndex = 0, onClose, provider }: Lightb
       <div className={styles.Controls}>
         <div className={styles.TopBar}>
           <div className={styles.Tools}>
-            {!isCurrentItemGif && (
+            {!isCurrentItemGif && hasActions && (
               <>
                 <IconButton onClick={copyImage} Icon={IconCopy2} size='large' isFilled={isCopied} />
                 <IconButton onClick={downloadImage} Icon={IconDownload2} size='large' />

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -37,6 +37,7 @@ export class FeatureFlags implements FeatureFlagValues {
   declare enableAuraZApp: boolean;
   declare enableProfile: boolean;
   declare enableUserProfiles: boolean;
+  declare enablePostMedia: boolean;
 
   constructor() {
     this.config = process.env.NODE_ENV === 'production' ? productionFlags : developmentFlags;

--- a/src/lib/feature-flags/development.ts
+++ b/src/lib/feature-flags/development.ts
@@ -30,4 +30,5 @@ export const developmentFlags: FeatureFlagDefinitions = {
   },
   enableProfile: { defaultValue: true },
   enableUserProfiles: { defaultValue: true },
+  enablePostMedia: { defaultValue: true },
 };

--- a/src/lib/feature-flags/flags.ts
+++ b/src/lib/feature-flags/flags.ts
@@ -26,7 +26,8 @@ export type FeatureFlagKey =
   | 'enableFeedChat'
   | 'enableAuraZApp'
   | 'enableProfile'
-  | 'enableUserProfiles';
+  | 'enableUserProfiles'
+  | 'enablePostMedia';
 
 export interface FeatureFlagConfig {
   defaultValue: boolean;

--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -35,4 +35,5 @@ export const productionFlags: FeatureFlagDefinitions = {
   },
   enableProfile: { defaultValue: true },
   enableUserProfiles: { defaultValue: true },
+  enablePostMedia: { defaultValue: false },
 };

--- a/src/store/dialogs/index.ts
+++ b/src/store/dialogs/index.ts
@@ -6,6 +6,7 @@ export type DialogState = {
     isOpen: boolean;
     media: any[];
     startingIndex: number;
+    hasActions?: boolean;
   };
 };
 
@@ -15,6 +16,7 @@ export const initialState: DialogState = {
     isOpen: false,
     media: [],
     startingIndex: 0,
+    hasActions: true,
   },
 };
 
@@ -28,11 +30,12 @@ const slice = createSlice({
     closeDeleteMessage: (state) => {
       state.deleteMessageId = null;
     },
-    openLightbox: (state, action: PayloadAction<{ media: any[]; startingIndex: number }>) => {
+    openLightbox: (state, action: PayloadAction<{ media: any[]; startingIndex: number; hasActions?: boolean }>) => {
       state.lightbox = {
         isOpen: true,
         media: action.payload.media,
         startingIndex: action.payload.startingIndex,
+        hasActions: action.payload.hasActions,
       };
     },
     closeLightbox: (state) => {

--- a/src/store/posts/media-api.ts
+++ b/src/store/posts/media-api.ts
@@ -1,0 +1,68 @@
+import { post, get } from '../../lib/api/rest';
+import { Response } from 'superagent';
+
+export interface MediaUploadResponse {
+  id: string;
+  centralizedStorageKey: string;
+}
+
+export interface MediaDetailsResponse {
+  media: {
+    id: string;
+    width: number;
+    height: number;
+    mimeType: string;
+    fileSize: number;
+  };
+  signedUrl: string; // Valid for 60 seconds
+}
+
+/**
+ * Uploads a media file to the backend
+ * @param file The file to upload
+ * @returns Promise resolving to MediaUploadResponse
+ */
+export async function uploadMedia(file: File): Promise<MediaUploadResponse> {
+  try {
+    const response = await new Promise<Response>((resolve, reject) => {
+      post('/api/media')
+        .attach('file', file)
+        .end((err, res) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(res);
+          }
+        });
+    });
+
+    if (!response.ok) {
+      throw new Error(response.body.message ?? 'Failed to upload media');
+    }
+
+    return response.body;
+  } catch (error: any) {
+    console.error('Failed to upload media:', error);
+    throw new Error(error.response?.body?.message ?? 'Failed to upload media');
+  }
+}
+
+/**
+ * Gets media details and a signed URL for displaying the media
+ * @param mediaId The ID of the media to fetch
+ * @returns Promise resolving to MediaDetailsResponse
+ */
+export async function getMediaDetails(mediaId: string): Promise<MediaDetailsResponse> {
+  try {
+    const response = await get(`/api/media/${mediaId}`);
+
+    if (!response.ok) {
+      throw new Error(response.body.message ?? 'Failed to fetch media details');
+    }
+
+    return response.body;
+  } catch (error: any) {
+    console.error('Failed to fetch media details:', error);
+    throw new Error(error.response?.body?.message ?? 'Failed to fetch media details');
+  }
+}

--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -180,6 +180,7 @@ export function* sendPost(action) {
             },
             userId: user.id,
             zid: userZid,
+            mediaId: res.mediaId,
           }),
         ],
       });

--- a/src/store/posts/utils.ts
+++ b/src/store/posts/utils.ts
@@ -3,6 +3,7 @@ import { get, post } from '../../lib/api/rest';
 import { getWagmiConfig } from '../../lib/web3/wagmi-config';
 import { getWalletClient } from '@wagmi/core';
 import { ethers } from 'ethers';
+import { featureFlags } from '../../lib/feature-flags';
 
 export interface SignedMessagePayload {
   created_at: string;
@@ -47,6 +48,7 @@ export function mapPostToMatrixMessage(post) {
     isAdmin: false,
     isPost: true,
     media: null,
+    mediaId: post.mediaId,
     mentionedUsers: [],
     message: post.text,
     optimisticId: post.id,
@@ -91,6 +93,11 @@ export async function uploadPost(formData: FormData, worldZid: string) {
     const replyTo = formData.get('replyTo');
     if (replyTo) {
       request = request.field('replyTo', replyTo);
+    }
+
+    const mediaId = formData.get('mediaId');
+    if (featureFlags.enablePostMedia && mediaId) {
+      request = request.field('mediaId', mediaId);
     }
 
     request.end((err, res) => {


### PR DESCRIPTION
### What does this do?
- implements and wires up ability to post image media
- ensures only one image can be selected at once
- fetches post media when loading posts
- adds placeholders for improved ui

### Why are we making this change?
- to be able to add image media to posts on creation & load

### How do I test this?
- run tests as usual
- run UI and attempt to post media

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
