### PR TITLE
feat: Move email link to linked-accounts panel

### DIFF
--- a/src/components/messenger/user-profile/account-management-panel/container.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.test.tsx
@@ -21,14 +21,6 @@ describe('Container', () => {
       return Container.mapState(state);
     };
 
-    it('isAddEmailModalOpen', () => {
-      const props = subject({
-        accountManagement: { isAddEmailAccountModalOpen: true } as AccountManagementState,
-      });
-
-      expect(props.isAddEmailModalOpen).toEqual(true);
-    });
-
     it('successMessage', () => {
       const props = subject({
         accountManagement: { successMessage: 'success' } as AccountManagementState,
@@ -68,58 +60,6 @@ describe('Container', () => {
         });
 
         expect(props.error).toEqual('');
-      });
-    });
-
-    describe('currentUser', () => {
-      test('currentUser', () => {
-        const props = subject({
-          authentication: {
-            user: {
-              data: {
-                id: 'user-id',
-                profileSummary: {
-                  primaryEmail: 'email@zero.tech',
-                  firstName: 'John',
-                  lastName: 'Doe',
-                  profileImage: 'image',
-                },
-                wallets: [{ id: 'wallet-id-1', publicAddress: 'address456' }],
-              },
-            },
-          } as any,
-        });
-
-        expect(props.currentUser).toEqual({
-          userId: 'user-id',
-          firstName: 'John',
-          lastName: 'Doe',
-          profileImage: 'image',
-          primaryEmail: 'email@zero.tech',
-          wallets: [{ id: 'wallet-id-1', publicAddress: 'address456' }],
-        });
-      });
-    });
-
-    describe('canAddEmail', () => {
-      test('can add email', () => {
-        const props = subject({
-          authentication: {
-            user: { data: { profileSummary: { primaryEmail: null } } },
-          } as any,
-        });
-
-        expect(props.canAddEmail).toEqual(true);
-      });
-
-      test('cannot add email', () => {
-        const props = subject({
-          authentication: {
-            user: { data: { profileSummary: { primaryEmail: 'email@zero.tech' } } },
-          } as any,
-        });
-
-        expect(props.canAddEmail).toEqual(false);
       });
     });
   });

--- a/src/components/messenger/user-profile/account-management-panel/container.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/container.tsx
@@ -4,31 +4,21 @@ import { RootState } from '../../../../store/reducer';
 import { connectContainer } from '../../../../store/redux-container';
 
 import { AccountManagementPanel } from './index';
-import {
-  openAddEmailAccountModal,
-  closeAddEmailAccountModal,
-  reset,
-  Errors,
-  addNewWallet,
-  State,
-} from '../../../../store/account-management';
+import { reset, Errors, addNewWallet, State } from '../../../../store/account-management';
 import { currentUserSelector } from '../../../../store/authentication/selectors';
+import { Wallet } from '../../../../store/authentication/types';
 
 export interface PublicProperties {
   onClose?: () => void;
 }
 
 export interface Properties extends PublicProperties {
-  isAddEmailModalOpen: boolean;
   error: string;
   successMessage: string;
-  currentUser: any;
-  canAddEmail: boolean;
+  wallets: Wallet[];
   connectedWalletAddr: string;
   addWalletState: State;
 
-  openAddEmailAccountModal: () => void;
-  closeAddEmailAccountModal: () => void;
   addNewWallet: () => void;
   onReset: () => void;
 }
@@ -41,30 +31,18 @@ export class Container extends React.Component<Properties> {
     } = state;
 
     const currentUser = currentUserSelector(state);
