### PR TITLE
feat(zero-pro-badge): only show zero pro badge hover card and text content when user is not a pro subscriber

### DIFF
--- a/src/components/zero-pro-badge/index.tsx
+++ b/src/components/zero-pro-badge/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { IconZeroProVerified } from '@zero-tech/zui/icons';
 import * as HoverCard from '@radix-ui/react-hover-card';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { openZeroPro } from '../../store/user-profile';
+import { userZeroProSubscriptionSelector } from '../../store/authentication/selectors';
 
 import styles from './styles.module.scss';
 
@@ -14,6 +15,7 @@ export interface ZeroProBadgeProps {
 export const ZeroProBadge: React.FC<ZeroProBadgeProps> = ({ size = 16, className }) => {
   const dispatch = useDispatch();
   const [isOpen, setIsOpen] = React.useState(false);
+  const isZeroProSubscriber = useSelector(userZeroProSubscriptionSelector);
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -37,12 +39,14 @@ export const ZeroProBadge: React.FC<ZeroProBadgeProps> = ({ size = 16, className
     <HoverCard.Root openDelay={0} closeDelay={100} open={isOpen} onOpenChange={setIsOpen}>
       <HoverCard.Trigger asChild={true}>{badge}</HoverCard.Trigger>
       <HoverCard.Portal>
-        <HoverCard.Content className={styles.HoverContent} sideOffset={5}>
-          <div className={styles.TooltipText} onClick={handleClick} onMouseDown={(e) => e.preventDefault()}>
-            Zero Pro Subscriber
-          </div>
-          <HoverCard.Arrow className={styles.Arrow} />
-        </HoverCard.Content>
+        {!isZeroProSubscriber && (
+          <HoverCard.Content className={styles.HoverContent} sideOffset={5}>
+            <div className={styles.TooltipText} onClick={handleClick} onMouseDown={(e) => e.preventDefault()}>
+              Zero Pro Subscriber
+            </div>
+            <HoverCard.Arrow className={styles.Arrow} />
+          </HoverCard.Content>
+        )}
       </HoverCard.Portal>
     </HoverCard.Root>
   );


### PR DESCRIPTION
### What does this do?
- only show zero pro badge hover card and text content when user is not a pro subscriber

### Why are we making this change?
- improved ux

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
