### PR TITLE
refactor: update citizen list item to use dedicated ProfileLinkNavigation component

### DIFF
--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
-
 import { User } from '../../store/channels';
 import { bemClassName } from '../../lib/bem';
 import { displayName } from '../../lib/user';
+import { Wallet } from '../../store/authentication/types';
 
 import './styles.scss';
 import { MemberManagementMenuContainer } from '../messenger/group-management/member-management-menu/container';
 import classNames from 'classnames';
 import { MatrixAvatar } from '../matrix-avatar';
+import { ProfileLinkNavigation } from '../profile-link-navigation';
 
 const cn = bemClassName('citizen-list-item');
 
@@ -27,6 +28,14 @@ interface State {
 export class CitizenListItem extends React.Component<Properties, State> {
   state: State = {
     isMenuOpen: false,
+  };
+
+  getThirdWebWalletAddress = () => {
+    const { wallets } = this.props.user;
+    if (!wallets?.length) return undefined;
+
+    const thirdWebWallet = wallets.find((wallet: Wallet) => wallet.isThirdWeb);
+    return thirdWebWallet?.publicAddress;
   };
 
   publishMemberClick = () => {
@@ -54,7 +63,12 @@ export class CitizenListItem extends React.Component<Properties, State> {
         tabIndex={0}
       >
         <div {...cn('details')}>
-          <MatrixAvatar size={'small'} imageURL={this.props.user.profileImage} tabIndex={-1} />
+          <ProfileLinkNavigation
+            primaryZid={this.props.user.primaryZID}
+            thirdWebAddress={this.getThirdWebWalletAddress()}
+          >
+            <MatrixAvatar size={'small'} imageURL={this.props.user.profileImage} tabIndex={-1} />
+          </ProfileLinkNavigation>
           <div {...cn('text-container')}>
             <span {...cn('name')}>{displayName(this.props.user)}</span>
             <span {...cn('handle')}>{this.props.user.displaySubHandle}</span>

--- a/src/components/messenger/group-management/index.test.tsx
+++ b/src/components/messenger/group-management/index.test.tsx
@@ -33,8 +33,6 @@ describe(GroupManagement, () => {
       startEditConversation: () => null,
       startAddGroupMember: () => null,
       setLeaveGroupStatus: () => null,
-      onMemberClick: () => null,
-      openUserProfile: () => null,
 
       ...props,
     };

--- a/src/components/messenger/group-management/index.tsx
+++ b/src/components/messenger/group-management/index.tsx
@@ -34,8 +34,6 @@ export interface Properties {
   startEditConversation: () => void;
   startAddGroupMember: () => void;
   setLeaveGroupStatus: (status: LeaveGroupDialogStatus) => void;
-  onMemberClick: (userId: string) => void;
-  openUserProfile: () => void;
 }
 
 export class GroupManagement extends React.PureComponent<Properties> {
@@ -81,8 +79,6 @@ export class GroupManagement extends React.PureComponent<Properties> {
             onLeave={this.props.setLeaveGroupStatus}
             onEdit={this.props.startEditConversation}
             onBack={this.props.onBack}
-            onMemberSelected={this.props.onMemberClick}
-            openUserProfile={this.props.openUserProfile}
           />
         )}
         {this.props.stage === Stage.None && (
@@ -94,8 +90,6 @@ export class GroupManagement extends React.PureComponent<Properties> {
             conversationAdminIds={this.props.conversationAdminIds}
             conversationModeratorIds={this.props.conversationModeratorIds}
             onAdd={this.props.startAddGroupMember}
-            onMemberSelected={this.props.onMemberClick}
-            openUserProfile={this.props.openUserProfile}
           />
         )}
       </>

--- a/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.test.tsx
@@ -29,8 +29,6 @@ describe(ViewGroupInformationPanel, () => {
       onLeave: () => null,
       onEdit: () => null,
       onBack: () => null,
-      onMemberSelected: () => null,
-      openUserProfile: () => null,
       ...props,
     };
 
@@ -62,32 +60,6 @@ describe(ViewGroupInformationPanel, () => {
     wrapper.find(c('add-icon')).simulate('click');
 
     expect(onAdd).toHaveBeenCalled();
-  });
-
-  it('publishes onMemberSelected event', () => {
-    const onMemberSelected = jest.fn();
-    const otherMembers = [
-      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
-    ] as User[];
-
-    const wrapper = subject({ onMemberSelected, otherMembers });
-
-    wrapper.find(CitizenListItem).at(1).simulate('selected', 'otherMember1');
-
-    expect(onMemberSelected).toHaveBeenCalled();
-  });
-
-  it('publishes openUserProfile event', () => {
-    const openUserProfile = jest.fn();
-
-    const wrapper = subject({
-      openUserProfile,
-      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
-    });
-
-    wrapper.find(CitizenListItem).at(0).simulate('selected', 'currentUser');
-
-    expect(openUserProfile).toHaveBeenCalled();
   });
 
   it('publishes onLeave event', () => {

--- a/src/components/messenger/group-management/view-group-information-panel/index.tsx
+++ b/src/components/messenger/group-management/view-group-information-panel/index.tsx
@@ -34,8 +34,6 @@ export interface Properties {
   onLeave: (status: LeaveGroupDialogStatus) => void;
   onEdit: () => void;
   onBack: () => void;
-  onMemberSelected: (userId: string) => void;
-  openUserProfile: () => void;
 }
 
 interface State {
@@ -67,14 +65,6 @@ export class ViewGroupInformationPanel extends React.Component<Properties, State
 
   openLeaveGroup = () => {
     this.props.onLeave(LeaveGroupDialogStatus.OPEN);
-  };
-
-  memberSelected = (userId: string) => {
-    this.props.onMemberSelected(userId);
-  };
-
-  openProfile = () => {
-    this.props.openUserProfile();
   };
 
   loadMoreMembers = () => {
@@ -139,18 +129,9 @@ export class ViewGroupInformationPanel extends React.Component<Properties, State
 
         <div {...cn('member-list')}>
           <ScrollbarContainer>
-            <CitizenListItem
-              user={this.props.currentUser}
-              tag={this.getTag(this.props.currentUser)}
-              onSelected={this.openProfile}
-            ></CitizenListItem>
+            <CitizenListItem user={this.props.currentUser} tag={this.getTag(this.props.currentUser)}></CitizenListItem>
             {visibleMembers.map((u) => (
-              <CitizenListItem
-                key={u.userId}
-                user={u}
-                tag={this.getTag(u)}
-                onSelected={this.memberSelected}
-              ></CitizenListItem>
+              <CitizenListItem key={u.userId} user={u} tag={this.getTag(u)}></CitizenListItem>
             ))}
           </ScrollbarContainer>
 

--- a/src/components/messenger/group-management/view-members-panel/index.test.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.test.tsx
@@ -20,8 +20,7 @@ describe(ViewMembersPanel, () => {
       conversationModeratorIds: [],
 
       onAdd: () => null,
-      onMemberSelected: () => null,
-      openUserProfile: () => null,
+
       ...props,
     };
 
@@ -75,32 +74,6 @@ describe(ViewMembersPanel, () => {
     wrapper.find(c('add-icon')).simulate('click');
 
     expect(onAdd).toHaveBeenCalled();
-  });
-
-  it('publishes onMemberSelected event', () => {
-    const onMemberSelected = jest.fn();
-    const otherMembers = [
-      { userId: 'otherMember1', matrixId: 'matrix-id-1', firstName: 'Adam' },
-    ] as User[];
-
-    const wrapper = subject({ onMemberSelected, otherMembers });
-
-    wrapper.find(CitizenListItem).at(1).simulate('selected', 'otherMember1');
-
-    expect(onMemberSelected).toHaveBeenCalled();
-  });
-
-  it('publishes openUserProfile event', () => {
-    const openUserProfile = jest.fn();
-
-    const wrapper = subject({
-      openUserProfile,
-      currentUser: { userId: 'currentUser', matrixId: 'matrix-id-4', firstName: 'Tom' } as any,
-    });
-
-    wrapper.find(CitizenListItem).at(0).simulate('selected', 'currentUser');
-
-    expect(openUserProfile).toHaveBeenCalled();
   });
 
   it('renders add icon button when current user can add members', () => {

--- a/src/components/messenger/group-management/view-members-panel/index.tsx
+++ b/src/components/messenger/group-management/view-members-panel/index.tsx
@@ -25,8 +25,6 @@ export interface Properties {
   conversationModeratorIds: string[];
 
   onAdd: () => void;
-  onMemberSelected: (userId: string) => void;
-  openUserProfile: () => void;
 }
 
 interface State {
@@ -48,14 +46,6 @@ export class ViewMembersPanel extends React.Component<Properties, State> {
 
   addMember = () => {
     this.props.onAdd();
-  };
-
-  memberSelected = (userId: string) => {
-    this.props.onMemberSelected(userId);
-  };
-
-  openProfile = () => {
-    this.props.openUserProfile();
   };
 
   loadMoreMembers = () => {
@@ -96,18 +86,9 @@ export class ViewMembersPanel extends React.Component<Properties, State> {
 
         <div {...cn('member-list')}>
           <ScrollbarContainer>
-            <CitizenListItem
-              user={this.props.currentUser}
-              tag={this.getTag(this.props.currentUser)}
-              onSelected={this.openProfile}
-            ></CitizenListItem>
+            <CitizenListItem user={this.props.currentUser} tag={this.getTag(this.props.currentUser)}></CitizenListItem>
             {visibleMembers.map((u) => (
-              <CitizenListItem
-                key={u.userId}
-                user={u}
-                tag={this.getTag(u)}
-                onSelected={this.memberSelected}
-              ></CitizenListItem>
+              <CitizenListItem key={u.userId} user={u} tag={this.getTag(u)}></CitizenListItem>
             ))}
           </ScrollbarContainer>
 

--- a/src/components/profile-link-navigation/index.tsx
+++ b/src/components/profile-link-navigation/index.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface ProfileLinkNavigationProps {
+  primaryZid?: string;
+  thirdWebAddress?: string;
+  children: ReactNode;
+}
+
+const PreventPropagation = ({ children }: { children: ReactNode }) => {
+  return <div onClick={(e) => e.stopPropagation()}>{children}</div>;
+};
+
+export const ProfileLinkNavigation = ({ primaryZid, thirdWebAddress, children }: ProfileLinkNavigationProps) => {
+  // Use primaryZID if available, otherwise fall back to ThirdWeb wallet address
+  // Remove '0://' prefix from ZID if present
+  const profileIdentifier = primaryZid?.replace('0://', '') ?? thirdWebAddress;
+
+  // If we don't have either identifier, just render the children without a link
+  if (!profileIdentifier) {
+    return <>{children}</>;
+  }
+
+  return (
+    <PreventPropagation>
+      <Link to={`/profile/${profileIdentifier}`}>{children}</Link>
+    </PreventPropagation>
+  );
+};


### PR DESCRIPTION
### What does this do?
We're replacing the clickable CitizenListItem behavior with a dedicated ProfileLinkNavigation component that only makes the avatar clickable for profile navigation.

### Why are we making this change?
To prevent accidental conversation starts/opens when users intend to navigate to profiles by clicking outside the avatar area.

### How do I test this?
Run tests as usual
Open the members panels and click avatar to navigate to profile

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
