### PR TITLE
feat(conversation-item): add zero pro badge for one on one conversations

### DIFF
--- a/src/components/messenger/list/conversation-item/conversation-item.scss
+++ b/src/components/messenger/list/conversation-item/conversation-item.scss
@@ -40,6 +40,17 @@
     width: 100%;
     margin-bottom: 4.5px;
     overflow: hidden;
+    min-width: 0;
+  }
+
+  &__name-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-grow: 1;
+    min-width: 0;
+
+    width: 100%;
   }
 
   &__name {
@@ -48,9 +59,9 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    flex-grow: 1;
     font-size: $font-size-medium;
     line-height: 20px;
+    flex-shrink: 1;
 
     &[is-unread='true'] {
       font-weight: 600;
@@ -62,14 +73,15 @@
     display: flex;
     justify-content: flex-end;
     min-width: 42px;
-
+    flex-shrink: 0;
     font-weight: 400;
     font-size: 10px;
     line-height: 15px;
     white-space: nowrap;
   }
 
-  &__muted-icon {
+  &__muted-icon,
+  &__badge-icon {
     @include glass-text-tertiary-color;
 
     margin-right: 6px;

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -6,7 +6,7 @@ import { DefaultRoomLabels, NormalizedChannel } from '../../../../store/channels
 import { MoreMenu } from './more-menu';
 import { MatrixAvatar } from '../../../matrix-avatar';
 
-import { IconBellOff1 } from '@zero-tech/zui/icons';
+import { IconBellOff1, IconZeroProVerified } from '@zero-tech/zui/icons';
 
 import { bemClassName } from '../../../../lib/bem';
 import './conversation-item.scss';
@@ -109,27 +109,28 @@ export const ConversationItem = memo(
     const isExpanded = !isCollapsed;
     const isOneOnOneConversation = isOneOnOne(conversation);
 
+    const user = useMemo(() => {
+      if (isOneOnOneConversation && conversation.otherMembers[0]) {
+        return getUser(conversation.otherMembers[0]);
+      }
+      return undefined;
+    }, [isOneOnOneConversation, conversation.otherMembers, getUser]);
+
+    const avatarUrl = useMemo(() => {
+      if (conversation.icon) {
+        return conversation.icon;
+      } else if (user) {
+        return user.profileImage;
+      }
+      return undefined;
+    }, [conversation.icon, user]);
+
     const displayDate = useMemo(() => {
       if (conversation.lastMessage) {
         return previewDisplayDate(conversation.lastMessage.createdAt);
       }
       return null;
     }, [conversation.lastMessage]);
-
-    const avatarUrl = useMemo(() => {
-      if (conversation.icon) {
-        return conversation.icon;
-      } else if (isOneOnOneConversation && conversation.otherMembers[0]) {
-        const user = getUser(conversation.otherMembers[0]);
-        return user.profileImage;
-      }
-      return undefined;
-    }, [
-      conversation.icon,
-      isOneOnOneConversation,
-      getUser,
-      conversation.otherMembers,
-    ]);
 
     return (
       <div
@@ -156,8 +157,11 @@ export const ConversationItem = memo(
         {isExpanded && (
           <div {...cn('summary')}>
             <div {...cn('header')}>
-              <div {...cn('name')} is-unread={isUnread.toString()}>
-                {highlightedName}
+              <div {...cn('name-container')}>
+                <div {...cn('name')} is-unread={isUnread.toString()}>
+                  {highlightedName}
+                </div>
+                {user?.subscriptions?.zeroPro && <IconZeroProVerified {...cn('badge-icon')} size={16} />}
               </div>
               {conversation.labels?.includes(DefaultRoomLabels.MUTE) && (
                 <IconBellOff1 {...cn('muted-icon')} size={16} />


### PR DESCRIPTION
### What does this do?
- adds zero pro badge for one on one conversations
- refactors the styling a little

### Why are we making this change?
- display badge like so

<img width="254" alt="Screenshot 2025-06-27 at 13 35 57" src="https://github.com/user-attachments/assets/a97ecacd-ad39-4ee3-9aa1-76593914699d" />


### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
