### PR TITLE
feat(create-channel/find-and-extract-token): add zChain token selection with TokenIcon display

### DIFF
--- a/src/apps/feed/components/create-channel/lib/hooks/useTokenFinder.ts
+++ b/src/apps/feed/components/create-channel/lib/hooks/useTokenFinder.ts
@@ -24,6 +24,24 @@ const COINGECKO_CHAIN_SLUGS: Record<number, string> = {
   43114: 'avalanche',
 };
 
+// zChain token data (hardcoded as requested)
+const ZCHAIN_TOKENS = {
+  MEOW: {
+    name: 'MEOW',
+    symbol: 'MEOW',
+    decimals: 18,
+    address: '0x6ce4a22AA99F9ae41D27E1eC3f40c32b8D0C3113',
+    logo: '/tokens/meow.png',
+  },
+  CATNIP: {
+    name: 'CATNIP',
+    symbol: 'CATNIP',
+    decimals: 18,
+    address: '0xc106C2851cAFf4f7c361948719085eeC8171DF04',
+    logo: null,
+  },
+};
+
 export interface TokenData {
   name: string;
   symbol: string;
@@ -41,6 +59,31 @@ export function useTokenFinder() {
 
   const resetError = useCallback(() => {
     setError(null);
+  }, []);
+
+  const findZChainToken = useCallback(async (tokenSymbol: 'MEOW' | 'CATNIP', network: string) => {
+    setLoading(true);
+    setError(null);
+    setToken(null);
+
+    try {
+      const tokenData = ZCHAIN_TOKENS[tokenSymbol];
+      if (!tokenData) {
+        throw new Error('Token not found');
+      }
+
+      const tokenResult: TokenData = {
+        ...tokenData,
+        chainId: 9369, // zChain chain ID (production)
+        network,
+      };
+
+      setToken(tokenResult);
+    } catch (err: any) {
+      setError('Token not found');
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   const findToken = useCallback(async (chainId: number, address: string, network: string) => {
@@ -104,6 +147,7 @@ export function useTokenFinder() {
     loading,
     error,
     findToken,
+    findZChainToken,
     resetError,
   };
 }

--- a/src/apps/feed/components/create-channel/stages/extract-token-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/extract-token-stage/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TokenData } from '../../lib/hooks/useTokenFinder';
+import { TokenIcon } from '../../../../../wallet/components/token-icon/token-icon';
 
 import styles from './styles.module.scss';
 
@@ -18,7 +19,7 @@ export const ExtractTokenStage: React.FC<ExtractTokenStageProps> = ({ token, onN
       <div className={styles.Title}>Token Found</div>
       <div className={styles.Subtitle}>Verify if this is the right token.</div>
       <div className={styles.TokenProfile}>
-        {token.logo && <img className={styles.TokenImage} src={token.logo} alt={token.name} />}
+        <TokenIcon url={token.logo} name={token.name} chainId={token.chainId} />
         <div className={styles.TokenName}>{token.name}</div>
         <div className={styles.TokenSymbol}>{token.symbol}</div>
       </div>

--- a/src/apps/feed/components/create-channel/stages/find-token-stage/index.tsx
+++ b/src/apps/feed/components/create-channel/stages/find-token-stage/index.tsx
@@ -10,9 +10,15 @@ interface FindTokenStageProps {
 }
 
 const NETWORKS = [
+  { id: 'zchain', label: 'zChain', chainId: 9369, disabled: false },
   { id: 'ethereum', label: 'Ethereum', chainId: 1, disabled: false },
   { id: 'polygon', label: 'Polygon', chainId: 137, disabled: true, className: styles.DisabledOption },
   { id: 'avalanche', label: 'Avalanche', chainId: 43114, disabled: true, className: styles.DisabledOption },
+];
+
+const ZCHAIN_TOKENS = [
+  { id: 'MEOW', label: 'MEOW', symbol: 'MEOW' },
+  { id: 'CATNIP', label: 'CATNIP', symbol: 'CATNIP' },
 ];
 
 function isValidAddress(address: string) {
@@ -22,14 +28,20 @@ function isValidAddress(address: string) {
 export const FindTokenStage: React.FC<FindTokenStageProps> = ({ onTokenFound }) => {
   const [network, setNetwork] = useState(NETWORKS[0].id);
   const [address, setAddress] = useState('');
-  const { token, loading, error, findToken, resetError } = useTokenFinder();
+  const [selectedZChainToken, setSelectedZChainToken] = useState('');
+  const { token, loading, error, findToken, findZChainToken, resetError } = useTokenFinder();
   const [submitted, setSubmitted] = useState(false);
+
+  const isZChain = network === 'zchain';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitted(true);
     const selected = NETWORKS.find((n) => n.id === network);
-    if (selected && address) {
+
+    if (isZChain && selectedZChainToken) {
+      await findZChainToken(selectedZChainToken as 'MEOW' | 'CATNIP', selected?.label || 'zChain');
+    } else if (selected && address) {
       await findToken(selected.chainId, address, selected.label);
     }
   };
@@ -47,11 +59,18 @@ export const FindTokenStage: React.FC<FindTokenStageProps> = ({ onTokenFound }) 
   // Reset error when user changes network or address
   const handleNetworkChange = (id: string) => {
     setNetwork(id);
+    setSelectedZChainToken('');
+    setAddress('');
     resetError();
   };
 
   const handleAddressChange = (val: string) => {
     setAddress(val);
+    resetError();
+  };
+
+  const handleZChainTokenChange = (tokenId: string) => {
+    setSelectedZChainToken(tokenId);
     resetError();
   };
 
@@ -63,12 +82,23 @@ export const FindTokenStage: React.FC<FindTokenStageProps> = ({ onTokenFound }) 
     className: n.className,
   }));
 
+  const zChainTokenItems = ZCHAIN_TOKENS.map((t) => ({
+    id: t.id,
+    label: t.label,
+    onSelect: () => handleZChainTokenChange(t.id),
+  }));
+
   const networkLabel = networkItems.find((n) => n.id === network)?.label;
+  const selectedZChainTokenLabel = zChainTokenItems.find((t) => t.id === selectedZChainToken)?.label;
+
+  const isFormValid = isZChain ? selectedZChainToken : network && isValidAddress(address);
 
   return (
     <div className={styles.Container}>
       <div className={styles.Title}>Find Your Token</div>
-      <div className={styles.Subtitle}>Enter the network and contract address for your token.</div>
+      <div className={styles.Subtitle}>
+        {isZChain ? 'Select a token from zChain.' : 'Enter the network and contract address for your token.'}
+      </div>
       <form className={styles.Form} onSubmit={handleSubmit}>
         <label className={styles.InputContainer}>
           Token Network
@@ -82,28 +112,43 @@ export const FindTokenStage: React.FC<FindTokenStageProps> = ({ onTokenFound }) 
           />
         </label>
 
-        <label className={styles.InputContainer}>
-          <div className={styles.LabelWrapper}>
-            Token Address
-            {loading && <Spinner className={styles.Spinner} />}
-            {error && <span className={`${styles.SubLabel} ${styles.Error}`}>{error}</span>}
-            {!error && !loading && <span className={styles.SubLabel}>Enter a valid token address</span>}
-          </div>
-          <Input
-            label=''
-            value={address}
-            onChange={handleAddressChange}
-            placeholder='Enter token address'
-            className={styles.Input}
-          />
-        </label>
+        {isZChain ? (
+          <label className={styles.InputContainer}>
+            <div className={styles.LabelWrapper}>
+              Token
+              {loading && <Spinner className={styles.Spinner} />}
+              {error && <span className={`${styles.SubLabel} ${styles.Error}`}>{error}</span>}
+              {!error && !loading && <span className={styles.SubLabel}>Select a token from zChain</span>}
+            </div>
+            <SelectInput
+              items={zChainTokenItems}
+              label=''
+              placeholder='Select a token'
+              value={selectedZChainTokenLabel}
+              itemSize='compact'
+              menuClassName={styles.SelectMenu}
+            />
+          </label>
+        ) : (
+          <label className={styles.InputContainer}>
+            <div className={styles.LabelWrapper}>
+              Token Address
+              {loading && <Spinner className={styles.Spinner} />}
+              {error && <span className={`${styles.SubLabel} ${styles.Error}`}>{error}</span>}
+              {!error && !loading && <span className={styles.SubLabel}>Enter a valid token address</span>}
+            </div>
+            <Input
+              label=''
+              value={address}
+              onChange={handleAddressChange}
+              placeholder='Enter token address'
+              className={styles.Input}
+            />
+          </label>
+        )}
 
-        <button
-          className={styles.ContinueButton}
-          type='submit'
-          disabled={loading || !network || !isValidAddress(address)}
-        >
-          Find Token
+        <button className={styles.ContinueButton} type='submit' disabled={loading || !isFormValid}>
+          {isZChain ? 'Select Token' : 'Find Token'}
         </button>
       </form>
     </div>

--- a/src/apps/feed/components/create-channel/stages/find-token-stage/styles.module.scss
+++ b/src/apps/feed/components/create-channel/stages/find-token-stage/styles.module.scss
@@ -22,7 +22,7 @@
   font-size: 12px;
   text-align: center;
   margin-bottom: 24px;
-  max-width: 320px;
+  width: 320px;
   line-height: 1.4;
 }
 
@@ -31,7 +31,7 @@
   flex-direction: column;
   gap: 16px;
   width: 100%;
-  max-width: 320px;
+  width: 320px;
 }
 
 .InputContainer {


### PR DESCRIPTION
### What does this do?
We're adding zChain as a network option with hardcoded MEOW and CATNIP token selection, and updating the extract token stage to use the TokenIcon component for consistent token display with proper fallbacks.

### Why are we making this change?
To simplify token selection for zChain users by providing a dropdown with the only two available tokens (MEOW and CATNIP) rather than requiring manual address input, and to ensure consistent token display with proper logos and fallbacks throughout the app.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
