### PR TITLE
fix(create-channel/tgc): fix create channel flow and minor ui flickering issues

### DIFF
--- a/src/apps/feed/components/create-channel/stages/creating-channel-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/creating-channel-stage/index.tsx
@@ -82,9 +82,13 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
         <div className={styles.ErrorTitle}>Failed to Create Channel</div>
         <div className={styles.ErrorText}>
           Channel creation failed. Your ZID has been purchased, but we encountered an issue creating the channel. Please
-          try again.
+          try again. If this issue persists, please contact support.
         </div>
         <div className={styles.SubmitButtonContainer}>
+          <Button className={styles.SubmitButton} variant={ButtonVariant.Primary} onPress={onComplete}>
+            Close
+          </Button>
+
           <Button
             className={styles.SubmitButton}
             variant={ButtonVariant.Primary}
@@ -94,10 +98,6 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
             isLoading={isCreating}
           >
             Retry
-          </Button>
-
-          <Button className={styles.SubmitButton} variant={ButtonVariant.Primary} onPress={onComplete}>
-            Close
           </Button>
         </div>
       </div>

--- a/src/apps/feed/components/create-channel/stages/creating-channel-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/creating-channel-stage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -27,12 +27,18 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
   const queryClient = useQueryClient();
   const { createChannel, isCreating, error, reset } = useCreateChannel();
 
