### PR TITLE
feat(profile/feed/post): implement profile return navigation with scroll position preservation

### DIFF
--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import { useFeed } from './lib/useFeed';
 import { Message } from '../message';
 import { Post } from '../post';
@@ -6,6 +7,8 @@ import { Waypoint } from '../../../../components/waypoint';
 import { Panel, PanelBody, PanelHeader, PanelTitle, PanelTitleToggle } from '../../../../components/layout/panel';
 import { useState, useEffect } from 'react';
 import { FeedFilter, getLastFeedFilter, setLastFeedFilter } from '../../../../lib/last-feed-filter';
+import { useReturnFromProfileNavigation } from '../../lib/useReturnFromProfileNavigation';
+import { BackButton } from '../post-view-container/back-button';
 
 import styles from './styles.module.scss';
 
@@ -39,6 +42,8 @@ export const Feed = ({
   showFollowingToggle = false,
 }: FeedProps) => {
   const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(getLastFeedFilter());
+  const location = useLocation();
+  const isProfileRoute = location.pathname.startsWith('/profile');
 
   useEffect(() => {
     if (showFollowingToggle) {
@@ -69,7 +74,13 @@ export const Feed = ({
     userMeowBalance,
   } = useFeed(feedProps);
 
+  useReturnFromProfileNavigation();
+
   const renderHeader = () => {
+    if (isProfileRoute) {
+      return <BackButton />;
+    }
+
     if (!showFollowingToggle) {
       return <PanelTitle>{headerText}</PanelTitle>;
     }

--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -17,7 +17,8 @@ import Linkify from 'linkify-react';
 import { PostLinkPreview } from './link-preview';
 import { detectLinkType } from './link-preview/utils';
 import { PostMedia } from '../post-media';
-
+import { useGetReturnFromProfilePath } from '../../lib/useGetReturnFromProfilePath';
+import { RETURN_POST_ID_KEY, RETURN_PATH_KEY } from '../../lib/useReturnFromProfileNavigation';
 import classNames from 'classnames';
 import styles from './styles.module.scss';
 
@@ -117,7 +118,7 @@ export const Post = ({
       <div className={classNames(styles.Container, className)} has-author={author ? '' : null} data-variant={variant}>
         {variant === 'default' && (
           <div className={styles.Avatar}>
-            <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress}>
+            <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress} postId={messageId}>
               <MatrixAvatar size='regular' imageURL={avatarUrl} />
             </ProfileLink>
           </div>
@@ -138,7 +139,7 @@ export const Post = ({
             <div className={styles.Details}>
               {variant === 'expanded' && (
                 <div className={styles.Avatar}>
-                  <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress}>
+                  <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress} postId={messageId}>
                     <MatrixAvatar size='regular' imageURL={avatarUrl} />
                   </ProfileLink>
                 </div>
@@ -146,7 +147,7 @@ export const Post = ({
               <div className={styles.Wrapper}>
                 {/* @ts-ignore */}
                 <Name className={styles.Name} variant='name'>
-                  <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress}>
+                  <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress} postId={messageId}>
                     {nickname}
                   </ProfileLink>
                   <span>⋅</span>
@@ -262,14 +263,22 @@ const ProfileLink = ({
   primaryZid,
   publicAddress,
   children,
+  postId,
 }: {
   primaryZid: string;
   publicAddress: string;
   children: ReactNode;
+  postId: string;
 }) => {
+  const { returnPath } = useGetReturnFromProfilePath();
+
+  const searchParams = new URLSearchParams();
+  searchParams.set(RETURN_POST_ID_KEY, postId);
+  searchParams.set(RETURN_PATH_KEY, returnPath);
+
   return (
     <PreventPropagation>
-      <Link to={`/profile/${primaryZid ?? publicAddress}`}>{children}</Link>
+      <Link to={`/profile/${primaryZid ?? publicAddress}?${searchParams.toString()}`}>{children}</Link>
     </PreventPropagation>
   );
 };

--- a/src/apps/feed/lib/useGetReturnFromProfilePath.ts
+++ b/src/apps/feed/lib/useGetReturnFromProfilePath.ts
@@ -1,0 +1,21 @@
+import { useRouteMatch } from 'react-router-dom';
+
+export const useGetReturnFromProfilePath = () => {
+  const route = useRouteMatch();
+  const isHome = route.path?.startsWith('/home');
+  const isProfile = route.path?.startsWith('/profile');
+  const isFeed = route.path?.startsWith('/feed');
+  const isConversation = route.path?.startsWith('/conversation');
+
+  const getReturnFromProfilePath = () => {
+    if (isHome) return '/home';
+    if (isProfile) return `/profile/${route.params?.zid}`;
+    if (isFeed) return `/feed/${route.params?.zid}`;
+    if (isConversation) return `/conversation/${route.params?.conversationId}`;
+    return '/feed';
+  };
+
+  return {
+    returnPath: getReturnFromProfilePath(),
+  };
+};

--- a/src/apps/feed/lib/useReturnFromProfileNavigation.ts
+++ b/src/apps/feed/lib/useReturnFromProfileNavigation.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const RETURN_DATA_KEY = 'profileReturnData';
+export const RETURN_POST_ID_KEY = 'returnPostId';
+export const RETURN_PATH_KEY = 'returnPath';
+
+interface ReturnData {
+  postId: string;
+  path: string;
+}
+
+export const useReturnFromProfileNavigation = (postId?: string) => {
+  const location = useLocation();
+
+  // Handle scrolling to post when returning
+  useEffect(() => {
+    // If we have a postId in the URL, we're already at the post
+    if (postId) return;
+
+    const storedData = sessionStorage.getItem(RETURN_DATA_KEY);
+    if (!storedData) return;
+
+    try {
+      const { postId: returnPostId, path: returnPath } = JSON.parse(storedData);
+
+      // If we're on the return path and have a post ID, scroll to it
+      if (returnPath === location.pathname && returnPostId) {
+        const postElement = document.querySelector(`[data-post-id="${returnPostId}"]`);
+        if (postElement) {
+          postElement.scrollIntoView({ behavior: 'auto', block: 'center' });
+        }
+      }
+    } catch (error) {
+      console.error('Error handling return data:', error);
+    }
+  }, [postId, location.pathname]);
+
+  // Store return data when navigating to profile
+  const storeReturnFromProfileData = (returnPostId: string, returnPath: string) => {
+    if (returnPostId && returnPath) {
+      const returnData: ReturnData = {
+        postId: returnPostId,
+        path: returnPath,
+      };
+      sessionStorage.setItem(RETURN_DATA_KEY, JSON.stringify(returnData));
+    }
+  };
+
+  return {
+    storeReturnFromProfileData,
+  };
+};

--- a/src/apps/profile/index.tsx
+++ b/src/apps/profile/index.tsx
@@ -1,15 +1,31 @@
-import { useRouteMatch } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { UserPanel } from './panels/UserPanel';
 import { Switcher } from './panels/Switcher';
 import { PostView } from '../feed/components/post-view-container';
-import { useScrollPosition } from '../../lib/hooks/useScrollPosition';
+import { useEffect } from 'react';
+import {
+  useReturnFromProfileNavigation,
+  RETURN_POST_ID_KEY,
+  RETURN_PATH_KEY,
+} from '../feed/lib/useReturnFromProfileNavigation';
 
 import styles from './styles.module.scss';
 
 export const ProfileApp = () => {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const returnPostId = searchParams.get(RETURN_POST_ID_KEY);
+  const returnPath = searchParams.get(RETURN_PATH_KEY);
+  const { storeReturnFromProfileData } = useReturnFromProfileNavigation();
+
+  useEffect(() => {
+    if (returnPostId && returnPath) {
+      storeReturnFromProfileData(returnPostId, returnPath);
+    }
+  }, [returnPostId, returnPath, storeReturnFromProfileData]);
+
   const route = useRouteMatch<{ zid: string; postId?: string }>('/profile/:zid/:postId?');
   const postId = route?.params?.postId;
-  useScrollPosition(postId);
 
   return (
     <div className={styles.Wrapper}>


### PR DESCRIPTION
### What does this do?
We're implementing a return navigation system that preserves scroll position when navigating back from a profile view to the feed.

### Why are we making this change?
To improve user experience by maintaining context when navigating between profile and feed views, ensuring users return to their exact previous position.

### How do I test this?
Run tests as usual
Run ui, visit a profile from one of the feeds, then navigate back and check you are in the same location as before

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
