### PR TITLE
feat(profile/user-panel): add and wire up message button to user profile panel

### DIFF
--- a/src/apps/profile/panels/UserPanel/index.tsx
+++ b/src/apps/profile/panels/UserPanel/index.tsx
@@ -2,23 +2,34 @@ import { useUserPanel } from './useUserPanel';
 
 import { Panel, PanelBody } from '../../../../components/layout/panel';
 import { MatrixAvatar } from '../../../../components/matrix-avatar';
-import { IconLogoZero } from '@zero-tech/zui/icons';
+import { IconLogoZero, IconMessage01 } from '@zero-tech/zui/icons';
 import MatrixMask from './matrix-mask.svg?react';
 import { FollowButton } from '../../../../components/follow-button';
 import { FollowCounts } from '../../../../components/follow-counts';
 import { Skeleton } from '@zero-tech/zui/components/Skeleton';
+import { IconButton } from '@zero-tech/zui/components';
 
 import styles from './styles.module.scss';
 
 export const UserPanel = () => {
-  const { handle, profileImageUrl, zid, isLoading, userId, isCurrentUser, followersCount, followingCount } =
-    useUserPanel();
+  const {
+    handle,
+    profileImageUrl,
+    zid,
+    isLoading,
+    userId,
+    isCurrentUser,
+    followersCount,
+    followingCount,
+    handleStartConversation,
+  } = useUserPanel();
 
   return (
     <Panel className={styles.Container}>
       <PanelBody className={styles.Body}>
         <div>
           <IconLogoZero size={18} />
+
           <div className={styles.Header}>
             <MatrixAvatar className={styles.Avatar} imageURL={profileImageUrl} size='regular' />
             <MatrixMask className={styles.Mask} />
@@ -38,7 +49,18 @@ export const UserPanel = () => {
                   className={styles.FollowCounts}
                 />
               )}
-              {!isCurrentUser && <FollowButton targetUserId={userId} className={styles.FollowButton} />}
+              <div className={styles.ActionButtons}>
+                {!isCurrentUser && <FollowButton targetUserId={userId} className={styles.FollowButton} />}
+                {!isCurrentUser && (
+                  <IconButton
+                    Icon={IconMessage01}
+                    onClick={handleStartConversation}
+                    aria-label='Start conversation'
+                    className={styles.MessageButton}
+                    data-testid='message-button'
+                  />
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/apps/profile/panels/UserPanel/index.vitest.tsx
+++ b/src/apps/profile/panels/UserPanel/index.vitest.tsx
@@ -35,8 +35,18 @@ vi.mock('../../../../components/follow-counts', () => ({
   )),
 }));
 
+vi.mock('@zero-tech/zui/components', () => ({
+  IconButton: vi.fn(({ onClick, Icon, 'data-testid': testId, ...props }) => (
+    <button onClick={onClick} data-testid={testId} {...props}>
+      <Icon />
+    </button>
+  )),
+}));
+
 describe('UserPanel', () => {
   describe('when user has all profile data', () => {
+    const handleStartConversation = vi.fn();
+
     beforeEach(() => {
       vi.mocked(useUserPanel).mockReturnValue({
         handle: 'testuser',
@@ -47,6 +57,7 @@ describe('UserPanel', () => {
         isCurrentUser: false,
         followersCount: 100,
         followingCount: 50,
+        handleStartConversation,
       });
 
       renderWithProviders(<UserPanel />);
@@ -78,6 +89,17 @@ describe('UserPanel', () => {
       expect(followButton).toBeInTheDocument();
       expect(followButton).toHaveAttribute('data-user-id', 'test-user-id');
     });
+
+    it('renders message button for other users', () => {
+      const messageButton = screen.getByTestId('message-button');
+      expect(messageButton).toBeInTheDocument();
+    });
+
+    it('calls handleStartConversation when message button is clicked', () => {
+      const messageButton = screen.getByTestId('message-button');
+      messageButton.click();
+      expect(handleStartConversation).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('when viewing own profile', () => {
@@ -91,6 +113,7 @@ describe('UserPanel', () => {
         isCurrentUser: true,
         followersCount: 100,
         followingCount: 50,
+        handleStartConversation: vi.fn(),
       });
 
       renderWithProviders(<UserPanel />);
@@ -98,6 +121,10 @@ describe('UserPanel', () => {
 
     it('does not render follow button', () => {
       expect(screen.queryByTestId('mock-follow-button')).not.toBeInTheDocument();
+    });
+
+    it('does not render message button', () => {
+      expect(screen.queryByTestId('message-button')).not.toBeInTheDocument();
     });
 
     it('still renders follow counts', () => {
@@ -117,6 +144,7 @@ describe('UserPanel', () => {
         isCurrentUser: false,
         followersCount: 100,
         followingCount: 50,
+        handleStartConversation: vi.fn(),
       });
 
       renderWithProviders(<UserPanel />);
@@ -125,6 +153,10 @@ describe('UserPanel', () => {
     it('does not render follow button or counts while loading', () => {
       expect(screen.queryByTestId('mock-follow-button')).not.toBeInTheDocument();
       expect(screen.queryByTestId('mock-follow-counts')).not.toBeInTheDocument();
+    });
+
+    it('does not render message button while loading', () => {
+      expect(screen.queryByTestId('message-button')).not.toBeInTheDocument();
     });
   });
 
@@ -138,6 +170,7 @@ describe('UserPanel', () => {
       isCurrentUser: false,
       followersCount: 100,
       followingCount: 50,
+      handleStartConversation: vi.fn(),
     });
 
     renderWithProviders(<UserPanel />);

--- a/src/apps/profile/panels/UserPanel/styles.module.scss
+++ b/src/apps/profile/panels/UserPanel/styles.module.scss
@@ -100,3 +100,17 @@
   width: 100%;
   justify-content: center;
 }
+
+.ActionButtons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.MessageButton {
+  color: var(--color-secondary-11);
+  background: var(--zui-colors-background-secondary);
+  border-radius: 8px;
+  padding: 8px;
+  margin-top: 16px;
+}

--- a/src/apps/profile/panels/UserPanel/useUserPanel.ts
+++ b/src/apps/profile/panels/UserPanel/useUserPanel.ts
@@ -1,10 +1,12 @@
 import { useProfileApp } from '../../lib/useProfileApp';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
+import { createConversation } from '../../../../store/create-conversation';
 
 export const useUserPanel = () => {
   const { data, isLoading } = useProfileApp();
   const currentUser = useSelector(currentUserSelector);
+  const dispatch = useDispatch();
 
   const handle = data?.handle;
   const profileImageUrl = data?.profileImage;
@@ -13,6 +15,11 @@ export const useUserPanel = () => {
   const isCurrentUser = userId === currentUser?.id;
   const followersCount = data?.followersCount;
   const followingCount = data?.followingCount;
+
+  const handleStartConversation = () => {
+    if (!userId) return;
+    dispatch(createConversation({ userIds: [userId] }));
+  };
 
   return {
     handle,
@@ -23,5 +30,6 @@ export const useUserPanel = () => {
     isLoading,
     followersCount,
     followingCount,
+    handleStartConversation,
   };
 };


### PR DESCRIPTION
### What does this do?
Adding a message button to the UserPanel component that allows users to start conversations with other users.

### Why are we making this change?
To enable direct messaging between users from their profile pages, improving the platform's communication capabilities.

### How do I test this?
Run tests as usual
Visit a users profile and click the Message Icon button to create/open a conversation with that user

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
