### PR TITLE
fix: Reset backgrounds by changing key

### DIFF
--- a/src/store/background/constants.ts
+++ b/src/store/background/constants.ts
@@ -1,0 +1,1 @@
+export const keyStorageMainBackground = 'mainBackground:selectedMainBackgroundv2';

--- a/src/store/background/index.ts
+++ b/src/store/background/index.ts
@@ -1,4 +1,5 @@
 import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { keyStorageMainBackground } from './constants';
 
 export enum SagaActionTypes {
   SetMainBackground = 'background/setMainBackground',
@@ -22,8 +23,7 @@ export interface BackgroundState {
 }
 
 const initialState: BackgroundState = {
-  selectedMainBackground:
-    (localStorage.getItem('mainBackground:selectedMainBackground') as MainBackground) || MainBackground.None,
+  selectedMainBackground: (localStorage.getItem(keyStorageMainBackground) as MainBackground) || MainBackground.None,
 };
 
 const slice = createSlice({

--- a/src/store/background/saga.test.ts
+++ b/src/store/background/saga.test.ts
@@ -3,6 +3,7 @@ import { expectSaga } from 'redux-saga-test-plan';
 import { setMainBackground } from './saga';
 
 import { MainBackground, reducer } from '.';
+import { keyStorageMainBackground } from './constants';
 
 describe('setMainBackground', () => {
   beforeAll(() => {
@@ -24,6 +25,6 @@ describe('setMainBackground', () => {
 
   it('should handle dot-grid background', async () => {
     expectSaga(setMainBackground, { payload: MainBackground.DotGrid }).withReducer(reducer).run();
-    expect(localStorage.setItem).toHaveBeenCalledWith('mainBackground:selectedMainBackground', MainBackground.DotGrid);
+    expect(localStorage.setItem).toHaveBeenCalledWith(keyStorageMainBackground, MainBackground.DotGrid);
   });
 });

--- a/src/store/background/saga.ts
+++ b/src/store/background/saga.ts
@@ -1,7 +1,6 @@
 import { takeLatest, put } from 'redux-saga/effects';
 import { SagaActionTypes, setSelectedMainBackground } from '.';
-
-export const keyStorageMainBackground = 'mainBackground:selectedMainBackground';
+import { keyStorageMainBackground } from './constants';
 
 export function* setMainBackground(action) {
   const selectedMainBackground = action.payload;


### PR DESCRIPTION
### What does this do?
Changes the localstorage key for backgrounds

### Why are we making this change?
Recent design changes look best with no background, so resetting back to that. User can change it again if they want to
