### PR TITLE
Adding matrix debug flag

### DIFF
--- a/src/lib/chat/matrix/matrix-client-instance.ts
+++ b/src/lib/chat/matrix/matrix-client-instance.ts
@@ -1,4 +1,5 @@
 import { MatrixClient } from '../matrix-client';
+import { featureFlags } from '../../feature-flags';
 
 class MatrixInstance {
   private _clientInstance: MatrixClient;
@@ -18,4 +19,9 @@ class MatrixInstance {
 }
 
 const Matrix = new MatrixInstance();
+if (featureFlags.enableMatrixDebug) {
+  // @ts-ignore
+  window.Matrix = Matrix;
+}
+
 export default Matrix;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -38,6 +38,7 @@ export class FeatureFlags implements FeatureFlagValues {
   declare enableProfile: boolean;
   declare enableUserProfiles: boolean;
   declare enablePostMedia: boolean;
+  declare enableMatrixDebug: boolean;
 
   constructor() {
     this.config = process.env.NODE_ENV === 'production' ? productionFlags : developmentFlags;

--- a/src/lib/feature-flags/development.ts
+++ b/src/lib/feature-flags/development.ts
@@ -31,4 +31,5 @@ export const developmentFlags: FeatureFlagDefinitions = {
   enableProfile: { defaultValue: true },
   enableUserProfiles: { defaultValue: true },
   enablePostMedia: { defaultValue: true },
+  enableMatrixDebug: { defaultValue: true },
 };

--- a/src/lib/feature-flags/flags.ts
+++ b/src/lib/feature-flags/flags.ts
@@ -27,7 +27,8 @@ export type FeatureFlagKey =
   | 'enableAuraZApp'
   | 'enableProfile'
   | 'enableUserProfiles'
-  | 'enablePostMedia';
+  | 'enablePostMedia'
+  | 'enableMatrixDebug';
 
 export interface FeatureFlagConfig {
   defaultValue: boolean;

--- a/src/lib/feature-flags/production.ts
+++ b/src/lib/feature-flags/production.ts
@@ -36,4 +36,5 @@ export const productionFlags: FeatureFlagDefinitions = {
   enableProfile: { defaultValue: true },
   enableUserProfiles: { defaultValue: true },
   enablePostMedia: { defaultValue: true },
+  enableMatrixDebug: { defaultValue: false },
 };


### PR DESCRIPTION
### What does this do?
Adds a new feature flag for matrix debugging.

### Why are we making this change?
We have no way to see what state Matrix is in. This gives us the ability to read state from Matrix to debug issues that are very hard to reproduce.