-  const handleCreateChannel = useCallback(async () => {
+  const handleClose = useCallback(() => {
+    setLastActiveFeed(selectedZid);
+    history.push(`/feed/${selectedZid}`);
+    onComplete();
+  }, [selectedZid, history, onComplete]);
+
+  const handleCreateCommunity = useCallback(async () => {
     if (!tokenData) {
       return;
     }
 
-    // Reset any previous error state when retrying
+    // Reset any previous error state
     reset();
 
     const result = await createChannel({
@@ -49,30 +55,15 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
       queryClient.invalidateQueries({ queryKey: ['token-gated-channels', 'all'] });
 
       setSuccess(true);
-
-      // Navigate to the new channel after a brief delay
-      setTimeout(() => {
-        setLastActiveFeed(selectedZid);
-        history.push(`/feed/${selectedZid}`);
-        onComplete();
-      }, 1500);
     }
   }, [
     selectedZid,
     tokenData,
     joiningFee,
-    history,
-    onComplete,
     createChannel,
     reset,
     queryClient,
   ]);
-
-  useEffect(() => {
-    if (tokenData) {
-      handleCreateChannel();
-    }
-  }, [handleCreateChannel, tokenData]);
 
   if (isCreating) {
     return (
@@ -98,11 +89,15 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
             className={styles.SubmitButton}
             variant={ButtonVariant.Primary}
             isSubmit
-            onPress={handleCreateChannel}
+            onPress={handleCreateCommunity}
             isDisabled={isCreating}
             isLoading={isCreating}
           >
             Retry
+          </Button>
+
+          <Button className={styles.SubmitButton} variant={ButtonVariant.Primary} onPress={onComplete}>
+            Close
           </Button>
         </div>
       </div>
@@ -117,7 +112,7 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
         </div>
         <div className={styles.SuccessTitle}>Successfully Created 0://{selectedZid} community</div>
         <div className={styles.SubmitButtonContainer}>
-          <Button className={styles.SubmitButton} variant={ButtonVariant.Primary} isSubmit onPress={onComplete}>
+          <Button className={styles.SubmitButton} variant={ButtonVariant.Primary} isSubmit onPress={handleClose}>
             View Channel
           </Button>
         </div>
@@ -125,5 +120,27 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
     );
   }
 
-  return null;
+  // Show success message with create community button
+  return (
+    <div className={styles.SuccessContainer}>
+      <div className={styles.LogoGlassWrapper}>
+        <ZeroProSymbol width={120} height={140} />
+      </div>
+      <div className={styles.SuccessTitle}>
+        Your ZID 0://{selectedZid} has been successfully minted. You can now create your community.
+      </div>
+      <div className={styles.SubmitButtonContainer}>
+        <Button
+          className={styles.SubmitButton}
+          variant={ButtonVariant.Primary}
+          isSubmit
+          onPress={handleCreateCommunity}
+          isDisabled={isCreating}
+          isLoading={isCreating}
+        >
+          Create Community
+        </Button>
+      </div>
+    </div>
+  );
 };

--- a/src/apps/feed/components/create-channel/stages/creating-channel-stage/styles.module.scss
+++ b/src/apps/feed/components/create-channel/stages/creating-channel-stage/styles.module.scss
@@ -58,7 +58,7 @@
 .ZidTitle {
   @include glass-text-secondary-color;
 
-  font-size: 24px;
+  font-size: 16px;
   text-align: center;
   margin-bottom: 32px;
 }
@@ -67,6 +67,7 @@
   color: theme.$color-secondary-11;
   text-align: center;
   margin-bottom: 16px;
+  font-size: 14px;
 }
 
 .SubmitButtonContainer {
@@ -74,6 +75,7 @@
   display: flex;
   justify-content: center;
   margin-top: 24px;
+  gap: 16px;
 }
 
 .SubmitButton {

--- a/src/apps/feed/components/join-channel/index.tsx
+++ b/src/apps/feed/components/join-channel/index.tsx
@@ -36,11 +36,20 @@ export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements
   // Handle mutation state changes
   useEffect(() => {
     if (joinChannelMutation.isError) {
-      setJoinError(
-        isLegacyChannel
-          ? `Failed to join channel. You must own a subdomain of 0://${zid} to join.`
-          : `Failed to join channel. You must hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} to join.`
-      );
+      const errorMessage = joinChannelMutation.error?.message || '';
+
+      // Check for specific error types
+      if (errorMessage.includes('Too Many Requests') || errorMessage.includes('rate limit')) {
+        setJoinError(
+          'Too many requests. Please wait a moment and try again. This usually happens when the network is busy.'
+        );
+      } else {
+        setJoinError(
+          isLegacyChannel
+            ? `Failed to join channel. You must own a subdomain of 0://${zid} to join.`
+            : `Failed to join channel. You must hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} to join.`
+        );
+      }
     } else if (joinChannelMutation.isSuccess) {
       // Success - the mutation will automatically invalidate queries and refresh the UI
       // The user will now see the FeedChatContainer instead of JoinChannel
@@ -48,6 +57,7 @@ export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements
   }, [
     joinChannelMutation.isError,
     joinChannelMutation.isSuccess,
+    joinChannelMutation.error,
     zid,
     isLegacyChannel,
     tokenRequirements,

--- a/src/apps/feed/components/join-channel/index.tsx
+++ b/src/apps/feed/components/join-channel/index.tsx
@@ -28,6 +28,8 @@ export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements
 
   const handleJoin = useCallback(async () => {
     setJoinError(null);
+    // Reset the mutation state to clear previous error
+    joinChannelMutation.reset();
     joinChannelMutation.mutate(zid);
   }, [joinChannelMutation, zid]);
 

--- a/src/apps/feed/components/join-channel/index.tsx
+++ b/src/apps/feed/components/join-channel/index.tsx
@@ -106,15 +106,17 @@ export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements
           )}
         </div>
 
-        <Button
-          className={styles.JoinButton}
-          variant={ButtonVariant.Primary}
-          onPress={handleJoin}
-          isDisabled={joinChannelMutation.isPending}
-          isLoading={joinChannelMutation.isPending}
-        >
-          Join Channel
-        </Button>
+        {!isLegacyChannel && (
+          <Button
+            className={styles.JoinButton}
+            variant={ButtonVariant.Primary}
+            onPress={handleJoin}
+            isDisabled={joinChannelMutation.isPending}
+            isLoading={joinChannelMutation.isPending}
+          >
+            Join Channel
+          </Button>
+        )}
 
         <div className={styles.ErrorContainer}>
           <div className={`${styles.ErrorMessage} ${joinError ? styles.ErrorVisible : styles.ErrorHidden}`}>


### PR DESCRIPTION
### What does this do?
Create Channel Flow:
Replace automatic useEffect-driven channel creation with manual "Create Community" button
Remove useEffect that was causing infinite re-renders and multiple API calls
Add user-controlled navigation with "View Channel" button
Remove automatic navigation to prevent race conditions

Join Channel Flow:
Add joinChannelMutation.reset() to clear previous error state on retry
Add specific error handling for "Too Many Requests" rate limit errors
Show user-friendly messages instead of generic balance errors

Error Handling:
Improve error messages for rate limit scenarios
Prevent error flickering when users retry join attempts
Distinguish between network issues and insufficient token balance

### Why are we making this change?
Improve the flow and fix ux issues

### How do I test this?

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
