### PR TITLE
feat(posts): make zid optional for posting, use wallet address as fallback author identifier

### DIFF
--- a/src/apps/feed/components/feed/lib/useFeed.ts
+++ b/src/apps/feed/components/feed/lib/useFeed.ts
@@ -7,7 +7,7 @@ import { get } from '../../../../../lib/api/rest';
 import { PAGE_SIZE } from '../../../lib/constants';
 import { mapPostToMatrixMessage } from '../../../../../store/posts/utils';
 import { useMeowPost } from '../../../lib/useMeowPost';
-import { primaryZIDSelector, userIdSelector } from '../../../../../store/authentication/selectors';
+import { primaryZIDSelector, userIdSelector, currentUserSelector } from '../../../../../store/authentication/selectors';
 import { useMeowBalance } from '../../../lib/useMeowBalance';
 import { searchMyNetworksByName } from '../../../../../platform-apps/channels/util/api';
 import { MemberNetworks } from '../../../../../store/users/types';
@@ -24,6 +24,7 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
   const currentUserId = useSelector(userIdSelector);
   const { meowBalance: userMeowBalance } = useMeowBalance();
   const primaryZID = useSelector(primaryZIDSelector);
+  const currentUser = useSelector(currentUserSelector);
   const [searchResults, setSearchResults] = useState<MemberNetworks[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -119,7 +120,7 @@ export const useFeed = ({ zid, userId, isLoading: isLoadingProp, following }: Us
   const isEmpty = data?.pages.every((page) => page.length === 0);
 
   return {
-    channelZid: zid ?? primaryZID,
+    channelZid: zid ?? primaryZID ?? currentUser?.zeroWalletAddress ?? currentUser?.primaryWalletAddress,
     fetchNextPage,
     hasLoadedMessages,
     hasNextPage,

--- a/src/apps/feed/lib/useSubmitPost.ts
+++ b/src/apps/feed/lib/useSubmitPost.ts
@@ -37,22 +37,29 @@ export const useSubmitPost = () => {
       const { message, replyToId, channelZid, mediaId, quoteOf } = params;
       const formattedUserPrimaryZid = userPrimaryZid?.replace('0://', '');
 
-      const authorAddress = currentUser?.zeroWalletAddress;
+      // Use ZID if available, otherwise use any available wallet address as author identifier
+      const authorIdentifier =
+        formattedUserPrimaryZid || currentUser?.zeroWalletAddress || currentUser?.primaryWalletAddress;
 
-      if (!formattedUserPrimaryZid) {
-        throw new Error('Please set a primary ZID in your profile');
+      if (!authorIdentifier) {
+        throw new Error('Please connect a wallet or set a primary ZID');
       }
 
       if (!channelZid) {
         throw new Error('Channel ZID is invalid');
       }
 
-      if (!authorAddress) {
-        throw new Error('ZERO wallet is not connected');
+      // Check if user has any wallets
+      if (!userWallets || userWallets.length === 0) {
+        throw new Error('Please connect a wallet to post');
       }
 
-      if (!userWallets.find((w) => w.publicAddress.toLowerCase() === authorAddress.toLowerCase())) {
-        throw new Error('Wallet is not linked to your account');
+      // Use the first available wallet address for signing
+      const authorAddress =
+        currentUser?.zeroWalletAddress || currentUser?.primaryWalletAddress || userWallets[0]?.publicAddress;
+
+      if (!authorAddress) {
+        throw new Error('No wallet address available');
       }
 
       const createdAt = new Date().getTime();
@@ -61,7 +68,7 @@ export const useSubmitPost = () => {
         created_at: createdAt.toString(),
         text: message,
         wallet_address: authorAddress,
-        zid: formattedUserPrimaryZid,
+        zid: authorIdentifier,
       };
 
       const unsignedPost = JSON.stringify(payloadToSign);
@@ -82,7 +89,7 @@ export const useSubmitPost = () => {
       formData.append('text', message);
       formData.append('unsignedMessage', unsignedPost);
       formData.append('signedMessage', signedPost);
-      formData.append('zid', formattedUserPrimaryZid);
+      formData.append('zid', authorIdentifier);
       formData.append('walletAddress', authorAddress);
       if (quoteOf) {
         formData.append('quoteOf', quoteOf);
@@ -117,6 +124,7 @@ export const useSubmitPost = () => {
       }
 
       const formattedZid = currentUser?.primaryZID?.replace('0://', '');
+      const authorIdentifier = formattedZid || currentUser?.zeroWalletAddress || currentUser?.primaryWalletAddress;
 
       const optimisticId = uuidv4();
 
@@ -138,7 +146,7 @@ export const useSubmitPost = () => {
           firstName: currentUser?.profileSummary?.firstName,
           displaySubHandle: currentUser?.primaryZID,
           avatarUrl: currentUser?.profileSummary?.profileImage,
-          primaryZid: formattedZid,
+          primaryZid: authorIdentifier,
           publicAddress: currentUser?.primaryWalletAddress,
           isZeroProSubscriber: false,
         },

--- a/src/components/app-bar/post-button/index.tsx
+++ b/src/components/app-bar/post-button/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { primaryZIDSelector } from '../../../store/authentication/selectors';
+import { primaryZIDSelector, currentUserSelector } from '../../../store/authentication/selectors';
 import { useSelector } from 'react-redux';
 
 import { PostModal } from './modal';
@@ -11,9 +11,16 @@ import styles from './styles.module.scss';
 
 export const PostButton = () => {
   const userZid = useSelector(primaryZIDSelector);
+  const currentUser = useSelector(currentUserSelector);
   const [isPostModalOpen, setIsPostModalOpen] = useState(false);
 
-  if (!userZid) {
+  // Allow posting if user has either ZID or any wallet
+  if (
+    !userZid &&
+    !currentUser?.zeroWalletAddress &&
+    !currentUser?.primaryWalletAddress &&
+    (!currentUser?.wallets || currentUser.wallets.length === 0)
+  ) {
     return null;
   }
 

--- a/src/components/app-bar/post-button/modal.tsx
+++ b/src/components/app-bar/post-button/modal.tsx
@@ -4,7 +4,7 @@ import { useHistory, useRouteMatch } from 'react-router-dom';
 
 import { Modal } from '@zero-tech/zui/components/Modal';
 import { PostInput } from '../../../apps/feed/components/post-input-hook';
-import { primaryZIDSelector } from '../../../store/authentication/selectors';
+import { primaryZIDSelector, currentUserSelector } from '../../../store/authentication/selectors';
 import { quotingPostSelector } from '../../../store/posts/selectors';
 
 import styles from './styles.module.scss';
@@ -24,12 +24,14 @@ export const PostModal = ({ open, onOpenChange }: PostModalProps) => {
 
 const Content = ({ onOpenChange }: { onOpenChange: (open: boolean) => void }) => {
   const primaryZID = useSelector(primaryZIDSelector);
+  const currentUser = useSelector(currentUserSelector);
   const quotingPost = useSelector(quotingPostSelector);
   const history = useHistory();
   const route = useRouteMatch<{ zid: string }>('/feed/:zid');
 
-  // Use current channel ZID if on a channel feed, otherwise use user's primary ZID
-  const channelZid = route?.params?.zid || primaryZID;
+  // Use current channel ZID if on a channel feed, otherwise use user's primary ZID or any wallet address
+  const channelZid =
+    route?.params?.zid || primaryZID || currentUser?.zeroWalletAddress || currentUser?.primaryWalletAddress;
 
   const containerRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
### What does this do?
We're removing the ZID requirement for posting and allowing users to post using their account abstraction wallet address when no ZID is set.

### Why are we making this change?
To allow all users to post on the feed regardless of whether they have set up a ZID, using their wallet address as the author identifier when no ZID is available.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
