### PR TITLE
Fix: Ensure login/logout cycle isn't broken due to errors

### DIFF
--- a/src/lib/chat/matrix/matrix-client-instance.ts
+++ b/src/lib/chat/matrix/matrix-client-instance.ts
@@ -12,6 +12,7 @@ class MatrixInstance {
   }
 
   resetClientInstance() {
+    this._clientInstance.disconnect();
     this._clientInstance = new MatrixClient();
   }
 }

--- a/src/lib/chat/session-storage.test.ts
+++ b/src/lib/chat/session-storage.test.ts
@@ -30,7 +30,7 @@ describe('session storage', () => {
 
   it('removes localStorage vars on clear', async () => {
     const getItem = jest.fn((key) => (key === 'mxz_device_id' ? 'abc123' : ''));
-    const client = subject({ getItem });
+    const client = subject({ getItem, mxz_device_id: 'abc123', mxz_user_id: '@bob:zos-matrix' });
 
     client.clear();
 

--- a/src/lib/chat/session-storage.ts
+++ b/src/lib/chat/session-storage.ts
@@ -7,11 +7,8 @@ export class SessionStorage {
   constructor(private storage = localStorage) {}
 
   clear() {
-    this.storage.removeItem('mxz_device_id');
-    this.storage.removeItem('mxz_user_id');
-
     const allKeys = Object.keys(this.storage);
-    const filterKeys = allKeys.filter((key) => key.includes('mxjssdk_memory_filter'));
+    const filterKeys = allKeys.filter((key) => key.includes('mxjssdk_memory_filter') || key.includes('mxz_'));
     filterKeys.forEach((key) => this.storage.removeItem(key));
   }
 


### PR DESCRIPTION
### What does this do?
Ensures the integrity of the login/logout system even if we encounter errors.

### Why are we making this change?
There is an error that can cause the matrix client to get in a bad state. When this happens, the login/logout system breaks and the user can't get back into a working state without logging out and refreshing the page.

### How do I test this?
Login
Open local storage and change your device id
Refresh, you'll see a Matrix error
Log out
Log in
The app should be working correctly.

