### PR TITLE
Adding back channel zid logic that was missing

### DIFF
--- a/src/lib/chat/matrix/matrix-adapter.ts
+++ b/src/lib/chat/matrix/matrix-adapter.ts
@@ -33,6 +33,8 @@ export class MatrixAdapter {
       moderatorIds: mods,
       labels,
       isSocialChannel,
+      // this isn't the best way to get the zid as it relies on the name format, but it's a quick fix
+      zid: isSocialChannel ? room.name?.split('://')[1] : null,
     };
   }
 


### PR DESCRIPTION
### What does this do?
Adding this back in as it was not properly migrated with the sliding sync update