### PR TITLE
Fix: Message info panel readby

### DIFF
--- a/src/components/chat-view-container/chat-view-container.tsx
+++ b/src/components/chat-view-container/chat-view-container.tsx
@@ -9,9 +9,9 @@ import { isOneOnOne as isOneOnOneUtil } from '../../store/channels-list/utils';
 import { useChannelSelector } from '../../store/hooks';
 import { currentUserSelector } from '../../store/authentication/selectors';
 import { backupExistsSelector } from '../../store/matrix/selectors';
-import { isSecondarySidekickOpenSelector } from '../../store/group-management/selectors';
 import InvertedScroll from '../inverted-scroll';
 import { usePrevious } from '../../lib/hooks/usePrevious';
+import { isMemberPanelOpenSelector } from '../../store/panels/selectors';
 
 export interface PublicProperties {
   channelId: string;
@@ -24,7 +24,7 @@ export const ChatViewContainer = forwardRef<InvertedScroll, PublicProperties>((p
   const dispatch = useDispatch();
 
   const user = useSelector(currentUserSelector);
-  const isSecondarySidekickOpen = useSelector(isSecondarySidekickOpenSelector);
+  const isSecondarySidekickOpen = useSelector(isMemberPanelOpenSelector);
   const backupExists = useSelector(backupExistsSelector);
 
   const channel = useChannelSelector(channelId);

--- a/src/components/chat-view-container/chat-view-container.vitest.tsx
+++ b/src/components/chat-view-container/chat-view-container.vitest.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../store/matrix';
 import { ChatView as ImportedChatView } from './chat-view';
 import { NormalizedChannel, MessagesFetchState, CHANNEL_DEFAULTS } from '../../store/channels';
+import { isMemberPanelOpenSelector as importedIsMemberPanelOpenSelector } from '../../store/panels/selectors';
 
 vi.mock('../../store/messages', async () => {
   const actual = await vi.importActual('../../store/messages');
@@ -41,6 +42,10 @@ vi.mock('../../store/hooks', () => ({
   useChannelSelector: vi.fn(),
 }));
 
+vi.mock('../../store/panels/selectors', () => ({
+  isMemberPanelOpenSelector: vi.fn(),
+}));
+
 vi.mock('./chat-view', () => ({
   ChatView: vi.fn(({ onFetchMore, onReload, onHiddenMessageInfoClick, ...props }) => {
     return (
@@ -54,6 +59,7 @@ vi.mock('./chat-view', () => ({
 }));
 
 const mockUseChannelSelector = vi.mocked(importedUseChannelSelector);
+const mockIsMemberPanelOpenSelector = vi.mocked(importedIsMemberPanelOpenSelector);
 const mockIsOneOnOneUtil = vi.mocked(importedIsOneOnOne);
 const mockFetchMessages = vi.mocked(importedFetchMessages);
 const mockSyncMessages = vi.mocked(importedSyncMessages);
@@ -129,6 +135,7 @@ describe('ChatViewContainer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseChannelSelector.mockReturnValue(defaultChannel);
+    mockIsMemberPanelOpenSelector.mockReturnValue(false);
     mockIsOneOnOneUtil.mockReturnValue(false);
   });
 
@@ -235,6 +242,7 @@ describe('ChatViewContainer', () => {
       name: 'Prop Test Channel',
     };
     mockUseChannelSelector.mockReturnValue(channelForPropTest);
+    mockIsMemberPanelOpenSelector.mockReturnValue(true);
     mockIsOneOnOneUtil.mockReturnValue(true);
 
     renderComponent(

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -160,13 +160,13 @@ export const ChatView = React.forwardRef<InvertedScroll, Properties>(
 
     const openMessageInfoHandler = useCallback(
       (messageId: string) => {
-        dispatch(openMessageInfo({ messageId }));
+        dispatch(openMessageInfo({ messageId, channelId: id }));
 
         if (!isSecondarySidekickOpen) {
           dispatch(toggleSecondarySidekick());
         }
       },
-      [isSecondarySidekickOpen, dispatch]
+      [dispatch, id, isSecondarySidekickOpen]
     );
 
     const searchMentionableUsersHandler = useCallback(

--- a/src/components/chat-view-container/chat-view.vitest.tsx
+++ b/src/components/chat-view-container/chat-view.vitest.tsx
@@ -394,7 +394,10 @@ describe('ChatView', () => {
         screen.getByTestId('chat-message').click();
 
         expect(mockDispatch).toHaveBeenCalled();
-        expect(openMessageInfo).toHaveBeenCalledWith({ messageId: mockChatMessageProps.message.id });
+        expect(openMessageInfo).toHaveBeenCalledWith({
+          messageId: mockChatMessageProps.message.id,
+          channelId: 'channel-1',
+        });
       });
 
       it('should dispatch toggleSecondarySidekick if isSecondarySidekickOpen is false when onOpenMessageInfo is called', () => {
@@ -423,7 +426,7 @@ describe('ChatView', () => {
         screen.getByTestId('chat-message').click();
 
         expect(mockDispatch).toHaveBeenCalledTimes(2);
-        expect(openMessageInfo).toHaveBeenCalledWith({ messageId: messageWithoutMedia.id });
+        expect(openMessageInfo).toHaveBeenCalledWith({ messageId: messageWithoutMedia.id, channelId: 'channel-1' });
         expect(toggleSecondarySidekick).toHaveBeenCalledTimes(1);
       });
 
@@ -453,7 +456,7 @@ describe('ChatView', () => {
         screen.getByTestId('chat-message').click();
 
         expect(mockDispatch).toHaveBeenCalledTimes(1);
-        expect(openMessageInfo).toHaveBeenCalledWith({ messageId: messageWithoutMedia.id });
+        expect(openMessageInfo).toHaveBeenCalledWith({ messageId: messageWithoutMedia.id, channelId: 'channel-1' });
         expect(toggleSecondarySidekick).not.toHaveBeenCalled();
       });
 

--- a/src/components/messenger/message-info/container.tsx
+++ b/src/components/messenger/message-info/container.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { connectContainer } from '../../../store/redux-container';
 import { RootState } from '../../../store/reducer';
 import { closeMessageInfo } from '../../../store/message-info';
-import { denormalize as denormalizeChannel, User } from '../../../store/channels';
+import { User } from '../../../store/channels';
 import { OverviewPanel } from './overview-panel';
+import { makeGetUsersByIds } from '../../../store/users/selectors';
+import { rawChannel } from '../../../store/channels/selectors';
+import { messageSelector } from '../../../store/messages/saga';
 
 export interface PublicProperties {}
 
@@ -24,13 +27,15 @@ export class Container extends React.Component<Properties> {
       chat: { activeConversationId },
       messageInfo: { selectedMessageId },
     } = state;
+    const selectUsersByIdsInstance = makeGetUsersByIds();
+    const usersSelector = (ids: string[]) => selectUsersByIdsInstance(state, ids);
+    const channel = rawChannel(state, activeConversationId);
+    const selectedMessage = messageSelector(selectedMessageId)(state);
+    const otherMembers = usersSelector(channel.otherMembers || []);
 
-    const channel = denormalizeChannel(activeConversationId, state) || {};
-    const messages = channel.messages || [];
-    const selectedMessage = messages.find((msg) => msg.id === selectedMessageId) || {};
     const sentBy = selectedMessage?.sender?.userId !== user.data?.id ? selectedMessage?.sender : null;
     const readBy = (selectedMessage.readBy || []).filter((user) => user.userId !== selectedMessage?.sender?.userId);
-    const sentTo = (channel.otherMembers || []).filter(
+    const sentTo = otherMembers.filter(
       (user) =>
         !readBy.some((readUser) => readUser.userId === user.userId) && user.userId !== selectedMessage.sender?.userId
     );

--- a/src/store/group-management/selectors.ts
+++ b/src/store/group-management/selectors.ts
@@ -1,5 +1,3 @@
 import { RootState } from '../reducer';
 
-export const isSecondarySidekickOpenSelector = (state: RootState) => state.groupManagement.isSecondarySidekickOpen;
-
 export const leaveGroupDialogStatusSelector = (state: RootState) => state.groupManagement.leaveGroupDialogStatus;

--- a/src/store/message-info/index.ts
+++ b/src/store/message-info/index.ts
@@ -10,7 +10,7 @@ export enum SagaActionTypes {
   CloseMessageInfo = 'message-info/close-message-info',
 }
 
-export const openMessageInfo = createAction<{ messageId: string }>(SagaActionTypes.OpenMessageInfo);
+export const openMessageInfo = createAction<{ messageId: string; channelId: string }>(SagaActionTypes.OpenMessageInfo);
 export const closeMessageInfo = createAction(SagaActionTypes.CloseMessageInfo);
 
 export type MessageInfoState = {

--- a/src/store/message-info/saga.test.ts
+++ b/src/store/message-info/saga.test.ts
@@ -7,19 +7,19 @@ import { resetConversationManagement } from '../group-management/saga';
 import { mapMessageReadByUsers } from '../messages/saga';
 
 describe('message-info saga', () => {
-  const roomId = 'room-id';
+  const channelId = 'room-id';
   const messageId = 'message-id';
 
   describe('openOverview', () => {
     it('sets the selected message ID and maps message readBy users', async () => {
-      await expectSaga(openOverview, { payload: { roomId, messageId } })
+      await expectSaga(openOverview, { payload: { channelId, messageId } })
         .provide([
           [matchers.call.fn(resetConversationManagement), undefined],
           [matchers.call.fn(mapMessageReadByUsers), undefined],
         ])
         .put(setStage(Stage.Overview))
         .put(setSelectedMessageId(messageId))
-        .call(mapMessageReadByUsers, messageId, roomId)
+        .call(mapMessageReadByUsers, messageId, channelId)
         .run();
     });
   });

--- a/src/store/message-info/saga.ts
+++ b/src/store/message-info/saga.ts
@@ -14,13 +14,13 @@ function* authWatcher() {
 }
 
 export function* openOverview(action) {
-  const { roomId, messageId } = action.payload;
+  const { channelId, messageId } = action.payload;
 
   yield call(resetConversationManagement);
   yield put(setStage(Stage.Overview));
   yield put(setSelectedMessageId(messageId));
 
-  yield call(mapMessageReadByUsers, messageId, roomId);
+  yield call(mapMessageReadByUsers, messageId, channelId);
 }
 
 export function* closeOverview() {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -572,11 +572,9 @@ export function* mapMessageReadByUsers(messageId, channelId) {
       receipts.map((receipt) => receipt.userId)
     );
 
-    const selectedMessage = yield select(messageSelector(messageId));
-    const filteredReceipts = receipts.filter((receipt) => receipt.ts >= selectedMessage?.createdAt);
     const currentUser = yield select(currentUserSelector());
 
-    const readByUsers = filteredReceipts
+    const readByUsers = receipts
       .map((receipt) => {
         return zeroUsersMap.get(receipt.userId);
       })

--- a/src/store/panels/selectors.ts
+++ b/src/store/panels/selectors.ts
@@ -4,3 +4,7 @@ import { Panel } from './constants';
 export const getPanelOpenState = (state: RootState, panel: Panel): boolean => {
   return !!state.panels.openStates[panel];
 };
+
+export const isMemberPanelOpenSelector = (state: RootState): boolean => {
+  return getPanelOpenState(state, Panel.MEMBERS);
+};


### PR DESCRIPTION
### What does this do?
Fixes the message info read by list not working

### Why are we making this change?
The action modifying the readby of the message wasn't wired up properly.
The toggle sidekick selector wasn't looking at the right state so it was always closing the panel if you had it open and selected message info on another message

### How do I test this?
Select message info on a message, see the read by users, select info on another message, panel should stay open.
