### PR TITLE
Fixes re-rendering images on optimistic update

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -193,7 +193,7 @@ export const ChatView = React.forwardRef<InvertedScroll, Properties>(
 
           return (
             <ChatMessage
-              key={message.id}
+              key={message.optimisticId || message.id}
               message={message}
               isUserOwner={isUserOwner}
               isUserOwnerOfParentMessage={isUserOwnerOfParentMessage}


### PR DESCRIPTION
### What does this do?
Fixes the images in messages flickering due to being re-rendered when the optimistic message is updated.
Now we keep the optimistic id as the key while it's defined.
