### PR TITLE
feat(channels-app/sidekick): add token price display to feed items for token-gated channels

### DIFF
--- a/src/apps/feed/components/sidekick/components/feed-item/index.tsx
+++ b/src/apps/feed/components/sidekick/components/feed-item/index.tsx
@@ -1,35 +1,32 @@
-import { ReactNode } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { IconBellOff1, IconUser } from '@zero-tech/zui/icons';
+import { IconArrowDown, IconArrowUp, IconUser } from '@zero-tech/zui/icons';
 import { setLastActiveFeed } from '../../../../../../lib/last-feed';
+import { formatMarketCap, formatPriceChange, formatTokenPrice } from '../../lib/utils';
 
 import styles from './styles.module.scss';
 
 interface FeedItemProps {
   route: string;
-  children: ReactNode;
-  isSelected?: boolean;
   zid: string;
+  isSelected?: boolean;
   memberCount?: number;
-  isMuted?: boolean;
-  hasUnreadHighlights?: boolean;
-  hasUnreadTotal?: boolean;
-  unreadCount?: number;
-  unreadHighlight?: number;
+  tokenMarketCap?: number;
+  tokenSymbol?: string;
+  tokenPriceUsd?: number;
+  tokenPriceChange?: number;
 }
 
 export const FeedItem = ({
   route,
-  children,
-  isSelected,
   zid,
+  isSelected,
   memberCount,
-  isMuted,
-  hasUnreadHighlights,
-  hasUnreadTotal,
-  unreadCount,
-  unreadHighlight,
+  tokenMarketCap,
+  tokenSymbol,
+  tokenPriceUsd,
+  tokenPriceChange,
 }: FeedItemProps) => {
   const history = useHistory();
 
@@ -46,20 +43,45 @@ export const FeedItem = ({
     >
       <div className={styles.Content}>
         <div className={styles.Header}>
-          <div className={styles.NameContainer}>{children}</div>
-
-          <div className={styles.UnreadContainer}>
-            {isMuted && <IconBellOff1 className={styles.MutedIcon} size={14} />}
-            {!hasUnreadHighlights && hasUnreadTotal && <div className={styles.UnreadCount}>{unreadCount}</div>}
-            {hasUnreadHighlights && <div className={styles.UnreadHighlight}>{unreadHighlight}</div>}
+          <div className={styles.NameContainer}>
+            <div className={styles.FeedName}>
+              <div>{zid}</div>
+            </div>
           </div>
+
+          {tokenSymbol && <div className={styles.TokenSymbol}>{tokenSymbol}</div>}
+
+          {tokenPriceUsd && <div className={styles.TokenPriceUsd}>{formatTokenPrice(tokenPriceUsd)}</div>}
         </div>
 
-        <div className={styles.IconsContainer}>
-          {memberCount !== undefined && (
-            <div className={styles.MemberCountContainer}>
-              <IconUser className={styles.MemberCountIcon} size={12} />
-              <div className={styles.MemberCount}>{memberCount.toLocaleString()}</div>
+        <div className={styles.InfoContainer}>
+          <div className={styles.InfoIconContainer}>
+            {memberCount !== undefined && (
+              <div className={styles.TotalCountContainer}>
+                <IconUser className={styles.TotalCountIcon} size={14} />
+                <div className={styles.TotalCount}>{memberCount.toLocaleString()}</div>
+              </div>
+            )}
+
+            {tokenMarketCap && (
+              <div className={styles.TotalCountContainer}>
+                <IconUser className={styles.TotalCountIcon} size={14} />
+                <div className={styles.TotalCount}>{formatMarketCap(tokenMarketCap)}</div>
+              </div>
+            )}
+          </div>
+
+          {tokenPriceChange && (
+            <div className={styles.TokenPriceChangeContainer}>
+              {tokenPriceChange >= 0 ? (
+                <IconArrowUp className={`${styles.TokenPriceChangeIcon} ${styles.Up}`} size={14} />
+              ) : (
+                <IconArrowDown className={`${styles.TokenPriceChangeIcon} ${styles.Down}`} size={14} />
+              )}
+
+              <div className={`${styles.TokenPriceChange} ${tokenPriceChange >= 0 ? styles.Up : styles.Down}`}>
+                {formatPriceChange(tokenPriceChange)}
+              </div>
             </div>
           )}
         </div>

--- a/src/apps/feed/components/sidekick/components/feed-item/styles.module.scss
+++ b/src/apps/feed/components/sidekick/components/feed-item/styles.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  height: 44px;
+  height: 48px;
   margin-bottom: 8px;
   padding: 0 8px;
   border-radius: 8px;
@@ -35,6 +35,9 @@
   flex-shrink: 1;
   flex-grow: 1;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .Header {
@@ -44,93 +47,99 @@
   margin-bottom: 2px;
   overflow: hidden;
   min-width: 0;
+  gap: 4px;
 }
 
 .NameContainer {
   display: flex;
   align-items: center;
-  gap: 4px;
   flex-grow: 1;
   min-width: 0;
   width: 100%;
 }
 
-.UnreadContainer {
+.FeedName {
+  display: flex;
+  overflow: hidden;
+  font-size: 14px;
+
+  > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.InfoContainer {
   display: flex;
   align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
+  justify-content: space-between;
 }
 
-.IconsContainer {
+.InfoIconContainer {
   display: flex;
   align-items: center;
+  gap: 16px;
 }
 
-.MutedIcon {
-  @include glass-text-tertiary-color;
-  align-self: center;
-}
-
-.UnreadCount {
-  @include glass-state-default-color;
-  @include glass-glow-highlight-small;
-  @include glass-materials-raised;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 0;
-  flex-shrink: 0;
-  color: theme.$color-secondary-transparency-11;
-  border-radius: 50%;
-  width: 14px;
-  height: 14px;
-  text-align: center;
-  font-size: 8px;
-  font-weight: 700;
-  line-height: 11px;
-  letter-spacing: 0.32px;
-}
-
-.UnreadHighlight {
-  @include glass-state-default-color;
-  @include glass-glow-highlight-small;
-  @include glass-materials-raised;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 0;
-  flex-shrink: 0;
-  color: #9054f1;
-  border-radius: 50%;
-  width: 14px;
-  height: 14px;
-  text-align: center;
-  font-size: 8px;
-  font-weight: 700;
-  line-height: 11px;
-  letter-spacing: 0.32px;
-}
-
-.MemberCountContainer {
+.TotalCountContainer {
   display: flex;
   align-items: center;
   gap: 2px;
   margin-left: -2px;
 }
 
-.MemberCountIcon {
+.TotalCountIcon {
   @include glass-text-tertiary-color;
 }
 
-.MemberCount {
+.TotalCount {
   @include glass-text-tertiary-color;
 
-  font-size: 10px;
+  font-size: 12px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  margin-top: 1.5px;
+}
+
+.TokenSymbol {
+  @include glass-text-tertiary-color;
+}
+
+.TokenPriceContainer {
+  display: flex;
+  align-items: center;
+}
+
+.TokenPriceUsd {
+  @include glass-text-primary-color;
+}
+
+.TokenPriceChangeContainer {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  justify-content: flex-end;
+}
+
+.TokenPriceChange {
+  &.Up {
+    color: theme.$color-secondary-11;
+  }
+
+  &.Down {
+    color: theme.$color-failure-11;
+  }
+
+  font-size: 12px;
+}
+
+.TokenPriceChangeIcon {
+  &.Up {
+    color: theme.$color-secondary-11;
+  }
+
+  &.Down {
+    color: theme.$color-failure-11;
+  }
 }

--- a/src/apps/feed/components/sidekick/index.tsx
+++ b/src/apps/feed/components/sidekick/index.tsx
@@ -18,6 +18,24 @@ import { FeedItem } from './components/feed-item';
 
 import styles from './styles.module.scss';
 
+const tabsData: TabData[] = [
+  {
+    id: Tab.Channels,
+    label: 'Channels',
+    ariaLabel: 'Channels tab',
+  },
+  {
+    id: Tab.Explore,
+    label: 'Explore',
+    ariaLabel: 'Explore tab',
+  },
+  {
+    id: Tab.Airdrops,
+    label: 'Airdrops',
+    ariaLabel: 'Airdrops tab',
+  },
+];
+
 export const Sidekick = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useState<Tab>(() => {
@@ -34,9 +52,8 @@ export const Sidekick = () => {
     allChannels,
     search,
     setSearch,
-    unreadCounts,
-    mutedChannels,
     memberCounts,
+    tokenInfoMap,
   } = useSidekick();
 
   const handleCreateChannel = () => {
@@ -50,9 +67,8 @@ export const Sidekick = () => {
 
   const renderFeedItems = (channels: any[]) => {
     return channels?.map((channel) => {
-      const hasUnreadHighlights = unreadCounts[channel.zid]?.highlight > 0;
-      const hasUnreadTotal = unreadCounts[channel.zid]?.total > 0;
-      const isMuted = mutedChannels[channel.zid];
+      const tokenInfo = tokenInfoMap.get(channel.zid);
+
       return (
         <FeedItem
           key={channel.zid}
@@ -60,37 +76,14 @@ export const Sidekick = () => {
           isSelected={selectedZId === channel.zid}
           zid={channel.zid}
           memberCount={channel.memberCount || memberCounts[channel.zid]}
-          isMuted={isMuted}
-          hasUnreadHighlights={hasUnreadHighlights}
-          hasUnreadTotal={hasUnreadTotal}
-          unreadCount={unreadCounts[channel.zid]?.total}
-          unreadHighlight={unreadCounts[channel.zid]?.highlight}
-        >
-          <div className={styles.FeedName}>
-            <div>{channel.zid}</div>
-          </div>
-        </FeedItem>
+          tokenSymbol={tokenInfo?.tokenSymbol}
+          tokenPriceUsd={tokenInfo?.priceData.usd}
+          tokenPriceChange={tokenInfo?.priceData.change24h}
+          tokenMarketCap={tokenInfo?.priceData.marketCap}
+        />
       );
     });
   };
-
-  const tabsData: TabData[] = [
-    {
-      id: Tab.Channels,
-      label: 'Channels',
-      ariaLabel: 'Channels tab',
-    },
-    {
-      id: Tab.Explore,
-      label: 'Explore',
-      ariaLabel: 'Explore tab',
-    },
-    {
-      id: Tab.Airdrops,
-      label: 'Airdrops',
-      ariaLabel: 'Airdrops tab',
-    },
-  ];
 
   const renderContent = () => {
     switch (selectedTab) {

--- a/src/apps/feed/components/sidekick/lib/types.ts
+++ b/src/apps/feed/components/sidekick/lib/types.ts
@@ -1,0 +1,24 @@
+export interface TokenPriceData {
+  usd: number;
+  marketCap: number;
+  volume24h: number;
+  change24h: number;
+  lastUpdatedAt: number;
+}
+
+export interface TokenInfoResponse {
+  tokenAddress: string;
+  tokenSymbol: string;
+  tokenAmount: string;
+  network: string;
+  priceData: TokenPriceData;
+}
+
+export interface ChannelItem {
+  zid: string;
+  memberCount?: number;
+  tokenSymbol?: string;
+  tokenAmount?: string;
+  tokenAddress?: string;
+  network?: string;
+}

--- a/src/apps/feed/components/sidekick/lib/useLegacyChannels.ts
+++ b/src/apps/feed/components/sidekick/lib/useLegacyChannels.ts
@@ -1,8 +1,7 @@
-import { useOwnedZids } from '../../../../../../lib/hooks/useOwnedZids';
+import { useOwnedZids } from '../../../../../lib/hooks/useOwnedZids';
 
 interface LegacyChannelData {
-  joinedLegacyZids: string[];
-  unjoinedLegacyZids: string[];
+  uniqueLegacyZids: string[];
   isLoading: boolean;
   isError: boolean;
 }
@@ -15,15 +14,8 @@ export const useLegacyChannels = (): LegacyChannelData => {
   const legacyZids = ownedZids?.map((zid) => zid.split('.')[0]);
   const uniqueLegacyZids = legacyZids ? ([...new Set(legacyZids)] as string[]) : [];
 
-  // All owned legacy ZIDs go to Channels tab
-  const joinedLegacyZids = uniqueLegacyZids;
-
-  // No legacy channels in Explore tab (all owned channels are in Channels tab)
-  const unjoinedLegacyZids: string[] = [];
-
   return {
-    joinedLegacyZids,
-    unjoinedLegacyZids,
+    uniqueLegacyZids,
     isLoading: isLoadingOwned,
     isError: isErrorOwned,
   };

--- a/src/apps/feed/components/sidekick/lib/useSidekick.ts
+++ b/src/apps/feed/components/sidekick/lib/useSidekick.ts
@@ -1,14 +1,11 @@
 import { useRouteMatch } from 'react-router-dom';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { selectMutedChannels, selectSocialChannelsUnreadCounts, selectSocialChannelsMemberCounts } from './selectors';
-import { useLegacyChannels } from './hooks/useLegacyChannels';
-import { useChannelLists, type ChannelItem } from './hooks/useChannelLists';
-
-export interface UnreadCount {
-  total: number;
-  highlight: number;
-}
+import { selectSocialChannelsMemberCounts } from './selectors';
+import { useLegacyChannels } from './useLegacyChannels';
+import { useChannelLists } from './useChannelLists';
+import { useTokenInfoBatch } from './useTokenInfoBatch';
+import { ChannelItem, TokenInfoResponse } from './types';
 
 interface UseSidekickReturn {
   isErrorZids: boolean;
@@ -19,10 +16,9 @@ interface UseSidekickReturn {
   usersChannels?: ChannelItem[];
   allChannels?: ChannelItem[];
   search: string;
-  unreadCounts: { [zid: string]: UnreadCount };
-  mutedChannels: { [zid: string]: boolean };
   memberCounts: { [zid: string]: number };
   setSearch: (search: string) => void;
+  tokenInfoMap: Map<string, TokenInfoResponse>;
 }
 
 export const useSidekick = (): UseSidekickReturn => {
@@ -32,12 +28,7 @@ export const useSidekick = (): UseSidekickReturn => {
   const selectedZId = route?.params?.zid;
 
   // Get legacy channel data
-  const {
-    joinedLegacyZids,
-    unjoinedLegacyZids,
-    isLoading: isLoadingLegacy,
-    isError: isErrorLegacy,
-  } = useLegacyChannels();
+  const { uniqueLegacyZids, isLoading: isLoadingLegacy, isError: isErrorLegacy } = useLegacyChannels();
 
   // Get channel lists data
   const {
@@ -46,7 +37,7 @@ export const useSidekick = (): UseSidekickReturn => {
     isLoading: isLoadingChannels,
     isErrorMine,
     isErrorAll,
-  } = useChannelLists(joinedLegacyZids, unjoinedLegacyZids);
+  } = useChannelLists(uniqueLegacyZids);
 
   // Apply search filter to user channels
   const filteredUserChannels = usersChannels?.filter((channel) =>
@@ -58,9 +49,13 @@ export const useSidekick = (): UseSidekickReturn => {
     channel.zid.toLowerCase().includes(search.toLowerCase())
   );
 
-  const unreadCounts = useSelector(selectSocialChannelsUnreadCounts);
-  const mutedChannels = useSelector(selectMutedChannels);
   const memberCounts = useSelector(selectSocialChannelsMemberCounts);
+
+  // Fetch token info for all channels
+  const { tokenInfoMap } = useTokenInfoBatch([
+    ...(filteredUserChannels || []),
+    ...(filteredAllChannelsWithSearch || []),
+  ]);
 
   return {
     isErrorZids: isErrorLegacy,
@@ -72,8 +67,7 @@ export const useSidekick = (): UseSidekickReturn => {
     allChannels: filteredAllChannelsWithSearch,
     search,
     setSearch,
-    unreadCounts,
-    mutedChannels,
     memberCounts,
+    tokenInfoMap,
   };
 };

--- a/src/apps/feed/components/sidekick/lib/useTokenInfoBatch.ts
+++ b/src/apps/feed/components/sidekick/lib/useTokenInfoBatch.ts
@@ -1,0 +1,47 @@
+import { useQueries } from '@tanstack/react-query';
+import { get } from '../../../../../lib/api/rest';
+import { ChannelItem, TokenInfoResponse } from './types';
+
+export const useTokenInfoBatch = (channels: ChannelItem[]) => {
+  // Filter to only channels that have token requirements (token-gated channels)
+  const tokenGatedChannels = channels.filter((channel) => channel.tokenAddress && channel.network);
+
+  const zids = tokenGatedChannels.map((channel) => channel.zid);
+
+  const results = useQueries({
+    queries: zids.map((zid) => ({
+      queryKey: ['token-info', zid],
+      queryFn: async (): Promise<TokenInfoResponse> => {
+        const response = await get(`/${zid}/token/info`);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch token info for ${zid}`);
+        }
+
+        return response.body;
+      },
+      enabled: !!zid,
+      staleTime: 1000 * 60 * 2, // 2 minutes - token prices change frequently
+      gcTime: 1000 * 60 * 10, // 10 minutes
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    })),
+  });
+
+  const tokenInfoMap = new Map<string, TokenInfoResponse>();
+  const isLoading = results.some((result) => result.isLoading);
+  const isError = results.some((result) => result.isError);
+
+  results.forEach((result, index) => {
+    if (result.data && zids[index]) {
+      tokenInfoMap.set(zids[index], result.data);
+    }
+  });
+
+  return {
+    tokenInfoMap,
+    isLoading,
+    isError,
+    results,
+  };
+};

--- a/src/apps/feed/components/sidekick/lib/utils.ts
+++ b/src/apps/feed/components/sidekick/lib/utils.ts
@@ -1,0 +1,20 @@
+export const formatTokenPrice = (price: number): string => {
+  return `$${price >= 1 ? price.toFixed(2) : price.toFixed(6)}`;
+};
+
+export const formatMarketCap = (marketCap: number): string => {
+  if (marketCap >= 1e9) {
+    return `$${(marketCap / 1e9).toFixed(2)}B`;
+  }
+  if (marketCap >= 1e6) {
+    return `$${(marketCap / 1e6).toFixed(2)}M`;
+  }
+  if (marketCap >= 1e3) {
+    return `$${(marketCap / 1e3).toFixed(2)}K`;
+  }
+  return `$${marketCap.toFixed(0)}`;
+};
+
+export const formatPriceChange = (change: number): string => {
+  return `${change.toFixed(2)}%`;
+};

--- a/src/apps/feed/components/sidekick/styles.module.scss
+++ b/src/apps/feed/components/sidekick/styles.module.scss
@@ -93,18 +93,6 @@
   overflow-x: hidden;
 }
 
-.FeedName {
-  display: flex;
-  max-width: calc(100% - 24px);
-  overflow: hidden;
-
-  > div {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-
 .Actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### What does this do?
We're adding token price information (symbol, price, market cap, 24h change) to the feed item UI for token-gated channels.

### Why are we making this change?
To provide users with real-time token price data and market information directly in the channel list, enhancing the user experience for token-gated communities.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
