### PR TITLE
feat: show Zero Pro badge in user search results using new subscription data from backend

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -6,6 +6,7 @@ import { highlightFilter, itemToOption } from '../lib/utils';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { Waypoint } from '../../waypoint';
 import classNames from 'classnames';
+import { IconZeroProVerified } from '@zero-tech/zui/icons';
 
 import './styles.scss';
 import '../list/styles.scss';
@@ -136,8 +137,11 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
                   <MatrixAvatar size='regular' imageURL={r.image} tabIndex={-1} />
 
                   <div className='autocomplete-members__user-details'>
-                    <div className='autocomplete-members__label'>
-                      {highlightFilter(r.label, this.state.searchString)}
+                    <div className='autocomplete-members__label-container'>
+                      <div className='autocomplete-members__label'>
+                        {highlightFilter(r.label, this.state.searchString)}
+                      </div>
+                      {r.isZeroProSubscriber && <IconZeroProVerified size={16} />}
                     </div>
                     {r?.subLabel && <div className='autocomplete-members__sub-label'>{r.subLabel}</div>}
                   </div>

--- a/src/components/messenger/autocomplete-members/styles.scss
+++ b/src/components/messenger/autocomplete-members/styles.scss
@@ -56,6 +56,14 @@
     overflow: hidden;
   }
 
+  &__label-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    width: 100%;
+  }
+
   &__label {
     @include glass-text-primary-color;
 

--- a/src/components/messenger/lib/types.ts
+++ b/src/components/messenger/lib/types.ts
@@ -5,6 +5,10 @@ export interface Item {
   image?: string;
   primaryZID: string;
   primaryWalletAddress: string;
+  subscriptions?: {
+    zeroPro: boolean;
+    wilderPro: boolean;
+  };
 }
 
 export interface Option {
@@ -12,4 +16,5 @@ export interface Option {
   label: string;
   image?: string;
   subLabel?: string;
+  isZeroProSubscriber?: boolean;
 }

--- a/src/components/messenger/lib/utils.tsx
+++ b/src/components/messenger/lib/utils.tsx
@@ -8,6 +8,7 @@ export const itemToOption = (item: Item): Option => {
     label: item.name,
     image: item.image,
     subLabel: getUserSubHandle(item.primaryZID, item.primaryWalletAddress),
+    isZeroProSubscriber: item.subscriptions?.zeroPro,
   };
 };
 

--- a/src/components/messenger/list/user-search-results/index.tsx
+++ b/src/components/messenger/list/user-search-results/index.tsx
@@ -5,6 +5,7 @@ import { highlightFilter } from '../../lib/utils';
 import { Waypoint } from '../../../waypoint';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { MatrixAvatar } from '../../../matrix-avatar';
+import { IconZeroProVerified } from '@zero-tech/zui/icons';
 
 import { bemClassName } from '../../../../lib/bem';
 import './user-search-results.scss';
@@ -86,7 +87,10 @@ export class UserSearchResults extends React.Component<Properties, State> {
             <MatrixAvatar size='regular' imageURL={userResult.image} tabIndex={-1} />
 
             <div {...cn('user-details')}>
-              <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
+              <div {...cn('label-container')}>
+                <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
+                {userResult.isZeroProSubscriber && <IconZeroProVerified size={16} />}
+              </div>
               {userResult?.subLabel && <div {...cn('sub-label')}>{userResult.subLabel}</div>}
             </div>
           </div>

--- a/src/components/messenger/list/user-search-results/user-search-results.scss
+++ b/src/components/messenger/list/user-search-results/user-search-results.scss
@@ -41,6 +41,14 @@
     width: 100%;
   }
 
+  &__label-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    width: 100%;
+  }
+
   &__label {
     @include glass-text-primary-color;
 

--- a/src/store/users/types.ts
+++ b/src/store/users/types.ts
@@ -8,6 +8,10 @@ export interface MemberNetworks {
   primaryZID: string;
   primaryWalletAddress: string;
   thirdWebWalletAddress?: string;
+  subscriptions?: {
+    zeroPro: boolean;
+    wilderPro: boolean;
+  };
 }
 
 export interface SimplifiedUser {


### PR DESCRIPTION
### What does this do?
We are updating the frontend to display a Zero Pro badge in user search results based on subscription status returned by the backend.

### Why are we making this change?
This change makes it easy to visually identify Zero Pro subscribers directly in search results, improving user experience and feature visibility.

### How do I test this?
run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
