### PR TITLE
chore: use explorer URL in manifest

### DIFF
--- a/src/apps/explorer/manifest.ts
+++ b/src/apps/explorer/manifest.ts
@@ -1,8 +1,9 @@
+import { config } from '../../config';
 import { ZAppManifest } from '../external-app/types/manifest';
 
 export const ExplorerManifest: ZAppManifest = {
   title: 'Explorer',
   route: '/explorer',
-  url: 'https://explorer.zero.tech/',
+  url: config.znsExplorerUrl || '',
   features: [],
 };


### PR DESCRIPTION
### What does this do?

- Changes Explorer manifest file to use Explorer URL from env, rather than the hardcoded value.
