### PR TITLE
feat(feed/header): add global user search drawer to feed header and wire up profile navigation

### DIFF
--- a/src/apps/feed/components/feed/index.tsx
+++ b/src/apps/feed/components/feed/index.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'react';
 import { FeedFilter, getLastFeedFilter, setLastFeedFilter } from '../../../../lib/last-feed-filter';
 import { useReturnFromProfileNavigation } from '../../lib/useReturnFromProfileNavigation';
 import { BackButton } from '../post-view-container/back-button';
+import { SearchDrawer } from './search-drawer';
 
 import styles from './styles.module.scss';
 
@@ -72,6 +73,10 @@ export const Feed = ({
     posts,
     currentUserId,
     userMeowBalance,
+    searchResults,
+    isSearching,
+    handleSearch,
+    searchValue,
   } = useFeed(feedProps);
 
   useReturnFromProfileNavigation();
@@ -95,7 +100,15 @@ export const Feed = ({
 
   return (
     <Panel className={styles.Feed}>
-      <PanelHeader>{renderHeader()}</PanelHeader>
+      <PanelHeader>
+        {renderHeader()}
+        <SearchDrawer
+          searchResults={searchResults}
+          isSearching={isSearching}
+          onSearch={handleSearch}
+          searchValue={searchValue}
+        />
+      </PanelHeader>
       <PanelBody className={styles.Panel}>
         {channelZid && isPostingEnabled && <PostInput className={styles.Input} channelZid={channelZid} />}
         {isLoading && <Message>Loading posts...</Message>}

--- a/src/apps/feed/components/feed/lib/useFeed.ts
+++ b/src/apps/feed/components/feed/lib/useFeed.ts
@@ -1,5 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
+import { debounce } from 'lodash';
+import { useCallback, useState, useMemo } from 'react';
 
 import { get } from '../../../../../lib/api/rest';
 import { PAGE_SIZE } from '../../../lib/constants';
@@ -7,6 +9,8 @@ import { mapPostToMatrixMessage } from '../../../../../store/posts/utils';
 import { useMeowPost } from '../../../lib/useMeowPost';
 import { primaryZIDSelector, userIdSelector } from '../../../../../store/authentication/selectors';
 import { userRewardsMeowBalanceSelector } from '../../../../../store/rewards/selectors';
+import { searchMyNetworksByName } from '../../../../../platform-apps/channels/util/api';
+import { MemberNetworks } from '../../../../../store/users/types';
 
 interface UseFeedParams {
   zid?: string;
@@ -19,6 +23,26 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
   const currentUserId = useSelector(userIdSelector);
   const userMeowBalance = useSelector(userRewardsMeowBalanceSelector);
   const primaryZID = useSelector(primaryZIDSelector);
+  const [searchResults, setSearchResults] = useState<MemberNetworks[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+
+  const performSearch = useCallback(async (searchText: string) => {
+    const usersApiResult = await searchMyNetworksByName(searchText);
+    setSearchResults(usersApiResult);
+    setIsSearching(false);
+  }, []);
+
+  const debouncedSearch = useMemo(() => debounce(performSearch, 800), [performSearch]);
+
+  const handleSearch = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+      setIsSearching(true);
+      debouncedSearch(value);
+    },
+    [debouncedSearch]
+  );
 
   const queryKey = ['posts', { zid, userId, ...(typeof following === 'boolean' ? { following } : {}) }];
 
@@ -73,6 +97,10 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
     posts: data,
     currentUserId,
     userMeowBalance,
+    searchResults,
+    isSearching,
+    searchValue,
+    handleSearch,
   };
 };
 

--- a/src/apps/feed/components/feed/search-drawer/index.tsx
+++ b/src/apps/feed/components/feed/search-drawer/index.tsx
@@ -1,0 +1,88 @@
+import { useState, useRef, useEffect } from 'react';
+import { Input } from '@zero-tech/zui/components';
+import { IconSearchMd } from '@zero-tech/zui/icons';
+import { MatrixAvatar } from '../../../../../components/matrix-avatar';
+import { ProfileLinkNavigation } from '../../../../../components/profile-link-navigation';
+import styles from './styles.module.scss';
+
+interface SearchDrawerProps {
+  searchResults: any[];
+  isSearching: boolean;
+  searchValue: string;
+  onSearch: (value: string) => void;
+}
+
+export const SearchDrawer = ({ searchResults, isSearching, searchValue, onSearch }: SearchDrawerProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        onSearch('');
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onSearch]);
+
+  const handleSearchChange = (value: string) => {
+    onSearch(value);
+  };
+
+  const handleToggleDrawer = () => {
+    if (isOpen) {
+      onSearch('');
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className={styles.Container} ref={containerRef}>
+      <div className={styles.IconContainer} onClick={handleToggleDrawer}>
+        <IconSearchMd size={18} />
+      </div>
+      <div className={`${styles.Drawer} ${isOpen ? styles.DrawerOpen : ''}`}>
+        {isOpen && (
+          <div className={styles.InputContainer}>
+            <Input
+              className={styles.Input}
+              size={'small'}
+              type={'search'}
+              placeholder='Search users...'
+              value={searchValue}
+              onChange={handleSearchChange}
+            />
+          </div>
+        )}
+      </div>
+      {isOpen && searchValue && (isSearching || searchResults.length > 0) && (
+        <div className={styles.SearchResults}>
+          {isSearching ? (
+            <div className={styles.SearchLoading}>Searching...</div>
+          ) : (
+            searchResults.map((user) => (
+              <ProfileLinkNavigation
+                key={user.id}
+                primaryZid={user?.primaryZID}
+                thirdWebAddress={user?.primaryWalletAddress}
+              >
+                <div className={styles.SearchResultItem}>
+                  <MatrixAvatar size='small' imageURL={user.profileImage} />
+                  <div className={styles.UserInfo}>
+                    <span className={styles.UserName}>{user.name}</span>
+                    {user?.primaryZID && <span className={styles.UserHandle}>{user.primaryZID}</span>}
+                  </div>
+                </div>
+              </ProfileLinkNavigation>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/apps/feed/components/feed/search-drawer/styles.module.scss
+++ b/src/apps/feed/components/feed/search-drawer/styles.module.scss
@@ -1,0 +1,108 @@
+@use '../../../../../variables' as variables;
+
+.Container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 36px;
+  box-sizing: border-box;
+  transition: width 0.15s ease-in-out;
+  z-index: 1000;
+}
+
+.IconContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--color-greyscale-11);
+
+  &:hover {
+    background: var(--color-greyscale-2);
+  }
+}
+
+.Drawer {
+  position: absolute;
+  right: 44px;
+  width: 0;
+  overflow: hidden;
+  transition: width 0.15s ease-in-out;
+  background: var(--color-greyscale-1);
+  border-radius: 18px;
+  border: 1px solid var(--color-greyscale-3);
+  backdrop-filter: blur(30px);
+}
+
+.DrawerOpen {
+  width: 200px;
+}
+
+.InputContainer {
+  width: 100%;
+}
+
+.Input {
+  width: 100%;
+}
+
+.SearchResults {
+  position: absolute;
+  top: 100%;
+  right: 43px;
+  width: 200px;
+  margin-top: 2px;
+  background: var(--color-greyscale-1);
+  border: 1px solid var(--color-greyscale-3);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.SearchLoading {
+  padding: 8px;
+  color: var(--color-greyscale-11);
+  font-size: 14px;
+  text-align: center;
+}
+
+.SearchResultItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  cursor: pointer;
+  color: var(--color-greyscale-12);
+  font-size: 14px;
+
+  &:hover {
+    background: var(--color-greyscale-2);
+  }
+}
+
+.UserInfo {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.UserName {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.UserHandle {
+  color: var(--color-greyscale-11);
+  font-size: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/layout/panel/styles.module.scss
+++ b/src/components/layout/panel/styles.module.scss
@@ -80,6 +80,7 @@ $header-color: var(--color-greyscale-11);
   font-size: 14px;
 
   background: $header-background;
+  z-index: 1;
 }
 
 .Title,


### PR DESCRIPTION
### What does this do?
We're adding a search drawer to the Feed header that allows users to search for and navigate to other users' profiles.

### Why are we making this change?
To improve user navigation and discovery by providing quick access to user profiles directly from the Feed.

### How do I test this?
Run tests as usual
Run UI and navigate to a app with feed. click search icon, search user and click user to navigate to profile

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
