### PR TITLE
feat: add followers and following lists to user profiles

### DIFF
--- a/src/apps/profile/lib/useFollow.ts
+++ b/src/apps/profile/lib/useFollow.ts
@@ -26,6 +26,9 @@ export const useFollow = (targetUserId: string) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['profile'] }),
         queryClient.invalidateQueries({ queryKey: ['followStatus', targetUserId] }),
+        // Invalidate both the target user's and current user's follow lists
+        queryClient.invalidateQueries({ queryKey: ['followList', targetUserId, 'followers'] }),
+        queryClient.invalidateQueries({ queryKey: ['followList', targetUserId, 'following'] }),
       ]);
     },
     onError: (error) => {
@@ -42,6 +45,9 @@ export const useFollow = (targetUserId: string) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['profile'] }),
         queryClient.invalidateQueries({ queryKey: ['followStatus', targetUserId] }),
+        // Invalidate both the target user's and current user's follow lists
+        queryClient.invalidateQueries({ queryKey: ['followList', targetUserId, 'followers'] }),
+        queryClient.invalidateQueries({ queryKey: ['followList', targetUserId, 'following'] }),
       ]);
     },
     onError: (error) => {

--- a/src/apps/profile/lib/useFollowList.ts
+++ b/src/apps/profile/lib/useFollowList.ts
@@ -1,0 +1,71 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getFollowers, getFollowing, UserFollowDetails } from '../../../store/user-follows/api';
+import { User } from '../../../store/channels';
+import { Wallet } from '../../../store/authentication/types';
+import { getUserSubHandle } from '../../../lib/user';
+
+const transformUser = (user: UserFollowDetails): Omit<User, 'wallets'> & { wallets: Wallet[] } => {
+  const wallets: Wallet[] = [
+    {
+      id: user.userId,
+      publicAddress: user.wallets.primaryWalletAddress,
+      isThirdWeb: false,
+    },
+  ];
+
+  if (user.wallets.thirdWebWalletAddress) {
+    wallets.push({
+      id: user.userId,
+      publicAddress: user.wallets.thirdWebWalletAddress,
+      isThirdWeb: true,
+    });
+  }
+
+  return {
+    userId: user.userId,
+    matrixId: '',
+    firstName: user.firstName,
+    lastName: '',
+    profileId: '',
+    isOnline: false,
+    profileImage: user.profileImage,
+    lastSeenAt: '',
+    primaryZID: user.primaryZID,
+    displaySubHandle: getUserSubHandle(user.primaryZID, user.wallets.primaryWalletAddress),
+    wallets,
+  };
+};
+
+export const useFollowList = (userId: string, type: 'followers' | 'following') => {
+  const { data, isLoading, error, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['followList', userId, type],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response =
+        type === 'followers'
+          ? await getFollowers(userId, pageParam as number)
+          : await getFollowing(userId, pageParam as number);
+
+      return {
+        users: response.users.map(transformUser),
+        nextPage: response.nextPage,
+        total: response.total,
+      };
+    },
+    getNextPageParam: (lastPage) => lastPage?.nextPage ?? undefined,
+    initialPageParam: 1,
+    enabled: !!userId,
+  });
+
+  const users = data?.pages?.flatMap((page) => page?.users ?? []) ?? [];
+  const total = data?.pages?.[0]?.total ?? 0;
+
+  return {
+    users,
+    total,
+    isLoading,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  };
+};

