### PR TITLE
refactor(use-post-media): optimize post media caching with React Query to reduce network requests

### DIFF
--- a/src/apps/feed/lib/usePostMedia.ts
+++ b/src/apps/feed/lib/usePostMedia.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getMediaDetails } from '../../../store/posts/media-api';
 
 const URL_REFRESH_INTERVAL = 45 * 1000; // 45 seconds (before 60-second expiration)
+const STALE_TIME = 1000 * 60 * 60;
 
 export function usePostMedia(mediaId?: string) {
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
@@ -13,18 +14,25 @@ export function usePostMedia(mediaId?: string) {
     queryFn: () => (mediaId ? getMediaDetails(mediaId) : null),
     enabled: !!mediaId,
     refetchInterval: refreshInterval ?? false,
+    staleTime: STALE_TIME,
+    gcTime: STALE_TIME * 2,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 
   useEffect(() => {
     if (data?.signedUrl) {
       setCurrentUrl(data.signedUrl);
-      // Set up refresh interval
-      const interval = setInterval(() => {
-        setRefreshInterval(URL_REFRESH_INTERVAL);
-      }, URL_REFRESH_INTERVAL);
-      return () => clearInterval(interval);
+      // Set up refresh interval only if we don't have cached data
+      if (!data.media) {
+        const interval = setInterval(() => {
+          setRefreshInterval(URL_REFRESH_INTERVAL);
+        }, URL_REFRESH_INTERVAL);
+        return () => clearInterval(interval);
+      }
     }
-  }, [data?.signedUrl]);
+  }, [data?.signedUrl, data?.media]);
 
   return {
     mediaUrl: currentUrl,


### PR DESCRIPTION
### What does this do?
We're enhancing the usePostMedia hook's caching strategy by implementing longer cache durations, smarter refetching rules, and optimized URL refresh intervals.

### Why are we making this change?
To significantly reduce network requests and improve performance by reusing cached media data for up to 2 hours and preventing unnecessary refetches, which will result in fewer loading states and a smoother user experience.

### How do I test this?
Run tests as usual
Run UI and check network requests when re-rendering post media

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
