### PR TITLE
feat(post-media): add video support to post media uploads

### DIFF
--- a/src/apps/feed/components/post-input/index.test.tsx
+++ b/src/apps/feed/components/post-input/index.test.tsx
@@ -90,7 +90,7 @@ describe('PostInput', () => {
     const wrapper = subject({});
     const dropZone = wrapper.find(Dropzone);
 
-    expect(dropZone.prop('accept')).toEqual({ 'image/*': [] });
+    expect(dropZone.prop('accept')).toEqual({ 'image/*': [], 'video/*': [] });
     expect(dropZone.prop('maxSize')).toEqual(config.cloudinary.max_file_size);
   });
 

--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -12,6 +12,7 @@ import { ViewModes } from '../../../../shared-components/theme-engine';
 import { IconFaceSmile, IconStickerCircle } from '@zero-tech/zui/icons';
 import { PostMediaMenu } from './menu';
 import { featureFlags } from '../../../../lib/feature-flags';
+import AttachmentCards from '../../../../platform-apps/channels/attachment-cards';
 
 import { bemClassName } from '../../../../lib/bem';
 import classNames from 'classnames';
@@ -108,11 +109,16 @@ export class PostInput extends React.Component<Properties, State> {
   get mimeTypes() {
     return {
       'image/*': [],
+      'video/*': [],
     };
   }
 
   get images() {
     return this.state.media.filter((m) => m.mediaType === MediaType.Image);
+  }
+
+  get videos() {
+    return this.state.media.filter((m) => m.mediaType === MediaType.Video);
   }
 
   onSubmit = (): void => {
@@ -251,6 +257,7 @@ export class PostInput extends React.Component<Properties, State> {
 
                   <div {...cn('image')}>
                     <ImageCards images={this.images} onRemoveImage={this.removeMediaPreview} size='small' />
+                    <AttachmentCards attachments={this.videos} onRemove={this.removeMediaPreview} />
                   </div>
 
                   <div {...cn('actions')}>

--- a/src/apps/feed/components/post-input/menu/index.tsx
+++ b/src/apps/feed/components/post-input/menu/index.tsx
@@ -8,7 +8,7 @@ import { config } from '../../../../../config';
 import './styles.scss';
 
 export interface Properties {
-  onSelected: (images: Media[]) => void;
+  onSelected: (media: Media[]) => void;
 }
 
 interface State {
@@ -18,13 +18,13 @@ interface State {
 export class PostMediaMenu extends React.Component<Properties, State> {
   state = { isDropRejectedNotificationOpen: false };
 
-  imagesSelected = (acceptedFiles): void => {
+  mediaSelected = (acceptedFiles): void => {
     this.setState({ isDropRejectedNotificationOpen: false });
 
-    const newImages: Media[] = dropzoneToMedia(acceptedFiles);
+    const newMedia: Media[] = dropzoneToMedia(acceptedFiles);
 
-    if (newImages.length) {
-      this.props.onSelected(newImages);
+    if (newMedia.length) {
+      this.props.onSelected(newMedia);
     }
   };
 
@@ -55,8 +55,8 @@ export class PostMediaMenu extends React.Component<Properties, State> {
       <>
         <Dropzone
           onDropRejected={this.onDropRejected}
-          onDrop={this.imagesSelected}
-          accept={{ 'image/*': [], 'image/gif': ['.gif'] }}
+          onDrop={this.mediaSelected}
+          accept={{ 'image/*': [], 'image/gif': ['.gif'], 'video/*': [] }}
           maxSize={config.cloudinary.max_file_size}
         >
           {({ getRootProps, getInputProps, open }) => (

--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -31,7 +31,7 @@ export const PostMedia = ({ mediaId }: PostMediaProps) => {
     e.stopPropagation();
     if (mediaUrl && mediaDetails) {
       const media: Media = {
-        type: MediaType.Image,
+        type: mediaDetails.mimeType?.startsWith('video/') ? MediaType.Video : MediaType.Image,
         url: mediaUrl,
         name: 'Post media',
         width: mediaDetails.width,
@@ -57,9 +57,22 @@ export const PostMedia = ({ mediaId }: PostMediaProps) => {
     );
   }
 
+  const isVideo = mediaDetails?.mimeType?.startsWith('video/');
+
   return (
     <div className={styles.BlockImage} onClick={handleClick}>
-      <img src={mediaUrl} alt={'post media'} onLoad={handleImageLoad} style={!isImageLoaded ? { width, height } : {}} />
+      {isVideo ? (
+        <video controls className={styles.Video}>
+          <source src={mediaUrl} type={mediaDetails?.mimeType} />
+        </video>
+      ) : (
+        <img
+          src={mediaUrl}
+          alt={'post media'}
+          onLoad={handleImageLoad}
+          style={!isImageLoaded ? { width, height } : {}}
+        />
+      )}
     </div>
   );
 };

--- a/src/apps/feed/components/post-media/styles.module.scss
+++ b/src/apps/feed/components/post-media/styles.module.scss
@@ -75,3 +75,15 @@
     background-position: 600px 0;
   }
 }
+
+.Video {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 520px;
+  object-fit: contain;
+  border-radius: 16px;
+  background-color: var(--color-primary-1);
+  display: block;
+  margin: auto;
+}

--- a/src/apps/feed/lib/usePostMedia.ts
+++ b/src/apps/feed/lib/usePostMedia.ts
@@ -3,36 +3,29 @@ import { useQuery } from '@tanstack/react-query';
 import { getMediaDetails } from '../../../store/posts/media-api';
 
 const URL_REFRESH_INTERVAL = 45 * 1000; // 45 seconds (before 60-second expiration)
-const STALE_TIME = 1000 * 60 * 60;
+const STALE_TIME = 30 * 1000; // 30 seconds - half of URL expiration time
+const GC_TIME = 60 * 1000; // 1 minute - same as URL expiration
 
 export function usePostMedia(mediaId?: string) {
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
-  const [refreshInterval, setRefreshInterval] = useState<number | null>(null);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['media', mediaId],
     queryFn: () => (mediaId ? getMediaDetails(mediaId) : null),
     enabled: !!mediaId,
-    refetchInterval: refreshInterval ?? false,
+    refetchInterval: URL_REFRESH_INTERVAL,
     staleTime: STALE_TIME,
-    gcTime: STALE_TIME * 2,
+    gcTime: GC_TIME,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    refetchOnReconnect: true,
   });
 
   useEffect(() => {
     if (data?.signedUrl) {
       setCurrentUrl(data.signedUrl);
-      // Set up refresh interval only if we don't have cached data
-      if (!data.media) {
-        const interval = setInterval(() => {
-          setRefreshInterval(URL_REFRESH_INTERVAL);
-        }, URL_REFRESH_INTERVAL);
-        return () => clearInterval(interval);
-      }
     }
-  }, [data?.signedUrl, data?.media]);
+  }, [data?.signedUrl]);
 
   return {
     mediaUrl: currentUrl,


### PR DESCRIPTION
### What does this do?
- adds video support to post media uploads
- tweaks use post media stale / interval times to prevent media no longer being displayed after expiration from backend

### Why are we making this change?
- allow users to post video media

### How do I test this?
- run tests as usual
- run UI and attempt to upload a video in a post

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
