### PR TITLE
Fix error in optimistic message update flow

### DIFF
--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -76,6 +76,12 @@ export interface Channel {
   zid?: string;
 }
 
+export interface ReceiveChannel extends Omit<Channel, 'messages' | 'otherMembers' | 'memberHistory'> {
+  messages: (string | Message)[];
+  otherMembers: (string | User)[];
+  memberHistory: (string | User)[];
+}
+
 export const CHANNEL_DEFAULTS = {
   optimisticId: '',
   name: '',

--- a/src/store/channels/saga.ts
+++ b/src/store/channels/saga.ts
@@ -1,5 +1,5 @@
 import { takeLatest, put, call, select, spawn, take } from 'redux-saga/effects';
-import { SagaActionTypes, rawReceive, schema, removeAll, Channel, CHANNEL_DEFAULTS } from '.';
+import { SagaActionTypes, rawReceive, schema, removeAll, CHANNEL_DEFAULTS, ReceiveChannel } from '.';
 import { takeEveryFromBus } from '../../lib/saga';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
 import { currentUserSelector } from '../authentication/saga';
@@ -129,7 +129,7 @@ export function* clearChannels() {
   yield put(removeAll({ schema: schema.key }));
 }
 
-export function* receiveChannel(channel: Partial<Channel>) {
+export function* receiveChannel(channel: Partial<ReceiveChannel>) {
   const existing = yield select(channelSelector(channel.id));
   let data = { ...channel };
   if (!existing) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -482,7 +482,7 @@ export function* receiveActiveChannelMessage(channelId: string) {
 export function* receiveOptimisticMessage(action: ReceiveOptimisticMessageAction) {
   const { message, roomId } = action.payload;
   // hydrate message with redux data
-  const newMessage = yield call(mapMessagesAndPreview, [message], roomId);
+  const newMessage: Message[] = yield call(mapMessagesAndPreview, [message], roomId);
   const channel = yield select((state) => rawChannel(state, roomId));
   const existingMessages = channel.messages;
   // replace the optimistic message with the real message
@@ -491,10 +491,10 @@ export function* receiveOptimisticMessage(action: ReceiveOptimisticMessageAction
     existingMessages,
     newMessage[0]
   );
-  if (!newMessages) {
+  if (!newMessages || !newMessage[0]) {
     return;
   }
-  const fullMessage = newMessages.find((message) => typeof message !== 'string' && message.id === newMessage.id) as
+  const fullMessage = newMessages.find((message) => typeof message !== 'string' && message.id === newMessage[0].id) as
     | Message
     | undefined;
   if (!fullMessage) {


### PR DESCRIPTION
### What does this do?
Adds null checking for optimistic message updating.
Also updates the receive channel type to specify that messages and users can be ids or the full objects
