### PR TITLE
feat(feed): add All/Following feed filter toggle to HomeApp with shared panel toggle component

### DIFF
--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -43,6 +43,14 @@ export const Feed = ({
   showFollowingToggle = false,
 }: FeedProps) => {
   const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(FeedFilter.Following);
+
+  const feedProps = {
+    zid,
+    userId,
+    isLoading: isLoadingProp,
+    ...(showFollowingToggle ? { following: selectedFilter === FeedFilter.Following } : {}),
+  };
+
   const {
     channelZid,
     fetchNextPage,
@@ -57,12 +65,7 @@ export const Feed = ({
     posts,
     currentUserId,
     userMeowBalance,
-  } = useFeed({
-    zid,
-    userId,
-    isLoading: isLoadingProp,
-    following: selectedFilter === FeedFilter.Following,
-  });
+  } = useFeed(feedProps);
 
   const renderHeader = () => {
     if (!showFollowingToggle) {

--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -1,12 +1,22 @@
 import { useFeed } from './lib/useFeed';
-
 import { Message } from '../message';
 import { Post } from '../post';
 import { PostInput } from '../post-input-hook';
 import { Waypoint } from '../../../../components/waypoint';
-import { Panel, PanelBody, PanelHeader, PanelTitle } from '../../../../components/layout/panel';
+import { Panel, PanelBody, PanelHeader, PanelTitle, PanelTitleToggle } from '../../../../components/layout/panel';
+import { useState } from 'react';
 
 import styles from './styles.module.scss';
+
+enum FeedFilter {
+  All = 'all',
+  Following = 'following',
+}
+
+const FEED_TOGGLE_OPTIONS = [
+  { key: FeedFilter.Following, label: 'Following' },
+  { key: FeedFilter.All, label: 'All' },
+];
 
 export interface FeedProps {
   /**
@@ -19,9 +29,20 @@ export interface FeedProps {
   userId?: string;
   isPostingEnabled?: boolean;
   isLoading?: boolean;
+  /**
+   * Whether to show the following toggle
+   */
+  showFollowingToggle?: boolean;
 }
 
-export const Feed = ({ zid, isPostingEnabled = true, userId, isLoading: isLoadingProp }: FeedProps) => {
+export const Feed = ({
+  zid,
+  isPostingEnabled = true,
+  userId,
+  isLoading: isLoadingProp,
+  showFollowingToggle = false,
+}: FeedProps) => {
+  const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(FeedFilter.Following);
   const {
     channelZid,
     fetchNextPage,
@@ -36,13 +57,29 @@ export const Feed = ({ zid, isPostingEnabled = true, userId, isLoading: isLoadin
     posts,
     currentUserId,
     userMeowBalance,
-  } = useFeed({ zid, userId, isLoading: isLoadingProp });
+  } = useFeed({
+    zid,
+    userId,
+    isLoading: isLoadingProp,
+    following: selectedFilter === FeedFilter.Following,
+  });
+
+  const renderHeader = () => {
+    if (!showFollowingToggle) {
+      return <PanelTitle>{headerText}</PanelTitle>;
+    }
+    return (
+      <PanelTitleToggle
+        options={FEED_TOGGLE_OPTIONS}
+        value={selectedFilter}
+        onChange={(key) => setSelectedFilter(key as FeedFilter)}
+      />
+    );
+  };
 
   return (
     <Panel className={styles.Feed}>
-      <PanelHeader>
-        <PanelTitle>{headerText}</PanelTitle>
-      </PanelHeader>
+      <PanelHeader>{renderHeader()}</PanelHeader>
       <PanelBody className={styles.Panel}>
         {channelZid && isPostingEnabled && <PostInput className={styles.Input} channelZid={channelZid} />}
         {isLoading && <Message>Loading posts...</Message>}

--- a/src/apps/feed/components/feed/lib/useFeed.ts
+++ b/src/apps/feed/components/feed/lib/useFeed.ts
@@ -20,8 +20,10 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
   const userMeowBalance = useSelector(userRewardsMeowBalanceSelector);
   const primaryZID = useSelector(primaryZIDSelector);
 
+  const queryKey = ['posts', { zid, userId, ...(typeof following === 'boolean' ? { following } : {}) }];
+
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: ['posts', { zid, userId, following }],
+    queryKey,
     queryFn: async ({ pageParam = 0 }) => {
       let endpoint;
 
@@ -35,8 +37,8 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
       if (userId) {
         params.append('user_id', userId);
       }
-      if (following) {
-        params.append('following', 'true');
+      if (typeof following === 'boolean') {
+        params.append('following', String(following));
       }
 
       const queryString = params.toString();

--- a/src/apps/home/index.tsx
+++ b/src/apps/home/index.tsx
@@ -20,7 +20,7 @@ export const HomeApp = () => {
 
   return (
     <div className={styles.Home}>
-      <Feed />
+      <Feed showFollowingToggle={true} />
     </div>
   );
 };

--- a/src/components/layout/panel/index.tsx
+++ b/src/components/layout/panel/index.tsx
@@ -18,6 +18,13 @@ export interface PanelProps {
   name?: string;
 }
 
+export interface PanelTitleToggleProps {
+  options: { key: string; label: string }[];
+  value: string;
+  onChange: (key: string) => void;
+  className?: string;
+}
+
 export const LegacyPanel = forwardRef(
   (
     { children, className, panel, name }: Pick<PanelProps, 'children' | 'className' | 'panel' | 'name'>,
@@ -77,6 +84,22 @@ export const PanelHeader = ({ children, className }: Pick<PanelProps, 'children'
 
 export const PanelTitle = ({ children, className }: Pick<PanelProps, 'children' | 'className'>) => {
   return <div className={cn(styles.Title, className)}>{children}</div>;
+};
+
+export const PanelTitleToggle = ({ options, value, onChange, className }: PanelTitleToggleProps) => {
+  return (
+    <div className={cn(styles.HeaderToggle, className)}>
+      {options.map((option) => (
+        <div
+          key={option.key}
+          className={cn(styles.ToggleOption, { [styles.Active]: value === option.key })}
+          onClick={() => onChange(option.key)}
+        >
+          {option.label}
+        </div>
+      ))}
+    </div>
+  );
 };
 
 export const PanelCollapsed = ({ className }: Pick<PanelProps, 'className'>) => {

--- a/src/components/layout/panel/styles.module.scss
+++ b/src/components/layout/panel/styles.module.scss
@@ -118,3 +118,24 @@ $header-color: var(--color-greyscale-11);
 
   cursor: pointer;
 }
+
+.HeaderToggle {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.ToggleOption {
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &.Active {
+    opacity: 1;
+    color: var(--color-secondary-11) !important;
+  }
+}


### PR DESCRIPTION
### What does this do?
We’re adding a toggle to the HomeApp feed to let users filter between “All” posts and posts from users they follow, using a new shared PanelTitleToggle component.

### Why are we making this change?
To improve user experience by allowing users to easily view either all posts or just those from people they follow, and to lay the groundwork for more personalized feeds.

### How do I test this?
Run tests as usual
Run UI and visit HomeApp

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
