### PR TITLE
Filter social channels notifications from showing up in messenger

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -242,18 +242,20 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
   );
 
   const tabUnreadCount = useMemo(() => {
-    return conversations.reduce<Record<string, number>>(
-      (acc, c) => {
-        acc[Tab.All] += c.unreadCount.total;
-        for (const label of c.labels) {
-          if (Object.values(DefaultRoomLabels).some((l) => l === label) && label !== DefaultRoomLabels.ARCHIVED) {
-            acc[tabLabelMap[label]] += c.unreadCount.total;
+    return conversations
+      .filter((c) => !c.isSocialChannel)
+      .reduce<Record<string, number>>(
+        (acc, c) => {
+          acc[Tab.All] += c.unreadCount.total;
+          for (const label of c.labels) {
+            if (Object.values(DefaultRoomLabels).some((l) => l === label) && label !== DefaultRoomLabels.ARCHIVED) {
+              acc[tabLabelMap[label]] += c.unreadCount.total;
+            }
           }
-        }
-        return acc;
-      },
-      { [Tab.Favorites]: 0, [Tab.All]: 0, [Tab.Work]: 0, [Tab.Family]: 0, [Tab.Social]: 0 }
-    );
+          return acc;
+        },
+        { [Tab.Favorites]: 0, [Tab.All]: 0, [Tab.Work]: 0, [Tab.Family]: 0, [Tab.Social]: 0 }
+      );
   }, [conversations]);
 
   const renderTabList = () => {

--- a/src/components/messenger/list/conversation-list-panel/index.vitest.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.vitest.tsx
@@ -458,6 +458,29 @@ describe('Tab Interactions & State Management', () => {
     expect(allBadgeMany).toBeInTheDocument();
     expect(allBadgeMany).toHaveTextContent('99+');
   });
+
+  it('social channels unread counts do not contribute to All tab notifications', () => {
+    const conversationsWithSocialChannel = [
+      stubConversation({
+        id: 'social-1',
+        name: 'Social Channel',
+        isSocialChannel: true,
+        unreadCount: { total: 10, highlight: 0 },
+      }),
+      stubConversation({
+        id: 'normal-1',
+        name: 'Normal Channel',
+        isSocialChannel: false,
+        unreadCount: { total: 5, highlight: 0 },
+      }),
+    ];
+    renderComponent({}, conversationsWithSocialChannel);
+
+    const allTab = screen.getByRole('tab', { name: /All tab/i });
+    const allBadge = allTab.querySelector('.' + getClassName('tab-badge') + ' span');
+    expect(allBadge).toBeInTheDocument();
+    expect(allBadge).toHaveTextContent('5'); // Only counts the non-social channel's unread count
+  });
 });
 
 describe('Conversation List Operations & Interactions', () => {


### PR DESCRIPTION
### What does this do?
Filters out social channel notification counts in messenger tabs

### Why are we making this change?
Social channels shouldn't affect notification counts in messenger
