### PR TITLE
Remove dead space from the profile card in User Profile panel

### DIFF
--- a/src/apps/profile/panels/UserPanel/styles.module.scss
+++ b/src/apps/profile/panels/UserPanel/styles.module.scss
@@ -112,7 +112,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 48px;
+  min-height: 0;
 }
 
 .MessageButton {


### PR DESCRIPTION
Before:
<img width="371" height="398" alt="image" src="https://github.com/user-attachments/assets/5e5a5bc1-9094-4805-90e5-c3925c3eaaf3" />


After:
<img width="334" height="335" alt="image" src="https://github.com/user-attachments/assets/dafea7f3-dc72-47b8-9a08-280c7db22290" />

