### PR TITLE
fix: Remove telegram link

### DIFF
--- a/src/components/messenger/user-profile/linked-accounts-panel/constants.ts
+++ b/src/components/messenger/user-profile/linked-accounts-panel/constants.ts
@@ -1,2 +1,2 @@
 import { Provider } from './types/providers';
-export const AVAILABLE_ACCOUNTS = [Provider.EpicGames, Provider.Telegram];
+export const AVAILABLE_ACCOUNTS = [Provider.EpicGames];


### PR DESCRIPTION
### What does this do?
Removes telegram link from linking options as it's currently disabled, and isn't working
