### PR TITLE
feat(message-uploads): enable 1gb uploads for pro users

### DIFF
--- a/src/components/message-input/menu/menu.tsx
+++ b/src/components/message-input/menu/menu.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import Dropzone from 'react-dropzone';
-import { bytesToMB, dropzoneToMedia, Media } from '../utils';
+import { dropzoneToMedia, formatFileSize, Media } from '../utils';
 import { IconPlus } from '@zero-tech/zui/icons';
+import { IconButton, ToastNotification } from '@zero-tech/zui/components';
 
 import './styles.scss';
-import { IconButton, ToastNotification } from '@zero-tech/zui/components';
-import { config } from '../../../config';
 
 export interface Properties {
   onSelected: (images: Media[]) => void;
@@ -31,7 +30,7 @@ export default class Menu extends React.Component<Properties, State> {
   };
 
   renderToastNotification = () => {
-    const maxSize = bytesToMB(config.cloudinary.max_file_size);
+    const maxSize = formatFileSize(this.props.maxSize);
 
     return (
       <ToastNotification
@@ -48,7 +47,10 @@ export default class Menu extends React.Component<Properties, State> {
   onDropRejected = (rejectedFiles) => {
     const rejectedFile = rejectedFiles[0]; // Assuming only one file is rejected
     if (rejectedFile?.errors[0]?.code === 'file-too-large') {
-      this.setState({ isDropRejectedNotificationOpen: true });
+      // Reset first, then show again to ensure the toast can be triggered multiple times
+      this.setState({ isDropRejectedNotificationOpen: false }, () => {
+        this.setState({ isDropRejectedNotificationOpen: true });
+      });
     }
   };
 

--- a/src/components/message-input/styles.scss
+++ b/src/components/message-input/styles.scss
@@ -115,3 +115,7 @@
     color: theme.$color-warning-11;
   }
 }
+
+.message-input-toast-notification {
+  padding: 64px 8px;
+}

--- a/src/components/message-input/utils.ts
+++ b/src/components/message-input/utils.ts
@@ -93,3 +93,22 @@ export function bytesToMB(bytes) {
   const formattedMegabytes = megabytes.toFixed(2).replace(/\.00$/, '');
   return `${formattedMegabytes} MB`;
 }
+
+export function formatFileSize(bytes) {
+  if (typeof bytes !== 'number') {
+    return 'Invalid input';
+  }
+
+  const GB = 1024 * 1024 * 1024;
+  const MB = 1024 * 1024;
+
+  if (bytes >= GB) {
+    const gigabytes = bytes / GB;
+    const formattedGB = gigabytes.toFixed(2).replace(/\.00$/, '');
+    return `${formattedGB} GB`;
+  } else {
+    const megabytes = bytes / MB;
+    const formattedMB = megabytes.toFixed(2).replace(/\.00$/, '');
+    return `${formattedMB} MB`;
+  }
+}

--- a/src/components/messenger/list/styles.scss
+++ b/src/components/messenger/list/styles.scss
@@ -59,5 +59,5 @@ $side-padding: 16px;
 }
 
 .invite-toast-notification {
-  padding: 64px;
+  padding: 64px 8px;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,9 +29,10 @@ export const config = {
   telegramBotUserId: process.env.REACT_APP_TELEGRAM_BOT_USER_ID,
   thirwebClientId: process.env.REACT_APP_THIRDWEB_CLIENT_ID,
   matrixHomeServerName: process.env.REACT_APP_MATRIX_HOME_SERVER_NAME,
-  postImageMaxFileSize: process.env.REACT_APP_POST_IMAGE_MAX_FILE_SIZE,
-  postGifMaxFileSize: process.env.REACT_APP_POST_GIF_MAX_FILE_SIZE,
-  postVideoMaxFileSize: process.env.REACT_APP_POST_VIDEO_MAX_FILE_SIZE,
+  messageFileSize: {
+    basicUser: parseInt(process.env.REACT_APP_MESSAGE_FILE_SIZE) || 10485760,
+    zeroProUser: 1073741824,
+  },
   postMedia: {
     imageMaxFileSize: parseInt(process.env.REACT_APP_POST_IMAGE_MAX_FILE_SIZE) || 10485760,
     gifMaxFileSize: parseInt(process.env.REACT_APP_POST_GIF_MAX_FILE_SIZE) || 15728640,

--- a/src/store/authentication/selectors.ts
+++ b/src/store/authentication/selectors.ts
@@ -27,3 +27,7 @@ export function userWalletsSelector(state: RootState) {
 export function userFirstNameSelector(state: RootState) {
   return state.authentication.user?.data?.profileSummary?.firstName;
 }
+
+export function userZeroProSubscriptionSelector(state: RootState) {
+  return state.authentication.user?.data?.subscriptions?.zeroPro || false;
+}


### PR DESCRIPTION
### What does this do?
- enables 1gb uploads for pro users

### Why are we making this change?
- allow pro users to upload larger files

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
