### PR TITLE
fix(profile-navigation): add missing author identifiers to post components in PostView and Replies to prevent undefined profile links

### DIFF
--- a/src/apps/feed/components/post-view-container/index.tsx
+++ b/src/apps/feed/components/post-view-container/index.tsx
@@ -57,6 +57,8 @@ export const PostView = ({ postId, isFeed }: PostViewProps) => {
                 channelZid={post.channelZid}
                 isSinglePostView={true}
                 mediaId={post.mediaId}
+                authorPrimaryZid={post.sender?.primaryZid}
+                authorPublicAddress={post.sender?.publicAddress}
               />
               <CommentInput channelZid={post.channelZid} isFeed={isFeed} postId={postId} />
             </div>

--- a/src/apps/feed/components/post-view-container/reply-list/index.tsx
+++ b/src/apps/feed/components/post-view-container/reply-list/index.tsx
@@ -36,6 +36,8 @@ export const Replies = ({ postId, isFeed }: RepliesProps) => {
                 channelZid={reply.channelZid}
                 avatarUrl={reply.sender?.avatarUrl}
                 mediaId={reply.mediaId}
+                authorPrimaryZid={reply.sender?.primaryZid}
+                authorPublicAddress={reply.sender?.publicAddress}
               />
             </li>
           ))


### PR DESCRIPTION
### What does this do?
We're adding the missing authorPrimaryZid and authorPublicAddress props to the Post components in both the PostView and Replies components.

### Why are we making this change?
To fix the issue where clicking on user profiles in post views and replies was resulting in /profile/undefined URLs instead of the correct profile paths.

### How do I test this?
run tests as usual
run ui and attempt profile navigation from post view / replies

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
