### PR TITLE
Open the ZNS explorer in the system browser on desktop

### DIFF
--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -1,5 +1,7 @@
 import { isDesktopApp } from '@todesktop/client-core/platform/todesktop';
-import { webContents, menu, platform, app } from '@todesktop/client-core';
+import { webContents, menu, platform, app, nativeWindow } from '@todesktop/client-core';
+
+import { config } from '../config';
 
 // Adapted from https://github.com/sindresorhus/electron-context-menu/
 const handleContextMenu = async (ev: any) => {
@@ -34,6 +36,51 @@ const handleContextMenu = async (ev: any) => {
   await menu.popup({ ref: menuRef });
 };
 
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Build a regex matching the explorer on any subdomain of its root domain. The
+// embedded explorer (config.znsExplorerUrl, e.g. explorer.zos.zero.tech) and
+// the public one the claim flow links out to (e.g. explorer.zero.tech) share a
+// root but differ by subdomain, so we match the whole family rather than one
+// exact host.
+const explorerUrlPattern = (rawUrl: string): string | undefined => {
+  try {
+    const labels = new URL(rawUrl).hostname.split('.');
+    if (labels.length < 2) {
+      return undefined;
+    }
+    const firstLabel = escapeRegExp(labels[0]);
+    const root = escapeRegExp(labels.slice(-2).join('.'));
+    return `https://${firstLabel}\\.(?:[a-z0-9-]+\\.)*${root}`;
+  } catch {
+    return undefined;
+  }
+};
+
+// ToDesktop treats same-domain URLs as internal and opens them in a new in-app
+// window. The ZNS explorer is on the same domain, so its "open in browser"
+// links (e.g. the domain-claim flow) would open in-app — where the user has no
+// browser wallet extension. Route the explorer's URLs to the system browser
+// instead. Other links keep ToDesktop's default handling (no fallback rule).
+const openExplorerInSystemBrowser = async () => {
+  if (!config.znsExplorerUrl) {
+    return;
+  }
+  const pattern = explorerUrlPattern(config.znsExplorerUrl);
+  if (!pattern) {
+    return;
+  }
+  try {
+    const ref = await nativeWindow.getWebContents();
+    await webContents.setWindowOpenRules({
+      ref,
+      rules: [{ regex: pattern, options: { action: 'openInBrowser' } }],
+    });
+  } catch (error) {
+    console.error('Failed to set explorer window-open rule', error);
+  }
+};
+
 export const desktopInit = () => {
   if (!isDesktopApp()) {
     return;
@@ -42,4 +89,5 @@ export const desktopInit = () => {
   console.log('Electron version:', platform.electron.getElectronVersion());
 
   webContents.on('context-menu', handleContextMenu);
+  void openExplorerInSystemBrowser();
 };


### PR DESCRIPTION
## What

On the desktop app (ToDesktop), clicking a link that opens the ZNS explorer (e.g. the domain-claim flow) opened it in a **new in-app window** instead of the user's browser. ToDesktop treats same-domain URLs as internal by default, and the explorer shares the app's root domain, so its `window.open` links were kept in-app — where the user has no browser wallet extension to complete a claim.

This registers a ToDesktop window-open rule in `desktopInit()` so explorer URLs open in the **system browser** instead.

## How

- Uses `webContents.setWindowOpenRules` with `{ action: "openInBrowser" }`.
- The regex is derived from `config.znsExplorerUrl` and matches the explorer on **any subdomain of its root domain**, because the embedded explorer (`explorer.zos.zero.tech`) and the public one the claim links out to (`explorer.zero.tech`) differ by subdomain.
- No fallback rule, so every other link keeps ToDesktop's default handling. In-iframe navigation (React Router `history.push` — domain rows, tabs, etc.) is unaffected, since only `window.open` events hit this rule.

## Scope / safety

- **Ships via the normal web deploy** (it's renderer code in `desktopInit`), so it reaches desktop users without a ToDesktop rebuild/release.
- Web build is unaffected (`isDesktopApp()` guard).
- Only explorer `window.open` URLs are externalized; leaderboard/DAO/other links and internal navigation are untouched.

## Testing

Verified via ToDesktop (local): clicking Claim in the embedded explorer opens the system browser; clicking a domain row stays in-app.
