### PR TITLE
refactor(post-media/lightbox): prevent lightbox from opening for video media in post media component and continue to play inline as intended

### DIFF
--- a/src/apps/feed/components/post-media/index.tsx
+++ b/src/apps/feed/components/post-media/index.tsx
@@ -29,9 +29,11 @@ export const PostMedia = ({ mediaId }: PostMediaProps) => {
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (mediaUrl && mediaDetails) {
+    if (!mediaUrl || !mediaDetails) return;
+
+    if (!mediaDetails.mimeType?.startsWith('video/')) {
       const media: Media = {
-        type: mediaDetails.mimeType?.startsWith('video/') ? MediaType.Video : MediaType.Image,
+        type: MediaType.Image,
         url: mediaUrl,
         name: 'Post media',
         width: mediaDetails.width,


### PR DESCRIPTION
### What does this do?
We are updating the PostMedia component to only open the lightbox for non-video media types.

### Why are we making this change?
This maintains consistent UX by ensuring videos play inline and are not shown in the lightbox, matching existing behavior.

### How do I test this?
Run tests as usual
Run UI and click video - check lightbox does not open

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
