### PR TITLE
fix(feed/search-drawer): use users third web wallet instead of primary wallet address for profile navigation on search results

### DIFF
--- a/src/apps/feed/components/feed/search-drawer/index.tsx
+++ b/src/apps/feed/components/feed/search-drawer/index.tsx
@@ -69,7 +69,7 @@ export const SearchDrawer = ({ searchResults, isSearching, searchValue, onSearch
               <ProfileLinkNavigation
                 key={user.id}
                 primaryZid={user?.primaryZID}
-                thirdWebAddress={user?.primaryWalletAddress}
+                thirdWebAddress={user?.wallets?.find((wallet) => wallet.isThirdWeb)?.publicAddress}
               >
                 <div className={styles.SearchResultItem}>
                   <MatrixAvatar size='small' imageURL={user.profileImage} />


### PR DESCRIPTION
### What does this do?
- replaces primary wallet address with users third web wallet address in order to user profile navigation correctly

