### PR TITLE
Fix: Fix moderator events in sliding sync

### DIFF
--- a/src/components/messenger/conversation-actions/container.test.tsx
+++ b/src/components/messenger/conversation-actions/container.test.tsx
@@ -131,8 +131,10 @@ describe('ConversationActionsContainer', () => {
 
       it('is true when current user is room moderator', () => {
         const state = new StoreBuilder()
-          .withActiveConversation(stubConversation({ moderatorIds: ['current-user-id'], isSocialChannel: false }))
-          .withCurrentUser(stubAuthenticatedUser({ id: 'current-user-id' }));
+          .withActiveConversation(
+            stubConversation({ moderatorIds: ['current-user-matrix-id'], isSocialChannel: false })
+          )
+          .withCurrentUser(stubAuthenticatedUser({ matrixId: 'current-user-matrix-id' }));
 
         expect(ConversationActionsContainer.mapState(state.build())).toEqual(
           expect.objectContaining({ canEdit: true })

--- a/src/components/messenger/conversation-actions/container.tsx
+++ b/src/components/messenger/conversation-actions/container.tsx
@@ -52,7 +52,7 @@ export class Container extends React.Component<Properties> {
     const hasMultipleMembers = (directMessage?.otherMembers || []).length > 1;
     const isSocialChannel = directMessage?.isSocialChannel;
     const isCurrentUserRoomAdmin = directMessage?.adminMatrixIds?.includes(currentUser?.matrixId) ?? false;
-    const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.id) ?? false;
+    const isCurrentUserRoomModerator = directMessage?.moderatorIds?.includes(currentUser?.matrixId) ?? false;
 
     const canLeaveRoom = !isSocialChannel && !isCurrentUserRoomAdmin && hasMultipleMembers;
     const canEdit = !isSocialChannel && (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !isOneOnOne;

--- a/src/components/messenger/conversation-actions/container.tsx
+++ b/src/components/messenger/conversation-actions/container.tsx
@@ -56,7 +56,7 @@ export class Container extends React.Component<Properties> {
 
     const canLeaveRoom = !isSocialChannel && !isCurrentUserRoomAdmin && hasMultipleMembers;
     const canEdit = !isSocialChannel && (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !isOneOnOne;
-    const canAddMembers = !isSocialChannel && isCurrentUserRoomAdmin && !isOneOnOne;
+    const canAddMembers = !isSocialChannel && (isCurrentUserRoomAdmin || isCurrentUserRoomModerator) && !isOneOnOne;
     const canViewDetails = !isOneOnOne || isSocialChannel;
     const canReportUser = isOneOnOne && !isSocialChannel;
 

--- a/src/components/messenger/group-management/container.test.tsx
+++ b/src/components/messenger/group-management/container.test.tsx
@@ -77,7 +77,7 @@ describe(Container, () => {
       test('gets true when user is moderator', () => {
         const state = new StoreBuilder()
           .managingGroup({})
-          .withCurrentUser({ id: 'user-id' })
+          .withCurrentUser({ matrixId: 'user-id' })
           .withActiveConversation({ id: 'user-id', moderatorIds: ['user-id'] });
 
         expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canAddMembers: true }));
@@ -117,7 +117,7 @@ describe(Container, () => {
       test('gets true when user is moderator', () => {
         const state = new StoreBuilder()
           .managingGroup({})
-          .withCurrentUser({ id: 'user-id' })
+          .withCurrentUser({ matrixId: 'user-id' })
           .withActiveConversation({ id: 'user-id', moderatorIds: ['user-id'] });
 
         expect(Container.mapState(state.build())).toEqual(expect.objectContaining({ canEditGroup: true }));

--- a/src/components/messenger/group-management/container.tsx
+++ b/src/components/messenger/group-management/container.tsx
@@ -83,7 +83,7 @@ export class Container extends React.Component<Properties> {
     const conversationAdminIds = conversation?.adminMatrixIds;
     const conversationModeratorIds = conversation?.moderatorIds;
     const isCurrentUserRoomAdmin = conversationAdminIds?.includes(currentUser?.matrixId) ?? false;
-    const isCurrentUserRoomModerator = conversationModeratorIds?.includes(currentUser?.id) ?? false;
+    const isCurrentUserRoomModerator = conversationModeratorIds?.includes(currentUser?.matrixId) ?? false;
     const existingConversations = allDenormalizedChannelsSelector(state);
 
     return {

--- a/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
+++ b/src/components/messenger/group-management/edit-conversation-panel/index.test.tsx
@@ -148,15 +148,15 @@ describe(EditConversationPanel, () => {
 
     it('renders the members with appropriate tags', function () {
       const wrapper = subject({
-        currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
+        currentUser: { userId: 'currentUser', matrixId: 'matrix-id-0', firstName: 'Tom' } as any,
         otherMembers: [
           { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
           { userId: 'otherMember2', matrixId: 'matrix-id-2', firstName: 'Charlie' },
           { userId: 'otherMember3', matrixId: 'matrix-id-3', firstName: 'Eve' },
           { userId: 'otherMember4', matrixId: 'matrix-id-4', firstName: 'Frank' },
         ] as User[],
-        conversationAdminIds: ['matrix-id-4'],
-        conversationModeratorIds: ['otherMember2', 'otherMember4'],
+        conversationAdminIds: ['matrix-id-0'],
+        conversationModeratorIds: ['matrix-id-2', 'matrix-id-4'],
       });
 
       expect(wrapper.find(CitizenListItem).map((c) => c.prop('tag'))).toEqual([
@@ -212,7 +212,7 @@ describe(EditConversationPanel, () => {
           { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
         ] as User[],
         conversationAdminIds: [],
-        conversationModeratorIds: ['currentUser', 'otherMember1'],
+        conversationModeratorIds: ['matrix-id-4', 'matrix-id-1'],
       });
 
       // current user is a moderator and the member is also a moderator (same power_levels)
@@ -226,7 +226,7 @@ describe(EditConversationPanel, () => {
           { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
         ] as User[],
         conversationAdminIds: [],
-        conversationModeratorIds: ['currentUser'],
+        conversationModeratorIds: ['matrix-id-4'],
       });
 
       // member is a normal user (neither admin nor moderator, lowest power_level)

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -211,7 +211,7 @@ describe(ViewGroupInformationPanel, () => {
         { userId: 'otherUser2', matrixId: 'matrix-id-2' },
       ] as User[],
       conversationAdminIds: [],
-      conversationModeratorIds: ['otherUser1'],
+      conversationModeratorIds: ['matrix-id-1'],
     });
 
     expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null); // current user is displayed at top

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -178,7 +178,7 @@ describe(ViewMembersPanel, () => {
         { userId: 'otherUser2', matrixId: 'matrix-id-2' },
       ] as User[],
       conversationAdminIds: [],
-      conversationModeratorIds: ['otherUser1'],
+      conversationModeratorIds: ['matrix-id-1'],
     });
 
     expect(wrapper.find(CitizenListItem).at(0)).toHaveProp('tag', null); // current user is displayed at top

--- a/src/components/messenger/list/utils/utils.test.ts
+++ b/src/components/messenger/list/utils/utils.test.ts
@@ -13,7 +13,7 @@ describe('sortMembers', () => {
       { userId: 'otherMember7', matrixId: 'matrix-id-7', firstName: 'Craig', isOnline: false },
     ] as any;
     const adminIds = ['matrix-id-2', 'matrix-id-3'];
-    const moderatorIds = ['otherMember5', 'otherMember6'];
+    const moderatorIds = ['matrix-id-5', 'matrix-id-6'];
 
     const sortedMembers = sortMembers(members, adminIds, moderatorIds);
     const expectedOrder = [
@@ -76,21 +76,21 @@ describe('isUserAdmin', () => {
 
 describe(isUserModerator, () => {
   it('returns true if the user is a moderator', () => {
-    const user = { userId: 'user1' } as User;
-    const moderatorIds = ['user1', 'user2'];
+    const user = { userId: 'user1', matrixId: 'matrix-id-1' } as User;
+    const moderatorIds = ['matrix-id-1', 'matrix-id-2'];
 
     expect(isUserModerator(user, moderatorIds)).toBe(true);
   });
 
   it('returns false if the user is not a moderator', () => {
-    const user = { userId: 'user3' } as User;
-    const moderatorIds = ['user1', 'user2'];
+    const user = { userId: 'user3', matrixId: 'matrix-id-3' } as User;
+    const moderatorIds = ['matrix-id-1', 'matrix-id-2'];
 
     expect(isUserModerator(user, moderatorIds)).toBe(false);
   });
 
   it('handles empty moderatorIds array', () => {
-    const user = { userId: 'user1' } as User;
+    const user = { userId: 'user1', matrixId: 'matrix-id-1' } as User;
     const moderatorIds: string[] = [];
 
     expect(isUserModerator(user, moderatorIds)).toBe(false);
@@ -123,8 +123,8 @@ describe(getTagForUser, () => {
   });
 
   it('returns "Mod" if the user is a moderator', () => {
-    const user = { userId: 'user1' } as User;
-    const moderatorIds = ['user1', 'user2'];
+    const user = { userId: 'user1', matrixId: 'matrix-id-1' } as User;
+    const moderatorIds = ['matrix-id-1', 'matrix-id-2'];
 
     expect(getTagForUser(user, [], moderatorIds)).toBe('Mod');
   });

--- a/src/components/messenger/list/utils/utils.tsx
+++ b/src/components/messenger/list/utils/utils.tsx
@@ -18,7 +18,7 @@ export function isUserAdmin(user: User, adminIds: string[]) {
 }
 
 export function isUserModerator(user: User, moderatorIds: string[]) {
-  return moderatorIds?.includes(user.userId);
+  return moderatorIds?.includes(user.matrixId);
 }
 
 export function sortMembers(members: User[], adminIds: string[], conversationModeratorIds: string[]) {

--- a/src/lib/chat/sliding-sync.ts
+++ b/src/lib/chat/sliding-sync.ts
@@ -24,6 +24,7 @@ const REQUIRED_STATE_LIST = [
   [CustomEventType.GROUP_TYPE, MSC3575_WILDCARD],
   [EventType.RoomMember, MSC3575_WILDCARD],
   [EventType.Receipt, ''],
+  [EventType.RoomPowerLevels, ''],
 ];
 
 // the things to fetch when a user clicks on a room

--- a/src/store/channels/saga.test.ts
+++ b/src/store/channels/saga.test.ts
@@ -94,7 +94,7 @@ describe(receiveChannel, () => {
     const initialState = new StoreBuilder()
       .withConversationList({
         id: 'room-id',
-        moderatorIds: ['user-1'],
+        moderatorIds: ['matrix-id-1'],
         name: 'Test Room',
         unreadCount: { total: 5, highlight: 0 },
       })
@@ -102,14 +102,14 @@ describe(receiveChannel, () => {
 
     const { storeState } = await expectSaga(receiveChannel, {
       id: 'room-id',
-      moderatorIds: ['user-1', 'user-2'],
+      moderatorIds: ['matrix-id-1', 'matrix-id-2'],
       unreadCount: { total: 0, highlight: 0 },
     })
       .withReducer(rootReducer, initialState)
       .run();
 
     const channel = denormalizeChannel('room-id', storeState);
-    expect(channel.moderatorIds).toEqual(['user-1', 'user-2']);
+    expect(channel.moderatorIds).toEqual(['matrix-id-1', 'matrix-id-2']);
     expect(channel.unreadCount).toEqual({ total: 0, highlight: 0 });
     expect(channel.name).toEqual('Test Room');
   });
@@ -117,14 +117,14 @@ describe(receiveChannel, () => {
   it('creates a new channel with default values if it does not exist', async () => {
     const { storeState } = await expectSaga(receiveChannel, {
       id: 'new-room-id',
-      moderatorIds: ['user-1'],
+      moderatorIds: ['matrix-id-1'],
       name: 'New Room',
     })
       .withReducer(rootReducer)
       .run();
 
     const channel = denormalizeChannel('new-room-id', storeState);
-    expect(channel.moderatorIds).toEqual(['user-1']);
+    expect(channel.moderatorIds).toEqual(['matrix-id-1']);
     expect(channel.name).toEqual('New Room');
     expect(channel.unreadCount).toEqual({ total: 0, highlight: 0 });
     expect(channel.messages).toEqual([]);
@@ -282,19 +282,19 @@ describe(receivedRoomMemberPowerLevelChanged, () => {
     })
       .withReducer(rootReducer, initialState)
       .provide([
-        [matchers.select(userByMatrixIdSelector, 'matrix-id-1'), { userId: 'user-id-1' }],
+        [matchers.select(userByMatrixIdSelector, 'matrix-id-1'), { userId: 'user-id-1', matrixId: 'matrix-id-1' }],
       ])
       .run();
 
     const channel = denormalizeChannel('room-id', storeState);
-    expect(channel.moderatorIds).toEqual(['user-id-1']);
+    expect(channel.moderatorIds).toEqual(['matrix-id-1']);
   });
 
   it('does not add a moderator if they are already a moderator', async () => {
     const initialState = new StoreBuilder()
       .withConversationList({
         id: 'room-id',
-        moderatorIds: ['user-id-1'],
+        moderatorIds: ['matrix-id-1'],
         name: 'Test Room',
         unreadCount: { total: 0, highlight: 0 },
       })
@@ -306,19 +306,19 @@ describe(receivedRoomMemberPowerLevelChanged, () => {
     })
       .withReducer(rootReducer, initialState)
       .provide([
-        [matchers.select(userByMatrixIdSelector, 'matrix-id-1'), { userId: 'user-id-1' }],
+        [matchers.select(userByMatrixIdSelector, 'matrix-id-1'), { userId: 'user-id-1', matrixId: 'matrix-id-1' }],
       ])
       .run();
 
     const channel = denormalizeChannel('room-id', storeState);
-    expect(channel.moderatorIds).toEqual(['user-id-1']);
+    expect(channel.moderatorIds).toEqual(['matrix-id-1']);
   });
 
   it('removes a moderator when their power level is set to Viewer', async () => {
     const initialState = new StoreBuilder()
       .withConversationList({
         id: 'room-id',
-        moderatorIds: ['user-id-1'],
+        moderatorIds: ['matrix-id-1'],
         name: 'Test Room',
         unreadCount: { total: 0, highlight: 0 },
       })
@@ -330,7 +330,7 @@ describe(receivedRoomMemberPowerLevelChanged, () => {
     })
       .withReducer(rootReducer, initialState)
       .provide([
-        [matchers.select(userByMatrixIdSelector, 'matrix-id-1'), { userId: 'user-id-1' }],
+        [matchers.select(userByMatrixIdSelector, 'matrix-id-1'), { userId: 'user-id-1', matrixId: 'matrix-id-1' }],
       ])
       .run();
 

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -233,13 +233,13 @@ export function* receivedRoomMemberPowerLevelChanged(action) {
   let moderatorIds = cloneDeep(channel.moderatorIds || []);
 
   if (powerLevel === PowerLevels.Moderator) {
-    if (!moderatorIds.includes(user.userId)) {
-      moderatorIds.push(user.userId);
+    if (!moderatorIds.includes(user.matrixId)) {
+      moderatorIds.push(user.matrixId);
     }
   }
 
   if (powerLevel === PowerLevels.Viewer) {
-    const index = moderatorIds.indexOf(user.userId);
+    const index = moderatorIds.indexOf(user.matrixId);
     if (index !== -1) {
       moderatorIds.splice(index, 1);
     }


### PR DESCRIPTION
### What does this do?
Adds moderator events to sliding sync.
Fixes moderators not being able to use the invite user UI

### Why are we making this change?
Moderator functionality wasn't working in the UI

### How do I test this?
Add user as a moderator
Switch to that user and make sure they have the appropriate UI elements for their permissions

