### PR TITLE
fix(post): preserve whitespace and line breaks in post content while maintaining link previews

### DIFF
--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -90,18 +90,21 @@ export const Post = ({
   ]);
 
   const multilineText = useMemo(
-    () =>
-      displayText?.split('\n').map((line, index) => {
-        const linkType = detectLinkType(line);
-        const hasPreview = linkType !== null;
+    () => (
+      <div className={styles.TextContainer}>
+        {displayText.split('\n').map((line, index) => {
+          const linkType = detectLinkType(line);
+          const hasPreview = linkType !== null;
 
-        return (
-          <div key={index}>
-            <p className={styles.Text}>{line}</p>
-            {hasPreview && <PostLinkPreview url={line} />}
-          </div>
-        );
-      }),
+          return (
+            <div key={index} className={styles.TextLine}>
+              <span className={styles.Text}>{line}</span>
+              {hasPreview && <PostLinkPreview url={line} />}
+            </div>
+          );
+        })}
+      </div>
+    ),
     [displayText]
   );
 

--- a/src/apps/feed/components/post/styles.module.scss
+++ b/src/apps/feed/components/post/styles.module.scss
@@ -80,6 +80,17 @@
   }
 }
 
+.TextContainer {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.TextLine {
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 1.5em;
+}
+
 .Text {
   white-space: pre-wrap;
   word-break: break-word;


### PR DESCRIPTION
### What does this do?
We're modifying the post content rendering to preserve whitespace and line breaks while maintaining link preview functionality.

### Why are we making this change?
To ensure post content displays exactly as entered by users, including multiple line breaks and spaces, while keeping the existing link preview feature intact.

### How do I test this?
Run tests as usual
Run ui and create a multi line post with white space

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
