### PR TITLE
Update meowing to use wallet balance, implement batching (upto 4s)

### DIFF
--- a/src/apps/feed/components/feed/lib/useFeed.ts
+++ b/src/apps/feed/components/feed/lib/useFeed.ts
@@ -8,7 +8,7 @@ import { PAGE_SIZE } from '../../../lib/constants';
 import { mapPostToMatrixMessage } from '../../../../../store/posts/utils';
 import { useMeowPost } from '../../../lib/useMeowPost';
 import { primaryZIDSelector, userIdSelector } from '../../../../../store/authentication/selectors';
-import { userRewardsMeowBalanceSelector } from '../../../../../store/rewards/selectors';
+import { useMeowBalance } from '../../../lib/useMeowBalance';
 import { searchMyNetworksByName } from '../../../../../platform-apps/channels/util/api';
 import { MemberNetworks } from '../../../../../store/users/types';
 import { queuedPostsByFeedSelector } from '../../../../../store/post-queue/selectors';
@@ -22,7 +22,7 @@ interface UseFeedParams {
 
 export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: UseFeedParams) => {
   const currentUserId = useSelector(userIdSelector);
-  const userMeowBalance = useSelector(userRewardsMeowBalanceSelector);
+  const { meowBalance: userMeowBalance } = useMeowBalance();
   const primaryZID = useSelector(primaryZIDSelector);
   const [searchResults, setSearchResults] = useState<MemberNetworks[]>([]);
   const [isSearching, setIsSearching] = useState(false);

--- a/src/apps/feed/components/post-view-container/reply-list/useReplyList.ts
+++ b/src/apps/feed/components/post-view-container/reply-list/useReplyList.ts
@@ -6,12 +6,12 @@ import { PAGE_SIZE } from '../../../lib/constants';
 import { getPostReplies, mapPostToMatrixMessage } from '../../../../../store/posts/utils';
 import { useMeowPost } from '../../../lib/useMeowPost';
 import { userIdSelector } from '../../../../../store/authentication/selectors';
-import { userRewardsMeowBalanceSelector } from '../../../../../store/rewards/selectors';
+import { useMeowBalance } from '../../../lib/useMeowBalance';
 import { queuedCommentsByPostSelector } from '../../../../../store/post-queue/selectors';
 
 export const useReplyList = (postId: string) => {
   const userId = useSelector(userIdSelector);
-  const userMeowBalance = useSelector(userRewardsMeowBalanceSelector);
+  const { meowBalance: userMeowBalance } = useMeowBalance();
   const { meowPost, meowPostFeed } = useMeowPost();
 
   const queuedComments = useSelector(queuedCommentsByPostSelector(postId));

--- a/src/apps/feed/components/post-view-container/usePostView.ts
+++ b/src/apps/feed/components/post-view-container/usePostView.ts
@@ -3,11 +3,11 @@ import { useSelector } from 'react-redux';
 import { getPost, mapPostToMatrixMessage } from '../../../../store/posts/utils';
 import { useMeowPost } from '../../lib/useMeowPost';
 import { userIdSelector } from '../../../../store/authentication/selectors';
-import { userRewardsMeowBalanceSelector } from '../../../../store/rewards/selectors';
+import { useMeowBalance } from '../../lib/useMeowBalance';
 
 export const usePostView = (postId: string) => {
   const userId = useSelector(userIdSelector);
-  const userMeowBalance = useSelector(userRewardsMeowBalanceSelector);
+  const { meowBalance: userMeowBalance } = useMeowBalance();
   const { meowPost, meowPostFeed } = useMeowPost();
 
   const { data, isLoading: isLoadingPost } = useQuery({

--- a/src/apps/feed/components/post/actions/meow/lib.ts
+++ b/src/apps/feed/components/post/actions/meow/lib.ts
@@ -1,5 +1,5 @@
 const INCREMENTS = 1;
-const MS_BETWEEN_INCREMENTS = 75;
+const MS_BETWEEN_INCREMENTS = 110;
 const OPTIONS = 100;
 const MAX_SCALE = 1.25;
 

--- a/src/apps/feed/lib/useMeowBalance.ts
+++ b/src/apps/feed/lib/useMeowBalance.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { get } from '../../../lib/api/rest';
+import { selectedWalletAddressSelector } from '../../../store/wallet/selectors';
+import { MEOW_TOKEN_ADDRESS } from '../../wallet/constants';
+
+/**
+ * Hook to fetch user's MEOW token balance from their Z-chain wallet
+ */
+export const useMeowBalance = () => {
+  const userAddress = useSelector(selectedWalletAddressSelector);
+
+  const {
+    data: meowBalance,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['meowBalance', userAddress, MEOW_TOKEN_ADDRESS],
+    queryFn: async (): Promise<string> => {
+      if (!userAddress) return '0';
+
+      const response = await get(`/api/wallet/${userAddress}/token/${MEOW_TOKEN_ADDRESS}/balance`).send();
+
+      console.log('response : ', response);
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch MEOW token balance');
+      }
+
+      return response.body.balance || '0';
+    },
+    enabled: !!userAddress,
+    staleTime: 2 * 60 * 1000, // Consider data fresh for 2 minutes
+    gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
+    retry: 1,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    refetchInterval: 5 * 60 * 1000,
+  });
+
+  // Memoize the return value to prevent unnecessary re-renders
+  return useMemo(
+    () => ({
+      meowBalance: meowBalance || '0',
+      isLoading,
+      error: error?.message || null,
+      refetch, // Manual refresh for transactions or explicit user actions
+    }),
+    [
+      meowBalance,
+      isLoading,
+      error,
+      refetch,
+    ]
+  );
+};

--- a/src/apps/feed/lib/useMeowPost.ts
+++ b/src/apps/feed/lib/useMeowPost.ts
@@ -1,67 +1,137 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
+import { useCallback, useRef } from 'react';
 import { SagaActionTypes } from '../../../store/posts';
 import { ethers } from 'ethers';
 import { meowPost as meowPostApi } from '../../../store/posts/utils';
+import { formatWeiAmount } from '../../../lib/number';
+import { useMeowBalance } from './useMeowBalance';
 
 export const useMeowPost = () => {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
+  const { meowBalance } = useMeowBalance();
 
-  const { mutate } = useMutation({
-    mutationFn: async ({ postId, meowAmount }: { postId: string; meowAmount: string }) => {
-      const meowAmountWei = ethers.utils.parseEther(meowAmount.toString());
-      const res = await meowPostApi(postId, meowAmountWei.toString());
+  // Batching state - single post at a time
+  const pendingPostId = useRef<string | null>(null);
+  const pendingAmount = useRef<number>(0);
+  const timeout = useRef<NodeJS.Timeout | null>(null);
 
-      if (!res.ok) {
-        throw new Error('Failed to meow post');
+  // Store the original state before any optimistic updates for proper rollback
+  const previousPost = useRef<any>(null);
+  const previousPosts = useRef<any>(null);
+
+  // updates the UI state before the API call is made
+  const updatePostCachesOptimistically = useCallback(
+    (postId: string, meowAmount: string, isFirstMeowForPost: boolean) => {
+      if (isFirstMeowForPost) {
+        previousPost.current = queryClient.getQueryData(['posts', { postId }]);
+        previousPosts.current = queryClient.getQueryData(['posts']);
       }
-      return { postId, meowAmount };
-    },
-
-    onMutate: async ({ postId, meowAmount }) => {
-      await queryClient.cancelQueries({ queryKey: ['posts'] });
-
-      const previousPost = queryClient.getQueryData(['posts', { postId }]);
-      const previousPosts = queryClient.getQueryData(['posts']);
 
       queryClient.setQueryData(['posts', { postId }], (data: any) => {
-        if (!data) {
-          return;
-        }
-
+        if (!data) return data;
         return updatePostReactions(data, postId, meowAmount);
       });
 
       queryClient.setQueriesData({ queryKey: ['posts'] }, (data: any) => {
         if (!data?.pages) return data;
-
         return {
           ...data,
           pages: data.pages.map((page) => page.map((post) => updatePostReactions(post, postId, meowAmount))),
         };
       });
+    },
+    [queryClient]
+  );
 
-      return { previousPost, previousPosts };
+  const { mutate } = useMutation({
+    mutationFn: async ({ postId, meowAmount }: { postId: string; meowAmount: string }) => {
+      // Validate against user's balance - cap at available balance
+      const userBalance = Number(formatWeiAmount(meowBalance));
+      const requestedAmount = Number(meowAmount);
+      const cappedAmount = Math.min(requestedAmount, userBalance);
+
+      const meowAmountWei = ethers.utils.parseEther(cappedAmount.toString());
+      const res = await meowPostApi(postId, meowAmountWei.toString());
+
+      if (!res.ok) {
+        throw new Error('Failed to meow post');
+      }
+      return { postId, meowAmount: cappedAmount.toString() };
     },
 
-    onError: (_error, _variables, context) => {
-      if (context?.previousPost) {
-        queryClient.setQueryData(['posts', { postId: _variables.postId }], context.previousPost);
+    // No onMutate needed - we save state in updatePostCachesOptimistically
+
+    onError: (_error, _variables, _context) => {
+      if (previousPost.current) {
+        queryClient.setQueryData(['posts', { postId: _variables.postId }], previousPost.current);
       }
-      if (context?.previousPosts) {
-        queryClient.setQueryData(['posts'], context.previousPosts);
+      if (previousPosts.current) {
+        queryClient.setQueryData(['posts'], previousPosts.current);
       }
     },
 
     onSettled: () => {
+      // Clear saved state and refresh data
+      previousPost.current = null;
+      previousPosts.current = null;
+
       queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.invalidateQueries({ queryKey: ['meowBalance'] });
     },
   });
 
-  const meowPostFeed = (postId: string, meowAmount: string) => {
-    mutate({ postId, meowAmount });
-  };
+  /**
+   * We're first batching the MEOWs (in a 4s interval) and
+   * then sending them to the server.
+   */
+  const meowPostFeed = useCallback(
+    (postId: string, meowAmount: string) => {
+      const amount = Number(meowAmount);
+
+      // If MEOWing a different post, immediately send pending MEOWs to the server for the previous post
+      if (pendingPostId.current && pendingPostId.current !== postId && pendingAmount.current > 0) {
+        if (timeout.current) {
+          clearTimeout(timeout.current);
+          timeout.current = null;
+        }
+
+        // Send the previous post's accumulated MEOWs
+        mutate({ postId: pendingPostId.current, meowAmount: pendingAmount.current.toString() });
+
+        // Reset state
+        pendingAmount.current = 0;
+      }
+
+      // Check if this is the first MEOW for this post
+      const isFirstMeowForPost = !pendingPostId.current || pendingPostId.current !== postId;
+
+      // Set current post and add to accumulated amount
+      pendingPostId.current = postId;
+      pendingAmount.current += amount;
+
+      // Immediately update UI optimistically (saves original state if first MEOW)
+      updatePostCachesOptimistically(postId, meowAmount, isFirstMeowForPost);
+
+      // Clear existing timer and start a new 4-second timer
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
+
+      timeout.current = setTimeout(() => {
+        if (pendingAmount.current > 0 && pendingPostId.current) {
+          mutate({ postId: pendingPostId.current, meowAmount: pendingAmount.current.toString() });
+        }
+
+        // Reset state
+        pendingPostId.current = null;
+        pendingAmount.current = 0;
+        timeout.current = null;
+      }, 4000);
+    },
+    [mutate, updatePostCachesOptimistically]
+  );
 
   const meowPost = (postId: string, meowAmount: string) => {
     dispatch({ type: SagaActionTypes.MeowPost, payload: { postId, meowAmount } });


### PR DESCRIPTION
### What does this do?

- Uses the user wallet balance before triggering a meow (previously, we were using the rewards.meow Redux state)
- Implements batching functionality: which means that we collect the meows for an interval of 4 seconds. For example, if I click on the meow button and I click on it again within this 4-second interval, it will batch those meows together and call the API with the collective amount.