### PR TITLE
Fix conversation-item avatar url logic

### DIFF
--- a/src/components/messenger/list/conversation-item/index.vitest.tsx
+++ b/src/components/messenger/list/conversation-item/index.vitest.tsx
@@ -3,7 +3,13 @@ import { vi } from 'vitest';
 import { renderWithProviders } from '../../../../test-utils';
 
 import { ConversationItem } from './index';
-import { Channel, ConversationStatus, DefaultRoomLabels, MessagesFetchState, User } from '../../../../store/channels';
+import {
+  ConversationStatus,
+  DefaultRoomLabels,
+  MessagesFetchState,
+  NormalizedChannel,
+  User,
+} from '../../../../store/channels';
 import { MatrixAvatar } from '../../../matrix-avatar';
 import { bemClassName } from '../../../../lib/bem';
 import { previewDisplayDate } from '../../../../lib/chat/chat-message';
@@ -79,7 +85,7 @@ describe('ConversationItem', () => {
     sender: { userId: string };
   }
 
-  const baseConversation: Channel = {
+  const baseConversation: NormalizedChannel = {
     id: 'conv-1',
     optimisticId: '',
     name: '',
@@ -121,11 +127,15 @@ describe('ConversationItem', () => {
   describe('Avatar Display', () => {
     it('should render the correct avatar for a one-on-one conversation', () => {
       const user1 = createMockUser('user-1', 'John', 'Doe', 'john.jpg');
+      const users = [user1];
+      mockGetUser.mockImplementation((userId: string) => {
+        return users.find((u) => u.userId === userId) || createMockUser(userId, `User-${userId}`, '');
+      });
       renderComponent({
         conversation: {
           ...baseConversation,
           totalMembers: 2,
-          otherMembers: [user1],
+          otherMembers: [user1.userId],
         },
       });
       expect(MatrixAvatar).toHaveBeenCalledWith(
@@ -142,11 +152,15 @@ describe('ConversationItem', () => {
     it('should render the correct avatar for a group conversation with a group icon', () => {
       const user1 = createMockUser('user-1', 'John', 'Doe');
       const user2 = createMockUser('user-2', 'Jane', 'Smith');
+      const users = [user1, user2];
+      mockGetUser.mockImplementation((userId: string) => {
+        return users.find((u) => u.userId === userId) || createMockUser(userId, `User-${userId}`, '');
+      });
       renderComponent({
         conversation: {
           ...baseConversation,
           icon: 'group-icon.png',
-          otherMembers: [user1, user2],
+          otherMembers: [user1.userId, user2.userId],
         },
       });
       expect(MatrixAvatar).toHaveBeenCalledWith(
@@ -163,11 +177,15 @@ describe('ConversationItem', () => {
     it('should render a generic group avatar for a group conversation without a specific icon', () => {
       const user1 = createMockUser('user-1', 'John', 'Doe');
       const user2 = createMockUser('user-2', 'Jane', 'Smith');
+      const users = [user1, user2];
+      mockGetUser.mockImplementation((userId: string) => {
+        return users.find((u) => u.userId === userId) || createMockUser(userId, `User-${userId}`, '');
+      });
       renderComponent({
         conversation: {
           ...baseConversation,
           icon: '',
-          otherMembers: [user1, user2],
+          otherMembers: [user1.userId, user2.userId],
         },
       });
       expect(MatrixAvatar).toHaveBeenCalledWith(
@@ -185,11 +203,15 @@ describe('ConversationItem', () => {
   describe('Conversation Title Display', () => {
     it("should display the other member's name for a one-on-one conversation", () => {
       const user1 = createMockUser('user-1', 'Alice', 'Wonderland');
+      const users = [user1];
+      mockGetUser.mockImplementation((userId: string) => {
+        return users.find((u) => u.userId === userId) || createMockUser(userId, `User-${userId}`, '');
+      });
       renderComponent({
         conversation: {
           ...baseConversation,
           name: '',
-          otherMembers: [user1],
+          otherMembers: [user1.userId],
         },
       });
       expect(screen.getByText('Alice Wonderland')).toBeInTheDocument();
@@ -198,11 +220,15 @@ describe('ConversationItem', () => {
     it('should display a list of member names for a multi-member conversation', () => {
       const user1 = createMockUser('user-1', 'Bob', 'Builder');
       const user2 = createMockUser('user-2', 'Charlie', 'Chaplin');
+      const users = [user1, user2];
+      mockGetUser.mockImplementation((userId: string) => {
+        return users.find((u) => u.userId === userId) || createMockUser(userId, `User-${userId}`, '');
+      });
       renderComponent({
         conversation: {
           ...baseConversation,
           name: '',
-          otherMembers: [user1, user2],
+          otherMembers: [user1.userId, user2.userId],
         },
       });
       expect(screen.getByText('Bob Builder, Charlie Chaplin')).toBeInTheDocument();
@@ -210,11 +236,15 @@ describe('ConversationItem', () => {
 
     it('should display the custom name if the conversation has one', () => {
       const user1 = createMockUser('user-1', 'David', 'Copperfield');
+      const users = [user1];
+      mockGetUser.mockImplementation((userId: string) => {
+        return users.find((u) => u.userId === userId) || createMockUser(userId, `User-${userId}`, '');
+      });
       renderComponent({
         conversation: {
           ...baseConversation,
           name: 'Custom Group Name',
-          otherMembers: [user1],
+          otherMembers: [user1.userId],
         },
       });
       expect(screen.getByText('Custom Group Name')).toBeInTheDocument();

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 
 import {
-  Channel,
   DefaultRoomLabels,
+  NormalizedChannel,
   onAddLabel,
   onRemoveLabel,
   openConversation,
@@ -133,7 +133,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
     }
   }, [horizontalScroll]);
 
-  const getConversationsByLabel = useCallback((label: string, conversation: Channel) => {
+  const getConversationsByLabel = useCallback((label: string, conversation: NormalizedChannel) => {
     const isLabelMatch = conversation.labels?.includes(label);
     const isArchived = conversation.labels?.includes(DefaultRoomLabels.ARCHIVED);
     if (label === Tab.All) {
@@ -147,7 +147,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
 
   const filteredConversations = useMemo(() => {
     if (!filter) {
-      return conversations.filter((conversation: Channel) => {
+      return conversations.filter((conversation: NormalizedChannel) => {
         const render = !conversation.isSocialChannel && 'bumpStamp' in conversation;
         const labelMatch = getConversationsByLabel(tabLabelMap[selectedTab], conversation);
         return render && labelMatch;
@@ -193,7 +193,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
       setFilter(newSearch);
 
       const oneOnOneConversations = conversations.filter((c) => isOneOnOne(c));
-      const oneOnOneConversationMemberIds = oneOnOneConversations.flatMap((c) => c.otherMembers.map((m) => m.userId));
+      const oneOnOneConversationMemberIds = oneOnOneConversations.flatMap((c) => c.otherMembers);
 
       const items: MemberNetworks[] = await search(newSearch);
       const filteredUserItems = items?.filter((item) => !oneOnOneConversationMemberIds.includes(item.id) && item.id);

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -76,6 +76,12 @@ export interface Channel {
   zid?: string;
 }
 
+export interface NormalizedChannel extends Omit<Channel, 'messages' | 'otherMembers' | 'memberHistory'> {
+  messages: string[];
+  otherMembers: string[];
+  memberHistory: string[];
+}
+
 export interface ReceiveChannel extends Omit<Channel, 'messages' | 'otherMembers' | 'memberHistory'> {
   messages: (string | Message)[];
   otherMembers: (string | User)[];

--- a/src/store/channels/selectors.ts
+++ b/src/store/channels/selectors.ts
@@ -1,4 +1,4 @@
-import { Channel, DefaultRoomLabels, denormalize } from '.';
+import { Channel, DefaultRoomLabels, denormalize, NormalizedChannel } from '.';
 import { RootState } from '../reducer';
 import getDeepProperty from 'lodash.get';
 import { createSelector } from '@reduxjs/toolkit';
@@ -14,8 +14,8 @@ export const channelSelector =
     return denormalize(channelId, state);
   };
 
-export const allChannelsSelector = (state: RootState): Channel[] => {
-  const channels = getDeepProperty(state, 'normalized.channels', {}) as Record<string, Channel>;
+export const allChannelsSelector = (state: RootState): NormalizedChannel[] => {
+  const channels = getDeepProperty(state, 'normalized.channels', {}) as Record<string, NormalizedChannel>;
   return Object.values(channels).sort(byBumpStamp);
 };
 


### PR DESCRIPTION
### What does this do?
Fixes the conversation-item typing that was covering up an issue with avatar url logic
