### PR TITLE
feat(user-search): expose ThirdWeb wallet address in user search API response

### DIFF
--- a/src/apps/feed/components/feed/lib/useFeed.ts
+++ b/src/apps/feed/components/feed/lib/useFeed.ts
@@ -38,8 +38,13 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
   const handleSearch = useCallback(
     (value: string) => {
       setSearchValue(value);
-      setIsSearching(true);
-      debouncedSearch(value);
+      if (value.trim()) {
+        setIsSearching(true);
+        debouncedSearch(value);
+      } else {
+        setIsSearching(false);
+        setSearchResults([]);
+      }
     },
     [debouncedSearch]
   );

--- a/src/apps/feed/components/feed/search-drawer/index.tsx
+++ b/src/apps/feed/components/feed/search-drawer/index.tsx
@@ -69,7 +69,7 @@ export const SearchDrawer = ({ searchResults, isSearching, searchValue, onSearch
               <ProfileLinkNavigation
                 key={user.id}
                 primaryZid={user?.primaryZID}
-                thirdWebAddress={user?.wallets?.find((wallet) => wallet.isThirdWeb)?.publicAddress}
+                thirdWebAddress={user?.thirdWebWalletAddress}
               >
                 <div className={styles.SearchResultItem}>
                   <MatrixAvatar size='small' imageURL={user.profileImage} />

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -6,6 +6,7 @@ export interface MemberNetworks {
   type: string;
   primaryZID: string;
   primaryWalletAddress: string;
+  thirdWebWalletAddress?: string;
 }
 
 export interface SimplifiedUser {


### PR DESCRIPTION
### What does this do?
Adding the thirdWebWalletAddress field to the /api/v2/users/searchInNetworksByName API response.

### Why are we making this change?
To enable proper profile navigation in the search drawer by providing access to users' ThirdWeb wallet addresses.

### How do I test this?
Run tests as usual
In feed user search, search for a user and check network tab for thirdweb wallet address

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
