### PR TITLE
fix: disable unstake button when no staked balance

### DIFF
--- a/src/apps/staking/features/view-pool/index.tsx
+++ b/src/apps/staking/features/view-pool/index.tsx
@@ -175,7 +175,10 @@ export const ViewPool = ({ poolName, poolAddress, chainId, poolIconImageUrl, onS
 
       <div className={styles.Actions}>
         {featureFlags.enableUnstaking && (
-          <Button onPress={onUnstake} isDisabled={isClaimingRewards}>
+          <Button
+            onPress={onUnstake}
+            isDisabled={isClaimingRewards || !userStakedAmount || unlockedBalanceFormatted === 0}
+          >
             Unstake
           </Button>
         )}


### PR DESCRIPTION
- If the user has no staked tokens, the unstake button should be disabled.