### PR TITLE
feat(channels-app/join-token-gated-chat-join): implement token-gated channel joining with access validation and UI state management

### DIFF
--- a/src/apps/feed/components/feed-chat/container.tsx
+++ b/src/apps/feed/components/feed-chat/container.tsx
@@ -1,20 +1,30 @@
-import { useOwnedZids } from '../../../../lib/hooks/useOwnedZids';
-import { parseWorldZid } from '../../../../lib/zid';
 import { FeedChatContainer } from './index';
+import { JoinChannel } from '../join-channel';
 import { useRouteMatch } from 'react-router-dom';
+import { useJoinChannelInfo } from '../join-channel/hooks/useJoinChannelInfo';
 
 export const FeedChat = () => {
   const route = useRouteMatch<{ zid: string }>('/feed/:zid');
   const zid = route?.params?.zid;
-  const { zids } = useOwnedZids();
+  const { channelInfo, isLoading } = useJoinChannelInfo(zid);
 
-  // Check if the current ZID is owned by the user
-  const isOwnedZid = zid && zids?.some((userZid) => parseWorldZid(userZid) === zid);
-
-  // Only render if the user owns this ZID
-  if (!isOwnedZid) {
+  if (!zid) {
     return null;
   }
 
-  return <FeedChatContainer zid={zid} />;
+  if (channelInfo?.isMember) {
+    return <FeedChatContainer zid={zid} />;
+  }
+
+  if (!channelInfo?.isMember && !isLoading) {
+    return (
+      <JoinChannel
+        zid={zid}
+        isLegacyChannel={!channelInfo?.isTokenGated}
+        tokenRequirements={channelInfo?.tokenRequirements}
+      />
+    );
+  }
+
+  return null;
 };

--- a/src/apps/feed/components/feed-chat/index.tsx
+++ b/src/apps/feed/components/feed-chat/index.tsx
@@ -40,6 +40,7 @@ export interface Properties extends PublicProperties {
 
 export class Container extends React.Component<Properties> {
   chatViewContainerRef = null;
+  hasValidated = false;
 
   constructor(props: Properties) {
     super(props);
@@ -73,17 +74,20 @@ export class Container extends React.Component<Properties> {
   }
 
   componentDidMount(): void {
-    if (this.props.zid) {
+    if (this.props.zid && !this.hasValidated) {
       const roomAlias = `${this.props.zid}:${config.matrixHomeServerName}`;
       this.props.validateFeedChat(roomAlias);
+      this.hasValidated = true;
     }
   }
 
   componentDidUpdate(prevProps: Properties): void {
     if (this.props.zid !== prevProps.zid) {
-      if (this.props.zid) {
+      this.hasValidated = false; // Reset flag when zid changes
+      if (this.props.zid && !this.hasValidated) {
         const roomAlias = `${this.props.zid}:${config.matrixHomeServerName}`;
         this.props.validateFeedChat(roomAlias);
+        this.hasValidated = true;
       }
     }
   }

--- a/src/apps/feed/components/join-channel/hooks/useJoinChannelInfo.ts
+++ b/src/apps/feed/components/join-channel/hooks/useJoinChannelInfo.ts
@@ -1,0 +1,88 @@
+import { useQuery } from '@tanstack/react-query';
+import { post, get } from '../../../../../lib/api/rest';
+
+interface TokenRequirements {
+  symbol: string;
+  amount: string;
+  address: string;
+}
+
+interface ChannelInfo {
+  isTokenGated: boolean;
+  tokenRequirements?: TokenRequirements;
+  isMember: boolean;
+}
+
+export const useJoinChannelInfo = (zid: string | undefined) => {
+  const {
+    data: channelInfo,
+    isLoading,
+    error,
+  } = useQuery<ChannelInfo>({
+    queryKey: ['channel-info', zid],
+    queryFn: async () => {
+      if (!zid) {
+        return null;
+      }
+
+      const zna = zid.replace('0://', '');
+
+      // Check if user has access to the channel
+
+      // TODO: we should only check access if the zid is not in the users list of zids in channels app
+      // But we still need to figure out how to display those zids in the list
+      // as these can't just be domains they own
+      const accessResponse = await post('/token-gated-channels/check-access').send({ zid: zna });
+      const hasAccess = accessResponse.ok ? accessResponse.body.hasAccess : false;
+
+      // If user has access, return immediately - no need to fetch settings
+      if (hasAccess) {
+        return {
+          isTokenGated: false, // We don't know, but it doesn't matter since user has access
+          isMember: true,
+        };
+      }
+
+      // If user doesn't have access, we need to determine if this is a token-gated channel
+      // or a legacy channel to show the appropriate UI
+      try {
+        const settingsResponse = await get(`/token-gated-channels/settings/${zna}`);
+
+        if (settingsResponse.ok) {
+          const data = settingsResponse.body;
+          return {
+            isTokenGated: true,
+            tokenRequirements: {
+              symbol: data.tokenSymbol,
+              amount: data.tokenAmount,
+              address: data.tokenAddress,
+            },
+            isMember: false,
+          };
+        } else {
+          // No token gated settings found, treat as legacy channel
+          return {
+            isTokenGated: false,
+            isMember: false,
+          };
+        }
+      } catch (error) {
+        // If settings request fails, treat as legacy channel
+        return {
+          isTokenGated: false,
+          isMember: false,
+        };
+      }
+    },
+    enabled: !!zid,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    channelInfo,
+    isLoading,
+    error,
+  };
+};

--- a/src/apps/feed/components/join-channel/index.tsx
+++ b/src/apps/feed/components/join-channel/index.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Variant as ButtonVariant } from '@zero-tech/zui/components/Button';
+import { IconLock } from '@zero-tech/zui/icons';
+import { Panel, PanelBody, PanelHeader, PanelTitle } from '../../../../components/layout/panel';
+import { SagaActionTypes } from '../../../../store/chat';
+import { config } from '../../../../config';
+import { RootState } from '../../../../store';
+
+import styles from './styles.module.scss';
+
+interface TokenRequirements {
+  symbol: string;
+  amount: string;
+  address: string;
+}
+
+interface JoinChannelProps {
+  zid: string;
+  tokenRequirements?: TokenRequirements;
+  isLegacyChannel?: boolean;
+}
+
+const selectChatState = (state: RootState) => ({
+  joinRoomErrorContent: state.chat.joinRoomErrorContent,
+  isJoiningConversation: state.chat.isJoiningConversation,
+});
+
+export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements, isLegacyChannel }) => {
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [isJoining, setIsJoining] = useState(false);
+  const [hasAttemptedJoin, setHasAttemptedJoin] = useState(false);
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
+
+  const { joinRoomErrorContent, isJoiningConversation } = useSelector(selectChatState);
+
+  const formatAddress = (address: string) => {
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  const handleJoin = useCallback(async () => {
+    setJoinError(null);
+    setIsJoining(true);
+    setHasAttemptedJoin(true);
+
+    const zna = zid.replace('0://', '');
+    const roomAlias = `${zna}:${config.matrixHomeServerName}`;
+
+    // Dispatch validateFeedChat to attempt joining and validate requirements
+    dispatch({
+      type: SagaActionTypes.ValidateFeedChat,
+      payload: { id: roomAlias },
+    });
+  }, [
+    dispatch,
+    zid,
+  ]);
+
+  // Watch for Redux state changes to handle success/error
+  useEffect(() => {
+    if (!hasAttemptedJoin) {
+      return; // Don't process anything until user actually attempts to join
+    }
+
+    if (joinRoomErrorContent) {
+      setJoinError(
+        isLegacyChannel
+          ? `Failed to join channel. You must own a subdomain of 0://${zid} to join.`
+          : `Failed to join channel. You must hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} to join.`
+      );
+      setIsJoining(false);
+    } else if (!isJoiningConversation && !joinRoomErrorContent && hasAttemptedJoin) {
+      setIsJoining(false);
+      // Invalidate cache to trigger refetch and show chat interface
+      queryClient.invalidateQueries({ queryKey: ['channel-info', zid] });
+    }
+  }, [
+    joinRoomErrorContent,
+    isJoiningConversation,
+    hasAttemptedJoin,
+    history,
+    zid,
+    isLegacyChannel,
+    tokenRequirements,
+    queryClient,
+  ]);
+
+  const renderContent = () => {
+    return (
+      <div className={styles.JoinContent}>
+        <div className={styles.LockIcon}>
+          <IconLock size={48} />
+        </div>
+
+        <div className={styles.JoinTitle}>Join Token-Gated Channel</div>
+
+        <div className={styles.JoinText}>
+          {isLegacyChannel
+            ? `This channel requires you to own a subdomain of 0://${zid} to join.`
+            : `This channel requires you to hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} to join.`}
+        </div>
+
+        <div className={styles.TokenInfoBox}>
+          {isLegacyChannel ? (
+            <>
+              <div className={styles.InfoRow}>
+                <span className={styles.InfoRowLabel}>Domain</span>
+                <span className={styles.InfoRowValue}>0://{zid}</span>
+              </div>
+              <div className={styles.InfoRow}>
+                <span className={styles.InfoRowLabel}>Requirement</span>
+                <span className={styles.InfoRowValue}>Subdomain ownership</span>
+              </div>
+              <div className={styles.InfoRow}>
+                <span className={styles.InfoRowLabel}>Example</span>
+                <span className={styles.InfoRowValue}>0://{zid}.example</span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className={styles.InfoRow}>
+                <span className={styles.InfoRowLabel}>Token Symbol</span>
+                <span className={styles.InfoRowValue}>{tokenRequirements?.symbol}</span>
+              </div>
+              <div className={styles.InfoRow}>
+                <span className={styles.InfoRowLabel}>Required Amount</span>
+                <span className={styles.InfoRowValue}>
+                  {tokenRequirements?.amount} {tokenRequirements?.symbol}
+                </span>
+              </div>
+              <div className={styles.InfoRow}>
+                <span className={styles.InfoRowLabel}>Token Address</span>
+                <span className={styles.InfoRowValue}>{formatAddress(tokenRequirements?.address || '')}</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        <Button
+          className={styles.JoinButton}
+          variant={ButtonVariant.Primary}
+          onPress={handleJoin}
+          isDisabled={isJoining}
+          isLoading={isJoining}
+        >
+          Join Channel
+        </Button>
+
+        <div className={styles.ErrorContainer}>
+          <div className={`${styles.ErrorMessage} ${joinError ? styles.ErrorVisible : styles.ErrorHidden}`}>
+            {joinError || ' '}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Panel className={styles.Container}>
+      <PanelHeader className={styles.PanelHeader}>
+        <PanelTitle className={styles.PanelTitle}>0://{zid}</PanelTitle>
+      </PanelHeader>
+      <PanelBody className={styles.Panel}>{renderContent()}</PanelBody>
+    </Panel>
+  );
+};

--- a/src/apps/feed/components/join-channel/styles.module.scss
+++ b/src/apps/feed/components/join-channel/styles.module.scss
@@ -1,0 +1,133 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../glass';
+
+.Container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.PanelHeader {
+  flex-shrink: 0;
+}
+
+.Panel {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.JoinContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  max-width: 400px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 40px 24px;
+}
+
+.LockIcon {
+  @include glass-text-secondary-color;
+  margin-bottom: 24px;
+  opacity: 0.8;
+}
+
+.ChannelTitle {
+  font-size: 24px;
+  font-weight: 600;
+  color: theme.$color-secondary-11;
+  margin-bottom: 16px;
+}
+
+.JoinTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: theme.$color-secondary-11;
+  margin-bottom: 12px;
+}
+
+.JoinText {
+  @include glass-text-secondary-color;
+  font-size: 14px;
+  line-height: 1.5;
+  margin-bottom: 24px;
+  max-width: 320px;
+}
+
+.TokenInfoBox {
+  background: rgba(21, 23, 25, 0.85);
+  border-radius: 16px;
+  padding: 16px;
+  width: 100%;
+  max-width: 340px;
+  box-sizing: border-box;
+  border: 1px solid #23262a;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.InfoRow {
+  @include glass-text-primary-color;
+  display: flex;
+  justify-content: space-between;
+  font-size: 15px;
+}
+
+.InfoRowLabel {
+  @include glass-text-secondary-color;
+  font-size: 12px;
+}
+
+.InfoRowValue {
+  @include glass-text-primary-color;
+  font-size: 12px;
+}
+
+.ErrorContainer {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  height: 44px;
+  margin-top: 16px;
+}
+
+.ErrorMessage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(255, 59, 48, 0.1);
+  border: 1px solid rgba(255, 59, 48, 0.3);
+  border-radius: 8px;
+  padding: 12px;
+  color: theme.$color-failure-11;
+  font-size: 12px;
+  text-align: center;
+  transition: opacity 0.2s ease;
+  white-space: pre-line;
+  line-height: 1.4;
+}
+
+.ErrorVisible {
+  opacity: 1;
+}
+
+.ErrorHidden {
+  opacity: 0;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+
+.JoinButton {
+  width: 100%;
+  max-width: 320px;
+  height: 48px;
+  font-weight: 600;
+}


### PR DESCRIPTION
### What does this do?
We're implementing a complete token-gated channel joining flow that includes access validation, settings fetching for non-members, join functionality via Redux saga, error handling, and seamless UI transitions from join screen to chat interface.

### Why are we making this change?
We need to support token-gated channels where users must hold specific tokens or own subdomains to join, replacing the previous legacy channel system with a more flexible and secure access control mechanism.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
