### PR TITLE
fix(home-app-posts): ensure consistent channel ZID formatting in post submission API calls

### DIFF
--- a/src/store/posts/utils.ts
+++ b/src/store/posts/utils.ts
@@ -81,7 +81,7 @@ export function mapPostToMatrixMessage(post) {
  */
 export async function uploadPost(formData: FormData, worldZid: string) {
   return new Promise(async (resolve, reject) => {
-    const endpoint = `/api/v2/posts/channel/${worldZid}`;
+    const endpoint = `/api/v2/posts/channel/${stripZidPrefix(worldZid)}`;
 
     let request = post(endpoint)
       .field('text', formData.get('text'))
@@ -108,6 +108,10 @@ export async function uploadPost(formData: FormData, worldZid: string) {
       }
     });
   });
+}
+
+function stripZidPrefix(zid?: string) {
+  return zid?.replace(/^0:\/\//, '');
 }
 
 export async function getWallet() {


### PR DESCRIPTION
### What does this do?
We are updating the uploadPost function to automatically remove the 0:// prefix from the channel ZID before constructing the API endpoint.

### Why are we making this change?
This ensures the API receives the correct channel (zid) identifier format, preventing 404 errors when posting from different parts of the app.

### How do I test this?
Run tests as usual
Post on Home App

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
