### PR TITLE
Update Leaderboard app: Make users name linked to their profile

### DIFF
--- a/src/apps/leaderboard/components/table-header/index.tsx
+++ b/src/apps/leaderboard/components/table-header/index.tsx
@@ -26,7 +26,7 @@ export const TableHeader = () => {
           <span>Joined</span>
         </th>
         <th className={styles.meowColumn}>
-          <span>MEOW</span>
+          <span>MEOW Earned</span>
         </th>
         <th className={styles.codeColumn}>
           <span>Code</span>

--- a/src/apps/leaderboard/components/table-header/styles.module.scss
+++ b/src/apps/leaderboard/components/table-header/styles.module.scss
@@ -59,7 +59,7 @@
 }
 
 .meowColumn {
-  width: 12%;
+  width: 13%;
   text-align: right;
 }
 

--- a/src/apps/leaderboard/components/table-row/user-display/index.tsx
+++ b/src/apps/leaderboard/components/table-row/user-display/index.tsx
@@ -1,4 +1,5 @@
 import { IconZeroProVerified } from '@zero-tech/zui/icons';
+import { Link } from 'react-router-dom';
 
 import styles from './styles.module.scss';
 
@@ -8,22 +9,36 @@ interface UserDisplayProps {
   isProUser: boolean;
 }
 
-export const UserDisplay = ({ name, primaryZid, isProUser }: UserDisplayProps) => {
-  return (
-    <div className={styles.userContainer}>
-      <div className={styles.nameRow}>
-        <span className={styles.name}>{name}</span>
-        {isProUser && (
-          <div className={styles.proBadge}>
-            <IconZeroProVerified size={16} />
-          </div>
-        )}
-      </div>
-      {primaryZid && (
-        <div className={styles.zidRow}>
-          <span className={styles.zid}>{primaryZid}</span>
+const UserContent = ({ name, primaryZid, isProUser }: UserDisplayProps) => (
+  <div className={styles.userContainer}>
+    <div className={styles.nameRow}>
+      <span className={styles.name}>{name}</span>
+      {isProUser && (
+        <div className={styles.proBadge}>
+          <IconZeroProVerified size={16} />
         </div>
       )}
     </div>
+    {primaryZid && (
+      <div className={styles.zidRow}>
+        <span className={styles.zid}>{primaryZid}</span>
+      </div>
+    )}
+  </div>
+);
+
+export const UserDisplay = ({ name, primaryZid, isProUser }: UserDisplayProps) => {
+  // Remove '0://' prefix from ZID if present for the URL
+  const profileIdentifier = primaryZid?.replace('0://', '');
+
+  // If we don't have a primaryZid, render without a link
+  if (!profileIdentifier) {
+    return <UserContent name={name} primaryZid={primaryZid} isProUser={isProUser} />;
+  }
+
+  return (
+    <Link to={`/profile/${profileIdentifier}`} className={styles.userLink}>
+      <UserContent name={name} primaryZid={primaryZid} isProUser={isProUser} />
+    </Link>
   );
 };

--- a/src/apps/leaderboard/components/table-row/user-display/styles.module.scss
+++ b/src/apps/leaderboard/components/table-row/user-display/styles.module.scss
@@ -1,3 +1,17 @@
+.userLink {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:hover .name {
+    color: var(--text-primary-hover, #01f4cb);
+  }
+}
+
 .userContainer {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### What does this do?

- Rename 'MEOW' column to 'MEOW Earned'
- User name are hyperlinked now to their profiles (while recording idk why but the cursor pointer doesn't turn to a hand)

https://github.com/user-attachments/assets/67e1d758-a5c7-4d49-9ea3-3107ff9577fe

