### PR TITLE
Fix: Handle matrix error and reset the app

### DIFF
--- a/src/lib/chat/matrix-client.ts
+++ b/src/lib/chat/matrix-client.ts
@@ -63,6 +63,7 @@ import { SecretStorageKeyDescription } from 'matrix-js-sdk/lib/secret-storage';
 import { SlidingSyncManager } from './sliding-sync';
 import { ReactionEventContent, RoomMessageEventContent } from 'matrix-js-sdk/lib/types';
 import { RelationType } from 'matrix-js-sdk/lib/@types/event';
+import { MatrixInitializationError } from './matrix/errors';
 
 export const USER_TYPING_TIMEOUT = 5000; // 5s
 
@@ -153,8 +154,10 @@ export class MatrixClient {
       try {
         await this.matrix.logout(true);
         this.matrix.removeAllListeners();
-        await this.matrix.clearStores();
         await this.matrix.store?.destroy();
+        // This can't be awaited because it's not properly implemented in the sdk.
+        // If there is an active connection to the db then it will hang indefinitely.
+        this.matrix.clearStores();
       } catch (error) {
         Sentry.captureException(error, {
           extra: {
@@ -1396,7 +1399,6 @@ export class MatrixClient {
       deviceId = credentials.deviceId;
     }
 
-    this.sessionStorage.clear();
     return await this.login(accessToken, deviceId);
   }
 
@@ -1477,10 +1479,14 @@ export class MatrixClient {
 
       this.matrix = this.sdk.createClient(createClientOpts);
       matrixStore?.startup();
-      await this.matrix.initRustCrypto();
-      this.cryptoApi = this.matrix.getCrypto();
-
-      this.cryptoApi.globalBlacklistUnverifiedDevices = false;
+      try {
+        await this.matrix.initRustCrypto();
+        this.cryptoApi = this.matrix.getCrypto();
+        this.cryptoApi.globalBlacklistUnverifiedDevices = false;
+      } catch (error) {
+        await this.disconnect();
+        throw new MatrixInitializationError();
+      }
 
       const slidingSync = await SlidingSyncManager.instance.setup(this.matrix);
       const startClientOpts: IStartClientOpts = {

--- a/src/lib/chat/matrix/errors.ts
+++ b/src/lib/chat/matrix/errors.ts
@@ -1,0 +1,6 @@
+export class MatrixInitializationError extends Error {
+  constructor(message: string = 'Matrix initialization failed') {
+    super(message);
+    this.name = 'MatrixInitializationError';
+  }
+}


### PR DESCRIPTION
### What does this do?
Handles the Matrix initialization error that can occur if the user id or device id don't match what's in the local crypto db.

### Why are we making this change?
Users can get stuck in a loop where their device id doesn't match what's in the crypto store, so the app will never finalize. This ensures that if the matrix crypto can't be initialized, the client will unwind and the app will be reset.

### How do I test this?
Manually break your device id by altering it in local storage
Reload the app, you should see the error page
Click try again, the app should now load properly
