### PR TITLE
feat(messenger-app/conversation-list): filter conversation list to only show encrypted conversations

### DIFF
--- a/src/components/messenger/list/conversation-list-panel/index.tsx
+++ b/src/components/messenger/list/conversation-list-panel/index.tsx
@@ -148,7 +148,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
   const filteredConversations = useMemo(() => {
     if (!filter) {
       return conversations.filter((conversation: NormalizedChannel) => {
-        const render = !conversation.isSocialChannel && 'bumpStamp' in conversation;
+        const render = !conversation.isSocialChannel && 'bumpStamp' in conversation && conversation.isEncrypted;
         const labelMatch = getConversationsByLabel(tabLabelMap[selectedTab], conversation);
         return render && labelMatch;
       });
@@ -162,7 +162,9 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
     const directMatches = getDirectMatches(conversations, searchRegEx);
     const indirectMatches = getIndirectMatches(conversations, searchRegEx);
 
-    return [...directMatches, ...indirectMatches].filter((c) => !archivedConversationIds.includes(c.id));
+    return [...directMatches, ...indirectMatches].filter(
+      (c) => !archivedConversationIds.includes(c.id) && c.isEncrypted
+    );
   }, [
     conversations,
     filter,
@@ -243,7 +245,7 @@ export const ConversationListPanel: React.FC<Properties> = React.memo((props) =>
 
   const tabUnreadCount = useMemo(() => {
     return conversations
-      .filter((c) => !c.isSocialChannel && !c.labels?.includes(DefaultRoomLabels.ARCHIVED))
+      .filter((c) => !c.isSocialChannel && !c.labels?.includes(DefaultRoomLabels.ARCHIVED) && c.isEncrypted)
       .reduce<Record<string, number>>(
         (acc, c) => {
           acc[Tab.All] += c.unreadCount.total;

--- a/src/lib/chat/matrix/matrix-adapter.ts
+++ b/src/lib/chat/matrix/matrix-adapter.ts
@@ -16,6 +16,7 @@ export class MatrixAdapter {
     const labels = Object.keys(room.tags || {});
     const [admins, mods] = Matrix.client.getRoomAdminsAndMods(room);
     const isSocialChannel = Matrix.client.getRoomGroupType(room) === 'social';
+    const isEncrypted = room.hasEncryptionStateEvent();
 
     const members = Matrix.client.getRoomMembers(room.roomId);
 
@@ -33,6 +34,7 @@ export class MatrixAdapter {
       moderatorIds: mods,
       labels,
       isSocialChannel,
+      isEncrypted,
       // this isn't the best way to get the zid as it relies on the name format, but it's a quick fix
       zid: isSocialChannel ? room.name?.split('://')[1] : null,
     };

--- a/src/store/channels/index.ts
+++ b/src/store/channels/index.ts
@@ -78,6 +78,7 @@ export interface Channel {
   otherMembersTyping: string[];
   labels?: string[];
   isSocialChannel?: boolean;
+  isEncrypted?: boolean;
   zid?: string;
 }
 
@@ -114,6 +115,7 @@ export const CHANNEL_DEFAULTS = {
   otherMembersTyping: [],
   labels: [],
   isSocialChannel: false,
+  isEncrypted: false,
   zid: null,
 };
 


### PR DESCRIPTION
### What does this do?
We're adding an isEncrypted property to the Channel interface, updating the MatrixAdapter to detect encryption status, and filtering the conversation list panel to only display encrypted conversations.

### Why are we making this change?
This is the first step in restructuring the messenger app to separate encrypted and unencrypted conversations, where encrypted conversations will remain in the main sidekick while unencrypted conversations will be moved elsewhere in upcoming changes.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
