### PR TITLE
refactor(post-input): update media file size validation to enforce correct limits for images and videos

### DIFF
--- a/src/apps/feed/components/post-input/index.test.tsx
+++ b/src/apps/feed/components/post-input/index.test.tsx
@@ -54,11 +54,11 @@ describe('PostInput', () => {
     const dropzone = wrapper.find(Dropzone).shallow();
 
     const textarea = dropzone.find('textarea');
-    wrapper.find(Dropzone).simulate('drop', [{ name: 'image1' }]);
+    wrapper.find(Dropzone).simulate('drop', [{ name: 'image1', size: 1024 * 1024, type: 'image/png' }]);
     textarea.simulate('keydown', { preventDefault() {}, key: Key.Enter, shiftKey: false });
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith('', [{ name: 'image1' }]);
+    expect(onSubmit).toHaveBeenCalledWith('', [{ name: 'image1', size: 1024 * 1024, type: 'image/png' }]);
   });
 
   it('submits post when submit button is clicked', () => {
@@ -79,11 +79,11 @@ describe('PostInput', () => {
     const wrapper = subject({ onSubmit, dropzoneToMedia });
     const dropzone = wrapper.find(Dropzone).shallow();
 
-    wrapper.find(Dropzone).simulate('drop', [{ name: 'image1' }]);
+    wrapper.find(Dropzone).simulate('drop', [{ name: 'image1', size: 1024 * 1024, type: 'image/png' }]);
     dropzone.find(Button).simulate('press');
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith('', [{ name: 'image1' }]);
+    expect(onSubmit).toHaveBeenCalledWith('', [{ name: 'image1', size: 1024 * 1024, type: 'image/png' }]);
   });
 
   it('renders Dropzone with correct mime types and max size', () => {

--- a/src/apps/feed/components/post-input/index.tsx
+++ b/src/apps/feed/components/post-input/index.tsx
@@ -32,7 +32,7 @@ import { MatrixAvatar } from '../../../../components/matrix-avatar';
 import { POST_MAX_LENGTH } from '../../lib/constants';
 import { Giphy } from '../../../../components/message-input/giphy/giphy';
 import { ToastNotification } from '@zero-tech/zui/components';
-import { getPostMediaMaxFileSize } from './utils';
+import { getPostMediaMaxFileSize, validateMediaFiles } from './utils';
 
 const SHOW_MAX_LABEL_THRESHOLD = 0.8 * POST_MAX_LENGTH;
 
@@ -174,9 +174,15 @@ export class PostInput extends React.Component<Properties, State> {
 
   imagesSelected = (acceptedFiles): void => {
     this.setState({ isDropRejectedNotificationOpen: false, rejectedType: null });
+    const { validFiles, rejectedFiles } = validateMediaFiles(acceptedFiles);
+    if (rejectedFiles.length > 0) {
+      this.setState({ isDropRejectedNotificationOpen: false, rejectedType: null }, () => {
+        this.setState({ isDropRejectedNotificationOpen: true, rejectedType: rejectedFiles[0].file.type });
+      });
+    }
     const newImages: Media[] = this.props.dropzoneToMedia
-      ? this.props.dropzoneToMedia(acceptedFiles)
-      : dropzoneToMedia(acceptedFiles);
+      ? this.props.dropzoneToMedia(validFiles)
+      : dropzoneToMedia(validFiles);
     if (newImages.length) {
       this.mediaSelected([newImages[0]]);
     }

--- a/src/apps/feed/components/post-input/menu/index.tsx
+++ b/src/apps/feed/components/post-input/menu/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Dropzone from 'react-dropzone';
 import { bytesToMB, dropzoneToMedia, Media } from '../../../../../components/message-input/utils';
-import { getPostMediaMaxFileSize } from '../utils';
+import { getPostMediaMaxFileSize, validateMediaFiles } from '../utils';
 import { IconPlus } from '@zero-tech/zui/icons';
 import { IconButton, ToastNotification } from '@zero-tech/zui/components';
 import { config } from '../../../../../config';
@@ -22,9 +22,13 @@ export class PostMediaMenu extends React.Component<Properties, State> {
 
   mediaSelected = (acceptedFiles): void => {
     this.setState({ isDropRejectedNotificationOpen: false, rejectedType: null });
-
-    const newMedia: Media[] = dropzoneToMedia(acceptedFiles);
-
+    const { validFiles, rejectedFiles } = validateMediaFiles(acceptedFiles);
+    if (rejectedFiles.length > 0) {
+      this.setState({ isDropRejectedNotificationOpen: false, rejectedType: null }, () => {
+        this.setState({ isDropRejectedNotificationOpen: true, rejectedType: rejectedFiles[0].file.type });
+      });
+    }
+    const newMedia: Media[] = dropzoneToMedia(validFiles);
     if (newMedia.length) {
       this.props.onSelected(newMedia);
     }

--- a/src/apps/feed/components/post-input/utils.ts
+++ b/src/apps/feed/components/post-input/utils.ts
@@ -13,3 +13,20 @@ export function getPostMediaMaxFileSize(mimeType: string): number {
   // fallback to smallest
   return config.postMedia.imageMaxFileSize;
 }
+
+export function validateMediaFiles(files: File[]): {
+  validFiles: File[];
+  rejectedFiles: { file: File; reason: string }[];
+} {
+  const validFiles: File[] = [];
+  const rejectedFiles: { file: File; reason: string }[] = [];
+  for (const file of files) {
+    const maxSize = getPostMediaMaxFileSize(file.type);
+    if (file.size > maxSize) {
+      rejectedFiles.push({ file, reason: 'file-too-large' });
+    } else {
+      validFiles.push(file);
+    }
+  }
+  return { validFiles, rejectedFiles };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ export const config = {
   postGifMaxFileSize: process.env.REACT_APP_POST_GIF_MAX_FILE_SIZE,
   postVideoMaxFileSize: process.env.REACT_APP_POST_VIDEO_MAX_FILE_SIZE,
   postMedia: {
-    imageMaxFileSize: parseInt(process.env.REACT_APP_POST_IMAGE_MAX_FILE_SIZE) || 5242880,
+    imageMaxFileSize: parseInt(process.env.REACT_APP_POST_IMAGE_MAX_FILE_SIZE) || 10485760,
     gifMaxFileSize: parseInt(process.env.REACT_APP_POST_GIF_MAX_FILE_SIZE) || 15728640,
     videoMaxFileSize: parseInt(process.env.REACT_APP_POST_VIDEO_MAX_FILE_SIZE) || 104857600,
   },

--- a/src/store/posts/utils.ts
+++ b/src/store/posts/utils.ts
@@ -81,7 +81,7 @@ export function mapPostToMatrixMessage(post) {
  */
 export async function uploadPost(formData: FormData, worldZid: string) {
   return new Promise(async (resolve, reject) => {
-    const endpoint = `/api/v2/posts/channel/${worldZid}`;
+    const endpoint = `/api/v2/posts/channel/${stripZidPrefix(worldZid)}`;
 
     let request = post(endpoint)
       .field('text', formData.get('text'))
@@ -108,6 +108,10 @@ export async function uploadPost(formData: FormData, worldZid: string) {
       }
     });
   });
+}
+
+function stripZidPrefix(zid?: string) {
+  return zid?.replace(/^0:\/\//, '');
 }
 
 export async function getWallet() {


### PR DESCRIPTION
### What does this do?
We are updating the file size validation logic to correctly enforce type-specific limits for images and videos, and moving this logic into a shared utility.

### Why are we making this change?
Previously, images could bypass their size limit due to using the video max size as a global limit; this change ensures each media type is validated against its correct maximum and improves code maintainability.

### How do I test this?
Run tests as usual
Attempt to post media of different sizes

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
