### PR TITLE
feat(zero-pro-badge): add clickable zero pro badge component and hover card

### DIFF
--- a/src/apps/feed/components/feed/search-drawer/index.tsx
+++ b/src/apps/feed/components/feed/search-drawer/index.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { IconButton, Input } from '@zero-tech/zui/components';
-import { IconSearchMd, IconZeroProVerified } from '@zero-tech/zui/icons';
+import { IconSearchMd } from '@zero-tech/zui/icons';
 import { MatrixAvatar } from '../../../../../components/matrix-avatar';
+import { ZeroProBadge } from '../../../../../components/zero-pro-badge';
 import { ProfileLinkNavigation } from '../../../../../components/profile-link-navigation';
 import styles from './styles.module.scss';
 
@@ -74,7 +75,7 @@ export const SearchDrawer = ({ searchResults, isSearching, searchValue, onSearch
                   <div className={styles.UserInfo}>
                     <div className={styles.UserNameContainer}>
                       <span className={styles.UserName}>{user.name}</span>
-                      {user?.subscriptions?.zeroPro && <IconZeroProVerified size={14} />}
+                      {user?.subscriptions?.zeroPro && <ZeroProBadge size={14} />}
                     </div>
                     {user?.primaryZID && <span className={styles.UserHandle}>{user.primaryZID}</span>}
                   </div>

--- a/src/apps/feed/components/post/index.tsx
+++ b/src/apps/feed/components/post/index.tsx
@@ -16,7 +16,8 @@ import { useGetReturnFromProfilePath } from '../../lib/useGetReturnFromProfilePa
 import { RETURN_POST_ID_KEY, RETURN_PATH_KEY } from '../../lib/useReturnFromProfileNavigation';
 import { ProfileCardHover } from '../../../../components/profile-card/hover';
 import classNames from 'classnames';
-import { IconZeroProVerified } from '@zero-tech/zui/icons';
+import { ZeroProBadge } from '../../../../components/zero-pro-badge';
+
 import { StatusAction } from './actions/status';
 import { useSelector } from 'react-redux';
 import { isOptimisticPostSelector } from '../../../../store/post-queue/selectors';
@@ -149,7 +150,7 @@ export const Post = ({
                   <ProfileLink primaryZid={authorPrimaryZid} publicAddress={authorPublicAddress} postId={messageId}>
                     {nickname}
                   </ProfileLink>
-                  {isZeroProSubscriber && <IconZeroProVerified size={18} />}
+                  {isZeroProSubscriber && <ZeroProBadge size={18} />}
                   <span>⋅</span>
                   {variant === 'default' && <Timestamp className={styles.Date} timestamp={timestamp} />}
                 </Name>

--- a/src/apps/feed/components/post/quote/index.tsx
+++ b/src/apps/feed/components/post/quote/index.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { MatrixAvatar } from '../../../../../components/matrix-avatar';
 import { Timestamp } from '@zero-tech/zui/components/Post/components/Timestamp';
-import { IconZeroProVerified } from '@zero-tech/zui/icons';
+import { ZeroProBadge } from '../../../../../components/zero-pro-badge';
 
 import classNames from 'classnames';
 import styles from './style.module.scss';
@@ -35,7 +35,7 @@ export const Details = forwardRef<HTMLDivElement, DetailsProps>(
           <MatrixAvatar size='small' imageURL={avatarURL} />
           <div className={styles.Name}>
             <span className={styles.NameText}>{name}</span>
-            {isZeroProSubscriber && <IconZeroProVerified size={18} />}
+            {isZeroProSubscriber && <ZeroProBadge size={18} />}
           </div>
         </div>
         {'⋅'}

--- a/src/apps/profile/panels/UserPanel/index.tsx
+++ b/src/apps/profile/panels/UserPanel/index.tsx
@@ -3,8 +3,9 @@ import { useUserPanel } from './useUserPanel';
 
 import { Panel, PanelBody } from '../../../../components/layout/panel';
 import { MatrixAvatar } from '../../../../components/matrix-avatar';
-import { IconLogoZero, IconMessage01, IconZeroProVerified } from '@zero-tech/zui/icons';
+import { IconLogoZero, IconMessage01 } from '@zero-tech/zui/icons';
 import MatrixMask from './matrix-mask.svg?react';
+import { ZeroProBadge } from '../../../../components/zero-pro-badge';
 import { FollowButton } from '../../../../components/follow-button';
 import { FollowCounts } from '../../../../components/follow-counts';
 import { Skeleton } from '@zero-tech/zui/components/Skeleton';
@@ -52,7 +53,7 @@ export const UserPanel = () => {
           <div className={styles.Name}>
             <div className={styles.NameAndBadgeWrapper}>
               <h1>{isLoading ? <Skeleton /> : handle}</h1>
-              {isZeroProSubscriber && <IconZeroProVerified size={18} />}
+              {isZeroProSubscriber && <ZeroProBadge size={18} />}
             </div>
             <h2>{isLoading ? <Skeleton /> : zid ? '0://' + zid : null}</h2>
           </div>

--- a/src/components/citizen-list-item/index.tsx
+++ b/src/components/citizen-list-item/index.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { MatrixAvatar } from '../matrix-avatar';
 import { ProfileLinkNavigation } from '../profile-link-navigation';
 import { ProfileCardHover } from '../profile-card/hover';
-import { IconZeroProVerified } from '@zero-tech/zui/icons';
+import { ZeroProBadge } from '../zero-pro-badge';
 const cn = bemClassName('citizen-list-item');
 
 export interface Properties {
@@ -81,7 +81,7 @@ export class CitizenListItem extends React.Component<Properties, State> {
           <div {...cn('text-container')}>
             <div {...cn('name-container')}>
               <span {...cn('name')}>{displayName(this.props.user)}</span>
-              {this.props.user?.subscriptions?.zeroPro && <IconZeroProVerified size={16} />}
+              {this.props.user?.subscriptions?.zeroPro && <ZeroProBadge size={16} />}
             </div>
             <span {...cn('handle')}>{this.props.user.displaySubHandle}</span>
           </div>

--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -5,8 +5,8 @@ import { Input } from '@zero-tech/zui/components';
 import { highlightFilter, itemToOption } from '../lib/utils';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { Waypoint } from '../../waypoint';
+import { ZeroProBadge } from '../../zero-pro-badge';
 import classNames from 'classnames';
-import { IconZeroProVerified } from '@zero-tech/zui/icons';
 
 import './styles.scss';
 import '../list/styles.scss';
@@ -141,7 +141,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
                       <div className='autocomplete-members__label'>
                         {highlightFilter(r.label, this.state.searchString)}
                       </div>
-                      {r.isZeroProSubscriber && <IconZeroProVerified size={16} />}
+                      {r.isZeroProSubscriber && <ZeroProBadge size={16} />}
                     </div>
                     {r?.subLabel && <div className='autocomplete-members__sub-label'>{r.subLabel}</div>}
                   </div>

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -5,8 +5,9 @@ import { DefaultRoomLabels, NormalizedChannel } from '../../../../store/channels
 
 import { MoreMenu } from './more-menu';
 import { MatrixAvatar } from '../../../matrix-avatar';
+import { ZeroProBadge } from '../../../zero-pro-badge';
 
-import { IconBellOff1, IconZeroProVerified } from '@zero-tech/zui/icons';
+import { IconBellOff1 } from '@zero-tech/zui/icons';
 
 import { bemClassName } from '../../../../lib/bem';
 import './conversation-item.scss';
@@ -161,7 +162,7 @@ export const ConversationItem = memo(
                 <div {...cn('name')} is-unread={isUnread.toString()}>
                   {highlightedName}
                 </div>
-                {user?.subscriptions?.zeroPro && <IconZeroProVerified {...cn('badge-icon')} size={16} />}
+                {user?.subscriptions?.zeroPro && <ZeroProBadge {...cn('badge-icon')} size={16} />}
               </div>
               {conversation.labels?.includes(DefaultRoomLabels.MUTE) && (
                 <IconBellOff1 {...cn('muted-icon')} size={16} />

--- a/src/components/messenger/list/selected-user-tag/index.tsx
+++ b/src/components/messenger/list/selected-user-tag/index.tsx
@@ -3,7 +3,8 @@ import * as React from 'react';
 import { Option } from '../../lib/types';
 
 import { IconButton } from '@zero-tech/zui/components';
-import { IconXClose, IconZeroProVerified } from '@zero-tech/zui/icons';
+import { IconXClose } from '@zero-tech/zui/icons';
+import { ZeroProBadge } from '../../../zero-pro-badge';
 
 import classNames from 'classnames';
 import { bemClassName } from '../../../../lib/bem';
@@ -44,7 +45,7 @@ export class SelectedUserTag extends React.Component<Properties> {
         <div {...cn('user-details')}>
           <div {...cn('user-label-container')}>
             <span {...cn('user-label')}>{option.label}</span>
-            {option.isZeroProSubscriber && <IconZeroProVerified size={16} />}
+            {option.isZeroProSubscriber && <ZeroProBadge size={16} />}
           </div>
           {option.subLabel && <span {...cn('user-sublabel')}>{option.subLabel}</span>}
         </div>

--- a/src/components/messenger/list/user-search-results/index.tsx
+++ b/src/components/messenger/list/user-search-results/index.tsx
@@ -5,7 +5,7 @@ import { highlightFilter } from '../../lib/utils';
 import { Waypoint } from '../../../waypoint';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { MatrixAvatar } from '../../../matrix-avatar';
-import { IconZeroProVerified } from '@zero-tech/zui/icons';
+import { ZeroProBadge } from '../../../zero-pro-badge';
 
 import { bemClassName } from '../../../../lib/bem';
 import './user-search-results.scss';
@@ -89,7 +89,7 @@ export class UserSearchResults extends React.Component<Properties, State> {
             <div {...cn('user-details')}>
               <div {...cn('label-container')}>
                 <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
-                {userResult.isZeroProSubscriber && <IconZeroProVerified size={16} />}
+                {userResult.isZeroProSubscriber && <ZeroProBadge size={16} />}
               </div>
               {userResult?.subLabel && <div {...cn('sub-label')}>{userResult.subLabel}</div>}
             </div>

--- a/src/components/messenger/user-profile/overview-panel/index.tsx
+++ b/src/components/messenger/user-profile/overview-panel/index.tsx
@@ -16,11 +16,11 @@ import {
   IconUser1,
   IconWallet3,
   IconTag1,
-  IconZeroProVerified,
 } from '@zero-tech/zui/icons';
 import { InviteDialogContainer } from '../../../invite-dialog/container';
 import { RewardsItemContainer } from './rewards-item/container';
 import { featureFlags } from '../../../../lib/feature-flags';
+import { ZeroProBadge } from '../../../zero-pro-badge';
 import { ScrollbarContainer } from '../../../scrollbar-container';
 import { useMatrixImage } from '../../../../lib/hooks/useMatrixImage';
 
@@ -122,7 +122,7 @@ export const OverviewPanel: React.FC<Properties> = (props) => {
         <div {...cn('name-container')}>
           <div {...cn('name-container-inner')}>
             <div {...cn('name')}>{props.name}</div>
-            {props.isZeroProSubscriber && <IconZeroProVerified size={18} />}
+            {props.isZeroProSubscriber && <ZeroProBadge size={18} />}
           </div>
           {props.subHandle && <div {...cn('sub-handle')}>{props.subHandle}</div>}
         </div>

--- a/src/components/profile-card/index.tsx
+++ b/src/components/profile-card/index.tsx
@@ -1,7 +1,8 @@
-import { IconMessage01, IconZeroProVerified } from '@zero-tech/zui/icons';
+import { IconMessage01 } from '@zero-tech/zui/icons';
 import { Button, SkeletonText, Variant, IconButton } from '@zero-tech/zui/components';
 
 import { MatrixAvatar } from '../matrix-avatar';
+import { ZeroProBadge } from '../zero-pro-badge';
 import { useProfileCard } from './lib/useProfileCard';
 
 import styles from './styles.module.scss';
@@ -59,7 +60,7 @@ export const ProfileCard = ({ userId }: ProfileCardProps) => {
       <div className={styles.Name}>
         <div className={styles.NameAndBadgeWrapper}>
           <SkeletonText className={styles.Handle} asyncText={{ text: handle, isLoading }} />
-          {isZeroProSubscriber && !isLoading && <IconZeroProVerified size={18} />}
+          {isZeroProSubscriber && !isLoading && <ZeroProBadge size={18} />}
         </div>
         <SkeletonText className={styles.Subhandle} asyncText={{ text: subhandle, isLoading }} />
       </div>

--- a/src/components/zero-pro-badge/index.tsx
+++ b/src/components/zero-pro-badge/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { IconZeroProVerified } from '@zero-tech/zui/icons';
+import * as HoverCard from '@radix-ui/react-hover-card';
+import { useDispatch } from 'react-redux';
+import { openZeroPro } from '../../store/user-profile';
+
+import styles from './styles.module.scss';
+
+export interface ZeroProBadgeProps {
+  className?: string;
+  size?: number;
+}
+
+export const ZeroProBadge: React.FC<ZeroProBadgeProps> = ({ size = 16, className }) => {
+  const dispatch = useDispatch();
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsOpen(false);
+    dispatch(openZeroPro());
+  };
+
+  const badge = (
+    <div
+      className={`${styles.Badge} ${styles.Clickable} ${className || ''}`}
+      onClick={handleClick}
+      onMouseDown={(e) => e.preventDefault()}
+      role='button'
+      tabIndex={0}
+    >
+      <IconZeroProVerified size={size} />
+    </div>
+  );
+
+  return (
+    <HoverCard.Root openDelay={0} closeDelay={100} open={isOpen} onOpenChange={setIsOpen}>
+      <HoverCard.Trigger asChild={true}>{badge}</HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content className={styles.HoverContent} sideOffset={5}>
+          <div className={styles.TooltipText} onClick={handleClick} onMouseDown={(e) => e.preventDefault()}>
+            Zero Pro Subscriber
+          </div>
+          <HoverCard.Arrow className={styles.Arrow} />
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
+  );
+};

--- a/src/components/zero-pro-badge/styles.module.scss
+++ b/src/components/zero-pro-badge/styles.module.scss
@@ -1,0 +1,108 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@use '../../_variables.scss' as variables;
+
+.Badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &.Clickable {
+    cursor: pointer;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}
+
+.HoverContent {
+  background: variables.$panel-background;
+  backdrop-filter: variables.$default-background-blur;
+  border-radius: variables.$border-radius;
+  padding: 8px 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 1px solid variables.$border-color;
+  animation-duration: 200ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+
+  &[data-state='open'][data-side='top'] {
+    animation-name: slideDownAndFade;
+  }
+
+  &[data-state='open'][data-side='right'] {
+    animation-name: slideLeftAndFade;
+  }
+
+  &[data-state='open'][data-side='bottom'] {
+    animation-name: slideUpAndFade;
+  }
+
+  &[data-state='open'][data-side='left'] {
+    animation-name: slideRightAndFade;
+  }
+}
+
+.TooltipText {
+  color: theme.$color-secondary-11;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  user-select: none;
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.Arrow {
+  fill: variables.$panel-background;
+  stroke: variables.$border-color;
+  stroke-width: 1px;
+}
+
+@keyframes slideUpAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideRightAndFade {
+  from {
+    opacity: 0;
+    transform: translateX(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideDownAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideLeftAndFade {
+  from {
+    opacity: 0;
+    transform: translateX(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
### What does this do?
Converting the static IconZeroProVerified badge into an interactive ZeroProBadge component with hover tooltips and click functionality to open the Zero Pro panel.

### Why are we making this change?
To improve user experience by providing clear visual feedback about Zero Pro subscriptions and allowing users to quickly access their subscription management from any badge throughout the app.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
