### PR TITLE
feat(post-media): enforce correct file size limits for post images, GIFs, and videos using config and shared utility

### DIFF
--- a/src/apps/feed/components/post-input/index.test.tsx
+++ b/src/apps/feed/components/post-input/index.test.tsx
@@ -91,7 +91,9 @@ describe('PostInput', () => {
     const dropZone = wrapper.find(Dropzone);
 
     expect(dropZone.prop('accept')).toEqual({ 'image/*': [], 'video/*': [] });
-    expect(dropZone.prop('maxSize')).toEqual(config.cloudinary.max_file_size);
+    expect(dropZone.prop('maxSize')).toEqual(
+      Math.max(config.postMedia.imageMaxFileSize, config.postMedia.gifMaxFileSize, config.postMedia.videoMaxFileSize)
+    );
   });
 
   it('call after render', () => {

--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -216,13 +216,20 @@ export class PostInput extends React.Component<Properties, State> {
     const isDisabled =
       (!this.state.value.trim() && !this.state.media.length) || this.props.isSubmitting || isPostTooLong;
 
+    // Set maxSize to the largest allowed, Dropzone will still reject based on this
+    const maxSize = Math.max(
+      config.postMedia.imageMaxFileSize,
+      config.postMedia.gifMaxFileSize,
+      config.postMedia.videoMaxFileSize
+    );
+
     return (
       <div>
         <Dropzone
           onDrop={this.imagesSelected}
           noClick
           accept={this.mimeTypes}
-          maxSize={config.cloudinary.max_file_size}
+          maxSize={maxSize}
           disabled={!featureFlags.enablePostMedia}
         >
           {({ getRootProps }) => (

--- a/src/apps/feed/components/post-input/utils.ts
+++ b/src/apps/feed/components/post-input/utils.ts
@@ -1,0 +1,15 @@
+import { config } from '../../../../config';
+
+export function getPostMediaMaxFileSize(mimeType: string): number {
+  if (mimeType === 'image/gif') {
+    return config.postMedia.gifMaxFileSize;
+  }
+  if (mimeType.startsWith('video/')) {
+    return config.postMedia.videoMaxFileSize;
+  }
+  if (mimeType.startsWith('image/')) {
+    return config.postMedia.imageMaxFileSize;
+  }
+  // fallback to smallest
+  return config.postMedia.imageMaxFileSize;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,4 +32,9 @@ export const config = {
   postImageMaxFileSize: process.env.REACT_APP_POST_IMAGE_MAX_FILE_SIZE,
   postGifMaxFileSize: process.env.REACT_APP_POST_GIF_MAX_FILE_SIZE,
   postVideoMaxFileSize: process.env.REACT_APP_POST_VIDEO_MAX_FILE_SIZE,
+  postMedia: {
+    imageMaxFileSize: parseInt(process.env.REACT_APP_POST_IMAGE_MAX_FILE_SIZE) || 5242880,
+    gifMaxFileSize: parseInt(process.env.REACT_APP_POST_GIF_MAX_FILE_SIZE) || 15728640,
+    videoMaxFileSize: parseInt(process.env.REACT_APP_POST_VIDEO_MAX_FILE_SIZE) || 104857600,
+  },
 };


### PR DESCRIPTION
### What does this do?
We are updating the post media Dropzone components to use type-specific file size limits from environment-configured values.

### Why are we making this change?
This ensures the frontend enforces the same media size restrictions as the backend, preventing user confusion and upload errors.

### How do I test this?
Run tests as usual
Run UI and select a range of file types and sizes

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
