### PR TITLE
refactor(token-app/token-launcher): remove initial buy amount input and approval step from token launcher

### DIFF
--- a/src/apps/token/components/token-launcher/FormInputs.tsx
+++ b/src/apps/token/components/token-launcher/FormInputs.tsx
@@ -3,10 +3,6 @@ import { Input } from '@zero-tech/zui/components/Input/Input';
 import { FormData, MAX_SYMBOL_LENGTH } from './utils';
 import { TokenIconUpload } from '../token-icon-upload';
 import { FeeStructure } from './FeeStructure';
-import { useBalancesQuery } from '../../../wallet/queries/useBalancesQuery';
-import { currentUserSelector } from '../../../../store/authentication/selectors';
-import { useSelector } from 'react-redux';
-import { MEOW_TOKEN_ADDRESS } from '../../../wallet/constants';
 import styles from './styles.module.scss';
 
 interface FormInputsProps {
@@ -26,18 +22,6 @@ export const FormInputs = ({
   onInputChange,
   onIconFileSelected,
 }: FormInputsProps) => {
-  const user = useSelector(currentUserSelector);
-  const userAddress = user?.zeroWalletAddress;
-
-  const { data: balancesData, isLoading: balancesLoading } = useBalancesQuery(userAddress || '');
-
-  const meowBalance = balancesData?.tokens?.find(
-    (token) => token.tokenAddress.toLowerCase() === MEOW_TOKEN_ADDRESS.toLowerCase()
-  );
-
-  const meowAmount = meowBalance ? parseFloat(meowBalance.amount) : 0;
-  const initialBuyAmount = parseFloat(formData.initialBuyAmount) || 0;
-  const hasInsufficientBalance = initialBuyAmount > 0 && initialBuyAmount > meowAmount;
   return (
     <div className={styles.FormContent}>
       <div className={styles.InputsSection}>
@@ -53,38 +37,6 @@ export const FormInputs = ({
           <div className={styles.HelperText}>
             Short symbol for your token (max {MAX_SYMBOL_LENGTH} characters, e.g., "BTC", "ETH")
           </div>
-        </div>
-
-        <div className={styles.InputGroup}>
-          <label className={styles.Label}>Initial Buy Amount (required) - Default: 0</label>
-          <Input
-            value={formData.initialBuyAmount}
-            onChange={onInputChange('initialBuyAmount')}
-            placeholder='e.g., 1000'
-            type='number'
-          />
-          <div className={styles.HelperTextContainer}>
-            <div className={styles.HelperText}>Amount of MEOW to provide as initial liquidity</div>
-            {userAddress && (
-              <div className={styles.BalanceInfo}>
-                <span className={styles.BalanceLabel}>Your MEOW Balance:</span>
-                {balancesLoading ? (
-                  <div className={styles.BalanceLoading}>
-                    <div className={styles.Spinner} />
-                  </div>
-                ) : (
-                  <span className={styles.BalanceAmount}>{meowAmount.toFixed(2)} MEOW</span>
-                )}
-              </div>
-            )}
-          </div>
-
-          {hasInsufficientBalance && (
-            <div className={styles.BalanceError}>
-              Insufficient MEOW balance. You need {initialBuyAmount.toFixed(2)} MEOW but only have{' '}
-              {meowAmount.toFixed(2)} MEOW.
-            </div>
-          )}
         </div>
 
         <div className={styles.InputGroup}>

--- a/src/apps/token/components/token-launcher/index.tsx
+++ b/src/apps/token/components/token-launcher/index.tsx
@@ -1,10 +1,6 @@
 import { PanelBody } from '../../../../components/layout/panel';
 import { Button } from '@zero-tech/zui/components/Button';
 import { useState } from 'react';
-import { useBalancesQuery } from '../../../wallet/queries/useBalancesQuery';
-import { currentUserSelector } from '../../../../store/authentication/selectors';
-import { useSelector } from 'react-redux';
-import { MEOW_TOKEN_ADDRESS } from '../../../wallet/constants';
 
 import styles from './styles.module.scss';
 import { validateFormData } from './utils';
@@ -28,17 +24,6 @@ export const TokenLauncher = ({ onBack, onViewToken }: TokenLauncherProps) => {
 
   const form = useTokenForm();
 
-  // Get user's MEOW balance for validation
-  const user = useSelector(currentUserSelector);
-  const userAddress = user?.zeroWalletAddress;
-  const { data: balancesData } = useBalancesQuery(userAddress || '');
-
-  const meowBalance = balancesData?.tokens?.find(
-    (token) => token.tokenAddress.toLowerCase() === MEOW_TOKEN_ADDRESS.toLowerCase()
-  );
-  const meowAmount = meowBalance ? parseFloat(meowBalance.amount) : 0;
-  const hasInsufficientBalance = form.hasInsufficientBalance(meowAmount);
-
   const submission = useTokenSubmission({
     formData: form.formData,
     selectedIconFile: form.selectedIconFile,
@@ -61,10 +46,10 @@ export const TokenLauncher = ({ onBack, onViewToken }: TokenLauncherProps) => {
     await submission.submit();
   };
 
-  const isDisabled = submission.isSubmitting || !form.isFormValid() || !!form.iconUploadError || hasInsufficientBalance;
+  const isDisabled = submission.isSubmitting || !form.isFormValid() || !!form.iconUploadError;
 
-  if (submission.isSubmitting || submission.isApproving) {
-    const title = submission.isApproving ? 'Approving transaction' : 'Creating your token';
+  if (submission.isSubmitting) {
+    const title = 'Creating your token';
     const subtitle = 'Just a moment...';
 
     return (

--- a/src/apps/token/components/token-launcher/styles.module.scss
+++ b/src/apps/token/components/token-launcher/styles.module.scss
@@ -145,18 +145,10 @@
   color: var(--text-primary);
 }
 
-.HelperTextContainer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-}
-
 .HelperText {
   font-size: 11px;
   color: var(--text-tertiary);
   line-height: 1.2;
-  flex: 1;
 }
 
 .ErrorMessage {
@@ -295,60 +287,4 @@
   color: var(--text-tertiary);
   font-size: 12px;
   line-height: 1.4;
-}
-
-.BalanceInfo {
-  display: flex;
-  align-items: center;
-  font-size: 10px;
-  gap: 4px;
-}
-
-.BalanceLabel {
-  font-size: 11px;
-  color: var(--text-tertiary);
-  line-height: 1.2;
-  font-weight: 500;
-}
-
-.BalanceAmount {
-  font-size: 11px;
-  color: var(--text-tertiary);
-  line-height: 1.2;
-  font-weight: 600;
-}
-
-.BalanceLoading {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.Spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid rgba(1, 244, 203, 0.3);
-  border-top: 2px solid var(--text-accent);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-.BalanceError {
-  margin-top: 8px;
-  padding: 8px 12px;
-  background: rgba(255, 59, 48, 0.1);
-  border: 1px solid rgba(255, 59, 48, 0.2);
-  border-radius: 6px;
-  color: var(--color-error);
-  font-size: 12px;
-  font-weight: 500;
 }

--- a/src/apps/token/components/token-launcher/utils.ts
+++ b/src/apps/token/components/token-launcher/utils.ts
@@ -10,7 +10,7 @@ export const MAX_SYMBOL_LENGTH = 10;
 export const GRADUATION_THRESHOLD = '800,000,000 tokens';
 
 export const validateFormData = (data: FormData, selectedIconFile?: File | null): string | null => {
-  if (!data.name || !data.symbol || !data.initialBuyAmount) {
+  if (!data.name || !data.symbol) {
     return 'Please fill in all required fields';
   }
 
@@ -20,11 +20,6 @@ export const validateFormData = (data: FormData, selectedIconFile?: File | null)
 
   if (data.symbol.length > MAX_SYMBOL_LENGTH) {
     return `Symbol must be ${MAX_SYMBOL_LENGTH} characters or less`;
-  }
-
-  const initialAmount = parseFloat(data.initialBuyAmount);
-  if (isNaN(initialAmount) || initialAmount < 0) {
-    return 'Initial buy amount must be a valid number greater than or equal to 0';
   }
 
   return null;

--- a/src/apps/token/hooks/useTokenForm.ts
+++ b/src/apps/token/hooks/useTokenForm.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FormData, validateFormData, isValidNumericInput, formatSymbolInput } from '../components/token-launcher/utils';
+import { FormData, validateFormData, formatSymbolInput } from '../components/token-launcher/utils';
 
 const INITIAL_FORM_DATA: FormData = {
   name: '',
@@ -18,13 +18,7 @@ export const useTokenForm = () => {
   const handleInputChange = (field: keyof FormData) => (value: string) => {
     let newFormData: FormData;
 
-    if (field === 'initialBuyAmount') {
-      if (isValidNumericInput(value)) {
-        newFormData = { ...formData, [field]: value };
-      } else {
-        return;
-      }
-    } else if (field === 'symbol') {
+    if (field === 'symbol') {
       newFormData = { ...formData, [field]: formatSymbolInput(value) };
     } else {
       newFormData = { ...formData, [field]: value };

--- a/src/apps/token/hooks/useTokenForm.ts
+++ b/src/apps/token/hooks/useTokenForm.ts
@@ -81,11 +81,6 @@ export const useTokenForm = () => {
     return validateFormData(formData, selectedIconFile) === null;
   };
 
-  const hasInsufficientBalance = (balance: number) => {
-    const initialBuyAmount = parseFloat(formData.initialBuyAmount) || 0;
-    return initialBuyAmount > 0 && initialBuyAmount > balance;
-  };
-
   return {
     formData,
     selectedIconFile,
@@ -97,6 +92,5 @@ export const useTokenForm = () => {
     setFormError,
     setIconError,
     isFormValid,
-    hasInsufficientBalance,
   };
 };

--- a/src/apps/token/hooks/useTokenSubmission.ts
+++ b/src/apps/token/hooks/useTokenSubmission.ts
@@ -1,13 +1,6 @@
 import { useCreateZBancToken } from './useCreateZBancToken';
 import { useUploadTokenIcon } from './useUploadTokenIcon';
 import { FormData } from '../components/token-launcher/utils';
-import { useTokenApproval } from '../../../apps/staking/lib/useTokenApproval';
-import { currentUserSelector } from '../../../store/authentication/selectors';
-import { useSelector } from 'react-redux';
-import { config } from '../../../config';
-
-const ZBANC_TOKEN_ADDRESS = config.zbancReserveTokenAddress;
-const ZBANC_SPENDER_ADDRESS = config.zbancFactoryAddress;
 
 interface UseTokenSubmissionProps {
   formData: FormData;
@@ -26,8 +19,6 @@ export const useTokenSubmission = ({
   setIconError,
   clearErrors,
 }: UseTokenSubmissionProps) => {
-  const userAddress = useSelector(currentUserSelector)?.zeroWalletAddress;
-  const approveToken = useTokenApproval();
   const createTokenMutation = useCreateZBancToken();
   const uploadIconMutation = useUploadTokenIcon();
 
@@ -42,30 +33,14 @@ export const useTokenSubmission = ({
     try {
       const initialBuyAmount = BigInt(Number(formData.initialBuyAmount) * 10 ** 18).toString();
 
-      // Get approval only if initial buy amount is greater than 0
-      if (parseFloat(formData.initialBuyAmount) > 0) {
-        const approvalResult = await approveToken.approve(
-          userAddress,
-          ZBANC_TOKEN_ADDRESS,
-          ZBANC_SPENDER_ADDRESS,
-          initialBuyAmount,
-          Number(config.zChainId)
-        );
-
-        if (!approvalResult.success) {
-          setFormError((approvalResult as any).error || 'Approval failed');
-          return;
-        }
-      }
-
-      // Then upload the icon
+      // Upload the icon first
       const uploadResult = await uploadIconMutation.mutateAsync(selectedIconFile);
       if (!uploadResult.success) {
         setIconError('Failed to upload icon');
         return;
       }
 
-      // Then create the token with the uploaded icon URL
+      // Create the token with the uploaded icon URL
       const result = await createTokenMutation.mutateAsync({
         name: formData.name,
         symbol: formData.symbol,
@@ -100,11 +75,9 @@ export const useTokenSubmission = ({
   };
 
   const isSubmitting = createTokenMutation.isPending || uploadIconMutation.isPending;
-  const isApproving = approveToken.isApproving;
 
   return {
     submit,
     isSubmitting,
-    isApproving,
   };
 };


### PR DESCRIPTION
### What does this do?
We're removing the Initial Buy Amount input field from the token launcher form and eliminating the ERC20 approval step from the token creation flow.

### Why are we making this change?
Since the initial buy amount is now hardcoded to "0" and users can't modify it, there's no need for the input field or the approval step since no MEOW tokens are being spent during token creation.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
