### PR TITLE
feat(channels-app): add tabbed navigation to feed sidekick with Channels, Explore, and Airdrops tabs

### DIFF
--- a/src/apps/feed/components/sidekick/components/tab-list/index.tsx
+++ b/src/apps/feed/components/sidekick/components/tab-list/index.tsx
@@ -1,0 +1,64 @@
+import React, { useRef, useCallback, useEffect } from 'react';
+import styles from './styles.module.scss';
+
+export enum Tab {
+  Channels = 'channels',
+  Explore = 'explore',
+  Airdrops = 'airdrops',
+}
+
+export interface TabData {
+  id: Tab;
+  label: string;
+  unreadCount?: number;
+  ariaLabel: string;
+}
+
+export interface TabListProps {
+  selectedTab: Tab;
+  onTabSelect: (tab: Tab) => void;
+  tabsData: TabData[];
+}
+
+export const TabList: React.FC<TabListProps> = ({ selectedTab, onTabSelect, tabsData }) => {
+  const tabListRef = useRef<HTMLDivElement>(null);
+
+  const horizontalScroll = useCallback((event: WheelEvent) => {
+    if (tabListRef.current && event.deltaY !== 0) {
+      event.preventDefault();
+      tabListRef.current.scrollLeft += event.deltaY;
+    }
+  }, []);
+
+  useEffect(() => {
+    const currentTabListRef = tabListRef.current;
+    if (currentTabListRef) {
+      currentTabListRef.addEventListener('wheel', horizontalScroll, { passive: false });
+      return () => {
+        currentTabListRef.removeEventListener('wheel', horizontalScroll);
+      };
+    }
+  }, [horizontalScroll]);
+
+  return (
+    <div className={styles.TabList} ref={tabListRef}>
+      {tabsData.map((tab) => (
+        <div
+          key={tab.id}
+          className={`${styles.Tab} ${selectedTab === tab.id ? styles.TabActive : ''}`}
+          onClick={() => onTabSelect(tab.id)}
+          aria-label={tab.ariaLabel}
+          role='tab'
+          aria-selected={selectedTab === tab.id}
+        >
+          {tab.label}
+          {!!tab.unreadCount && (
+            <div className={styles.TabBadge}>
+              <span>{tab.unreadCount > 99 ? '99+' : tab.unreadCount}</span>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/apps/feed/components/sidekick/components/tab-list/styles.module.scss
+++ b/src/apps/feed/components/sidekick/components/tab-list/styles.module.scss
@@ -1,0 +1,87 @@
+@use '~@zero-tech/zui/styles/theme' as theme;
+@import '../../../../../../variables';
+@import '../../../../../../layout';
+@import '../../../../../../glass';
+@import '../../../../../../functions';
+@import '../../../../../../scrollbar';
+
+.TabList {
+  @include horizontal-scrollbar();
+
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+  overflow-x: auto;
+  white-space: nowrap;
+  padding: 8px 0;
+  margin: 0 16px;
+
+  &::-webkit-scrollbar-thumb {
+    display: none;
+  }
+
+  &:hover {
+    &::-webkit-scrollbar-thumb {
+      display: block;
+    }
+
+    @include horizontal-scrollbar();
+
+    ~ .scrollbar-container__panel {
+      display: none;
+    }
+  }
+}
+
+.Tab {
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+  padding: 8px 4px 2px 4px;
+  border-bottom: 1px solid transparent;
+
+  @include glass-text-secondary-color;
+  font-size: 14px;
+  font-weight: 400;
+
+  &:hover {
+    @include glass-text-primary-color;
+    cursor: pointer;
+  }
+
+  &.TabActive {
+    color: theme.$color-secondary-11;
+    border-bottom: 1px solid $glass-highlight-color;
+
+    &:hover {
+      color: theme.$color-secondary-11;
+      cursor: auto;
+    }
+  }
+}
+
+.TabBadge {
+  position: absolute;
+  right: -10px;
+  top: -4px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  height: 12px;
+  min-width: 12px;
+  padding: 2px 4px;
+
+  border-radius: 9999px;
+  @include glass-materials-raised;
+  color: $glass-highlight-color;
+  @include glass-glow-highlight-small;
+
+  font-size: 8px;
+  font-weight: 500;
+  letter-spacing: 0.32px;
+}

--- a/src/apps/feed/components/sidekick/index.tsx
+++ b/src/apps/feed/components/sidekick/index.tsx
@@ -14,17 +14,102 @@ import { setLastActiveFeed } from '../../../../lib/last-feed';
 import { IconButton } from '@zero-tech/zui/components';
 import { featureFlags } from '../../../../lib/feature-flags';
 import { CreateChannelModal } from '../create-channel';
+import { TabList, Tab, TabData } from './components/tab-list';
+import { getLastActiveChannelsTab, setLastActiveChannelsTab } from '../../../../lib/last-channels-tab';
+import { calculateChannelsTabUnreadCount } from './lib/utils';
 
 import styles from './styles.module.scss';
 
 export const Sidekick = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [selectedTab, setSelectedTab] = useState<Tab>(() => {
+    const lastTab = getLastActiveChannelsTab();
+    return lastTab ? (lastTab as Tab) : Tab.Channels;
+  });
 
   const { isErrorZids, isLoadingZids, selectedZId, zids, search, setSearch, unreadCounts, mutedChannels } =
     useSidekick();
 
   const handleCreateChannel = () => {
     setIsCreateModalOpen(true);
+  };
+
+  const handleTabSelect = (tab: Tab) => {
+    setSelectedTab(tab);
+    setLastActiveChannelsTab(tab);
+  };
+
+  // Calculate total unread count for Channels tab
+  const channelsUnreadCount = calculateChannelsTabUnreadCount(unreadCounts, zids);
+
+  const tabsData: TabData[] = [
+    {
+      id: Tab.Channels,
+      label: 'Channels',
+      unreadCount: channelsUnreadCount,
+      ariaLabel: 'Channels tab',
+    },
+    {
+      id: Tab.Explore,
+      label: 'Explore',
+      unreadCount: 0,
+      ariaLabel: 'Explore tab',
+    },
+    {
+      id: Tab.Airdrops,
+      label: 'Airdrops',
+      unreadCount: 0,
+      ariaLabel: 'Airdrops tab',
+    },
+  ];
+
+  const renderContent = () => {
+    switch (selectedTab) {
+      case Tab.Channels:
+        return (
+          <ul className={styles.List}>
+            {isLoadingZids && <LoadingIndicator />}
+            {isErrorZids && <li>Error loading channels</li>}
+            {zids?.map((zid) => {
+              const hasUnreadHighlights = unreadCounts[zid]?.highlight > 0;
+              const hasUnreadTotal = unreadCounts[zid]?.total > 0;
+              const isMuted = mutedChannels[zid];
+              return (
+                <FeedItem key={zid} route={`/feed/${zid}`} isSelected={selectedZId === zid} zid={zid}>
+                  <div className={styles.FeedName}>
+                    <span>0://</span>
+                    <div>{zid}</div>
+                  </div>
+
+                  <div className={styles.ItemIcons}>
+                    {isMuted && <IconBellOff1 className={styles.MutedIcon} size={16} />}
+                    {!hasUnreadHighlights && hasUnreadTotal && (
+                      <div className={styles.UnreadCount}>{unreadCounts[zid]?.total}</div>
+                    )}
+                    {hasUnreadHighlights && (
+                      <div className={styles.UnreadHighlight}>{unreadCounts[zid]?.highlight}</div>
+                    )}
+                  </div>
+                </FeedItem>
+              );
+            })}
+          </ul>
+        );
+      case Tab.Explore:
+        return (
+          <div className={styles.EmptyState}>
+            <span>Explore channels coming soon</span>
+          </div>
+        );
+      case Tab.Airdrops:
+        return (
+          <div className={styles.EmptyState}>
+            <span>Airdrops coming soon</span>
+          </div>
+        );
+      default:
+        return null;
+    }
   };
 
   return (
@@ -50,35 +135,10 @@ export const Sidekick = () => {
               )}
             </div>
           </div>
-          <SidekickScroll>
-            <ul className={styles.List}>
-              {isLoadingZids && <LoadingIndicator />}
-              {isErrorZids && <li>Error loading channels</li>}
-              {zids?.map((zid) => {
-                const hasUnreadHighlights = unreadCounts[zid]?.highlight > 0;
-                const hasUnreadTotal = unreadCounts[zid]?.total > 0;
-                const isMuted = mutedChannels[zid];
-                return (
-                  <FeedItem key={zid} route={`/feed/${zid}`} isSelected={selectedZId === zid} zid={zid}>
-                    <div className={styles.FeedName}>
-                      <span>0://</span>
-                      <div>{zid}</div>
-                    </div>
 
-                    <div className={styles.ItemIcons}>
-                      {isMuted && <IconBellOff1 className={styles.MutedIcon} size={16} />}
-                      {!hasUnreadHighlights && hasUnreadTotal && (
-                        <div className={styles.UnreadCount}>{unreadCounts[zid]?.total}</div>
-                      )}
-                      {hasUnreadHighlights && (
-                        <div className={styles.UnreadHighlight}>{unreadCounts[zid]?.highlight}</div>
-                      )}
-                    </div>
-                  </FeedItem>
-                );
-              })}
-            </ul>
-          </SidekickScroll>
+          <TabList selectedTab={selectedTab} onTabSelect={handleTabSelect} tabsData={tabsData} />
+
+          <SidekickScroll>{renderContent()}</SidekickScroll>
         </SidekickContent>
       </SidekickContentPortal>
     </>

--- a/src/apps/feed/components/sidekick/lib/utils.ts
+++ b/src/apps/feed/components/sidekick/lib/utils.ts
@@ -1,0 +1,32 @@
+import { UnreadCount } from './useSidekick';
+
+/**
+ * Calculates the total unread count for the Channels tab
+ * @param unreadCounts - Object mapping ZIDs to their unread counts
+ * @param zids - Array of ZIDs to include in the calculation
+ * @returns Total unread count (prioritizes highlights over total counts)
+ */
+export const calculateChannelsTabUnreadCount = (
+  unreadCounts: { [zid: string]: UnreadCount },
+  zids?: string[]
+): number => {
+  if (!zids || zids.length === 0) {
+    return 0;
+  }
+
+  let totalUnread = 0;
+
+  zids.forEach((zid) => {
+    const unreadCount = unreadCounts[zid];
+    if (unreadCount) {
+      // Prioritize highlights over total counts
+      if (unreadCount.highlight > 0) {
+        totalUnread += unreadCount.highlight;
+      } else if (unreadCount.total > 0) {
+        totalUnread += unreadCount.total;
+      }
+    }
+  });
+
+  return totalUnread;
+};

--- a/src/apps/feed/components/sidekick/styles.module.scss
+++ b/src/apps/feed/components/sidekick/styles.module.scss
@@ -48,7 +48,7 @@
   list-style: none;
 
   width: 100%;
-  padding: 16px;
+  padding: 0 16px 16px 16px;
   margin: 0;
 
   display: flex;
@@ -168,4 +168,18 @@
 .CreateChannelButton {
   box-sizing: border-box;
   padding: 16px 16px 0 0;
+}
+
+.EmptyState {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  gap: 16px;
+  color: var(--color-greyscale-11);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
 }

--- a/src/lib/last-channels-tab.ts
+++ b/src/lib/last-channels-tab.ts
@@ -1,0 +1,15 @@
+const LAST_CHANNELS_TAB_KEY = 'last-active-channels-tab';
+
+export const setLastActiveChannelsTab = (tab: string): void => {
+  if (tab) {
+    localStorage.setItem(LAST_CHANNELS_TAB_KEY, tab);
+  }
+};
+
+export const getLastActiveChannelsTab = (): string | null => {
+  return localStorage.getItem(LAST_CHANNELS_TAB_KEY);
+};
+
+export const clearLastActiveChannelsTab = (): void => {
+  localStorage.removeItem(LAST_CHANNELS_TAB_KEY);
+};


### PR DESCRIPTION
### What does this do?
We're adding a tabbed navigation system to the feed app's sidekick component, replacing the single list view with three tabs (Channels, Explore, Airdrops) that mirror the messenger app's conversation list functionality.

### Why are we making this change?
We're implementing this to provide better organization and navigation for different types of content in the feed app, allowing users to switch between their joined channels, explore new channels, and access upcoming airdrops, while maintaining consistency with the existing messenger app's UI patterns.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
