### PR TITLE
feat(post-media): enable giphy post media and add giphy picker to post input

### DIFF
--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -9,7 +9,7 @@ import { IconButton } from '@zero-tech/zui/components/IconButton';
 import ImageCards from '../../../../platform-apps/channels/image-cards';
 import { PublicProperties as PublicPropertiesContainer } from './container';
 import { ViewModes } from '../../../../shared-components/theme-engine';
-import { IconFaceSmile } from '@zero-tech/zui/icons';
+import { IconFaceSmile, IconStickerCircle } from '@zero-tech/zui/icons';
 import { PostMediaMenu } from './menu';
 import { featureFlags } from '../../../../lib/feature-flags';
 
@@ -23,6 +23,7 @@ import { Media, addImagePreview, dropzoneToMedia, windowClipboard } from '../../
 import { EmojiPicker } from '../../../../components/message-input/emoji-picker/emoji-picker';
 import { MatrixAvatar } from '../../../../components/matrix-avatar';
 import { POST_MAX_LENGTH } from '../../lib/constants';
+import { Giphy } from '../../../../components/message-input/giphy/giphy';
 
 const SHOW_MAX_LABEL_THRESHOLD = 0.8 * POST_MAX_LENGTH;
 
@@ -46,6 +47,7 @@ interface State {
   value: string;
   media: Media[];
   isEmojisActive: boolean;
+  isGiphyActive: boolean;
 }
 
 export class PostInput extends React.Component<Properties, State> {
@@ -53,6 +55,7 @@ export class PostInput extends React.Component<Properties, State> {
     value: this.props.initialValue || '',
     media: [],
     isEmojisActive: false,
+    isGiphyActive: false,
   };
 
   private textareaRef: RefObject<HTMLTextAreaElement>;
@@ -168,7 +171,7 @@ export class PostInput extends React.Component<Properties, State> {
     const items = event.clipboardData.items;
 
     const newImages: any[] = Array.from(items)
-      .filter((item: any) => item.kind === 'file' && /image\/*/.test(item.type))
+      .filter((item: any) => item.kind === 'file' && (/image\/*/.test(item.type) || item.type === 'image/gif'))
       .map((file: any) => file.getAsFile())
       .filter(Boolean);
 
@@ -183,6 +186,23 @@ export class PostInput extends React.Component<Properties, State> {
   onInsertEmoji = (value: string) => {
     this.setState({ value });
     this.closeEmojis();
+  };
+
+  openGiphy = () => this.setState({ isGiphyActive: true });
+  closeGiphy = () => this.setState({ isGiphyActive: false });
+
+  onInsertGiphy = (giphy) => {
+    this.mediaSelected([
+      {
+        id: giphy.id.toString(),
+        name: giphy.title,
+        url: giphy.images.preview_gif.url,
+        type: MediaType.Image,
+        mediaType: MediaType.Image,
+        giphy,
+      },
+    ]);
+    this.closeGiphy();
   };
 
   renderInput() {
@@ -236,7 +256,12 @@ export class PostInput extends React.Component<Properties, State> {
                   <div {...cn('actions')}>
                     <div {...cn('icon-wrapper')}>
                       <IconButton onClick={this.openEmojis} Icon={IconFaceSmile} size={26} />
-                      {featureFlags.enablePostMedia && <PostMediaMenu onSelected={this.mediaSelected} />}
+                      {featureFlags.enablePostMedia && (
+                        <>
+                          <IconButton onClick={this.openGiphy} Icon={IconStickerCircle} size={26} />
+                          <PostMediaMenu onSelected={this.mediaSelected} />
+                        </>
+                      )}
                       <AnimatePresence>
                         {this.state.value.length > SHOW_MAX_LABEL_THRESHOLD && (
                           <motion.span
@@ -278,6 +303,14 @@ export class PostInput extends React.Component<Properties, State> {
                       onSelect={this.onInsertEmoji}
                     />
                   </div>
+
+                  {this.state.isGiphyActive && (
+                    <div {...cn('giphy-picker-container')} onClick={this.closeGiphy}>
+                      <div {...cn('giphy-picker-content')} onClick={(e) => e.stopPropagation()}>
+                        <Giphy onClickGif={this.onInsertGiphy} onClose={this.closeGiphy} />
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/apps/feed/components/post-input/menu/index.tsx
+++ b/src/apps/feed/components/post-input/menu/index.tsx
@@ -56,7 +56,7 @@ export class PostMediaMenu extends React.Component<Properties, State> {
         <Dropzone
           onDropRejected={this.onDropRejected}
           onDrop={this.imagesSelected}
-          accept={{ 'image/*': [] }}
+          accept={{ 'image/*': [], 'image/gif': ['.gif'] }}
           maxSize={config.cloudinary.max_file_size}
         >
           {({ getRootProps, getInputProps, open }) => (

--- a/src/apps/feed/components/post-input/styles.scss
+++ b/src/apps/feed/components/post-input/styles.scss
@@ -42,6 +42,29 @@
     color: theme.$color-greyscale-11;
   }
 
+  &__giphy-picker-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  &__giphy-picker-content {
+    background: var(--color-primary-1);
+    border-radius: 8px;
+    padding: 16px;
+    max-width: 90%;
+    max-height: 90vh;
+    overflow: auto;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+
   &__icon-wrapper {
     display: flex;
     gap: 4px;

--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -33,7 +33,7 @@ export const PostMedia = ({ mediaId }: PostMediaProps) => {
       const media: Media = {
         type: MediaType.Image,
         url: mediaUrl,
-        name: 'Post image',
+        name: 'Post media',
         width: mediaDetails.width,
         height: mediaDetails.height,
         mimetype: mediaDetails.mimeType,

--- a/src/apps/feed/lib/useSubmitPost.ts
+++ b/src/apps/feed/lib/useSubmitPost.ts
@@ -74,10 +74,19 @@ export const useSubmitPost = () => {
         try {
           const file = media[0].nativeFile;
           if (!file) {
-            throw new Error('Media file is missing');
+            if (media[0].giphy) {
+              const response = await fetch(media[0].giphy.images.original.url);
+              const blob = await response.blob();
+              const gifFile = new File([blob], `${media[0].giphy.id}.gif`, { type: 'image/gif' });
+              const uploadResponse = await uploadMedia(gifFile);
+              mediaId = uploadResponse.id;
+            } else {
+              throw new Error('Media file is missing');
+            }
+          } else {
+            const uploadResponse = await uploadMedia(file);
+            mediaId = uploadResponse.id;
           }
-          const uploadResponse = await uploadMedia(file);
-          mediaId = uploadResponse.id;
         } catch (e) {
           console.error('Failed to upload media:', e);
           throw new Error('Failed to upload media');


### PR DESCRIPTION
### What does this do?
We're adding a Giphy picker to the post input component with a modal overlay UI that appears centered on screen.

### Why are we making this change?
To enable users to easily search and select GIFs from Giphy when creating posts, with a user-friendly interface that works consistently regardless of where the picker is opened from.

### How do I test this?
Run tests as usual
Run UI and add gif to post creation

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
