### PR TITLE
feat(home-feed): persist feed filter state between navigation

### DIFF
--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -4,14 +4,10 @@ import { Post } from '../post';
 import { PostInput } from '../post-input-hook';
 import { Waypoint } from '../../../../components/waypoint';
 import { Panel, PanelBody, PanelHeader, PanelTitle, PanelTitleToggle } from '../../../../components/layout/panel';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { FeedFilter, getLastFeedFilter, setLastFeedFilter } from '../../../../lib/last-feed-filter';
 
 import styles from './styles.module.scss';
-
-enum FeedFilter {
-  All = 'all',
-  Following = 'following',
-}
 
 const FEED_TOGGLE_OPTIONS = [
   { key: FeedFilter.Following, label: 'Following' },
@@ -42,7 +38,13 @@ export const Feed = ({
   isLoading: isLoadingProp,
   showFollowingToggle = false,
 }: FeedProps) => {
-  const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(FeedFilter.Following);
+  const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(getLastFeedFilter());
+
+  useEffect(() => {
+    if (showFollowingToggle) {
+      setLastFeedFilter(selectedFilter);
+    }
+  }, [selectedFilter, showFollowingToggle]);
 
   const feedProps = {
     zid,

--- a/src/lib/last-feed-filter.ts
+++ b/src/lib/last-feed-filter.ts
@@ -1,0 +1,21 @@
+const LAST_FEED_FILTER_KEY = 'last-feed-filter';
+
+export enum FeedFilter {
+  All = 'all',
+  Following = 'following',
+}
+
+export const setLastFeedFilter = (filter: FeedFilter): void => {
+  if (filter) {
+    localStorage.setItem(LAST_FEED_FILTER_KEY, filter);
+  }
+};
+
+export const getLastFeedFilter = (): FeedFilter => {
+  const stored = localStorage.getItem(LAST_FEED_FILTER_KEY);
+  return stored === FeedFilter.All ? FeedFilter.All : FeedFilter.Following;
+};
+
+export const clearLastFeedFilter = (): void => {
+  localStorage.removeItem(LAST_FEED_FILTER_KEY);
+};

--- a/src/store/authentication/saga.test.ts
+++ b/src/store/authentication/saga.test.ts
@@ -35,6 +35,7 @@ import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
 import { clearIndexedDBStorage } from '../../lib/storage/clear-idb';
 import { clearLastActiveFeed } from '../../lib/last-feed';
+import { clearLastFeedFilter } from '../../lib/last-feed-filter';
 
 // Mock the media-cache module
 jest.mock('../../lib/storage/media-cache', () => ({
@@ -278,6 +279,10 @@ describe(forceLogout, () => {
 
   it('clears the last active feed', async () => {
     await expectLogoutSaga().call(clearLastActiveFeed).call(terminate).run();
+  });
+
+  it('clears the last feed filter', async () => {
+    await expectLogoutSaga().call(clearLastFeedFilter).call(terminate).run();
   });
 
   it('clears the user session', async () => {

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -18,6 +18,7 @@ import { clearLastActiveConversation } from '../../lib/last-conversation';
 import { clearLastActiveTab } from '../../lib/last-tab';
 import { clearRewards } from '../rewards/saga';
 import { clearLastActiveFeed } from '../../lib/last-feed';
+import { clearLastFeedFilter } from '../../lib/last-feed-filter';
 import { clearCache, performCacheMaintenance } from '../../lib/storage/media-cache';
 import { setSentryUser } from '../../utils';
 import { Events as ChatEvents, getChatBus } from '../chat/bus';
@@ -138,6 +139,7 @@ export function* forceLogout() {
   yield call(clearLastActiveConversation);
   yield call(clearLastActiveTab);
   yield call(clearLastActiveFeed);
+  yield call(clearLastFeedFilter);
   yield call(clearRewards);
   yield call(terminate);
 }


### PR DESCRIPTION
### What does this do?
We're adding localStorage persistence for the feed's "All/Following" toggle state.

### Why are we making this change?
To maintain the user's selected feed filter (All/Following) when navigating between posts and profiles, improving UX by preserving their view preference.

### How do I test this?
Run tests as usual
Visit the home app, navigate away, and then back. Check the filter is set to what it was before you navigated away.

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
