### PR TITLE
chore: bump zui version (`1.28.1`) -> (`1.29.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.9",
         "@web3-react/walletlink-connector": "^6.2.13",
-        "@zero-tech/zui": "^1.28.1",
+        "@zero-tech/zui": "^1.29.0",
         "assert": "^2.1.0",
         "blurhash": "^2.0.5",
         "buffer": "^6.0.3",
@@ -13105,10 +13105,9 @@
       "dev": true
     },
     "node_modules/@zero-tech/zui": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.28.1.tgz",
-      "integrity": "sha512-mNiAe4FFtOW+2qWc3DOqTEVlr+oo4zoYif7pGTz+pdH6jbjw75fm5IAgS792furJSHI9dCzHMGoXIWJLW3sNfw==",
-      "license": "ISC",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.29.0.tgz",
+      "integrity": "sha512-VKQCDG04LLZzMdXxHy8ACz8FyvXLVVs01WGU5DYBO6lxmQtk3Lsi1aIzoQWkHYGXcHesCwiz0eGqm1r9qWDE4Q==",
       "dependencies": {
         "@radix-ui/react-accessible-icon": "^1.1.2",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -53900,9 +53899,9 @@
       "dev": true
     },
     "@zero-tech/zui": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.28.1.tgz",
-      "integrity": "sha512-mNiAe4FFtOW+2qWc3DOqTEVlr+oo4zoYif7pGTz+pdH6jbjw75fm5IAgS792furJSHI9dCzHMGoXIWJLW3sNfw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-1.29.0.tgz",
+      "integrity": "sha512-VKQCDG04LLZzMdXxHy8ACz8FyvXLVVs01WGU5DYBO6lxmQtk3Lsi1aIzoQWkHYGXcHesCwiz0eGqm1r9qWDE4Q==",
       "requires": {
         "@radix-ui/react-accessible-icon": "^1.1.2",
         "@radix-ui/react-accordion": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/network-connector": "^6.1.9",
     "@web3-react/walletlink-connector": "^6.2.13",
-    "@zero-tech/zui": "^1.28.1",
+    "@zero-tech/zui": "^1.29.0",
     "assert": "^2.1.0",
     "blurhash": "^2.0.5",
     "buffer": "^6.0.3",


### PR DESCRIPTION
chore: bump zui version (`1.28.1`) -> (`1.29.0`)