### PR TITLE
Fix: Created at updating with optimistic messages.

### DIFF
--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -385,7 +385,7 @@ describe(replaceOptimisticMessage, () => {
     const currentMessages = ['message-1', 'optimistic-id', 'message-2'];
     const oldMessages = [
       { id: 'message-1' },
-      { id: 'optimistic-id', optimisticId: 'optimistic-id' },
+      { id: 'optimistic-id', optimisticId: 'optimistic-id', createdAt: 1234567890 },
       { id: 'message-2' },
     ] as any;
     const newMessage = {
@@ -414,7 +414,7 @@ describe(replaceOptimisticMessage, () => {
       .withReducer(rootReducer, initialState.build())
       .run();
 
-    const expectedNewMessage = { ...newMessage, sendStatus: MessageSendStatus.SUCCESS };
+    const expectedNewMessage = { ...newMessage, createdAt: 1234567890, sendStatus: MessageSendStatus.SUCCESS };
     expect(returnValue).toEqual(['message-1', expectedNewMessage, 'message-2']);
   });
 });

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -528,6 +528,7 @@ export function* replaceOptimisticMessage(currentMessages: string[], message: Me
   messages[messageIndex] = {
     ...optimisticMessage,
     ...message,
+    createdAt: optimisticMessage.createdAt,
     media: optimisticMessage.media,
     sendStatus: MessageSendStatus.SUCCESS,
   };


### PR DESCRIPTION
### What does this do?
Keeps the optimistic message `createdAt` timestamp

### Why are we making this change?
Messages could jump around if the timestamp from the server was far off from the optimistic timestamp. This could make the UI feel really off on slower connections
