### PR TITLE
refactor(posts): remove frontend zid fallback logic for post creation

### DIFF
--- a/src/apps/feed/lib/useSubmitPost.ts
+++ b/src/apps/feed/lib/useSubmitPost.ts
@@ -90,7 +90,9 @@ export const useSubmitPost = () => {
       formData.append('text', message);
       formData.append('unsignedMessage', unsignedPost);
       formData.append('signedMessage', signedPost);
-      formData.append('zid', formattedUserPrimaryZid);
+      if (formattedUserPrimaryZid) {
+        formData.append('zid', formattedUserPrimaryZid);
+      }
       formData.append('walletAddress', authorAddress);
       if (quoteOf) {
         formData.append('quoteOf', quoteOf);

--- a/src/apps/feed/lib/useSubmitPost.ts
+++ b/src/apps/feed/lib/useSubmitPost.ts
@@ -37,11 +37,12 @@ export const useSubmitPost = () => {
       const { message, replyToId, channelZid, mediaId, quoteOf } = params;
       const formattedUserPrimaryZid = userPrimaryZid?.replace('0://', '');
 
-      // Use ZID if available, otherwise use any available wallet address as author identifier
-      const authorIdentifier =
-        formattedUserPrimaryZid || currentUser?.zeroWalletAddress || currentUser?.primaryWalletAddress;
-
-      if (!authorIdentifier) {
+      if (
+        !formattedUserPrimaryZid &&
+        !currentUser?.zeroWalletAddress &&
+        !currentUser?.primaryWalletAddress &&
+        (!currentUser?.wallets || currentUser.wallets.length === 0)
+      ) {
         throw new Error('Please connect a wallet or set a primary ZID');
       }
 
@@ -68,7 +69,7 @@ export const useSubmitPost = () => {
         created_at: createdAt.toString(),
         text: message,
         wallet_address: authorAddress,
-        zid: authorIdentifier,
+        zid: formattedUserPrimaryZid,
       };
 
       const unsignedPost = JSON.stringify(payloadToSign);
@@ -89,7 +90,7 @@ export const useSubmitPost = () => {
       formData.append('text', message);
       formData.append('unsignedMessage', unsignedPost);
       formData.append('signedMessage', signedPost);
-      formData.append('zid', authorIdentifier);
+      formData.append('zid', formattedUserPrimaryZid);
       formData.append('walletAddress', authorAddress);
       if (quoteOf) {
         formData.append('quoteOf', quoteOf);
@@ -124,7 +125,6 @@ export const useSubmitPost = () => {
       }
 
       const formattedZid = currentUser?.primaryZID?.replace('0://', '');
-      const authorIdentifier = formattedZid || currentUser?.zeroWalletAddress || currentUser?.primaryWalletAddress;
 
       const optimisticId = uuidv4();
 
@@ -146,7 +146,7 @@ export const useSubmitPost = () => {
           firstName: currentUser?.profileSummary?.firstName,
           displaySubHandle: currentUser?.primaryZID ? currentUser?.primaryZID : '',
           avatarUrl: currentUser?.profileSummary?.profileImage,
-          primaryZid: authorIdentifier,
+          primaryZid: formattedZid,
           publicAddress: currentUser?.primaryWalletAddress,
           isZeroProSubscriber: false,
         },

--- a/src/store/posts/saga.ts
+++ b/src/store/posts/saga.ts
@@ -106,8 +106,8 @@ export function* sendPost(action) {
       walletClient = yield call(getWallet);
       connectedAddress = walletClient.account?.address;
     } catch (e) {
-      //
-      throw new Error('Please connect a wallet');
+      // If no EOA wallet is connected, we can still use Z wallet for posting
+      connectedAddress = null;
     }
 
     // Use Z wallet address if available, otherwise use connected wallet
@@ -119,7 +119,10 @@ export function* sendPost(action) {
     }
 
     // Verify the connected wallet is valid (either zeroWalletAddress, primaryWalletAddress, or in wallets array)
+    // Skip validation if using Z wallet (no EOA connection required)
+    const isUsingZWallet = authorAddress === user.zeroWalletAddress || authorAddress === user.primaryWalletAddress;
     const isValidWallet =
+      isUsingZWallet ||
       connectedAddress === user.zeroWalletAddress ||
       connectedAddress === user.primaryWalletAddress ||
       user.wallets.some((w) => w.publicAddress.toLowerCase() === connectedAddress.toLowerCase());

--- a/src/store/posts/utils.ts
+++ b/src/store/posts/utils.ts
@@ -89,8 +89,12 @@ export async function uploadPost(formData: FormData, worldZid: string) {
       .field('text', formData.get('text'))
       .field('unsignedMessage', formData.get('unsignedMessage'))
       .field('signedMessage', formData.get('signedMessage'))
-      .field('zid', formData.get('zid'))
       .field('walletAddress', formData.get('walletAddress'));
+
+    const zid = formData.get('zid');
+    if (zid) {
+      request = request.field('zid', zid);
+    }
 
     const replyTo = formData.get('replyTo');
     if (replyTo) {


### PR DESCRIPTION
### What does this do?
We're removing frontend ZID fallback logic and sending undefined for the zid field when users don't have a ZID, allowing the backend to handle wallet address fallback.

### Why are we making this change?
To simplify the frontend architecture by letting the backend determine the author identifier (ZID or wallet address) instead of duplicating this logic in the frontend.

### How do I test this?
Run tests as usual

### Key decisions and Risk Assessment:
  #### Things to consider:
  1. How will this affect security?
  1. How will this affect performance?
  1. Does this change any APIs?
