### PR TITLE
fix: refetch and get correct subscription data when successfully subscribed

### DIFF
--- a/src/apps/profile/lib/useProfile.ts
+++ b/src/apps/profile/lib/useProfile.ts
@@ -58,7 +58,7 @@ export const useProfile = ({ id }: UseProfileParams) => {
         userId: response.body.userId,
         followersCount: parseInt(response.body.followersCount) || 0,
         followingCount: parseInt(response.body.followingCount) || 0,
-        isZeroProSubscriber: response.body.subscriptions?.zeroPro,
+        isZeroProSubscriber: response.body.isZeroProSubscriber,
       };
     },
     staleTime: 0,

--- a/src/apps/profile/panels/UserPanel/useUserPanel.ts
+++ b/src/apps/profile/panels/UserPanel/useUserPanel.ts
@@ -18,7 +18,7 @@ export const useUserPanel = () => {
   const isCurrentUser = userId === currentUser?.id;
   const followersCount = data?.followersCount;
   const followingCount = data?.followingCount;
-  const isZeroProSubscriber = data?.isZeroProSubscriber;
+  const isZeroProSubscriber = isCurrentUser ? currentUser?.subscriptions?.zeroPro : data?.isZeroProSubscriber;
   const allChannels = useSelector(allChannelsSelector);
 
   const handleStartConversation = () => {

--- a/src/components/messenger/user-profile/container.tsx
+++ b/src/components/messenger/user-profile/container.tsx
@@ -53,7 +53,7 @@ export class Container extends React.Component<Properties> {
         firstName: currentUser?.profileSummary.firstName,
         profileImage: currentUser?.profileSummary.profileImage,
         displaySubHandle: getUserSubHandle(currentUser?.primaryZID, currentUser?.primaryWalletAddress),
-        isZeroProSubscriber: currentUser?.isZeroProSubscriber,
+        subscriptions: currentUser?.subscriptions,
       } as User,
       stage: userProfile.stage,
       backupExists: matrix.backupExists,
@@ -91,7 +91,7 @@ export class Container extends React.Component<Properties> {
         stage={this.props.stage}
         name={this.props.currentUser.firstName}
         image={this.props.currentUser.profileImage}
-        isZeroProSubscriber={this.props.currentUser.isZeroProSubscriber}
+        isZeroProSubscriber={this.props.currentUser.subscriptions?.zeroPro}
         subHandle={this.props.currentUser.displaySubHandle}
         onClose={this.props.closeUserProfile}
         onLogout={this.props.logout}

--- a/src/components/messenger/user-profile/zero-pro-panel/index.tsx
+++ b/src/components/messenger/user-profile/zero-pro-panel/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { PanelHeader } from '../../list/panel-header';
 import { Main } from './stages/Main';
@@ -10,6 +11,7 @@ import { Loading } from './stages/Loading';
 import { Error } from './stages/Error';
 import { usePollZeroProActiveStatus } from './usePollZeroProActiveStatus';
 import { BottomSheet } from './bottom-sheet';
+import { refreshCurrentUser } from '../../../../store/authentication';
 
 import styles from './styles.module.scss';
 
@@ -41,6 +43,7 @@ export const ZeroProPanel: React.FC<{ onClose: () => void; isZeroProSubscriber: 
   const [billingDetails, setBillingDetails] = useState<BillingDetails | null>(null);
   const [isPolling, setIsPolling] = useState(false);
   const [pollError, setPollError] = useState<string | null>(null);
+  const dispatch = useDispatch();
 
   const openPlan = useCallback(() => setActiveSheet(ZeroProStage.PaymentPlan), []);
   const openDetails = useCallback(() => setActiveSheet(ZeroProStage.Details), []);
@@ -68,6 +71,7 @@ export const ZeroProPanel: React.FC<{ onClose: () => void; isZeroProSubscriber: 
     () => {
       setIsPolling(false);
       setActiveSheet(ZeroProStage.Success);
+      dispatch(refreshCurrentUser());
     },
     () => {
       setIsPolling(false);

--- a/src/components/messenger/user-profile/zero-pro-panel/usePollZeroProActiveStatus.ts
+++ b/src/components/messenger/user-profile/zero-pro-panel/usePollZeroProActiveStatus.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from '../../../../lib/api/rest';
 
 export function usePollZeroProActiveStatus(
   shouldPoll: boolean,
@@ -13,8 +14,8 @@ export function usePollZeroProActiveStatus(
     let start = Date.now();
     async function poll() {
       while (isMounted) {
-        const res = await fetch('/subscription/status?type=ZERO');
-        const data = await res.json();
+        const response = await get('/subscription/status?type=ZERO');
+        const data = response.body;
         const status = data.subscription?.status ?? data.status;
         if (status === 'active') {
           onActive();

--- a/src/store/authentication/index.ts
+++ b/src/store/authentication/index.ts
@@ -5,11 +5,13 @@ export enum SagaActionTypes {
   Logout = 'authentication/saga/logout',
   ForceLogout = 'authentication/saga/force-logout',
   CloseLogoutModal = 'authentication/saga/close-logout-modal',
+  RefreshCurrentUser = 'authentication/saga/refresh-current-user',
 }
 
 export const logout = createAction(SagaActionTypes.Logout);
 export const forceLogout = createAction(SagaActionTypes.ForceLogout);
 export const closeLogoutModal = createAction(SagaActionTypes.CloseLogoutModal);
+export const refreshCurrentUser = createAction(SagaActionTypes.RefreshCurrentUser);
 
 export const initialState: AuthenticationState = {
   user: { data: null },

--- a/src/store/authentication/saga.ts
+++ b/src/store/authentication/saga.ts
@@ -1,5 +1,5 @@
 import { takeLatest, put, call, all, delay, spawn } from 'redux-saga/effects';
-import { SagaActionTypes, setDisplayLogoutModal, setUser } from '.';
+import { SagaActionTypes, setDisplayLogoutModal, setUser, refreshCurrentUser } from '.';
 import {
   nonceOrAuthorize as nonceOrAuthorizeApi,
   fetchCurrentUser,
@@ -126,6 +126,7 @@ export function* saga() {
   yield takeLatest(SagaActionTypes.Logout, logoutRequest);
   yield takeLatest(SagaActionTypes.ForceLogout, forceLogout);
   yield takeLatest(SagaActionTypes.CloseLogoutModal, closeLogoutModal);
+  yield takeLatest(refreshCurrentUser.type, getCurrentUser);
 
   const chatBus = yield call(getChatBus);
   yield takeEveryFromBus(chatBus, ChatEvents.InvalidToken, forceLogout);

--- a/src/store/authentication/types.ts
+++ b/src/store/authentication/types.ts
@@ -40,7 +40,10 @@ export interface User {
   primaryZID?: string;
   primaryWalletAddress?: string;
   totalRewards?: string;
-  isZeroProSubscriber?: boolean;
+  subscriptions?: {
+    zeroPro?: boolean;
+    wilderPro?: boolean;
+  };
 }
 
 export interface AuthenticationState {

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -22,7 +22,10 @@ export interface User {
   primaryWallet?: Wallet;
   wallets?: Wallet[];
   displaySubHandle?: string;
-  isZeroProSubscriber?: boolean;
+  subscriptions?: {
+    zeroPro?: boolean;
+    wilderPro?: boolean;
+  };
 }
 
 export enum MessagesFetchState {


### PR DESCRIPTION
### What does this do?
refetches current user data when subscription is successful

### Why are we making this change?
to display correct elements in ui 

### How do I test this?
run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
