### PR TITLE
feat(tokens-app): add launch token buttons to token app sidekick

### DIFF
--- a/src/apps/token/components/sidekick/index.tsx
+++ b/src/apps/token/components/sidekick/index.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { Input } from '@zero-tech/zui/components/Input/Input';
-import { IconSearchMd } from '@zero-tech/zui/icons';
+import { Button, Variant as ButtonVariant } from '@zero-tech/zui/components/Button';
+import { IconButton } from '@zero-tech/zui/components';
+import { IconSearchMd, IconCoinsStacked2, IconPlus } from '@zero-tech/zui/icons';
 import {
   ContentPortal as SidekickContentPortal,
   Content as SidekickContent,
@@ -36,6 +38,10 @@ export const Sidekick = () => {
   const location = useLocation();
   const [selectedTab, setSelectedTab] = useState<Tab>(Tab.Chains);
   const [search, setSearch] = useState('');
+
+  const handleLaunchToken = () => {
+    console.log('Launch Token clicked');
+  };
 
   // Extract current chain from URL
   const getCurrentChain = (): string | null => {
@@ -94,11 +100,23 @@ export const Sidekick = () => {
             wrapperClassName={styles.SearchWrapper}
             placeholder='Search chains...'
           />
+          <IconButton Icon={IconPlus} onClick={handleLaunchToken} aria-label='Launch new token' />
         </div>
 
         <TabList selectedTab={selectedTab} onTabSelect={handleTabSelect} tabsData={tabsData} />
 
         <SidekickScroll>{renderContent()}</SidekickScroll>
+
+        <div className={styles.LaunchButtonContainer}>
+          <Button
+            variant={ButtonVariant.Primary}
+            onPress={handleLaunchToken}
+            startEnhancer={<IconCoinsStacked2 size={16} />}
+            className={styles.LaunchButton}
+          >
+            <div className={styles.LaunchButtonText}>Launch Token</div>
+          </Button>
+        </div>
       </SidekickContent>
     </SidekickContentPortal>
   );

--- a/src/apps/token/components/sidekick/styles.module.scss
+++ b/src/apps/token/components/sidekick/styles.module.scss
@@ -1,5 +1,6 @@
 .Actions {
   display: flex;
+  align-items: center;
   gap: 8px;
   padding: 16px 16px 0;
 }
@@ -24,4 +25,35 @@
   list-style: none;
   padding: 0 16px;
   margin: 0;
+}
+
+.LaunchButtonContainer {
+  display: flex;
+  justify-content: center;
+
+  position: absolute;
+  bottom: 0;
+  left: 0;
+
+  width: 100%;
+  background: linear-gradient(to bottom, transparent, #121212 100%);
+  border-radius: 0 0 16px 16px;
+}
+
+.LaunchButton {
+  gap: 8px;
+  margin-bottom: 16px;
+  background: #181818;
+
+  &:hover {
+    background: #181818;
+  }
+
+  &:active {
+    background: #141414;
+  }
+}
+
+.LaunchButtonText {
+  margin-left: 4px;
 }


### PR DESCRIPTION
### What does this do?
We're adding two launch token buttons to the token app sidekick - a '+' icon button next to the search input and a footer button at the bottom of the sidekick.

### Why are we making this change?
We're adding these buttons to provide users with convenient ways to launch new tokens, following the same UI patterns used in the messenger and feed apps for consistency and better user experience.

### How do I test this?
Ru tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