--- a/src/apps/profile/panels/UserPanel/Follows/index.tsx
+++ b/src/apps/profile/panels/UserPanel/Follows/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Panel, PanelBody } from '../../../../../components/layout/panel';
+import { IconArrowLeft } from '@zero-tech/zui/icons';
+import { CitizenListItem } from '../../../../../components/citizen-list-item';
+import { ScrollbarContainer } from '../../../../../components/scrollbar-container';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
+import { Waypoint } from '../../../../../components/waypoint';
+import { useFollowList } from '../../../lib/useFollowList';
+
+import styles from './styles.module.scss';
+
+interface FollowsProps {
+  type: 'followers' | 'following';
+  userId: string;
+  onBack: () => void;
+}
+
+export const Follows: React.FC<FollowsProps> = ({ type, userId, onBack }) => {
+  const { users, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage, error } = useFollowList(userId, type);
+
+  const title = type === 'followers' ? 'Followers' : 'Following';
+
+  if (error) {
+    return <div>Unable to load {title}</div>;
+  }
+
+  return (
+    <Panel className={styles.Container}>
+      <PanelBody className={styles.Body}>
+        <div>
+          <div className={styles.Header}>
+            <button className={styles.BackButton} onClick={onBack}>
+              <IconArrowLeft size={18} />
+            </button>
+            <span className={styles.Label}>{title}</span>
+          </div>
+          <div className={styles.List}>
+            {isLoading ? (
+              <div className={styles.Loading}>
+                <Spinner />
+              </div>
+            ) : (
+              <ScrollbarContainer>
+                {users.map((user) => (
+                  <CitizenListItem key={user.userId} user={user} />
+                ))}
+                {hasNextPage && (
+                  <div className={styles.WaypointContainer}>
+                    <Waypoint onEnter={fetchNextPage} />
+                  </div>
+                )}
+                {isFetchingNextPage && (
+                  <div className={styles.LoadingMore}>
+                    <Spinner />
+                  </div>
+                )}
+              </ScrollbarContainer>
+            )}
+          </div>
+        </div>
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/src/apps/profile/panels/UserPanel/Follows/styles.module.scss
+++ b/src/apps/profile/panels/UserPanel/Follows/styles.module.scss
@@ -1,0 +1,55 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+
+.Container {
+  position: relative;
+  width: 270px;
+  overflow: hidden;
+}
+
+.Body {
+  height: 100%;
+}
+
+.BackButton {
+  position: absolute;
+  left: 0;
+  top: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: theme.$color-greyscale-12;
+  display: flex;
+  align-items: center;
+  z-index: 1;
+
+  &:hover {
+    color: theme.$color-greyscale-11;
+  }
+}
+
+.Header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+  position: relative;
+}
+
+.Label {
+  font-size: 14px;
+  font-weight: 400;
+  color: theme.$color-greyscale-11;
+}
+
+.List {
+  max-height: 502px;
+  overflow: hidden;
+}
+
+.Loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/src/apps/profile/panels/UserPanel/index.tsx
+++ b/src/apps/profile/panels/UserPanel/index.tsx
@@ -1,3 +1,4 @@
+import React, { useState, useEffect } from 'react';
 import { useUserPanel } from './useUserPanel';
 
 import { Panel, PanelBody } from '../../../../components/layout/panel';
@@ -7,12 +8,24 @@ import MatrixMask from './matrix-mask.svg?react';
 import { FollowButton } from '../../../../components/follow-button';
 import { FollowCounts } from '../../../../components/follow-counts';
 import { Skeleton } from '@zero-tech/zui/components/Skeleton';
+import { Follows } from './Follows';
 
 import styles from './styles.module.scss';
+
+type FollowType = 'followers' | 'following';
 
 export const UserPanel = () => {
   const { handle, profileImageUrl, zid, isLoading, userId, isCurrentUser, followersCount, followingCount } =
     useUserPanel();
+  const [activeFollowType, setActiveFollowType] = useState<FollowType | null>(null);
+
+  useEffect(() => {
+    setActiveFollowType(null);
+  }, [userId]);
+
+  if (activeFollowType && userId) {
+    return <Follows type={activeFollowType} userId={userId} onBack={() => setActiveFollowType(null)} />;
+  }
 
   return (
     <Panel className={styles.Container}>
@@ -36,6 +49,8 @@ export const UserPanel = () => {
                   followingCount={followingCount}
                   followersCount={followersCount}
                   className={styles.FollowCounts}
+                  onFollowingClick={() => setActiveFollowType('following')}
+                  onFollowersClick={() => setActiveFollowType('followers')}
                 />
               )}
               {!isCurrentUser && <FollowButton targetUserId={userId} className={styles.FollowButton} />}

--- a/src/components/follow-counts/index.tsx
+++ b/src/components/follow-counts/index.tsx
@@ -7,6 +7,8 @@ interface FollowCountsProps {
   showFollowing?: boolean;
   showFollowers?: boolean;
   className?: string;
+  onFollowingClick?: () => void;
+  onFollowersClick?: () => void;
 }
 
 export const FollowCounts: React.FC<FollowCountsProps> = ({
@@ -15,17 +17,34 @@ export const FollowCounts: React.FC<FollowCountsProps> = ({
   showFollowing = true,
   showFollowers = true,
   className,
+  onFollowingClick,
+  onFollowersClick,
 }) => {
+  const hasFollowers = followersCount > 0;
+  const hasFollowing = followingCount > 0;
+
+  const followingClick = () => {
+    if (hasFollowing) {
+      onFollowingClick?.();
+    }
+  };
+
+  const followersClick = () => {
+    if (hasFollowers) {
+      onFollowersClick?.();
+    }
+  };
+
   return (
     <div className={`${styles.FollowCounts} ${className || ''}`}>
       {showFollowing && (
-        <div className={styles.count}>
+        <div className={`${styles.count} ${hasFollowing ? styles.clickable : ''}`} onClick={followingClick}>
           <span className={styles.number}>{followingCount}</span>
           <span className={styles.label}>Following</span>
         </div>
       )}
       {showFollowers && (
-        <div className={styles.count}>
+        <div className={`${styles.count} ${hasFollowers ? styles.clickable : ''}`} onClick={followersClick}>
           <span className={styles.number}>{followersCount}</span>
           <span className={styles.label}>Followers</span>
         </div>

--- a/src/components/follow-counts/styles.module.scss
+++ b/src/components/follow-counts/styles.module.scss
@@ -10,6 +10,17 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 4px;
+
+    &.clickable {
+      cursor: pointer;
+
+      &:hover {
+        .label {
+          color: theme.$color-secondary-11;
+        }
+      }
+    }
 
     .number {
       font-weight: 600;

--- a/src/store/user-follows/api.ts
+++ b/src/store/user-follows/api.ts
@@ -7,6 +7,23 @@ export interface FollowResponse {
   createdAt: string;
 }
 
+export interface UserFollowDetails {
+  userId: string;
+  firstName: string;
+  profileImage: string;
+  primaryZID: string;
+  wallets: {
+    primaryWalletAddress: string;
+    thirdWebWalletAddress?: string;
+  };
+}
+
+export interface PaginatedResponse<T> {
+  users: T[];
+  nextPage: number | null;
+  total: number;
+}
+
 export interface ErrorResponse {
   error: string;
   reason: string;
@@ -82,5 +99,41 @@ export const getFollowersCount = async (userId: string): Promise<number> => {
       throw new Error(error.response.data.reason);
     }
     throw error;
+  }
+};
+
+export const getFollowers = async (
+  userId: string,
+  page = 1,
+  limit = 50
+): Promise<PaginatedResponse<UserFollowDetails>> => {
+  try {
+    const response = await get<PaginatedResponse<UserFollowDetails>>(`/api/v2/user-follows/${userId}/followers`, {
+      params: { page, limit },
+    });
+    return response.body;
+  } catch (error: any) {
+    if (error.response?.data?.reason) {
+      throw new Error(error.response.data.reason);
+    }
+    throw new Error('Failed to fetch followers');
+  }
+};
+
+export const getFollowing = async (
+  userId: string,
+  page = 1,
+  limit = 50
+): Promise<PaginatedResponse<UserFollowDetails>> => {
+  try {
+    const response = await get<PaginatedResponse<UserFollowDetails>>(`/api/v2/user-follows/${userId}/following`, {
+      params: { page, limit },
+    });
+    return response.body;
+  } catch (error: any) {
+    if (error.response?.data?.reason) {
+      throw new Error(error.response.data.reason);
+    }
+    throw new Error('Failed to fetch following users');
   }
 };


### PR DESCRIPTION
### What does this do?
We're adding the ability to view and navigate through a user's followers and following lists, including real-time updates when follow/unfollow actions occur, with proper pagination and data transformation.

### Why are we making this change?
We're making these changes to enhance user profiles by allowing users to discover and connect with other users through a social network feature that shows who they follow and who follows them.

### How do I test this?
Run tests as usual
Visit a user profile with followers/following count and click the count to view the lists

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
