### PR TITLE
feat(channels-app/join-channel): update error handling and join text content

### DIFF
--- a/src/apps/feed/components/join-channel/index.tsx
+++ b/src/apps/feed/components/join-channel/index.tsx
@@ -53,8 +53,8 @@ export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements
       } else {
         setJoinError(
           isLegacyChannel
-            ? `Failed to join channel. You must own a subdomain of 0://${zid} to join.`
-            : `Failed to join channel. You must hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} in a connected self custody wallet to join.`
+            ? `Failed to join channel. You must hold a subdomain of 0://${zid} in a connected wallet to join.`
+            : `Failed to join channel. You must hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} in a connected wallet to join.`
         );
       }
     } else if (joinChannelMutation.isSuccess) {
@@ -81,8 +81,8 @@ export const JoinChannel: React.FC<JoinChannelProps> = ({ zid, tokenRequirements
 
         <div className={styles.JoinText}>
           {isLegacyChannel
-            ? `This channel requires you to own a subdomain of 0://${zid} in a connected self-custody wallet to join.`
-            : `This channel requires you to hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} in a connected self-custody wallet to join.`}
+            ? `This channel requires you to own a subdomain of 0://${zid} in a connected wallet to join.`
+            : `This channel requires you to hold ${tokenRequirements?.amount} ${tokenRequirements?.symbol} in a connected wallet to join.`}
         </div>
 
         <div className={styles.JoinText}>


### PR DESCRIPTION
### What does this do?
- updates error handling and join text content

### Why are we making this change?
- no longer required to only have self-custody wallet holdings