### PR TITLE
fix(wallet): Update wallet receive warning

### DIFF
--- a/src/apps/wallet/home/components/receive-dialog.tsx
+++ b/src/apps/wallet/home/components/receive-dialog.tsx
@@ -24,7 +24,8 @@ export const ReceiveDialog = ({ open, onOpenChange }: ReceiveDialogProps) => {
         </div>
 
         <Alert variant='info' isFilled>
-          Only send Z Chain assets to this address
+          This address can only receive assets native to Z Chain. Other EVM assets sent to this address will be
+          inaccessible.
         </Alert>
 
         <div className={styles.qrCodeContainer}>


### PR DESCRIPTION
### What does this do?
Updates the warning on the wallet receive dialog to be more clear that only assets on Z Chain are supported.