-    const primaryEmail = currentUser?.profileSummary.primaryEmail;
 
     return {
       error: Container.mapErrors(accountManagement.errors),
       successMessage: accountManagement.successMessage,
-      isAddEmailModalOpen: accountManagement.isAddEmailAccountModalOpen,
       connectedWalletAddr: value?.address,
       addWalletState: accountManagement.state,
-      currentUser: {
-        userId: currentUser?.id,
-        firstName: currentUser?.profileSummary.firstName,
-        lastName: currentUser?.profileSummary.lastName,
-        profileImage: currentUser?.profileSummary.profileImage,
-        primaryEmail: currentUser?.profileSummary.primaryEmail,
-        wallets: currentUser?.wallets || [],
-      },
-      canAddEmail: !primaryEmail,
+      wallets: currentUser?.wallets || [],
     };
   }
 
   static mapActions(_props: Properties): Partial<Properties> {
     return {
-      openAddEmailAccountModal,
-      closeAddEmailAccountModal,
       addNewWallet,
       onReset: reset,
     };
@@ -86,13 +64,9 @@ export class Container extends React.Component<Properties> {
       <AccountManagementPanel
         error={this.props.error}
         successMessage={this.props.successMessage}
-        isAddEmailModalOpen={this.props.isAddEmailModalOpen}
-        currentUser={this.props.currentUser}
-        canAddEmail={this.props.canAddEmail}
+        wallets={this.props.wallets}
         connectedWalletAddr={this.props.connectedWalletAddr}
         addWalletState={this.props.addWalletState}
-        onOpenAddEmailModal={() => this.props.openAddEmailAccountModal()}
-        onCloseAddEmailModal={() => this.props.closeAddEmailAccountModal()}
         onAddNewWallet={this.props.addNewWallet}
         onBack={this.props.onClose}
         reset={this.props.onReset}

--- a/src/components/messenger/user-profile/account-management-panel/index.test.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.test.tsx
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 import { Properties, AccountManagementPanel } from '.';
 import { PanelHeader } from '../../list/panel-header';
 import { bem } from '../../../../lib/bem';
-import { Button } from '@zero-tech/zui/components/Button';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { State } from '../../../../store/account-management';
 
@@ -29,15 +28,10 @@ describe(AccountManagementPanel, () => {
     const allProps: Properties = {
       error: '',
       successMessage: '',
-      isAddEmailModalOpen: false,
-      currentUser: {},
-      canAddEmail: false,
       connectedWalletAddr: '',
       addWalletState: State.NONE,
-
+      wallets: [],
       onBack: () => {},
-      onOpenAddEmailModal: () => {},
-      onCloseAddEmailModal: () => {},
       reset: () => {},
       onAddNewWallet: () => {},
       ...props,
@@ -77,154 +71,78 @@ describe(AccountManagementPanel, () => {
 
   describe('self-custody wallets section', () => {
     it('renders wallets header (no wallet)', () => {
-      const wrapper = subject({ currentUser: { wallets: [], primaryEmail: 'test@zero.tech' } });
+      const wrapper = subject({ wallets: [] });
 
       expect(wrapper.find(c('wallets-header')).first().text()).toEqual('no self-custody wallets');
     });
 
     it('renders wallets header (1 wallet)', () => {
-      const wrapper = subject({ currentUser: { wallets: [{ id: 'wallet-id-1' }] } });
+      const wrapper = subject({ wallets: [{ id: 'wallet-id-1', publicAddress: '0x123', isThirdWeb: false }] });
 
       expect(wrapper.find(c('wallets-header')).first().text()).toEqual('1 self-custody wallet');
     });
 
     it('renders wallets header (multiple wallets)', () => {
-      const wrapper = subject({ currentUser: { wallets: [{ id: 'wallet-id-1' }, { id: 'wallet-id-2' }] } });
+      const wrapper = subject({
+        wallets: [
+          { id: 'wallet-id-1', publicAddress: '0x1', isThirdWeb: false },
+          { id: 'wallet-id-2', publicAddress: '0x2', isThirdWeb: false },
+        ],
+      });
 
       expect(wrapper.find(c('wallets-header')).text()).toEqual('2 self-custody wallets');
     });
 
     it('renders wallet list items', () => {
       const wrapper = subject({
-        currentUser: {
-          wallets: [
-            { id: 'wallet-id-1', publicAddress: 'address-1' },
-            { id: 'wallet-id-2', publicAddress: 'address-2' },
-          ],
-        },
+        wallets: [
+          { id: 'wallet-id-1', publicAddress: 'address-1', isThirdWeb: false },
+          { id: 'wallet-id-2', publicAddress: 'address-2', isThirdWeb: false },
+        ],
       });
 
       expect(wrapper.find('WalletListItem')).toHaveLength(2);
       expect(wrapper.find('WalletListItem').at(0).prop('wallet')).toEqual({
         id: 'wallet-id-1',
         publicAddress: 'address-1',
+        isThirdWeb: false,
       });
       expect(wrapper.find('WalletListItem').at(1).prop('wallet')).toEqual({
         id: 'wallet-id-2',
         publicAddress: 'address-2',
+        isThirdWeb: false,
       });
     });
 
     it('renders no wallets found alert', () => {
-      const wrapper = subject({ currentUser: { wallets: [], primaryEmail: 'test@zero.tech' } });
+      const wrapper = subject({ wallets: [] });
 
       expect(wrapper.find('Alert[variant="info"]').exists()).toEqual(true);
       expect(wrapper.find(c('alert-info-text')).text()).toEqual('No wallets found');
     });
   });
 
-  describe('email section', () => {
-    it('renders email header', () => {
-      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech' } });
-
-      expect(wrapper.find(c('email-header')).text()).toEqual('Email');
-    });
-
-    it('renders email item', () => {
-      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech' } });
-
-      expect(wrapper.find('CitizenListItem').prop('user')).toEqual({
-        firstName: 'test@zero.tech',
-        primaryEmail: 'test@zero.tech',
-      });
-    });
-
-    it('renders no email found alert', () => {
-      const wrapper = subject({
-        currentUser: { primaryEmail: null, wallets: [{ id: 'wallet-id-1', publicAddress: 'address456' }] },
-      });
-
-      expect(wrapper.find('Alert[variant="info"]').exists()).toEqual(true);
-      expect(wrapper.find(c('alert-info-text')).text()).toEqual('No email account found');
-    });
-
-    it('renders add email button if canAddEmail is true', () => {
-      const wrapper = subject({ currentUser: { primaryEmail: null }, canAddEmail: true });
-
-      expect(wrapper.find(Button).exists()).toEqual(true);
-      expect(wrapper.find(Button).prop('children')).toEqual('Add email');
-    });
-
-    it('does not render add email button if canAddEmail is false', () => {
-      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech' }, canAddEmail: false });
-
-      expect(wrapper.find(Button).exists()).toEqual(false);
-    });
-  });
-
-  describe('add email modal', () => {
-    it('renders add email modal if isAddEmailModalOpen is true', () => {
-      const wrapper = subject({ isAddEmailModalOpen: true });
-
-      expect(wrapper.find('Modal').prop('open')).toEqual(true);
-      expect(wrapper.find(c('add-email-title')).text()).toEqual('Add Email');
-    });
-
-    it('does not render add email modal if isAddEmailModalOpen is false', () => {
-      const wrapper = subject({ isAddEmailModalOpen: false });
-
-      expect(wrapper.find('Modal').prop('open')).toEqual(false);
-    });
-
-    it('publishes onOpenAddEmailModal when add email is clicked', () => {
-      const onOpenAddEmailModal = jest.fn();
-      const wrapper = subject({ onOpenAddEmailModal, currentUser: { primaryEmail: null }, canAddEmail: true });
-
-      wrapper.find(Button).simulate('press');
-
-      expect(onOpenAddEmailModal).toHaveBeenCalled();
-    });
-
-    it('publishes onCloseAddEmailModal event when modal is closed via onOpenChange', () => {
-      const onCloseAddEmailModal = jest.fn();
-      const wrapper = subject({ onCloseAddEmailModal, isAddEmailModalOpen: true });
-
-      wrapper.find('Modal').simulate('openChange', false);
-
-      expect(onCloseAddEmailModal).toHaveBeenCalled();
-    });
-
-    it('publishes onCloseAddEmailModal event when modal is closed via Close IconButton click', () => {
-      const onCloseAddEmailModal = jest.fn();
-      const wrapper = subject({ onCloseAddEmailModal, isAddEmailModalOpen: true });
-
-      wrapper.find('IconButton').simulate('click');
-
-      expect(onCloseAddEmailModal).toHaveBeenCalled();
-    });
-  });
-
   describe('link new wallet', () => {
     it('should render Add Wallet button if user has no wallet linked to his ZERO account', () => {
-      const wrapper = subject({ currentUser: { primaryEmail: 'ratik@zero.tech', wallets: [] } });
+      const wrapper = subject({ wallets: [] });
 
       expect(wrapper.find(ConnectButton.Custom).exists()).toEqual(true);
     });
 
     it('should not render Add Wallet button if user has a wallet linked to his ZERO account', () => {
-      const wrapper = subject({ currentUser: { primaryEmail: 'test@zero.tech', wallets: [{ id: 'wallet-id-1' }] } });
+      const wrapper = subject({ wallets: [{ id: 'wallet-id-1', publicAddress: '0x123', isThirdWeb: false }] });
       expect(wrapper.find(ConnectButton.Custom).exists()).toEqual(false);
     });
 
     it('should open Link Wallet modal when user clicks on Add Wallet, and metamask is connected', () => {
       const wrapper = subject({
-        currentUser: { primaryEmail: 'ratik@zero.tech', wallets: [] },
+        wallets: [],
         connectedWalletAddr: '0xA100C16E67884Da7d515211Bb065592079bEcde6',
       });
 
       wrapper.setState({ isUserLinkingNewWallet: true });
 
-      const linkWalletModal = wrapper.find('Modal').at(1);
+      const linkWalletModal = wrapper.find('Modal');
       expect(linkWalletModal.exists()).toEqual(true);
       expect(linkWalletModal.prop('title')).toEqual('Link Wallet');
       expect(linkWalletModal.find(c('link-new-wallet-modal')).text()).toEqual(
@@ -234,51 +152,51 @@ describe(AccountManagementPanel, () => {
 
     it('should update isUserLinkingNewWallet state to false when user closes Link Wallet modal', () => {
       const wrapper = subject({
-        currentUser: { primaryEmail: 'ratik@zero.tech', wallets: [] },
+        wallets: [],
         connectedWalletAddr: '0x123',
       });
 
       wrapper.setState({ isUserLinkingNewWallet: true });
 
-      const linkWalletModal = wrapper.find('Modal').at(1);
+      const linkWalletModal = wrapper.find('Modal');
       (linkWalletModal as any).props().onClose();
       expect(wrapper.state('isUserLinkingNewWallet')).toEqual(false);
     });
 
     it('does not render Link Wallet modal if error is set', () => {
       const wrapper = subject({
-        currentUser: { primaryEmail: 'ratik@zero.tech', wallets: [] },
+        wallets: [],
         connectedWalletAddr: '0x123',
         error: 'An error occurred',
       });
       wrapper.setState({ isUserLinkingNewWallet: true });
 
-      const linkWalletModal = wrapper.find('Modal').at(1);
+      const linkWalletModal = wrapper.find('Modal');
       expect(linkWalletModal.exists()).toEqual(false);
     });
 
     it('does not render Link Wallet modal if wallet is NOT connected', () => {
       const wrapper = subject({
-        currentUser: { primaryEmail: 'test@zero.tech', wallets: [] },
+        wallets: [],
         connectedWalletAddr: null,
       });
       wrapper.setState({ isUserLinkingNewWallet: true });
 
-      const linkWalletModal = wrapper.find('Modal').at(1);
+      const linkWalletModal = wrapper.find('Modal');
       expect(linkWalletModal.exists()).toEqual(false);
     });
 
     it('calls addNewWallet when user clicks on Link Wallet', () => {
       const addNewWallet = jest.fn();
       const wrapper = subject({
-        currentUser: { primaryEmail: 'ratik@zero.tech', wallets: [] },
+        wallets: [],
         connectedWalletAddr: '0x123',
         addWalletState: State.NONE,
         onAddNewWallet: addNewWallet,
       });
       wrapper.setState({ isUserLinkingNewWallet: true });
 
-      const linkWalletModal = wrapper.find('Modal').at(1);
+      const linkWalletModal = wrapper.find('Modal');
       (linkWalletModal as any).props().onPrimary();
 
       expect(addNewWallet).toHaveBeenCalled();
@@ -286,13 +204,13 @@ describe(AccountManagementPanel, () => {
 
     it('keeps Link Wallet button in loading state while IN_PROGRESS', () => {
       const wrapper = subject({
-        currentUser: { primaryEmail: 'ratik@zero.tech', wallets: [] },
+        wallets: [],
         connectedWalletAddr: '0x123',
         addWalletState: State.INPROGRESS,
       });
       wrapper.setState({ isUserLinkingNewWallet: true });
 
-      const linkWalletModal = wrapper.find('Modal').at(1);
+      const linkWalletModal = wrapper.find('Modal');
       expect(linkWalletModal.prop('isProcessing')).toEqual(true);
     });
   });
@@ -300,10 +218,7 @@ describe(AccountManagementPanel, () => {
   describe('thirdweb wallets section', () => {
     it('does not render thirdweb section when no thirdweb wallets exist', () => {
       const wrapper = subject({
-        currentUser: {
-          wallets: [],
-          primaryEmail: 'test@zero.tech',
-        },
+        wallets: [],
       });
 
       const thirdWebWallet = wrapper.find(c('wallets-header')).at(1);
@@ -312,10 +227,7 @@ describe(AccountManagementPanel, () => {
 
     it('renders thirdweb wallets', () => {
       const wrapper = subject({
-        currentUser: {
-          wallets: [{ id: 'wallet-id-1', isThirdWeb: true, publicAddress: '0x123' }],
-          primaryEmail: 'test@zero.tech',
-        },
+        wallets: [{ id: 'wallet-id-1', isThirdWeb: true, publicAddress: '0x123' }],
       });
 
       const thirdWebWallet = wrapper.find(c('wallets-header')).at(1);
@@ -331,13 +243,10 @@ describe(AccountManagementPanel, () => {
 
     it('renders both self-custody and thirdweb wallets', () => {
       const wrapper = subject({
-        currentUser: {
-          wallets: [
-            { id: 'thirdweb-wallet-id-1', isThirdWeb: true, publicAddress: '0x123' },
-            { id: 'self-custody-wallet-id-1', isThirdWeb: false, publicAddress: '0x456' },
-          ],
-          primaryEmail: 'test@zero.tech',
-        },
+        wallets: [
+          { id: 'thirdweb-wallet-id-1', isThirdWeb: true, publicAddress: '0x123' },
+          { id: 'self-custody-wallet-id-1', isThirdWeb: false, publicAddress: '0x456' },
+        ],
       });
 
       // 2 wallets in total
@@ -367,10 +276,7 @@ describe(AccountManagementPanel, () => {
     it('renders wallet with correct etherscan link', () => {
       const wallet = { id: 'wallet-id-1', isThirdWeb: true, publicAddress: '0x123' };
       const wrapper = subject({
-        currentUser: {
-          wallets: [wallet],
-          primaryEmail: 'test@zero.tech',
-        },
+        wallets: [wallet],
       });
 
       const walletLink = wrapper.find('a');

--- a/src/components/messenger/user-profile/account-management-panel/index.tsx
+++ b/src/components/messenger/user-profile/account-management-panel/index.tsx
@@ -3,34 +3,29 @@ import * as React from 'react';
 import { bemClassName } from '../../../../lib/bem';
 import { PanelHeader } from '../../list/panel-header';
 import { Button, Variant as ButtonVariant } from '@zero-tech/zui/components/Button';
-import { Alert, Modal as ZuiModal, IconButton } from '@zero-tech/zui/components';
+import { Alert } from '@zero-tech/zui/components';
 
-import { IconPlus, IconXClose } from '@zero-tech/zui/icons';
+import { IconPlus } from '@zero-tech/zui/icons';
 import './styles.scss';
 import { WalletListItem } from '../../../wallet-list-item';
-import { CitizenListItem } from '../../../citizen-list-item';
-import { CreateEmailAccountContainer } from '../../../../authentication/create-email-account/container';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { Color, Modal, Variant } from '../../../modal';
 import { State as AddWalletState } from '../../../../store/account-management';
 import { getChain } from '../../../../lib/web3/thirdweb/client';
+import { Wallet } from '../../../../store/authentication/types';
 
 const cn = bemClassName('account-management-panel');
 
 export interface Properties {
-  isAddEmailModalOpen: boolean;
   error: string;
   successMessage: string;
-  currentUser: any;
-  canAddEmail: boolean;
+  wallets: Wallet[];
   connectedWalletAddr: string;
   addWalletState: AddWalletState;
 
   onBack: () => void;
   reset: () => void; // reset saga state
-  onOpenAddEmailModal: () => void;
-  onCloseAddEmailModal: () => void;
   onAddNewWallet: () => void;
 }
 
@@ -52,8 +47,7 @@ export class AccountManagementPanel extends React.Component<Properties, State> {
   };
 
   getSelfCustodyWallets = () => {
-    const { currentUser } = this.props;
-    const wallets = currentUser?.wallets || [];
+    const { wallets } = this.props;
     return wallets.filter((w) => !w.isThirdWeb);
   };
 
@@ -113,8 +107,7 @@ export class AccountManagementPanel extends React.Component<Properties, State> {
   };
 
   getThirdWebWallets = () => {
-    const { currentUser } = this.props;
-    const wallets = currentUser?.wallets || [];
+    const { wallets } = this.props;
     return wallets.filter((w) => w.isThirdWeb === true);
   };
 
@@ -137,66 +130,6 @@ export class AccountManagementPanel extends React.Component<Properties, State> {
           </a>
         ))}
       </div>
-    );
-  };
-
-  renderEmailSection = () => {
-    const { currentUser } = this.props;
-
-    return (
-      <div {...cn('email-container')}>
-        <div {...cn('email-header')}>
-          <span>Email</span>
-        </div>
-
-        {currentUser?.primaryEmail ? (
-          <CitizenListItem user={{ ...currentUser, firstName: currentUser.primaryEmail }} tag={''} />
-        ) : (
-          <div {...cn('alert-small')}>
-            <Alert variant='info'>
-              <div {...cn('alert-info-text')}>No email account found</div>
-            </Alert>
-          </div>
-        )}
-
-        {this.props.canAddEmail && (
-          <div>
-            <Button
-              variant={ButtonVariant.Secondary}
-              onPress={this.props.onOpenAddEmailModal}
-              startEnhancer={<IconPlus size={20} isFilled />}
-            >
-              Add email
-            </Button>
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  renderAddEmailAccountModal = () => {
-    return (
-      <ZuiModal
-        open={this.props.isAddEmailModalOpen}
-        onOpenChange={(isOpen) => {
-          isOpen ? this.props.onOpenAddEmailModal() : this.props.onCloseAddEmailModal();
-        }}
-        {...cn('add-email-modal')}
-      >
-        <div {...cn('add-email-body')}>
-          <div {...cn('add-email-title-bar')}>
-            <h3 {...cn('add-email-title')}>Add Email</h3>
-            <IconButton
-              {...cn('add-email-close')}
-              size='large'
-              Icon={IconXClose}
-              onClick={this.props.onCloseAddEmailModal}
-            />
-          </div>
-
-          <CreateEmailAccountContainer addAccount />
-        </div>
-      </ZuiModal>
     );
   };
 
@@ -249,14 +182,13 @@ export class AccountManagementPanel extends React.Component<Properties, State> {
     return (
       <div {...cn()}>
         <div {...cn('header-container')}>
-          <PanelHeader title={'Accounts'} onBack={this.back} />
+          <PanelHeader title={'Wallets'} onBack={this.back} />
         </div>
 
         <ScrollbarContainer variant='on-hover'>
           <div {...cn('panel-content-wrapper')}>
             <div {...cn('content')}>
               {this.renderSelfCustodyWalletsSection()}
-              {this.renderEmailSection()}
               {this.renderThirdWebWalletsSection()}
 
               {this.props.error && (
@@ -272,7 +204,6 @@ export class AccountManagementPanel extends React.Component<Properties, State> {
               )}
             </div>
 
-            {this.renderAddEmailAccountModal()}
             {this.isLinkNewWalletModalOpen && this.renderLinkNewWalletModal()}
           </div>
         </ScrollbarContainer>

--- a/src/components/messenger/user-profile/account-management-panel/styles.scss
+++ b/src/components/messenger/user-profile/account-management-panel/styles.scss
@@ -82,53 +82,7 @@
     margin: 8px 0;
   }
 
-  &__add-email-modal {
-    padding-bottom: 0px;
-  }
-
   &__link-new-wallet-modal {
     width: 420px;
-  }
-
-  &__add-email-body {
-    width: 300px;
-
-    display: flex;
-    flex-direction: column;
-    gap: 40px;
-    overflow: hidden;
-    padding: calc(40px - 24px);
-    box-sizing: border-box;
-    max-height: calc(100vh - 54px);
-    min-height: 250px;
-    padding-bottom: 0px;
-  }
-
-  &__add-email-title-bar {
-    display: flex;
-    height: 43px;
-    @include glass-text-primary-color;
-    border-bottom: 1px solid $glass-separator-secondary-color;
-
-    > *:first-child {
-      flex-grow: 1;
-    }
-
-    > *:last-child {
-      flex-grow: 0;
-    }
-  }
-
-  &__add-email-title {
-    font-weight: 600;
-    font-size: 24px;
-    line-height: 29px;
-    margin: 0px;
-  }
-
-  &__add-email-close {
-    &:focus-visible {
-      outline: none;
-    }
   }
 }

--- a/src/components/messenger/user-profile/linked-accounts-panel/index.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/index.tsx
@@ -1,18 +1,24 @@
 import { PanelHeader } from '../../list/panel-header';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { bemClassName } from '../../../../lib/bem';
-
 import { LinkedAccount } from './components/linked-account';
 import { AvailableAccount } from './components/available-account';
 import { useLinkedAccountsQuery } from './queries/useLinkedAccountsQuery';
 import { Provider, ProviderLabels } from './types/providers';
-import { ModalConfirmation } from '@zero-tech/zui/components';
+import { Alert, Button, IconButton, Modal, ModalConfirmation } from '@zero-tech/zui/components';
+import { Variant as ButtonVariant } from '@zero-tech/zui/components/Button';
 import { useUnlinkAccountMutation } from './queries/useUnlinkAccountMutation';
 import { useCallback, useEffect, useState } from 'react';
 import { linkedAccountsQueryKeys } from './queries/keys';
 import { useQueryClient } from '@tanstack/react-query';
 import { AVAILABLE_ACCOUNTS } from './constants';
-
+import { currentUserSelector } from '../../../../store/authentication/selectors';
+import { useDispatch, useSelector } from 'react-redux';
+import { CitizenListItem } from '../../../citizen-list-item';
+import { IconPlus, IconXClose } from '@zero-tech/zui/icons';
+import { CreateEmailAccountContainer } from '../../../../authentication/create-email-account/container';
+import { isAddEmailAccountModalOpenSelector } from '../../../../store/account-management/selectors';
+import { openAddEmailAccountModal, closeAddEmailAccountModal } from '../../../../store/account-management';
 import './styles.scss';
 
 const cn = bemClassName('linked-accounts-panel');
@@ -22,9 +28,14 @@ export interface Properties {
 }
 
 export function LinkedAccountsPanel({ onBack }: Properties) {
+  const dispatch = useDispatch();
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
   const [providerToUnlink, setProviderToUnlink] = useState<Provider | null>(null);
   const [providerUserIdToUnlink, setProviderUserIdToUnlink] = useState<string | null>(null);
+
+  const isAddEmailModalOpen = useSelector(isAddEmailAccountModalOpenSelector);
+  const currentUser = useSelector(currentUserSelector);
+  const canAddEmail = !currentUser?.profileSummary.primaryEmail;
 
   const unlinkAccountMutation = useUnlinkAccountMutation();
   const { data: linkedAccounts = [] } = useLinkedAccountsQuery();
@@ -67,6 +78,14 @@ export function LinkedAccountsPanel({ onBack }: Properties) {
     );
   }, [providerToUnlink, providerUserIdToUnlink, unlinkAccountMutation]);
 
+  const openEmailModal = (open: boolean) => {
+    if (open) {
+      dispatch(openAddEmailAccountModal());
+    } else {
+      dispatch(closeAddEmailAccountModal());
+    }
+  };
+
   return (
     <div {...cn()}>
       <div {...cn('header-container')}>
@@ -75,6 +94,46 @@ export function LinkedAccountsPanel({ onBack }: Properties) {
 
       <ScrollbarContainer variant='on-hover'>
         <div {...cn('body')}>
+          <div {...cn('section')}>
+            <h3 {...cn('section-title')}>Email</h3>
+
+            <div>
+              {currentUser?.profileSummary.primaryEmail ? (
+                <CitizenListItem
+                  user={{
+                    ...currentUser,
+                    matrixId: currentUser.matrixId ?? '',
+                    userId: currentUser.id,
+                    firstName: currentUser.profileSummary.primaryEmail,
+                    lastName: '',
+                    profileImage: '',
+                    lastSeenAt: '',
+                    primaryZID: '',
+                  }}
+                  tag={''}
+                />
+              ) : (
+                <div {...cn('alert-small')}>
+                  <Alert variant='info'>
+                    <div {...cn('alert-info-text')}>No email account found</div>
+                  </Alert>
+                </div>
+              )}
+
+              {canAddEmail && (
+                <div>
+                  <Button
+                    variant={ButtonVariant.Secondary}
+                    onPress={() => openEmailModal(true)}
+                    startEnhancer={<IconPlus size={20} isFilled />}
+                  >
+                    Add email
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+
           {linkedAccounts.length > 0 && (
             <div {...cn('section')}>
               <h3 {...cn('section-title')}>Linked</h3>
@@ -98,6 +157,7 @@ export function LinkedAccountsPanel({ onBack }: Properties) {
           </div>
         </div>
       </ScrollbarContainer>
+
       {isConfirmationOpen && (
         <ModalConfirmation
           open
@@ -110,6 +170,30 @@ export function LinkedAccountsPanel({ onBack }: Properties) {
         >
           <p>Are you sure you want to unlink {ProviderLabels[providerToUnlink]}?</p>
         </ModalConfirmation>
+      )}
+
+      {isAddEmailModalOpen && (
+        <Modal
+          open={isAddEmailModalOpen}
+          onOpenChange={(isOpen) => {
+            isOpen ? openEmailModal(true) : openEmailModal(false);
+          }}
+          {...cn('add-email-modal')}
+        >
+          <div {...cn('add-email-body')}>
+            <div {...cn('add-email-title-bar')}>
+              <h3 {...cn('add-email-title')}>Add Email</h3>
+              <IconButton
+                {...cn('add-email-close')}
+                size='large'
+                Icon={IconXClose}
+                onClick={() => openEmailModal(false)}
+              />
+            </div>
+
+            <CreateEmailAccountContainer addAccount />
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/components/messenger/user-profile/linked-accounts-panel/index.tsx
+++ b/src/components/messenger/user-profile/linked-accounts-panel/index.tsx
@@ -173,13 +173,7 @@ export function LinkedAccountsPanel({ onBack }: Properties) {
       )}
 
       {isAddEmailModalOpen && (
-        <Modal
-          open={isAddEmailModalOpen}
-          onOpenChange={(isOpen) => {
-            isOpen ? openEmailModal(true) : openEmailModal(false);
-          }}
-          {...cn('add-email-modal')}
-        >
+        <Modal open={isAddEmailModalOpen} onOpenChange={openEmailModal} {...cn('add-email-modal')}>
           <div {...cn('add-email-body')}>
             <div {...cn('add-email-title-bar')}>
               <h3 {...cn('add-email-title')}>Add Email</h3>

--- a/src/components/messenger/user-profile/linked-accounts-panel/styles.scss
+++ b/src/components/messenger/user-profile/linked-accounts-panel/styles.scss
@@ -26,7 +26,6 @@
   &__section {
     display: flex;
     flex-direction: column;
-    gap: 12px;
   }
 
   &__section-title {
@@ -65,6 +64,68 @@
       background-color: theme.$color-secondary-11;
       flex-shrink: 0;
       display: block;
+    }
+  }
+
+  &__alert-small {
+    display: flex;
+    justify-content: center;
+    padding: 4px 8px 4px 0px;
+  }
+
+  &__alert-info-text {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  &__alert-text {
+    font-size: 14px;
+    line-height: 17px;
+  }
+
+  &__add-email-modal {
+    padding-bottom: 0px;
+  }
+
+  &__add-email-body {
+    width: 300px;
+
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    overflow: hidden;
+    padding: calc(40px - 24px);
+    box-sizing: border-box;
+    max-height: calc(100vh - 54px);
+    min-height: 250px;
+    padding-bottom: 0px;
+  }
+
+  &__add-email-title-bar {
+    display: flex;
+    height: 43px;
+    @include glass-text-primary-color;
+    border-bottom: 1px solid $glass-separator-secondary-color;
+
+    > *:first-child {
+      flex-grow: 1;
+    }
+
+    > *:last-child {
+      flex-grow: 0;
+    }
+  }
+
+  &__add-email-title {
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 29px;
+    margin: 0px;
+  }
+
+  &__add-email-close {
+    &:focus-visible {
+      outline: none;
     }
   }
 }

--- a/src/store/account-management/index.ts
+++ b/src/store/account-management/index.ts
@@ -1,5 +1,4 @@
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
-//import { Connectors } from '../../lib/web3';
 
 export enum SagaActionTypes {
   AddNewWallet = 'Wallets/addNewWallet',

--- a/src/store/account-management/selectors.ts
+++ b/src/store/account-management/selectors.ts
@@ -1,0 +1,5 @@
+import { RootState } from '../reducer';
+
+export const isAddEmailAccountModalOpenSelector = (state: RootState) => {
+  return state.accountManagement.isAddEmailAccountModalOpen;
+};


### PR DESCRIPTION
### What does this do?
Moves linking email from "Manage wallets" to "Linked Accounts" section

### Why are we making this change?
We renamed some sections so it makes more sense to have email in the linked accounts panel