### PR TITLE
Fix: Cleanup misc

### DIFF
--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -376,6 +376,9 @@ export const Message: React.FC<Properties> = memo(
     };
 
     const renderBody = () => {
+      const hasContent = media?.body || message || reactions || showTimestamp;
+      if (!hasContent) return null;
+
       return (
         <div {...cn('block-body')}>
           {media?.body && (

--- a/src/components/message/styles.scss
+++ b/src/components/message/styles.scss
@@ -351,7 +351,6 @@
 
     &--loading {
       padding: 4px;
-      border-top: 0.125rem solid theme.$color-greyscale-11;
     }
   }
 

--- a/src/store/messages/saga.test.ts
+++ b/src/store/messages/saga.test.ts
@@ -353,7 +353,7 @@ describe(replaceOptimisticMessage, () => {
     expect(returnValue).toEqual(null);
   });
 
-  it('returns null if there is no message identified by the optimisticId', async () => {
+  it('appends the message and sets send status to success if there is no message identified by the optimisticId', async () => {
     const currentMessages = ['message-1', 'message-2'];
     const newMessage = {
       id: 'new-message',
@@ -378,7 +378,7 @@ describe(replaceOptimisticMessage, () => {
 
     const { returnValue } = await expectSaga(replaceOptimisticMessage, currentMessages, newMessage).run();
 
-    expect(returnValue).toEqual(null);
+    expect(returnValue).toEqual([...currentMessages, { ...newMessage, sendStatus: MessageSendStatus.SUCCESS }]);
   });
 
   it('returns message list with replaced message and success status', async () => {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -517,6 +517,10 @@ export function* receiveOptimisticMessage(action: ReceiveOptimisticMessageAction
 }
 
 export function* replaceOptimisticMessage(currentMessages: string[], message: Message) {
+  if (!message.optimisticId) {
+    return null;
+  }
+
   const messageIndex = currentMessages.findIndex((id) => id === message.optimisticId);
 
   if (messageIndex < 0) {

--- a/src/store/messages/saga.ts
+++ b/src/store/messages/saga.ts
@@ -30,6 +30,8 @@ import { rawChannel } from '../channels/selectors';
 import { getUsersByMatrixIds } from '../users/saga';
 import { ReceiveNewMessageAction, ReceiveOptimisticMessageAction, SyncMessagesAction } from './types';
 
+const handledOptimisticIds = new Set<string>();
+
 const BATCH_INTERVAL = 500; // Debounce/batch interval in milliseconds
 
 export interface Payload {
@@ -244,6 +246,12 @@ export function* createOptimisticMessage(channelId, message, parentMessage, file
   const currentUser = yield select(currentUserSelector);
 
   const temporaryMessage = createOptimisticMessageObject(message, currentUser, parentMessage, file, rootMessageId);
+
+  // Check if already handled (real message arrived first)
+  if (handledOptimisticIds.has(temporaryMessage.optimisticId)) {
+    handledOptimisticIds.delete(temporaryMessage.optimisticId);
+    return { optimisticMessage: temporaryMessage }; // Skip adding to state
+  }
 
   yield call(receiveChannel, { id: channelId, messages: [...existingMessages, temporaryMessage] });
 
@@ -512,7 +520,16 @@ export function* replaceOptimisticMessage(currentMessages: string[], message: Me
   const messageIndex = currentMessages.findIndex((id) => id === message.optimisticId);
 
   if (messageIndex < 0) {
-    return null;
+    // No match: Real event arrived first. Append the real message.
+    handledOptimisticIds.add(message.optimisticId);
+    const messages = [
+      ...currentMessages,
+      {
+        ...message,
+        sendStatus: MessageSendStatus.SUCCESS,
+      },
+    ];
+    return messages;
   }
 
   const optimisticMessage = yield select(messageSelector(message.optimisticId));


### PR DESCRIPTION
### What does this do?
- Removes the border from the spinner. It looked silly having a spinning line attached to the spinner icon
- Hides empty space at the bottom of images with no body
- Fixes a race condition with images where they would sometimes not appear in the chat