### PR TITLE
Fix: Fix inviting users to channel

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -48,7 +48,10 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
     }
 
     const items = await this.props.search(searchString);
-    const options = items.map(itemToOption);
+    const options = items.map((item) => ({
+      ...itemToOption(item),
+      matrixId: item.matrixId,
+    }));
     const selectedOptions = this.props.selectedOptions || [];
     const filteredOptions = options.filter((o) => !selectedOptions.find((s) => s.value === o.value));
     this.setState({ results: filteredOptions });

--- a/src/components/messenger/lib/types.ts
+++ b/src/components/messenger/lib/types.ts
@@ -1,5 +1,6 @@
 export interface Item {
   id: string;
+  matrixId: string;
   name: string;
   image?: string;
   primaryZID: string;

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../store/channels';
 import { ConversationItem } from '../conversation-item';
 import { Input } from '@zero-tech/zui/components';
-import { Option } from '../../lib/types';
+import { Option, Item } from '../../lib/types';
 import { UserSearchResults } from '../user-search-results';
 import { itemToOption } from '../../lib/utils';
 import { ScrollbarContainer } from '../../../scrollbar-container';
@@ -27,7 +27,6 @@ import './conversation-list-panel.scss';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { isOneOnOne } from '../../../../store/channels-list/utils';
 import { allChannelsSelector } from '../../../../store/channels/selectors';
-import { MemberNetworks } from '../../../../store/users/types';
 import { CreateConversationButton } from '../create-conversation-button/create-conversation-button';
 import { userIdSelector } from '../../../../store/authentication/selectors';
 import { usersMapSelector } from '../../../../store/users/selectors';
@@ -65,7 +64,7 @@ export interface Properties {
   isLabelDataLoaded: boolean;
   isCollapsed: boolean;
 
-  search: (input: string) => Promise<MemberNetworks[]>;
+  search: (input: string) => Promise<Item[]>;
   onCreateConversation: (userId: string) => void;
 }
 
@@ -195,7 +194,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
       const oneOnOneConversations = conversations.filter((c) => isOneOnOne(c));
       const oneOnOneConversationMemberIds = oneOnOneConversations.flatMap((c) => c.otherMembers);
 
-      const items: MemberNetworks[] = await search(newSearch);
+      const items: Item[] = await search(newSearch);
       const filteredUserItems = items?.filter((item) => !oneOnOneConversationMemberIds.includes(item.id) && item.id);
 
       scrollToTop();

--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../store/channels';
 import { ConversationItem } from '../conversation-item';
 import { Input } from '@zero-tech/zui/components';
-import { Option, Item } from '../../lib/types';
+import { Option } from '../../lib/types';
 import { UserSearchResults } from '../user-search-results';
 import { itemToOption } from '../../lib/utils';
 import { ScrollbarContainer } from '../../../scrollbar-container';
@@ -30,6 +30,7 @@ import { allChannelsSelector } from '../../../../store/channels/selectors';
 import { CreateConversationButton } from '../create-conversation-button/create-conversation-button';
 import { userIdSelector } from '../../../../store/authentication/selectors';
 import { usersMapSelector } from '../../../../store/users/selectors';
+import { MemberNetworks } from '../../../../store/users/types';
 
 const cn = bemClassName('messages-list');
 
@@ -64,7 +65,7 @@ export interface Properties {
   isLabelDataLoaded: boolean;
   isCollapsed: boolean;
 
-  search: (input: string) => Promise<Item[]>;
+  search: (input: string) => Promise<MemberNetworks[]>;
   onCreateConversation: (userId: string) => void;
 }
 
@@ -194,7 +195,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
       const oneOnOneConversations = conversations.filter((c) => isOneOnOne(c));
       const oneOnOneConversationMemberIds = oneOnOneConversations.flatMap((c) => c.otherMembers);
 
-      const items: Item[] = await search(newSearch);
+      const items: MemberNetworks[] = await search(newSearch);
       const filteredUserItems = items?.filter((item) => !oneOnOneConversationMemberIds.includes(item.id) && item.id);
 
       scrollToTop();

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,7 +15,7 @@ import { closeConversationErrorDialog as closeConversationErrorDialogAction } fr
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
 import { GroupDetailsPanel } from './group-details-panel';
-import { Option } from '../lib/types';
+import { Item, Option } from '../lib/types';
 import { Modal } from '@zero-tech/zui/components';
 import { ErrorDialog } from '../../error-dialog';
 import { RewardsModalContainer } from '../../rewards-modal/container';
@@ -94,7 +94,7 @@ const MessengerListContainer: React.FC = () => {
   }, [debouncedSearch]);
 
   const usersInMyNetworks = useCallback(
-    (search: string): Promise<MemberNetworks[]> => {
+    (search: string): Promise<Item[]> => {
       return new Promise((resolve) => {
         currentSearchResolveRef.current = resolve;
         debouncedSearch(search);

--- a/src/components/messenger/list/index.tsx
+++ b/src/components/messenger/list/index.tsx
@@ -15,7 +15,7 @@ import { closeConversationErrorDialog as closeConversationErrorDialogAction } fr
 import CreateConversationPanel from './create-conversation-panel';
 import { ConversationListPanel } from './conversation-list-panel';
 import { GroupDetailsPanel } from './group-details-panel';
-import { Item, Option } from '../lib/types';
+import { Option } from '../lib/types';
 import { Modal } from '@zero-tech/zui/components';
 import { ErrorDialog } from '../../error-dialog';
 import { RewardsModalContainer } from '../../rewards-modal/container';
@@ -94,7 +94,7 @@ const MessengerListContainer: React.FC = () => {
   }, [debouncedSearch]);
 
   const usersInMyNetworks = useCallback(
-    (search: string): Promise<Item[]> => {
+    (search: string): Promise<MemberNetworks[]> => {
       return new Promise((resolve) => {
         currentSearchResolveRef.current = resolve;
         debouncedSearch(search);

--- a/src/store/group-management/saga.ts
+++ b/src/store/group-management/saga.ts
@@ -32,6 +32,8 @@ import { getPanelOpenState } from '../panels/selectors';
 import { setPanelState } from '../panels';
 import { Panel } from '../panels/constants';
 import { channelSelector } from '../channels/selectors';
+import { getUsersByMatrixIds } from '../users/saga';
+import { User } from '../channels';
 
 export function* reset() {
   yield put(setStage(Stage.None));
@@ -123,8 +125,9 @@ export function* roomMembersSelected(action) {
   yield put(setIsAddingMembers(true));
 
   try {
-    const userIds = selectedMembers.map((user) => user.value);
-    const users = yield select((state) => denormalizeUsers(userIds, state));
+    const matrixIds = selectedMembers.map((user) => user.matrixId);
+    const usersMap: Map<string, User> = yield call(getUsersByMatrixIds, matrixIds);
+    const users = Array.from(usersMap.values());
 
     const chatClient: Chat = yield call(chat.get);
     yield call([chatClient, chatClient.addMembersToRoom], roomId, users);

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -1,5 +1,6 @@
 export interface MemberNetworks {
   id: string;
+  matrixId: string;
   handle: string;
   profileImage: string;
   name: string;


### PR DESCRIPTION
### What does this do?
Correctly maps user selection to user objects for inviting to channel

### Why are we making this change?
We were pulling users directly from the redux store, but those users might not be in the store if you are not in any conversations with them. This caused the invite to fail since the users list would be empty.
Now, we use the standardized way of getting users that ensures they're loaded.

### How do I test this?
Search for a user that you don't have any conversations with and add them to a conversation
