### PR TITLE
feat: add loading spinner to purchase zid button when creating token gated channel

### DIFF
--- a/src/apps/feed/components/create-channel/stages/review-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/review-stage/index.tsx
@@ -11,6 +11,7 @@ import { parsePurchaseError } from './utils';
 import { TokenData } from '../../lib/hooks/useTokenFinder';
 
 import styles from './styles.module.scss';
+import { Spinner } from '@zero-tech/zui/components/LoadingIndicator';
 
 interface ReviewStageProps {
   onNext: () => void;
@@ -118,9 +119,15 @@ export const ReviewStage: React.FC<ReviewStageProps> = ({
 
       <div className={styles.InfoText}>By paying, you accept the Terms and Conditions</div>
 
-      <button className={styles.ContinueButton} onClick={handlePurchase} disabled={isPurchasing || !account || !signer}>
-        {isPurchasing ? 'Purchasing...' : !account ? 'Connect wallet to purchase' : `Pay ${meowAmount} MEOW`}
-      </button>
+      {isPurchasing ? (
+        <div className={styles.SpinnerContainer}>
+          <Spinner />
+        </div>
+      ) : (
+        <button className={styles.ContinueButton} onClick={handlePurchase} disabled={!account || !signer}>
+          {!account ? 'Connect wallet to purchase' : `Pay ${meowAmount} MEOW`}
+        </button>
+      )}
 
       <div className={styles.InfoContainer}>
         {isPurchasing && <div className={styles.Success}>Please confirm the transactions in your wallet</div>}

--- a/src/apps/feed/components/create-channel/stages/review-stage/styles.module.scss
+++ b/src/apps/feed/components/create-channel/stages/review-stage/styles.module.scss
@@ -136,3 +136,10 @@
   margin-top: 8px;
   max-width: 270px;
 }
+
+.SpinnerContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+}


### PR DESCRIPTION
### What does this do?
- improves loading state when purchasing a zid via the create channel (tgc) flow

### Why are we making this change?
- improve ux/ui

### How do I test this?
- run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
