### PR TITLE
fix(create-channel-tgc/creating-channel-stage): clarify token-gated channel creation error messages

### DIFF
--- a/src/apps/feed/components/create-channel/stages/creating-channel-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/creating-channel-stage/index.tsx
@@ -79,10 +79,10 @@ export const CreatingChannelStage: React.FC<CreatingChannelStageProps> = ({
       <div className={styles.ErrorContainer}>
         <div className={styles.ZidTitle}>0://{selectedZid}</div>
 
-        <div className={styles.ErrorTitle}>Failed to Create Channel</div>
+        <div className={styles.ErrorTitle}>Failed to Apply Token-Gated Settings</div>
         <div className={styles.ErrorText}>
-          Channel creation failed. Your ZID has been purchased, but we encountered an issue creating the channel. Please
-          try again. If this issue persists, please contact support.
+          Token-gated settings failed to be applied. Your ZID has been purchased, but we encountered an issue setting up
+          the token-gated requirements. Please try again. If this issue persists, please contact support.
         </div>
         <div className={styles.SubmitButtonContainer}>
           <Button className={styles.SubmitButton} variant={ButtonVariant.Primary} onPress={onComplete}>


### PR DESCRIPTION
### What does this do?
- Update error messaging

### Why are we making this change?
- To accurately reflect that token-gated settings failed to apply, not channel creation itself as a channel will still appear in the users channels list but as a domain/subdomain gated channel instead.

### How do I test this?
- Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
