### PR TITLE
refactor(zero-pro-badge): replace zero pro badge with hover card on conversation list items and search result items

### DIFF
--- a/src/components/messenger/autocomplete-members/index.tsx
+++ b/src/components/messenger/autocomplete-members/index.tsx
@@ -5,12 +5,12 @@ import { Input } from '@zero-tech/zui/components';
 import { highlightFilter, itemToOption } from '../lib/utils';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { Waypoint } from '../../waypoint';
-import { ZeroProBadge } from '../../zero-pro-badge';
 import classNames from 'classnames';
 
 import './styles.scss';
 import '../list/styles.scss';
 import { MatrixAvatar } from '../../matrix-avatar';
+import { IconZeroProVerified } from '@zero-tech/zui/icons';
 
 const PAGE_SIZE = 20;
 export interface Properties {
@@ -141,7 +141,7 @@ export class AutocompleteMembers extends React.Component<Properties, State> {
                       <div className='autocomplete-members__label'>
                         {highlightFilter(r.label, this.state.searchString)}
                       </div>
-                      {r.isZeroProSubscriber && <ZeroProBadge size={16} />}
+                      {r.isZeroProSubscriber && <IconZeroProVerified size={16} />}
                     </div>
                     {r?.subLabel && <div className='autocomplete-members__sub-label'>{r.subLabel}</div>}
                   </div>

--- a/src/components/messenger/list/conversation-item/index.tsx
+++ b/src/components/messenger/list/conversation-item/index.tsx
@@ -5,9 +5,8 @@ import { DefaultRoomLabels, NormalizedChannel } from '../../../../store/channels
 
 import { MoreMenu } from './more-menu';
 import { MatrixAvatar } from '../../../matrix-avatar';
-import { ZeroProBadge } from '../../../zero-pro-badge';
 
-import { IconBellOff1 } from '@zero-tech/zui/icons';
+import { IconBellOff1, IconZeroProVerified } from '@zero-tech/zui/icons';
 
 import { bemClassName } from '../../../../lib/bem';
 import './conversation-item.scss';
@@ -162,7 +161,7 @@ export const ConversationItem = memo(
                 <div {...cn('name')} is-unread={isUnread.toString()}>
                   {highlightedName}
                 </div>
-                {user?.subscriptions?.zeroPro && <ZeroProBadge {...cn('badge-icon')} size={16} />}
+                {user?.subscriptions?.zeroPro && <IconZeroProVerified {...cn('badge-icon')} size={16} />}
               </div>
               {conversation.labels?.includes(DefaultRoomLabels.MUTE) && (
                 <IconBellOff1 {...cn('muted-icon')} size={16} />

--- a/src/components/messenger/list/user-search-results/index.tsx
+++ b/src/components/messenger/list/user-search-results/index.tsx
@@ -5,7 +5,8 @@ import { highlightFilter } from '../../lib/utils';
 import { Waypoint } from '../../../waypoint';
 import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 import { MatrixAvatar } from '../../../matrix-avatar';
-import { ZeroProBadge } from '../../../zero-pro-badge';
+
+import { IconZeroProVerified } from '@zero-tech/zui/icons';
 
 import { bemClassName } from '../../../../lib/bem';
 import './user-search-results.scss';
@@ -89,7 +90,7 @@ export class UserSearchResults extends React.Component<Properties, State> {
             <div {...cn('user-details')}>
               <div {...cn('label-container')}>
                 <div {...cn('label')}>{highlightFilter(userResult.label, filter)}</div>
-                {userResult.isZeroProSubscriber && <ZeroProBadge size={16} />}
+                {userResult.isZeroProSubscriber && <IconZeroProVerified size={16} />}
               </div>
               {userResult?.subLabel && <div {...cn('sub-label')}>{userResult.subLabel}</div>}
             </div>


### PR DESCRIPTION
### What does this do?
- removes zero pro badge on conversation list items and search results/auto complete members and replaces with the zero pro icon.

### Why are we making this change?
- improved ux

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
