### PR TITLE
fix: prevent creating token-gated channels with zero joining fee

### DIFF
--- a/src/apps/feed/components/create-channel/stages/create-zid-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/create-zid-stage/index.tsx
@@ -38,11 +38,11 @@ export const CreateZidStage: React.FC<CreateZidStageProps> = ({ onNext, mainnetP
   const hasError = !!(availabilityError || priceError);
 
   const buttonConfig = useMemo(() => {
-    if (available && !isLoading) {
+    if (available && !isLoading && Number(fee) > 0) {
       return { text: 'Continue', disabled: false };
     }
     return { text: 'Enter a valid ZERO ID to continue', disabled: true };
-  }, [available, isLoading]);
+  }, [available, isLoading, fee]);
 
   const endEnhancer = useMemo(() => {
     if (isLoading) return <div className={styles.Spinner} />;


### PR DESCRIPTION
### What does this do?
We're adding validation to disable the continue button when the joining fee is set to 0 in the create channel flow.

### Why are we making this change?
To ensure token-gated channels always have a meaningful joining fee requirement, preventing users from creating channels that don't actually gate access with token ownership.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
