### PR TITLE
fix(channels-app/channels-lists): prioritize token-gated channels over legacy channels in deduplication logic

### DIFF
--- a/src/apps/feed/components/sidekick/lib/useChannelLists.ts
+++ b/src/apps/feed/components/sidekick/lib/useChannelLists.ts
@@ -10,7 +10,6 @@ interface ChannelListsData {
 }
 
 export const useChannelLists = (uniqueLegacyZids: string[]): ChannelListsData => {
-  console.log('XXX uniqueLegacyZids:', uniqueLegacyZids);
   // Fetch token-gated channels (user's channels) - always fetch for Channels tab
   const {
     data: tokenGatedChannelsData,
@@ -24,16 +23,8 @@ export const useChannelLists = (uniqueLegacyZids: string[]): ChannelListsData =>
   // Process token-gated channels (user's channels)
   const tokenGatedChannels = tokenGatedChannelsData?.channels || [];
 
-  console.log('XXX tokenGatedChannelsData:', tokenGatedChannelsData);
-  console.log('XXX tokenGatedChannels:', tokenGatedChannels);
-  console.log('XXX tokenGatedChannels length:', tokenGatedChannels.length);
-
   // Process all token-gated channels
   const allTokenGatedChannels = allTokenGatedChannelsData?.channels || [];
-
-  console.log('XXX allTokenGatedChannelsData:', allTokenGatedChannelsData);
-  console.log('XXX allTokenGatedChannels:', allTokenGatedChannels);
-  console.log('XXX allTokenGatedChannels length:', allTokenGatedChannels.length);
 
   // Combine legacy channels and user's token-gated channels for Channels tab
   const userChannels: ChannelItem[] = [
@@ -50,17 +41,10 @@ export const useChannelLists = (uniqueLegacyZids: string[]): ChannelListsData =>
     ...uniqueLegacyZids.map((zid) => ({ zid })),
   ];
 
-  console.log('XXX uniqueLegacyZids:', uniqueLegacyZids);
-  console.log('XXX userChannels before deduplication:', userChannels);
-  console.log('XXX userChannels length before deduplication:', userChannels.length);
-
   // Remove duplicates (keep first occurrence - token-gated channels will win)
   const finalUniqueUserChannels = userChannels.filter(
     (channel, index, self) => self.findIndex((c) => c.zid === channel.zid) === index
   );
-
-  console.log('XXX finalUniqueUserChannels:', finalUniqueUserChannels);
-  console.log('XXX finalUniqueUserChannels length:', finalUniqueUserChannels.length);
 
   // Process all channels for Explore tab
   const allChannels: ChannelItem[] = allTokenGatedChannels.map((channel) => ({


### PR DESCRIPTION
### What does this do?
We're modifying the deduplication logic in useChannelLists.ts to keep channels with token properties (tokenAddress and network) instead of always keeping the first occurrence.

### Why are we making this change?
To fix disappearing token price data by ensuring token-gated channels retain their properties through deduplication instead of being overwritten by incomplete legacy channels.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
