### PR TITLE
feat(chat-view/message): add ProfileCardHover to chat message avatars

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -30,6 +30,7 @@ import { useMatrixMedia } from '../../lib/hooks/useMatrixMedia';
 import { MatrixAvatar } from '../matrix-avatar';
 import { useLinkPreview } from '../../lib/hooks/useLinkPreview';
 import { ProfileLinkNavigation } from '../profile-link-navigation';
+import { ProfileCardHover } from '../../components/profile-card/hover';
 
 import './styles.scss';
 
@@ -436,7 +437,14 @@ export const Message: React.FC<Properties> = memo(
                 primaryZid={sender.primaryZID}
                 thirdWebAddress={sender.wallets?.find((wallet) => wallet.isThirdWeb)?.publicAddress}
               >
-                <MatrixAvatar size='medium' imageURL={sender.profileImage} tabIndex={-1} />
+                <ProfileCardHover
+                  userId={
+                    sender.primaryZID?.replace('0://', '') ??
+                    sender.wallets?.find((wallet) => wallet.isThirdWeb)?.publicAddress
+                  }
+                >
+                  <MatrixAvatar size='medium' imageURL={sender.profileImage} tabIndex={-1} />
+                </ProfileCardHover>
               </ProfileLinkNavigation>
             </div>
           </div>


### PR DESCRIPTION
We're adding the ProfileCardHover component around MatrixAvatar in chat messages to provide consistent user profile preview functionality across the application, matching the behavior already present in posts.


### How do I test this?
Run the UI and hover over avatars in group chats (messenger app) or the feed chat (channels app)