### PR TITLE
Fix: When sending messages in quick succession, the timing becomes out of order.

### DIFF
--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -21,7 +21,6 @@ import {
 import { bemClassName } from '../../lib/bem';
 import { useDispatch, useSelector } from 'react-redux';
 import { useChannelSelector, useMessagesSelector, useUsersSelector } from '../../store/hooks';
-// compareDatesAsc no longer used; sorting now uses clientSortKey
 import { ChatMessage } from './chat-message';
 import { openLightbox } from '../../store/dialogs';
 import { AdminMessageContainer } from '../admin-message/container';

--- a/src/components/chat-view-container/chat-view.tsx
+++ b/src/components/chat-view-container/chat-view.tsx
@@ -7,6 +7,7 @@ import InvertedScroll from '../inverted-scroll';
 import { ConversationStatus, MessagesFetchState } from '../../store/channels';
 import { searchMentionableUsersForChannel } from '../../platform-apps/channels/util/api';
 import './styles.scss';
+import { compareMessagesByClientOrder } from '../../store/messages/utils';
 import { ChatSkeleton } from './chat-skeleton';
 import {
   createMessageGroups,
@@ -20,7 +21,7 @@ import {
 import { bemClassName } from '../../lib/bem';
 import { useDispatch, useSelector } from 'react-redux';
 import { useChannelSelector, useMessagesSelector, useUsersSelector } from '../../store/hooks';
-import { compareDatesAsc } from '../../lib/date';
+// compareDatesAsc no longer used; sorting now uses clientSortKey
 import { ChatMessage } from './chat-message';
 import { openLightbox } from '../../store/dialogs';
 import { AdminMessageContainer } from '../admin-message/container';
@@ -102,9 +103,7 @@ export const ChatView = React.forwardRef<InvertedScroll, Properties>(
     }, []);
 
     const sortMessages = useCallback((messagesToSort: MessageModel[]) => {
-      return [...messagesToSort].sort((a, b) =>
-        compareDatesAsc(new Date(a.createdAt).toISOString(), new Date(b.createdAt).toISOString())
-      );
+      return [...messagesToSort].sort(compareMessagesByClientOrder);
     }, []);
 
     const getOldestTimestamp = useCallback((messages: MessageModel[] = []): number => {

--- a/src/lib/chat/matrix/chat-message.ts
+++ b/src/lib/chat/matrix/chat-message.ts
@@ -81,7 +81,7 @@ export function mapMatrixMessage(matrixEvent: Partial<IEvent>): MessageWithoutSe
     isPost: false,
     sendStatus: MessageSendStatus.SUCCESS,
     isAdmin: false,
-    optimisticId: content.optimisticId,
+    optimisticId: content.optimisticId ?? (content as any)?.info?.optimisticId,
     mentionedUsers: [],
     hidePreview: false,
     media: null,
@@ -136,7 +136,7 @@ export function mapEventToPostMessage(matrixEvent: IEvent): MessageWithoutSender
     message: content.body,
     createdAt: origin_server_ts,
     updatedAt: 0,
-    optimisticId: content.optimisticId,
+    optimisticId: content.optimisticId ?? (content as any)?.info?.optimisticId,
     // Left as undefined since we need data from redux. This will be populated in a saga
     // as a post processing step
     sender: undefined,

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -33,15 +33,6 @@ export function compareDatesDesc(a: string | number | Date, b: string | number |
   return -moment(a || BEGINNING_OF_TIME).diff(moment(b || BEGINNING_OF_TIME));
 }
 
-export function compareDatesAsc(a: string | number | Date, b: string | number | Date) {
-  const BEGINNING_OF_TIME = '1000-01-01';
-  return moment(a || BEGINNING_OF_TIME).diff(moment(b || BEGINNING_OF_TIME));
-}
-
-export function sortByCreatedAtAsc(a, b) {
-  return compareDatesAsc(a.createdAt, b.createdAt);
-}
-
 export function sortByCreatedAtDesc(a, b) {
   return compareDatesDesc(a.createdAt, b.createdAt);
 }

--- a/src/store/messages/index.ts
+++ b/src/store/messages/index.ts
@@ -83,6 +83,7 @@ export interface Message {
   isAdmin: boolean;
   createdAt: number;
   updatedAt: number;
+  clientSortKey?: number;
   sender: Sender;
   mentionedUsers: { id: string }[];
   hidePreview: boolean;

--- a/src/store/messages/utils.ts
+++ b/src/store/messages/utils.ts
@@ -96,3 +96,22 @@ export function getFileType(file: File) {
 
   return FileType.Attachment;
 }
+
+type OrderableMessage = {
+  id: string;
+  createdAt: number;
+  clientSortKey?: number;
+};
+
+const getClientOrderKey = (message: OrderableMessage): number => {
+  return typeof message?.clientSortKey === 'number' ? message.clientSortKey : message.createdAt;
+};
+
+// Used to sort messages by clientSortKey, then createdAt, and then id
+export const compareMessagesByClientOrder = (a: OrderableMessage, b: OrderableMessage): number => {
+  const aKey = getClientOrderKey(a);
+  const bKey = getClientOrderKey(b);
+  if (aKey !== bKey) return aKey - bKey;
+  if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+  return String(a.id).localeCompare(String(b.id));
+};


### PR DESCRIPTION
### What does this do?

**Problem**: If you send multiple messages in quick succession, sometimes (due to server load), they appear to be 'bouncing' on the UI (basically the timing becomes out of order). This can be more easily reproduced if you try to send multiple image messages at the same time: while they're all optimistically rendered initially at the same time, as soon as the first image upload is successful, the state is updated, and the `createdAt` changes from our optimistic message object to the actual matrix event. So, after that, when the UI sorts the messages, it can fall out of order (since the `optimisticMessage.createdAt` can be different from `canonicalMessage.createdAt`). 

Therefore, as the actual matrix events for the file upload keeps coming in, the order keeps getting changed (hence the 'bounce')

**Solution**: We introduce a `clientSortKey` when creating optimistic message(s). And when we receive the equivalent canonical matrix event, we preserve that sortKey, and therefore order the messages (both in the saga & in the UI), by the `clientSortKey`. This ensures that the order in which the optimistic messages appeared on the UI **stay the same** even after their canonical counterparts arrive. 



https://github.com/user-attachments/assets/507d39ff-3cfd-485a-b1ce-a96f9ad989ee
