### PR TITLE
refactor(invites): remove invite count from frontend for unlimited invites

### DIFF
--- a/src/components/invite-dialog/container.test.tsx
+++ b/src/components/invite-dialog/container.test.tsx
@@ -12,7 +12,6 @@ describe('Container', () => {
       inviteCode: '',
       inviteUrl: '',
       assetsPath: '',
-      inviteCount: 0,
       isLoading: false,
       fetchInvite: () => null,
       clearInvite: () => null,

--- a/src/components/invite-dialog/container.tsx
+++ b/src/components/invite-dialog/container.tsx
@@ -11,7 +11,6 @@ export interface PublicProperties {
 
 export interface Properties extends PublicProperties {
   inviteCode: string;
-  inviteCount: number;
   inviteUrl: string;
   assetsPath: string;
   isLoading: boolean;
@@ -28,7 +27,6 @@ export class Container extends React.Component<Properties> {
       inviteCode: createInvitation.code,
       inviteUrl: createInvitation.url,
       assetsPath: config.imageAssetsPath,
-      inviteCount: createInvitation.inviteCount,
       isLoading: createInvitation.isLoading,
     };
   }
@@ -49,7 +47,6 @@ export class Container extends React.Component<Properties> {
     return (
       <InviteDialog
         inviteCode={this.props.inviteCode}
-        inviteCount={this.props.inviteCount}
         inviteUrl={this.props.inviteUrl}
         assetsPath={this.props.assetsPath}
         onClose={this.props.onClose}

--- a/src/components/invite-dialog/index.test.tsx
+++ b/src/components/invite-dialog/index.test.tsx
@@ -13,7 +13,6 @@ describe('InviteDialog', () => {
       inviteCode: '',
       inviteUrl: '',
       assetsPath: '',
-      inviteCount: 0,
       clipboard: { write: () => null },
       isLoading: false,
       ...props,
@@ -21,12 +20,6 @@ describe('InviteDialog', () => {
 
     return shallow(<InviteDialog {...allProps} />);
   };
-
-  it('renders the code remaining number of invites', function () {
-    const wrapper = subject({ inviteCode: '23817', inviteCount: 2 });
-
-    expect(wrapper.find('.invite-dialog__remaining-invite').text()).toEqual('2');
-  });
 
   it('copies the invitation to the clipboard', function () {
     const clipboard = { write: jest.fn() };

--- a/src/components/invite-dialog/index.tsx
+++ b/src/components/invite-dialog/index.tsx
@@ -17,7 +17,6 @@ export interface Clipboard {
 
 export interface Properties {
   inviteCode: string;
-  inviteCount: number;
   inviteUrl: string;
   assetsPath: string;
   isLoading: boolean;
@@ -38,10 +37,6 @@ export class InviteDialog extends React.Component<Properties, State> {
 
   componentWillUnmount() {
     clearTimeout(this.buttonTimeout);
-  }
-
-  getInvitesRemaining() {
-    return this.props.inviteCount;
   }
 
   get inviteText() {
@@ -74,15 +69,6 @@ export class InviteDialog extends React.Component<Properties, State> {
           <Button onPress={this.writeInviteToClipboard} isDisabled={!this.props.inviteCode}>
             {this.state.copyText}
           </Button>
-
-          <div {...cn('remaining-invite-container')}>
-            {!this.props.isLoading && (
-              <>
-                <div {...cn('remaining-invite')}>{this.getInvitesRemaining()}</div>
-                <>Remaining</>
-              </>
-            )}
-          </div>
         </div>
       </div>
     );

--- a/src/components/invite-dialog/styles.scss
+++ b/src/components/invite-dialog/styles.scss
@@ -47,24 +47,4 @@
     line-height: 29px;
     width: 171px;
   }
-
-  &__remaining-invite-container {
-    @include glass-text-secondary-color;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: $font-size-medium;
-    line-height: 17px;
-    gap: 4px;
-    height: 20px;
-
-    margin-top: 16px;
-    animation: fadeIn 0.2s ease-in;
-  }
-
-  &__remaining-invite {
-    font-weight: 600;
-    line-height: 20px;
-  }
 }

--- a/src/store/create-invitation/index.ts
+++ b/src/store/create-invitation/index.ts
@@ -11,14 +11,12 @@ export const clearInvite = createAction(SagaActionTypes.Cancel);
 export type CreateInvitationState = {
   code: string;
   url: string;
-  inviteCount: number;
   isLoading: boolean;
 };
 
 const initialState: CreateInvitationState = {
   code: '',
   url: '',
-  inviteCount: 0,
   isLoading: false,
 };
 
@@ -29,7 +27,6 @@ const slice = createSlice({
     setInviteDetails: (state, action: PayloadAction<Omit<CreateInvitationState, 'isLoading'>>) => {
       state.code = action.payload.code;
       state.url = action.payload.url;
-      state.inviteCount = action.payload.inviteCount;
     },
     setLoading: (state, action: PayloadAction<CreateInvitationState['isLoading']>) => {
       state.isLoading = action.payload;
@@ -37,7 +34,6 @@ const slice = createSlice({
     reset: (state, _action: PayloadAction) => {
       state.code = initialState.code;
       state.url = initialState.url;
-      state.inviteCount = initialState.inviteCount;
     },
   },
 });

--- a/src/store/create-invitation/saga.test.ts
+++ b/src/store/create-invitation/saga.test.ts
@@ -16,11 +16,11 @@ describe('fetchInvite', () => {
         .provide([
           [
             call(getInvite),
-            { slug: '98762', inviteCount: 0 },
+            { slug: '98762' },
           ],
         ])
         .withReducer(rootReducer, {
-          createInvitation: { code: '', url: '', inviteCount: 0, isLoading: false },
+          createInvitation: { code: '', url: '', isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.GetCode })
         .run();
@@ -28,7 +28,6 @@ describe('fetchInvite', () => {
       expect(createInvitation).toEqual({
         code: '98762',
         url: 'https://www.example.com/invite',
-        inviteCount: 0,
         isLoading: false,
       });
     });
@@ -38,12 +37,12 @@ describe('fetchInvite', () => {
         storeState: { createInvitation },
       } = await expectSaga(fetchInvite)
         .withReducer(rootReducer, {
-          createInvitation: { code: 'something', url: 'url', inviteCount: 3, isLoading: false },
+          createInvitation: { code: 'something', url: 'url', isLoading: false },
         } as any)
         .dispatch({ type: SagaActionTypes.Cancel })
         .run();
 
-      expect(createInvitation).toEqual({ code: '', url: '', inviteCount: 0, isLoading: false });
+      expect(createInvitation).toEqual({ code: '', url: '', isLoading: false });
     });
   });
 });

--- a/src/store/create-invitation/saga.ts
+++ b/src/store/create-invitation/saga.ts
@@ -19,7 +19,6 @@ export function* fetchInvite() {
       setInviteDetails({
         code: invitation.slug,
         url: config.inviteUrl,
-        inviteCount: invitation.inviteCount,
       })
     );
     return;


### PR DESCRIPTION
### What does this do?
We're removing the invite count display and related state management from the frontend to support the new unlimited invites system.

### Why are we making this change?
We're making these changes because we're refactoring the invite system to use permanent, user-specific invite codes for Zero Pro subscriptions instead of limited invite counts.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
