### PR TITLE
feat(message/group-avatars): add profile navigation to group chat avatars

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -29,6 +29,7 @@ import { MessageMenu, MessageMenuProps } from './menu/messageMenu';
 import { useMatrixMedia } from '../../lib/hooks/useMatrixMedia';
 import { MatrixAvatar } from '../matrix-avatar';
 import { useLinkPreview } from '../../lib/hooks/useLinkPreview';
+import { ProfileLinkNavigation } from '../profile-link-navigation';
 
 import './styles.scss';
 
@@ -431,7 +432,12 @@ export const Message: React.FC<Properties> = memo(
         {showSenderAvatar && (
           <div {...cn('left')}>
             <div {...cn('author-avatar')}>
-              <MatrixAvatar size='medium' imageURL={sender.profileImage} tabIndex={-1} />
+              <ProfileLinkNavigation
+                primaryZid={sender.primaryZID}
+                thirdWebAddress={sender.wallets?.find((wallet) => wallet.isThirdWeb)?.publicAddress}
+              >
+                <MatrixAvatar size='medium' imageURL={sender.profileImage} tabIndex={-1} />
+              </ProfileLinkNavigation>
             </div>
           </div>
         )}

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -4,7 +4,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { createNormalizedSlice, removeAll } from '../normalized';
 
 import { ParentMessage } from '../../lib/chat/types';
-import { User } from '../authentication/types';
+import { User, Wallet } from '../authentication/types';
 import { EncryptedFile } from 'matrix-js-sdk/lib/types';
 
 export interface AttachmentUploadResult {
@@ -23,6 +23,7 @@ interface Sender {
   profileId: string;
   primaryZID: string;
   displaySubHandle?: string;
+  wallets?: Wallet[];
 }
 
 export enum MediaType {


### PR DESCRIPTION
### What does this do?
We're adding profile navigation functionality to avatars in group chat messages by wrapping the MatrixAvatar with ProfileLinkNavigation and updating the Sender interface to include wallet information.

### Why are we making this change?
To provide consistent user experience by allowing users to navigate to profiles by clicking avatars in group chats.

### How do I test this?
Run tests as usual
Navigate to a group conversation in messenger app and click a users avatar

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
