### PR TITLE
Fix: Fix last message formatting

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -126,8 +126,10 @@ export class Chat {
     }
     const liveTimeline = room.getLiveTimeline();
     const events = liveTimeline.getEvents();
-    const lastEvent = [...events].reverse().find((event) => event.getType() === EventType.RoomMessage);
-    return lastEvent ? mapMatrixMessage(lastEvent.getEffectiveEvent()) : null;
+    const effectiveEvents = events.map((event) => event.getEffectiveEvent());
+    const messages = this.matrix.processRawEventsToMessages(effectiveEvents);
+    const lastMessage = messages.reverse().find((message) => !message.isAdmin) as MessageWithoutSender;
+    return lastMessage ?? null;
   }
 
   async getMessagesByChannelId(channelId: string, lastCreatedAt?: number) {


### PR DESCRIPTION
### What does this do?
Ensures the messages are properly formatted (including edits/replies) before getting the last message

### Why are we making this change?
Mobile does some interesting things to a message when it's a reply of a reply, and then it gets edited. This causes some formatting issues if we use the raw event data, so we need to apply our standard formatting where we create a link to parent messages.

### How do I test this?
Reply to a reply, then edit. Things should look correct

|Before|After|
|---|---|
|![Screenshot 2025-05-14 at 8 21 49 AM](https://github.com/user-attachments/assets/8537b978-17dd-4d57-92ef-95dc77fe1215)|![Screenshot 2025-05-14 at 8 21 35 AM](https://github.com/user-attachments/assets/d554c674-78f3-4462-afaa-ce45eb325f2c)|
